### PR TITLE
Mask server password input fields

### DIFF
--- a/interfaces/Config/templates/config_server.tmpl
+++ b/interfaces/Config/templates/config_server.tmpl
@@ -35,7 +35,7 @@
                 </div>
                 <div class="field-pair alt">
                     <label class="config" for="password">$T('srv-password')</label>
-                    <input type="text" name="password" id="password" size="30" />
+                    <input type="password" name="password" id="password" size="30" />
                 </div>
                 <div class="field-pair">
                     <label class="config" for="connections">$T('srv-connections')</label>

--- a/interfaces/Plush/templates/config_server.tmpl
+++ b/interfaces/Plush/templates/config_server.tmpl
@@ -46,7 +46,7 @@
       <div class="field-pair alt">
         <label class="nocheck clearfix" for="password">
           <span class="component-title">$T('srv-password')</span>
-          <input type="text" size="25" name="password"/>
+          <input type="password" size="25" name="password"/>
         </label>
       </div>
       <div class="field-pair">
@@ -156,7 +156,7 @@
   <div class="field-pair alt">
     <label class="nocheck clearfix" for="password">
       <span class="component-title">$T('srv-password')</span>
-      <input type="text" size="25" name="password" value="$servers[$server]['password']" />
+      <input type="password" size="25" name="password" value="$servers[$server]['password']" />
     </label>
   </div>
   <div class="field-pair">


### PR DESCRIPTION
Changed server password input fields to type 'password' to mask the
input. This is good security practice, and stops people snooping over
your shoulder when entering passwords.
