### PR TITLE
Added --pidfile, in addition to --pidpath for Linux.

### DIFF
--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -265,6 +265,7 @@ def print_help():
     else:
         print "  -d  --daemon             Fork daemon process"
         print "      --pid <path>         Create a PID file in the listed folder (full path)"
+        print "      --pidfile <path>     Create a PID file with the given name (full path)"
     print
     print "      --force              Discard web-port timeout (see Wiki!)"
     print "  -h  --help               Print this message"
@@ -839,7 +840,7 @@ def commandline_handler(frozen=True):
                                     'weblogging=', 'server=', 'templates', 'no_ipv6',
                                     'template2', 'browser=', 'config-file=', 'force',
                                     'version', 'https=', 'autorestarted', 'repair', 'repair-all',
-                                    'log-all', 'no-login', 'pid=', 'new', 'sessions', 'console',
+                                    'log-all', 'no-login', 'pid=', 'new', 'sessions', 'console', 'pidfile=',
                                     # Below Win32 Service options
                                     'password=', 'username=', 'startup=', 'perfmonini=', 'perfmondll=',
                                     'interactive', 'wait=',
@@ -931,6 +932,7 @@ def main():
     no_login = False
     re_argv = [sys.argv[0]]
     pid_path = None
+    pid_file = None
     new_instance = False
     force_sessions = False
     osx_console = False
@@ -1011,6 +1013,10 @@ def main():
             no_login = True
         elif opt in ('--pid',):
             pid_path = arg
+            re_argv.append(opt)
+            re_argv.append(arg)
+        elif opt in ('--pidfile',):
+            pid_file = arg
             re_argv.append(opt)
             re_argv.append(arg)
         elif opt in ('--new',):
@@ -1579,8 +1585,8 @@ def main():
             # Write URL directly to registry
             set_connection_info(api_url)
 
-    if pid_path:
-        sabnzbd.pid_file(pid_path, cherryport)
+    if pid_path or pid_file:
+        sabnzbd.pid_file(pid_path, pid_file, cherryport)
 
     # Start all SABnzbd tasks
     logging.info('Starting %s-%s', sabnzbd.MY_NAME, sabnzbd.__version__)

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -1021,12 +1021,16 @@ def check_all_tasks():
     return True
 
 
-def pid_file(pid_path=None, port=0):
+def pid_file(pid_path=None, pid_file=None, port=0):
     """ Create or remove pid file
     """
     global DIR_PID
-    if not sabnzbd.WIN32 and pid_path and pid_path.startswith('/'):
-        DIR_PID = os.path.join(pid_path, 'sabnzbd-%s.pid' % port)
+
+    if not sabnzbd.WIN32:
+        if pid_path and pid_path.startswith('/'):
+            DIR_PID = os.path.join(pid_path, 'sabnzbd-%s.pid' % port)
+        elif pid_file and pid_file.startswith('/'):
+            DIR_PID = pid_file
 
     if DIR_PID:
         try:


### PR DESCRIPTION
Allows user to specify location of pidfile instead of pulling a unique one from port.

I've actually been using this patch with sab for 12 months+ and am now reinstalling the box so thought I'd make the effort with a pull-request.
