### PR TITLE
Logs in which rar file unwanted extension

### DIFF
--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -125,6 +125,7 @@ class Assembler(Thread):
                     unwanted = rar_contains_unwanted_file(filepath)
                     if unwanted:
                         logging.warning(Ta('WARNING: In "%s" unwanted extension in RAR file. Unwanted file is %s '), latin1(nzo.final_name), unwanted)
+                        logging.debug(Ta('Unwanted extension is in rar file %s'), filepath)
                         if cfg.action_on_unwanted_extensions() == 1:
                             logging.debug('Unwanted extension ... pausing')
                             nzo.unwanted_ext = True


### PR DESCRIPTION
Shows the rar file which contains the file with the unwanted extension. Example:

2014-06-14 20:51:52,479::DEBUG::[assembler:128] Unwanted extension is in rar file /home/sander/Downloads/incomplete/bla/bla.x264-tGc.part42.rar

Reason: get statistics whether typically only first and last rar file contain the unwanted extension (or also rar files in between). Goal: verify if scanning first and last rar will catch unwanted extensions
See http://forums.sabnzbd.org/viewtopic.php?f=4&t=17337&p=94817&hilit=unwanted#p94816
