### PR TITLE
relocate sanitize inside windows loop to not clobber unix paths during renaming

### DIFF
--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -1235,8 +1235,8 @@ def ip_extract():
 
 def renamer(old, new):
     """ Rename file/folder with retries for Win32 """
-    new = sanitize_filename(new)
     if sabnzbd.WIN32:
+        new = sanitize_filename(new)
         retries = 15
         while retries > 0:
             try:


### PR DESCRIPTION
Running sanitize_filename on unix filesystems when renaming shows or movies would cause the entire path to be renamed and placed inside the working dir. '/usr/home/sabnzbd/' would become '+usr+home+sabnzbd+'. Resulting in a failing post process.
