### PR TITLE
Find and log unrar version, and give a Warning if below 5.00

### DIFF
--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -505,6 +505,12 @@ def print_modules():
 
     if sabnzbd.newsunpack.RAR_COMMAND:
         logging.info("unrar binary... found (%s)", sabnzbd.newsunpack.RAR_COMMAND)
+        unrarversion = sabnzbd.newsunpack.unrar_version(sabnzbd.newsunpack.RAR_COMMAND)
+        if unrarversion:
+            logging.info("unrar binary version is %s", unrarversion)
+            unrarversionneeded = "5.00"
+            if unrarversion < unrarversionneeded:
+                logging.warning("unrar binary version is older than version %s", unrarversionneeded)
     else:
         logging.warning(T('unrar binary... NOT found'))
 

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -1679,6 +1679,17 @@ def unrar_check(rar):
             return (int(m.group(1)), int(m.group(2))) >= (3, 80)
     return False
 
+def unrar_version(rar):
+    """ Return version of unrar as string """
+    if rar:
+        try:
+            unraroutput = run_simple(rar)
+        except:
+            return False
+        versionnumber = re.findall("UNRAR ([\.0-9]*)", unraroutput)[0]
+        if versionnumber:
+            return versionnumber
+    return False
 
 #-------------------------------------------------------------------------------
 def sfv_check(sfv_path):


### PR DESCRIPTION
As unrar version 5.xx is needed for current downloads, find and log the unrar version, and give Warning if unrar version is below 5.00