### PR TITLE
Fix text in dropdowns being hard to see in chrome.

### DIFF
--- a/interfaces/smpl/templates/static/stylesheets/colorschemes/black.css
+++ b/interfaces/smpl/templates/static/stylesheets/colorschemes/black.css
@@ -83,7 +83,7 @@ table{border-spacing:0;}
 
 
 
-input, select {
+input, select, option {
 background-color:#232323;
 border-color:#3a3a3a;
 color:white;


### PR DESCRIPTION
option elements in Chrome inherit the text colour of their parent select element, but do not also inherit the background-colour, so let's force the style on the option element to be the same as the select so that we no longer have white-on-grey text in drop downs.
