### PR TITLE
QR Code Buttons for Plush

### DIFF
--- a/interfaces/Plush/templates/config_general.tmpl
+++ b/interfaces/Plush/templates/config_general.tmpl
@@ -112,6 +112,7 @@
           <span class="component-title">$T('opt-apikey')</span>
           <input type="text" id="apikey" value="$session" class="apikey">
           <input type="button" class="juiButton" value="$T('button-apikey')" id="generate_new_apikey" rel="$T('Plush-confirm')">
+          <input type="button" class="juiButton show_qrcode" value="QR Code" title="API Key QR Code" href="https://chart.googleapis.com/chart?chs=300x300&cht=qr&chl=$session" >
         </label>
         <label class="nocheck clearfix">
           <span class="component-title">&nbsp;</span>
@@ -123,6 +124,7 @@
           <span class="component-title">$T('opt-nzbkey')</span>
           <input type="text" id="nzbkey" value="$nzb_key" class="apikey">
           <input type="button" class="juiButton" value="$T('button-apikey')" id="generate_new_nzbkey" rel="$T('Plush-confirm')">
+          <input type="button" class="juiButton show_qrcode" value="QR Code" title="NZB Key QR Code" href="https://chart.googleapis.com/chart?chs=300x300&cht=qr&chl=$nzb_key" >
         </label>
         <label class="nocheck clearfix">
           <span class="component-title">&nbsp;</span>

--- a/interfaces/Plush/templates/static/javascripts/config.js
+++ b/interfaces/Plush/templates/static/javascripts/config.js
@@ -25,6 +25,7 @@ jQuery(document).ready(function($){
   $("#help").colorbox({ inline:true, href:"#help_modal", title:$("#help").text(),
     innerWidth:"375px", innerHeight:"350px", initialWidth:"375px", initialHeight:"350px", speed:0, opacity:0.7
   });
+  $(".show_qrcode").colorbox({ photo:true, innerHeight:"300px", innerWidth:"300px", speed:0, opacity: 0.7, scrolling:false });
 
   // jqueryui tabs/buttons
   $('.juiButton').button();


### PR DESCRIPTION
As per [this feature request](http://forums.sabnzbd.org/viewtopic.php?f=4&t=9710) on the forums.

Adds two simple buttons that pop up modals with the associated key as a QR Code. Intended to make setup for mobile apps less painful. So instead of having to type out a full hash, a user could click the QR Code button in SABnzbd, use a QR Code reader to read and copy the full hash to their mobile device, and then paste it into their mobile application.

The href in config_general.tmpl line 115 can be used as an example of what kind of link would be needed in other templates, should we decide to port this functionality across the board.
