### PR TITLE
Detection and reporting of unrar binary version, and rar version of rar files

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ Our many other commandline options are explained in depth [here](http://wiki.sab
 
 ## About Our Repo
 
-We're going to be attempting to follow the [gitflow model](http://nvie.com/posts/a-successful-git-branching-model/), so you can consider "master" to be whatever our present stable release build is (presently 0.6.x) and "develop" to be whatever our next build will be (presently 0.7.x). Once we transition from unstable to stable dev builds we'll create release branches, and encourage you to follow along and help us test.
+We're going to be attempting to follow the [gitflow model](http://nvie.com/posts/a-successful-git-branching-model/), so you can consider "master" to be whatever our present stable release build is (presently 0.7.x) and "develop" to be whatever our next build will be (presently 0.8.x). Once we transition from unstable to stable dev builds we'll create release branches, and encourage you to follow along and help us test.

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -478,6 +478,10 @@ def print_modules():
 
     if sabnzbd.newsunpack.RAR_COMMAND:
         logging.info("unrar binary... found (%s)", sabnzbd.newsunpack.RAR_COMMAND)
+        versionline = os.popen(sabnzbd.newsunpack.RAR_COMMAND).readlines()[1]	# the second line contains "UNRAR 4.20 freeware ... "
+        rarversionfullname = versionline.split('   ')[0]
+        rarversionnumberonly = versionline.split(' ')[1]	# to be used as a number ...
+        logging.info("unrar binary version is: %s", rarversionfullname)
     else:
         logging.warning(Ta('unrar binary... NOT found'))
 

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -540,7 +540,7 @@ def checkrarfile(filename):
     elif chunk.find(sig5) >= 0:
         return "Rar5 format"
     elif chunk.find(sig) >= 0:
-        return "yes RAR format"
+        return "probably RAR format"
     else:
         return "not RAR format"
 

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -521,9 +521,12 @@ def rar_extract(rarfile, numrars, one_folder, nzo, setname, extraction_path):
 
 def checkrarfile(filename):
     # check if filename is a rar file, and returns as text the findings
-    file = open(filename, 'rb')
-    chunk = file.read(100)	# read first 100 bytes
-    file.close()
+    try:
+        file = open(filename, 'rb')
+        chunk = file.read(100)	# read first 100 bytes
+        file.close()
+    except:
+        return "<no file>"
 
     # rar5 signature: 0x52 0x61 0x72 0x21 0x1A 0x07 0x01 0x00
     # rar4 signature: 0x52 0x61 0x72 0x21 0x1A 0x07 0x00
@@ -536,13 +539,13 @@ def checkrarfile(filename):
     sig5 = chr(0x52) + chr(0x61) + chr(0x72) + chr(0x21) + chr(0x1A) + chr(0x07) + chr(0x01) + chr(0x00)
 
     if chunk.find(sig4) >= 0:
-        return "Rar4 or lower"
+        return "rar4 (or lower) signature"
     elif chunk.find(sig5) >= 0:
-        return "Rar5 format"
+        return "rar5 signature"
     elif chunk.find(sig) >= 0:
-        return "probably RAR format"
+        return "rar signature"
     else:
-        return "not RAR format"
+        return "no valid rar signature"
 
 def rar_extract_core(rarfile, numrars, one_folder, nzo, setname, extraction_path, password):
     """ Unpack single rar set 'rarfile' to 'extraction_path'
@@ -596,7 +599,8 @@ def rar_extract_core(rarfile, numrars, one_folder, nzo, setname, extraction_path
 
     stup, need_shell, command, creationflags = build_command(command)
 
-    logging.debug("Type of rar file is %s", checkrarfile(rarfile))
+    logging.debug("Analyzing rar file ... %s found", checkrarfile(rarfile))
+
     logging.debug("Running unrar %s", command)
     p = subprocess.Popen(command, shell=need_shell, stdin=subprocess.PIPE,
                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT,


### PR DESCRIPTION
Detection and reporting of unrar binary version, and rar version of rar files, as discussed on https://forums.sabnzbd.org/viewtopic.php?f=4&t=17490

Example output in sabnzbd.log:

2014-05-07 21:40:31,845::INFO::[SABnzbd:484] unrar binary version is: UNRAR 5.00 beta 8 freeware
...
2014-05-07 22:06:32,256::DEBUG::[newsunpack:599] Type of rar file is Rar4 or lower
