### PR TITLE
It’s 2013! (update copyright year globally to 2013)

### DIFF
--- a/NSIS_Installer.nsi
+++ b/NSIS_Installer.nsi
@@ -1,6 +1,6 @@
 ; -*- coding: latin-1 -*-
 ;
-; Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+; Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 ;
 ; This program is free software; you can redistribute it and/or
 ; modify it under the terms of the GNU General Public License

--- a/SABHelper.py
+++ b/SABHelper.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2013 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -260,7 +260,7 @@ def print_version():
     print """
 %s-%s
 
-Copyright (C) 2008-2013, The SABnzbd-Team <team@sabnzbd.org>
+Copyright (C) 2008-2013, The SABnzbd Team <team@sabnzbd.org>
 SABnzbd comes with ABSOLUTELY NO WARRANTY.
 This is free software, and you are welcome to redistribute it
 under certain conditions. It is licensed under the

--- a/interfaces/Classic/README.TXT
+++ b/interfaces/Classic/README.TXT
@@ -1,5 +1,5 @@
 #
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/interfaces/Plush/templates/_inc_modals.tmpl
+++ b/interfaces/Plush/templates/_inc_modals.tmpl
@@ -10,7 +10,7 @@
     </table>
     <div class="sabnzbd_logo main_sprite_container sprite_sabnzbdplus_logo"></div>
     <p><strong>SABnzbd $T('version'):</strong> $version</p>
-    <p><small>Copyright (C) 2008-2012, The SABnzbd Team &lt;team@sabnzbd.org&gt;</small></p>
+    <p><small>Copyright &copy; 2008-2013, The SABnzbd Team &lt;team@sabnzbd.org&gt;</small></p>
     <p><small>$T('yourRights')</small></p>
   </div>
 

--- a/interfaces/wizard/README.TXT
+++ b/interfaces/wizard/README.TXT
@@ -1,5 +1,5 @@
 #
-# Copyright 2009 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2009 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/make_dmg.py
+++ b/make_dmg.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python -OO
 #
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/package.py
+++ b/package.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python -OO
 #
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -343,7 +343,7 @@ options = dict(
       name = 'SABnzbd',
       version = release,
       url = 'http://sourceforge.net/projects/sabnzbdplus',
-      author = 'The SABnzbd-Team',
+      author = 'The SABnzbd Team',
       author_email = 'team@sabnzbd.org',
       scripts = ['SABnzbd.py', 'SABHelper.py'], # One day, add  'setup.py'
       packages = ['sabnzbd', 'sabnzbd.utils', 'util'],
@@ -396,7 +396,7 @@ if target == 'app':
                'plist': {
                    'NSUIElement':1,
                    'CFBundleShortVersionString':release,
-                   'NSHumanReadableCopyright':'The SABnzbd-Team',
+                   'NSHumanReadableCopyright':'The SABnzbd Team',
                    'CFBundleIdentifier':'org.sabnzbd.team',
                    'CFBundleDocumentTypes':[NZBFILE],
                    },

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/articlecache.py
+++ b/sabnzbd/articlecache.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/bpsmeter.py
+++ b/sabnzbd/bpsmeter.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/config.py
+++ b/sabnzbd/config.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/constants.py
+++ b/sabnzbd/constants.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/database.py
+++ b/sabnzbd/database.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/decoder.py
+++ b/sabnzbd/decoder.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/decorators.py
+++ b/sabnzbd/decorators.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/dirscanner.py
+++ b/sabnzbd/dirscanner.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/emailer.py
+++ b/sabnzbd/emailer.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/encoding.py
+++ b/sabnzbd/encoding.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/growler.py
+++ b/sabnzbd/growler.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/lang.py
+++ b/sabnzbd/lang.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python -OO
 # -*- coding: utf-8 -*-
-# Copyright 2011 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2011 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/newzbin.py
+++ b/sabnzbd/newzbin.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/osxmenu.py
+++ b/sabnzbd/osxmenu.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/panic.py
+++ b/sabnzbd/panic.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/powersup.py
+++ b/sabnzbd/powersup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/sabtray.py
+++ b/sabnzbd/sabtray.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/scheduler.py
+++ b/sabnzbd/scheduler.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2011 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2011 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python -OO
 # -*- coding: UTF-8 -*-
-# Copyright 2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/trylist.py
+++ b/sabnzbd/trylist.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/tvsort.py
+++ b/sabnzbd/tvsort.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/utils/feedparser.py
+++ b/sabnzbd/utils/feedparser.py
@@ -11,7 +11,7 @@ Recommended: iconv_codec <http://cjkpython.i18n.org/>
 
 __version__ = "5.1.3"
 __license__ = """
-Copyright (c) 2010-2012 Kurt McKee <contactme@kurtmckee.org>
+Copyright (c) 2010-2013 Kurt McKee <contactme@kurtmckee.org>
 Copyright (c) 2002-2008 Mark Pilgrim
 All rights reserved.
 

--- a/sabnzbd/utils/servertests.py
+++ b/sabnzbd/utils/servertests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/utils/upload.py
+++ b/sabnzbd/utils/upload.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2009-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2009-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/sabnzbd/wizard.py
+++ b/sabnzbd/wizard.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 #
-# Copyright 2008-2009 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2009 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/tools/extract_pot.py
+++ b/tools/extract_pot.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2011-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2011-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -30,7 +30,7 @@ exec(code)
 # Fixed information for the POT header
 HEADER = r'''#
 # SABnzbd Translation Template file __TYPE__
-# Copyright (C) 2011-2012 by the SABnzbd Team
+# Copyright (C) 2011-2013 by the SABnzbd Team
 #   team@sabnzbd.org
 #
 msgid ""

--- a/tools/make_mo.py
+++ b/tools/make_mo.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python -OO
 # -*- coding: utf-8 -*-
-# Copyright 2010-2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2010-2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/util/apireg.py
+++ b/util/apireg.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2012 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2013 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/util/mailslot.py
+++ b/util/mailslot.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python -OO
-# Copyright 2008-2011 The SABnzbd-Team <team@sabnzbd.org>
+# Copyright 2008-2011 The SABnzbd Team <team@sabnzbd.org>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License


### PR DESCRIPTION
fix the copyright year in the code and in the web UI to correctly show **2008-2013** instead of 2008-2012. also fixed inconsistent hyphen that occasionally appeared in the words "SABnzbd-Team".
