### PR TITLE
Issue with Categories on nzbs.org

### DIFF
--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -153,9 +153,9 @@ class URLGrabber(Thread):
 
                 pp = future_nzo.pp
                 script = future_nzo.script
-                cat = future_nzo.cat
-                if (cat is None or cat == '*') and category:
-                    cat = misc.cat_convert(category)
+                cat = misc.cat_convert(category)
+                if not cat:
+                    cat = future_nzo.cat
                 priority = future_nzo.priority
                 nzbname = future_nzo.custom_name
 


### PR DESCRIPTION
This might be the wrong way to fix this, but future_nzo.cat was overriding the category provided by indexer header info.  In the case of nzbs.org Apps-Android is getting overridden by Apps.