### PR TITLE
Allow URLOpener to use http_proxy env var

### DIFF
--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -115,9 +115,9 @@ class URLGrabber(Thread):
                 else:
                     logging.info('Grabbing URL %s', url)
                 if '.nzbsrus.' in url:
-                    opener = urllib.URLopener({})
+                    opener = urllib.URLopener()
                 else:
-                    opener = urllib.FancyURLopener({})
+                    opener = urllib.FancyURLopener()
                 opener.prompt_user_passwd = None
                 opener.addheaders = []
                 opener.addheader('User-Agent', 'SABnzbd+/%s' % sabnzbd.version.__version__)


### PR DESCRIPTION
URLOpener can't take advantage of the following environment variables because an empty dict is passed into the constructor.
- http_proxy
- https_proxy
- no_proxy
