### PR TITLE
0.7.x

### DIFF
--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -490,7 +490,7 @@ class RSSQueue(object):
                 try:
                     if feeds[feed].enable.get():
                         if not active:
-                            logging.info('Starting scheduled RSS read-out')
+                            logging.info("Starting scheduled RSS read-out for %s", feeds[feed].name)
                         active = True
                         self.run_feed(feed, download=True, ignoreFirst=True)
                         # Wait 15 seconds, else sites may get irritated
@@ -504,7 +504,7 @@ class RSSQueue(object):
                     pass
             if active:
                 self.save()
-                logging.info('Finished scheduled RSS read-out')
+                logging.info("Finished scheduled RSS read-out for %s", feeds[feed].name)
 
 
     @synchronized(LOCK)


### PR DESCRIPTION
A couple of changes for newzbin/newzxxx site detection, based on pull request 59 earlier today.

A request to have the RSS feed name included in the info-level log instead of having to enable debug-level logging to get this information.

I am not very fluent in python so please verify these changes.
