### PR TITLE
Print out nzo_id when deleting history item.

### DIFF
--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -443,7 +443,7 @@ def _api_history(name, output, kwargs):
             jobs = value.split(',')
             for job in jobs:
                 del_hist_job(job, del_files)
-            return report(output)
+            return report(output, data=value)
         else:
             return report(output, _MSG_NO_VALUE)
     elif not name:


### PR DESCRIPTION
After using the API for a while, I have a (possible) minor improvement. Instead of returning `{status:True}` when a history item has been deleted, it would be much more helpful to the developer using the API to receive the nzo_id(s) of the item(s) removed. Not only would it indicate a successful deletion but also offer more information. Thoughts?
