### PR TITLE
Bandwidth api

### DIFF
--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -790,22 +790,22 @@ def _api_config_undefined(output, kwargs):
     return report(output, _MSG_NOT_IMPLEMENTED)
 
 
-def _api_bandwidth(name, output, kwargs):
+def _api_server_stats(name, output, kwargs):
     """ API: accepts output """
     sum_t, sum_m, sum_w, sum_d = BPSMeter.do.get_sums()
-    bw = {'total': sum_t, 'month': sum_m, 'week': sum_w, 'day': sum_d}
+    stats = {'total': sum_t, 'month': sum_m, 'week': sum_w, 'day': sum_d}
 
-    bw['servers'] = {}
+    stats['servers'] = {}
     for svr in config.get_servers():
        t, m, w, d = BPSMeter.do.amounts(svr)
-       bw['servers'][svr] = {'total': t or 0, 'month': m or 0, 'week': w or 0, 'day': d or 0}
+       stats['servers'][svr] = {'total': t or 0, 'month': m or 0, 'week': w or 0, 'day': d or 0}
 
-    return report(output, keyword='bandwidth', data=bw)
+    return report(output, keyword='', data=stats)
 
 
 #------------------------------------------------------------------------------
 _api_table = {
-    'bandwidth'       : _api_bandwidth,
+    'server_stats'    : _api_server_stats,
     'get_config'      : _api_get_config,
     'set_config'      : _api_set_config,
     'del_config'      : _api_del_config,


### PR DESCRIPTION
I wanted a way to pull per-server bandwidth statistics from the API. 

There is already "history" which has the totals, but I didn't see anything that exposes the per-server stats like "/config/server".  So, I added a new API mode for "bandwidth" which has both sums and per-server stats. 

Pretty new to python (and obviously SABnzbd code) so let me know if there's anything you'd like me to change.
