### PR TITLE
Change for the smpl interface.

### DIFF
--- a/interfaces/smpl/templates/main.tmpl
+++ b/interfaces/smpl/templates/main.tmpl
@@ -829,6 +829,11 @@ function lrb(url, extra, refresh)
     var elementt;
     if (element) elementt = document.getElementById(element);
     values = getFormValues(elementt);
+    if (elementt) {
+      elementt.onchange=function(){
+        saveelement.value = "$T('button-saveChanges')"
+      }
+    }
 
   var url = ''+extra;
   var d = doXHR(url+append,


### PR DESCRIPTION
This resets the submit button text from 'Saved' to 'Save Changes' on form changes that happen after an initial save to notify user has edited since last save and has unsaved changes.

http://www.quirksmode.org/dom/events/change.html -> form.onchange is compatible with all modern browsers.

If your interested in pulling this request I will go through and make some other tweaks to the smpl interface.
