### PR TITLE
add (example) systemd unit file

### DIFF
--- a/linux/sabnzbd@.service
+++ b/linux/sabnzbd@.service
@@ -1,0 +1,22 @@
+# copy or _hard_link to
+#   Debian: /lib/systemd/system/sabnzbd@.service
+#   others: /usr/lib/systemd/system/sabnzbd@.service
+#
+# To start SABNzbd once for USER use:
+#   systemctl start sabnzbd@USER.service
+#
+# To start SABNzbd on boot for USER use:
+#   systemctl enable sabnzbd@USER.service
+#
+# Config will be placed in ~USER/.sabnzbd/
+
+[Unit]
+Description=SABnzbd binary newsreader
+
+[Service]
+ExecStart=/opt/sabnzbd/SABnzbd.py --logging 1 --browser 0
+User=%I
+Group=%I
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
systemd is a modern replacement for Linux’ init system. 

systemd doesn’t require sabnzbd to fork, in fact it would make the unit file more complicated because of the manual pid-file management. Thus `--browser 0` is used to mimic the `--daemon` behaviour.

`--logging 1` is used because there’s really no downside to having debug information available via standard systemd methods (i.e. `systemctl status sabnzbd@sabuser.service` will also print the log).

Please let me know if there are any issues preventing the merge.
