### PR TITLE
Fix typo in config+comments: s/seperate/separate/g

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,7 +4,7 @@
 - Fix problem with %fn substitution in Sorting
 - Add special "wait_for_dfolder", enables waiting for external temp download folder
 - Work-around for servers that do not support STAT command
-- Removed articles are now listed seperately in download report
+- Removed articles are now listed separately in download report
 - Add "abort" option to encryption detection
 - Fix missing Retry link for "Out of retention" jobs.
 - Option to abort download when it is clear that not enough data is available

--- a/cherrypy/lib/sessions.py
+++ b/cherrypy/lib/sessions.py
@@ -492,7 +492,7 @@ class MemcachedSession(Session):
     # Wrap all .get and .set operations in a single lock.
     mc_lock = threading.RLock()
     
-    # This is a seperate set of locks per session id.
+    # This is a separate set of locks per session id.
     locks = {}
     
     servers = ['127.0.0.1:11211']

--- a/sabnzbd/database.py
+++ b/sabnzbd/database.py
@@ -237,7 +237,7 @@ class HistoryDB(object):
         fetched_items = len(items)
 
         # Unpack the single line stage log
-        # Stage Name is seperated by ::: stage lines by ; and stages by \r\n
+        # Stage Name is separated by ::: stage lines by ; and stages by \r\n
         items = [unpack_history_info(item) for item in items]
 
         return (items, fetched_items, total_items)
@@ -370,7 +370,7 @@ def build_history_info(nzo, storage='', downpath='', postproc_time=0, script_out
     # Get the dictionary containing the stages and their unpack process
     stages = decode_factory(nzo.unpack_info)
     # Pack the ditionary up into a single string
-    # Stage Name is seperated by ::: stage lines by ; and stages by \r\n
+    # Stage Name is separated by ::: stage lines by ; and stages by \r\n
     lines = []
     for key, results in stages.iteritems():
         lines.append('%s:::%s' % (key, ';'.join(results)))
@@ -385,7 +385,7 @@ def unpack_history_info(item):
         Expands the single line stage_log from the DB
         into a python dictionary for use in the history display
     '''
-    # Stage Name is seperated by ::: stage lines by ; and stages by \r\n
+    # Stage Name is separated by ::: stage lines by ; and stages by \r\n
     if item['stage_log']:
         try:
             lines = item['stage_log'].split('\r\n')

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -184,7 +184,7 @@ class NNTP(object):
             self.sock = socket.socket(af, socktype, proto)
 
         try:
-            # Windows must do the connection in a seperate thread due to non-blocking issues
+            # Windows must do the connection in a separate thread due to non-blocking issues
             # If the server wants to be blocked (for testing) then use the linux route
             if not block:
                 Thread(target=con, args=(self.sock, self.host, self.port, sslenabled, write_fds, self)).start()

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -594,7 +594,7 @@ SKIN_TEXT = {
 # Config->Cat
     'configCat' : TT('User-defined categories'),
     'explain-configCat' : TT('Defines post-processing and storage.'),
-    'explain-catTags' : TT('Use the "Groups / Indexer tags" column to map groups and tags to your categories.<br/>Wildcards are supported. Use commas to seperate terms.'),
+    'explain-catTags' : TT('Use the "Groups / Indexer tags" column to map groups and tags to your categories.<br/>Wildcards are supported. Use commas to separate terms.'),
     'explain-catTags2' : TT('Ending the path with an asterisk * will prevent creation of job folders.'),
     'explain-relFolder' : TT('Relative folders are based on'),
     'catFolderPath' : TT('Folder/Path'),

--- a/sabnzbd/tvsort.py
+++ b/sabnzbd/tvsort.py
@@ -235,7 +235,7 @@ class SeriesSorter(object):
 
 
     def get_multi_ep_naming(self, one, two, extras):
-        ''' Returns a list of unique values joined into a string and seperated by - (ex:01-02-03-04) '''
+        ''' Returns a list of unique values joined into a string and separated by - (ex:01-02-03-04) '''
         extra_list = [one]
         extra2_list = [two]
         for extra in extras:
@@ -1009,7 +1009,7 @@ def replace_word(input, one, two):
 def get_descriptions(match, name):
     '''
     If present, get a description from the nzb name.
-    A description has to be after the matched item, seperated either
+    A description has to be after the matched item, separated either
     like ' - Description' or '_-_Description'
     '''
     if match:

--- a/sabnzbd/utils/listquote.py
+++ b/sabnzbd/utils/listquote.py
@@ -275,7 +275,7 @@ def simplelist(inline):
 
 ##############################################
 # LineParser - a multi purpose line parser
-# handles lines with comma seperated values on it, followed by a comment
+# handles lines with comma separated values on it, followed by a comment
 # correctly handles quoting
 # *and* can handle nested lists - marked between '[...]' or '(...)'
 # See the docstring for how this works
@@ -786,7 +786,7 @@ Doesn't allow Python style string escaping (but has '&mjf-quot;' and '&mjf-lf;')
 Uses both \' and \" as quotes and sometimes doesn't quote at all - see
 elem_quote - may not *always* be compatible with other programs.
 
-Allow space seperated lists ? e.g. 10 5 100 20
+Allow space separated lists ? e.g. 10 5 100 20
 
 Lineparser could create tuples.
 


### PR DESCRIPTION
The word "separate" was misspelled on Config / Categories, which bugged me. This commit fixes that, plus the same typo which appears several times in the comments.
