### PR TITLE
if joining file check if XXX.000 is just splitter info, if yes skip it

### DIFF
--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -352,6 +352,9 @@ def file_join(nzo, workdir, workdir_complete, delete, joinables):
                 perc = (100.0 / size) * n
                 logging.debug("Processing %s", joinable)
                 nzo.set_action_line(T('Joining'), '%.0f%%' % perc)
+                if joinable.count(".000") == 1 and os.path.getsize(joinable)<1000 :
+                    logging.debug('Skipping: %s', joinable)
+                    continue
                 f = open(joinable, 'rb')
                 shutil.copyfileobj(f, joined_file, bufsize)
                 f.close()


### PR DESCRIPTION
When file is split with software like MasterSplitter , filename.000 is just info,  we have to skip it , if not merge file is corrupted ( unreadable wmv movie file for example ).

usually filename.000 created just for info is quite small , so if size is < 1kb we are skipping it.

this commit correct the problem for me , no regression found

tested with python 2.7.5 on fedora linux fc19
