### PR TITLE
tiny patch to help with free.xsusenet.com

### DIFF
--- a/sabnzbd/decoder.py
+++ b/sabnzbd/decoder.py
@@ -245,7 +245,7 @@ def decode(article, data):
         if not ybegin:
             found = False
             try:
-                for i in xrange(10):
+                for i in xrange(min(40, len(data))):
                     if data[i].startswith('begin '):
                         nzf.filename = name_fixer(data[i].split(None, 2)[2])
                         nzf.type = 'uu'
@@ -309,7 +309,7 @@ def yCheck(data):
     yend = None
 
     ## Check head
-    for i in xrange(40):
+    for i in xrange(min(40, len(data))):
         try:
             if data[i].startswith('=ybegin '):
                 splits = 3


### PR DESCRIPTION
Some peculiar usenet providers like 'free.xsusenet.com' require the use of
ARTICLE instead of BODY which means that the beginning of the actual uuencoded
data can start after more than 10 lines. yEnc already looks at first 40 lines.
