### PR TITLE
Front end engineering for searchable NZB queue!

### DIFF
--- a/interfaces/Plush/templates/main.tmpl
+++ b/interfaces/Plush/templates/main.tmpl
@@ -6,6 +6,7 @@
 
   <div id="hdr-queue" class="tilex_sprite_container sprite_tile_qh">
     <div class="logo main_sprite_container sprite_topleft_queue"><h1><!--#if $active_lang in ('de', 'fr') then $T('menu-queue') else $T('menu-queue').upper()#--></h1></div>
+    <form id="queueSearchForm" action="#"><input id="queueSearchBox" type="text" size="8" class="listSearchBox main_sprite_container sprite_h_search" /></form>
     <div class="queue-buttons queue-buttons-pause lang-$active_lang main_sprite_container sprite_topright_queue">
       <ul>
         <li class="main_sprite_container <!--#if $paused then 'sprite_q_pause_on' else 'sprite_q_pause'#-->" title="$T('link-pause') &frasl; $T('link-resume')" id="pause_resume"></li>
@@ -190,7 +191,7 @@
           <option value="0">$T('showAllHis')</option>
           <option value="1">$T('showFailedHis')</option>
         </select></li>
-        <li><form id="historySearchForm" action="#"><input id="historySearchBox" type="text" size="8" class="main_sprite_container sprite_h_search" /></form></li>
+        <li><form id="historySearchForm" action="#"><input id="historySearchBox" type="text" size="8" class="listSearchBox main_sprite_container sprite_h_search" /></form></li>
       </ul>
     </div>
   </div>

--- a/interfaces/Plush/templates/static/stylesheets/colorschemes/gold/gold.css
+++ b/interfaces/Plush/templates/static/stylesheets/colorschemes/gold/gold.css
@@ -539,20 +539,37 @@ body {
   width:350px;
 }
 
-#historySearchBox {
-  color:black;
-  width:120px;
-  border:0px;
+.listSearchBox {
+  color: black;
+  width: 120px;
+  border: 0px;
   margin: 7px 9px 1px 1px;
   padding-right:20px;
-  border:1px solid #444;
-background-color: #e5e5e5
-  /*background: url('images/sprite-main.png') no-repeat top right;
-  background-position: 0 -671px;*/
+  border: 1px solid #444;
+  background-color: #e5e5e5
 }
-#historySearchBox:hover,#historySearchBox:focus {
-  border:1px solid gray;
+.listSearchBox:hover,.listSearchBox:focus {
+  border: 1px solid gray;
 }
+
+#queueSearchForm {
+  display: block;
+  height: 0px;
+  text-align: right;
+  margin-right: 151px;
+}
+#queueSearchBox {
+  width: 121px;
+  margin-top: 35px;
+}
+/* a window narrower than this doesn't have room for the search box, so hide it */
+@media screen and (max-width:1100px) { #queueSearchForm { display: none; } }
+
+/* a window this size can fit a smaller search box, so shrink it */
+@media screen and (max-width:1200px) { #queueSearchBox { width: 90px; background-position-x: 95px;} } } }
+
+/* a window wider than this has enough room for a bigger box, so grow it to line up with histsearchbox below it */
+@media screen and (min-width:1190px) { #queueSearchBox { width: 121px; background-position-x: 125px;} }
 
 #hdr-queue {
   height: 67px;


### PR DESCRIPTION
> I've been trying to add a search box to the queue in Plush,
> like the History has. I haven't succeeded...

OK, I implemented the front-end UI changes to make the queue searchable! :mag: Search box adjusts as the window resizes and matches the history search UI.

@shypike, you'll need to tweak `_api_queue` to accept a search string filter param like `_api_history`, but i'm hoping that's easy for you now that the UI work's done (easy for me).

Changes tested in Chrome, Firefox, and Safari. Please LMK if there's an official SABnzbd browser suite that changes get tested against.

![searchable-queue-UI](https://f.cloud.github.com/assets/12213/138539/8f94f0fc-71b1-11e2-97b4-8f5021191878.png)
