### PR TITLE
DEBUG info if retrieving URL leads to an exception

### DIFF
--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -20,6 +20,7 @@ sabnzbd.urlgrabber - Queue for grabbing NZB files from websites
 """
 
 import os
+import sys
 import time
 import re
 import logging
@@ -132,6 +133,8 @@ class URLGrabber(Thread):
                     fn, header = opener.retrieve(url)
                 except:
                     fn = None
+                    logging.debug("Exception %s trying to get the url %s", sys.exc_info()[0], url)
+
 
                 if fn:
                     for tup in header.items():


### PR DESCRIPTION
Example:

2015-01-01 15:16:17,924::DEBUG::[urlgrabber:135] Exception <class 'urllib.ContentTooShortError'> trying to get the url https://www.blabla.com/nzedb/getnzb/fe1a1474a5026b74b5d63b78634f6b055add149a&i=3&r=de390776ff47336d50e5585876aa1704