### PR TITLE
suppress pynotify gtk display warning during startup when DISPLAY environment variable is not set

### DIFF
--- a/sabnzbd/growler.py
+++ b/sabnzbd/growler.py
@@ -36,7 +36,10 @@ try:
 except ImportError:
     _HAVE_OSX_GROWL = False
 try:
-    import pynotify
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        import pynotify
     _HAVE_NTFOSD = True
 except ImportError:
     _HAVE_NTFOSD = False


### PR DESCRIPTION
his Q'n'D patch turns gtk warnings into exceptions for handling during the initialization of xbmc/growler.py, thereby eliminating GTK errors about not being albe to access X when you start SABnzbd on a headless machine.
