### PR TITLE
Reset marker_file path to temporary _UNPACK_ path for marker_file deleti...

### DIFF
--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -367,6 +367,7 @@ def process_job(nzo):
             set_permissions(tmp_workdir_complete)
 
             if all_ok:
+                marker_file = os.path.join(tmp_workdir_complete, cfg.marker_file())    #reset marker_file for _UNPACK_ path
                 del_marker(marker_file)
                 remove_from_list(marker_file, newfiles)
 


### PR DESCRIPTION
...on

previously marker_file path was set to workdir_complete+cfg.marker_file() when in _UNPACK_ at time of deletion
