### PR TITLE
Handle server side 5xx problems more nicely

### DIFF
--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -342,6 +342,10 @@ class RSSQueue(object):
                 msg = Ta('Do not have valid authentication for feed %s') % feed
                 logging.info(msg)
                 return unicoder(msg)
+            if status >= 500 and status <=599:
+                msg = Ta('Server side error (server code %s); could not get %s on %s') % (status, feed, uri)
+                logging.info(msg)
+                return unicoder(msg)
 
             entries = d.get('entries')
             if 'bozo_exception' in d and not entries:


### PR DESCRIPTION
Logging improved to:

2014-06-09 13:09:50,889::INFO::[rss:347] Server side error (server code 503); could not get hockey nzbindex on http://www.nzbindex.nl/rss/?q=hockey&sort=agedesc&max=25
