### PR TITLE
Faster strip() function in decoder

### DIFF
--- a/sabnzbd/decoder.py
+++ b/sabnzbd/decoder.py
@@ -20,7 +20,7 @@ sabnzbd.decoder - article decoder
 """
 
 import Queue
-import binascii
+import zlib
 import logging
 import re
 from time import sleep
@@ -287,7 +287,7 @@ def decode(article, data):
                     j = '=%c' % (i + 64)
                     data = data.replace(j, chr(i))
                 decoded_data = data.translate(YDEC_TRANS)
-                crc = binascii.crc32(decoded_data)
+                crc = zlib.crc32(decoded_data)
                 partcrc = '%08X' % (crc & 2**32L - 1)
 
             if ypart:


### PR DESCRIPTION
From commit msg:
The strip function in the decoder is a bit of a hotspot. With a small cpu and a big pipe, everything counts.

Some timings on dev system:
From ~.08sec for 30k element list to ~.0008sec
From ~2sec for 150k element list to ~.004sec
