### PR TITLE
Fix trailing slash

### DIFF
--- a/interfaces/smpl/templates/main.tmpl
+++ b/interfaces/smpl/templates/main.tmpl
@@ -1129,7 +1129,7 @@ function loadingJSON(){
           <li><a class="config" href="$prefix/config/general/" onclick="lr('config/general/','', 0, 0);">$T('cmenu-general')</a></li>
           <li><a class="config" href="$prefix/config/folders/" onclick="lr('config/folders/','', 0, 0);">$T('cmenu-folders')</a> </li>
           <li><a class="config" href="$prefix/config/switches/" onclick="lr('config/switches/','', 0, 0);">$T('cmenu-switches')</a> </li>
-          <li><a class="config" href="$prefix/config/server" onclick="lr('config/server/','', 0, 0);">$T('cmenu-servers')</a> </li>
+          <li><a class="config" href="$prefix/config/server/" onclick="lr('config/server/','', 0, 0);">$T('cmenu-servers')</a> </li>
           <li><a class="config" href="$prefix/config/scheduling/" onclick="lr('config/scheduling/','', 0, 0);">$T('cmenu-scheduling')</a> </li>
           <li><a class="config" href="$prefix/config/rss/" onclick="lr('config/rss/','', 0, 0);">$T('cmenu-rss')</a> </li>
           <li><a class="config" href="$prefix/config/notify/" onclick="lr('config/notify/','', 0, 0);">$T('cmenu-notif')</a></li>


### PR DESCRIPTION
Fixed trailing slash for link to config/server for smpl template; this makes the link consistent with all the other left hand links
