### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:14.04
+
+MAINTAINER Johannes 'fish' Ziemke <docker@freigeist.org> @discordianfish
+
+RUN echo deb http://archive.ubuntu.com/ubuntu/ trusty multiverse >> \
+    /etc/apt/sources.list
+RUN apt-get -qy update && apt-get -qy install python python-cheetah unrar \
+    unzip python-yenc par2
+
+RUN    useradd sabnzbd -d /sab -m && chown -R sabnzbd:sabnzbd /sab
+VOLUME /sab
+ADD  . /sabnzbd
+
+EXPOSE 8080
+USER   sabnzbd
+ENV    HOME /sab
+
+ENTRYPOINT [ "python", "/sabnzbd/SABnzbd.py", "-s", "0.0.0.0:8080" ]


### PR DESCRIPTION
Hi,

I've created a Dockerfile for sabznbd and thought I propose to include that. After merging, you could add this repo as a automated build on hub.docker.com and people could just do a `docker run -p 127.0.0.1:8080:8080 sabnzbd/sabnzbd` to deploy it. For now, you can use my fork:

```
docker run -p 127.0.0.1:8080:8080 fish/sabnzbd
```

Usage:

```
    docker build -t sabnzb .
    docker run -p 127.0.0.1:8080:8080 sabnzb
```
