### PR TITLE
add nzo.nzo_id to user script params

### DIFF
--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -136,19 +136,19 @@ def find_programs(curdir):
         sabnzbd.newsunpack.RAR_PROBLEM = not unrar_check(sabnzbd.newsunpack.RAR_COMMAND)
 
 #------------------------------------------------------------------------------
-def external_processing(extern_proc, complete_dir, filename, nicename, cat, group, status):
+def external_processing(extern_proc, complete_dir, filename, nicename, cat, group, status, id):
     """ Run a user postproc script, return console output and exit value
     """
     command = [str(extern_proc), str(complete_dir), str(filename),
-               str(nicename), '', str(cat), str(group), str(status)]
+               str(nicename), '', str(cat), str(group), str(status), str(id)]
 
     if extern_proc.endswith('.py') and (sabnzbd.WIN32 or not os.access(extern_proc, os.X_OK)):
         command.insert(0, 'python')
     stup, need_shell, command, creationflags = build_command(command)
     env = fix_env()
 
-    logging.info('Running external script %s(%s, %s, %s, %s, %s, %s, %s)',
-                 extern_proc, complete_dir, filename, nicename, '', cat, group, status)
+    logging.info('Running external script %s(%s, %s, %s, %s, %s, %s, %s, %s)',
+                 extern_proc, complete_dir, filename, nicename, '', cat, group, status, id)
 
     try:
         p = subprocess.Popen(command, shell=need_shell, stdin=subprocess.PIPE,

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -427,7 +427,7 @@ def process_job(nzo):
                 nzo.set_action_line(T('Running script'), unicoder(script))
                 nzo.set_unpack_info('Script', T('Running user script %s') % unicoder(script), unique=True)
                 script_log, script_ret = external_processing(script_path, workdir_complete, nzo.filename,
-                                                             dirname, cat, nzo.group, job_result)
+                                                             dirname, cat, nzo.group, job_result, nzo.nzo_id)
                 script_line = get_last_line(script_log)
                 if script_log:
                     script_output = nzo.nzo_id


### PR DESCRIPTION
_Replaces #90, now based off sabnzbd/develop_

Pass the `nzo.nzo_id` to [post processing scripts](http://wiki.sabnzbd.org/user-scripts) as the last parameter to maintain compatibility.

API uses `nzo.nzo_id` as primary and not being able to easily reference this in post processing scripts is inflexible.

[Suggested addition to docs](http://wiki.sabnzbd.org/user-scripts):

```
|| 8 || Job ID e.g. SABnzbd_nzo_wgmb1m ||
```

<!---
@huboard:{"custom_state":"","order":91.0,"milestone_order":91.0}
-->
