### PR TITLE
Notification: Respect NotifyOSD-preference and allow testing UI values

### DIFF
--- a/interfaces/Config/templates/_inc_header_uc.tmpl
+++ b/interfaces/Config/templates/_inc_header_uc.tmpl
@@ -110,7 +110,11 @@
 
 		// could use .serializeArray() but that omits unchecked items
 		inputs.each(function (i,elem) {
-		    target[elem.name] = elem.value;
+	            if (elem.type == "checkbox") {
+	                target[elem.name] = elem.checked;
+	            } else {
+		        target[elem.name] = elem.value;
+	            }
 		});
 
 		return this;

--- a/interfaces/Config/templates/config_notify.tmpl
+++ b/interfaces/Config/templates/config_notify.tmpl
@@ -79,7 +79,7 @@
             </fieldset>
         </div><!-- /col1 -->
     </div><!-- /section -->
-    <div class="section">
+    <div class="section" id="growl">
         <div class="col2">
             <h3>$T('growlSettings')</h3>
         </div><!-- /col2 -->
@@ -164,10 +164,12 @@
         }
     });
     \$('#test_notification').click(function () {
+        var data = { mode: 'test_notif', apikey: '$session', output: 'json' };
+	\$("#growl").extractFormDataTo(data);
         \$.ajax({
             type: "GET",
             url: "../../tapi",
-            data: {mode: 'test_notif', apikey: '$session', output: 'json' },
+            data: data,
             beforeSend: function () {
                 \$('#test_notification').attr("disabled", "disabled");
                 \$('#testnotice-result').removeClass("success failure").addClass("loading").html('$T('post-Verifying')');

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -691,7 +691,7 @@ def _api_test_email(name, output, kwargs):
 def _api_test_notif(name, output, kwargs):
     """ API: send a test notification, return result """
     logging.info("Sending test notification")
-    res = sabnzbd.growler.send_notification('SABnzbd', T('Test Notification'), 'other', wait=True)
+    res = sabnzbd.growler.send_notification('SABnzbd', T('Test Notification'), 'other', wait=True, test=kwargs)
     return report(output, error=res)
 
 def _api_undefined(name, output, kwargs):


### PR DESCRIPTION
NotifyOSD preference was never respected. Fixed.

Testing is done on saved values, not UI values. Fixed, and made consistent with email.

I've tested everything I can on my Linux machine, but I don't have a Mac so I cannot test that growl works 100% beyond attempting to make connections to machines which will reject it. If you have a Mac handy you migth want to double-check that.

Apart from that, I think this should be good. Any objections or suggestions for improvements?
