### PR TITLE
Use 'minutes' instead of 'mins' so the History log can be fully translated

### DIFF
--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -72,7 +72,7 @@ SKIN_TEXT = {
     'hour' : TT('hour'), #: One hour
     'hours' : TT('hours'), #: Multiple hours
     'minute' : TT('min'), #: One minute
-    'minutes' : TT('mins'), #: Multiple minutes
+    'minutes' : TT('minutes'), #: Multiple minutes
     'second' : TT('sec'), #: One second
     'seconds' : TT('seconds'), #: Multiple seconds
     'day' : TT('day'),


### PR DESCRIPTION
Before this patch:
`已下载，耗时 18 minutes 17 秒，平均速度 471 KB/s`

After this patch:
`已下载，耗时 18 分钟 17 秒，平均速度 471 KB/s`
