### PR TITLE
Correct redirect if using incorrect path in URL: only rewrite path part

### DIFF
--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1538,7 +1538,6 @@ def main():
         browser_url = "https://%s:%s/sabnzbd" % (browserhost, cherryport)
     else:
         browser_url = "http://%s:%s/sabnzbd" % (browserhost, cherryport)
-    cherrypy.wsgiserver.REDIRECT_URL = browser_url
 
     sabnzbd.BROWSER_URL = browser_url
     if not autorestarted:

--- a/sabnzbd/panic.py
+++ b/sabnzbd/panic.py
@@ -279,10 +279,12 @@ def error_page_404(status, message, traceback, version):
     <head>
       <script type="text/javascript">
       <!--
-      location.href = "%s"
+      var full = location.protocol+'//'+location.hostname+(location.port ? ':'+location.port: '') + '/sabnzbd/' ;
+      location.href = full
       //-->
       </script>
     </head>
     <body><br/></body>
 </html>
-''' % cherrypy.wsgiserver.REDIRECT_URL
+'''
+


### PR DESCRIPTION
Correct redirect, as decribed on https://forums.sabnzbd.org/viewtopic.php?f=2&t=10443&p=95175#p95175
Only the path is rewritten, not the host (as it happened before)

So: http://192.168.1.111:8080/isnotthere now redirects to the correct URL http://192.168.1.111:8080/sabnzbd/
