### PR TITLE
Add support for restricting servers by category

### DIFF
--- a/interfaces/Config/templates/config_server.tmpl
+++ b/interfaces/Config/templates/config_server.tmpl
@@ -81,6 +81,15 @@
                     <span class="desc">$T('srv-optional')</span>
                 </div>
                 <div class="field-pair">
+                    <label class="config" for="categories">$T('srv-categories')</label>
+                    <select name="categories" multiple>
+                    <!--#for $cat in $cats#-->
+                      <option value="$cat" <!--#if $cat == "Default"#-->selected<!--#end if#-->>$cat</option>
+                    <!--#end for#-->
+                    </select>
+                    <span class="desc">$T('srv-explain-categories')</span>
+                </div>
+                <div class="field-pair">
                     <input type="submit" value="$T('button-addServer')" />
                     <input type="button" value="$T('button-testServer')" class="testServer" />
                 </div>
@@ -176,6 +185,15 @@
                     <label class="config" for="send_group$cur">$T('srv-send_group')</label>
                     <input type="checkbox" name="send_group" id="send_group$cur" value="1" <!--#if int($servers[$server]['send_group']) != 0 then 'checked="checked"' else ""#--> />
                     <span class="desc">$T('srv-explain-send_group')</span>
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="categories">$T('srv-categories')</label>
+                    <select name="categories" multiple>
+                    <!--#for $cat in $cats#-->
+                      <option value="$cat" <!--#if $cat in $servers[$server]['categories'] then 'selected' else ""#-->>$cat</option>
+                    <!--#end for#-->
+                    </select>
+                    <span class="desc">$T('srv-explain-categories')</span>
                 </div>
                 <div class="field-pair">
                     <input type="submit" value="$T('button-saveChanges')" class="saveButton" />

--- a/interfaces/Plush/templates/config_server.tmpl
+++ b/interfaces/Plush/templates/config_server.tmpl
@@ -121,6 +121,15 @@
           <span class="component-desc">&nbsp;</span>
         </label>
       </div>
+      <div class="field-pair">
+        <label class="config" for="categories">$T('srv-categories')</label>
+          <select name="categories" multiple>
+          <!--#for $cat in $cats#-->
+            <option value="$cat" <!--#if $cat == "Default"#-->selected<!--#end if#-->>$cat</option>
+          <!--#end for#-->
+          </select>
+        <span class="desc">$T('srv-explain-categories')</span>
+      </div>
     </fieldset>
     </form>
   </div><!-- /component-group1 -->
@@ -258,6 +267,15 @@
       <span class="component-title">$T('srv-optional')</span>
       <span class="component-desc">&nbsp;</span>
     </label>
+  </div>
+  <div class="field-pair">
+    <label class="config" for="categories">$T('srv-categories')</label>
+      <select name="categories" multiple>
+      <!--#for $cat in $cats#-->
+        <option value="$cat" <!--#if $cat in $servers[$server]['categories'] then 'selected' else ""#-->>$cat</option>
+      <!--#end for#-->
+      </select>
+    <span class="desc">$T('srv-explain-categories')</span>
   </div>
   </fieldset>
   </form>

--- a/interfaces/smpl/templates/config_server.tmpl
+++ b/interfaces/smpl/templates/config_server.tmpl
@@ -60,6 +60,14 @@
   <input class="radio" type="checkbox" name="optional" value="1" <!--#if int($servers[$server]['optional']) != 0 then "checked=1" else ""#--> /></label>
   </label><br class="clear" />
 
+  <label><span class="label">$T('srv-categories'):</span>
+    <select name="categories" multiple>
+    <!--#for $cat in $cats#-->
+      <option value="$cat" <!--#if $cat == "Default" then 'selected' else ""#-->>$cat</option>
+    <!--#end for#-->
+    </select></label>
+<br class="clear" />
+
   <label><span class="label">$T('srv-enable'):</span>
   <input class="radio" type="checkbox" name="enable" value="1" <!--#if int($servers[$server]['enable']) != 0 then "checked=1" else ""#--> /></label>
 <br class="clear" />
@@ -141,6 +149,14 @@
 
   <label><span class="label">$T('srv-optional'):</span>
     <input class="radio" type="checkbox" name="optional" value="1"></label>
+<br class="clear" />
+
+  <label><span class="label">$T('srv-categories'):</span>
+    <select name="categories" multiple>
+    <!--#for $cat in $cats#-->
+      <option value="$cat" <!--#if $cat in $servers[$server]['categories'] then 'selected' else ""#-->>$cat</option>
+    <!--#end for#-->
+    </select></label>
 <br class="clear" />
 
   <label><span class="label">$T('srv-enable'):</span>

--- a/sabnzbd/config.py
+++ b/sabnzbd/config.py
@@ -381,6 +381,7 @@ class ConfigServer(object):
         self.priority = OptionNumber(name, 'priority', 0, 0, 100, add=False)
         # 'fillserver' field only here in order to set a proper priority when converting
         self.fillserver = OptionBool(name, 'fillserver', False, add=False)
+        self.categories = OptionList(name, 'categories', default_val=['Default'], add=False)
 
         self.set_dict(values)
         add_to_database('servers', self.__name, self)
@@ -388,7 +389,8 @@ class ConfigServer(object):
     def set_dict(self, values):
         """ Set one or more fields, passed as dictionary """
         for kw in ('host', 'port', 'timeout', 'username', 'password', 'connections', 'fillserver',
-                   'ssl', 'ssl_type', 'send_group', 'enable', 'optional', 'retention', 'priority'):
+                   'ssl', 'ssl_type', 'send_group', 'enable', 'optional', 'retention', 'priority',
+                   'categories'):
             try:
                 value = values[kw]
             except KeyError:
@@ -416,6 +418,7 @@ class ConfigServer(object):
         dict['ssl_type'] = self.ssl_type()
         dict['send_group'] = self.send_group()
         dict['priority'] = self.priority()
+        dict['categories'] = self.categories()
         return dict
 
     def delete(self):

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -55,7 +55,7 @@ TIMER_LOCK = RLock()
 #------------------------------------------------------------------------------
 class Server(object):
     def __init__(self, id, host, port, timeout, threads, priority, ssl, ssl_type, send_group, username = None,
-                 password = None, optional=False, retention=0):
+                 password = None, optional=False, retention=0, categories = None):
         self.id = id
         self.newid = None
         self.restart = False
@@ -72,6 +72,8 @@ class Server(object):
 
         self.username = username
         self.password = password
+
+        self.categories = categories
 
         self.busy_threads = []
         self.idle_threads = []
@@ -183,6 +185,7 @@ class Downloader(Thread):
             username = srv.username()
             password = srv.password()
             optional = srv.optional()
+            categories = srv.categories()
             retention = float(srv.retention() * 24 * 3600) # days ==> seconds
             send_group = srv.send_group()
             create = True
@@ -200,7 +203,7 @@ class Downloader(Thread):
         if create and enabled and host and port and threads:
             self.servers.append(Server(newserver, host, port, timeout, threads, priority, ssl,
                                             ssl_type, send_group,
-                                            username, password, optional, retention))
+                                            username, password, optional, retention, categories=categories))
 
         return
 

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -1554,6 +1554,7 @@ class ConfigServer(object):
             if t:
                 new[svr]['amounts'] = to_units(t), to_units(m), to_units(w), to_units(d)
         conf['servers'] = new
+        conf['cats'] = list_cats(default=True)
 
         if sabnzbd.newswrapper.HAVE_SSL:
             conf['have_ssl'] = 1

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -116,7 +116,7 @@ class Article(TryList):
                         #if (server_check.priority() < found_priority and server_check.priority() < server.priority and not self.server_in_try_list(server_check)):
                         if (server_check.priority < found_priority):
                             if (server_check.priority < server.priority):
-                                if (not self.server_in_try_list(server_check)):
+                                if (not self.server_in_try_list(server_check)) and self.server_allowed(server_check):
                                     if log: logging.debug('Article %s | Server: %s | setting found priority to %s', self.article, server.host, server_check.priority)
                                     found_priority = server_check.priority
                     if found_priority == 1000:
@@ -138,6 +138,10 @@ class Article(TryList):
         if not self.art_id:
             self.art_id = sabnzbd.get_new_id("article", self.nzf.nzo.workpath)
         return self.art_id
+
+    def server_allowed(self, server):
+        """ Return true if this server is allowed to download this article. """
+        return self.nzf.nzo.server_allowed(server)
 
     def __getstate__(self):
         """ Save to pickle file, selecting attributes """
@@ -1189,6 +1193,16 @@ class NzbObject(TryList):
             self.nzo_info[log].append(txt)
         except:
             self.nzo_info[log] = [txt]
+
+    def server_allowed(self, server):
+        if not server.categories:
+            return False
+        if "Default" in server.categories:
+            return True
+        if self.cat in server.categories:
+            return True
+        # There are no default servers, and either we have no category, or no server matches our category
+        return False
 
     def get_article(self, server, servers):
         article = None

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -535,6 +535,8 @@ SKIN_TEXT = {
     'srv-bandwidth' : TT('Bandwidth'),
     'srv-send_group' : TT('Send Group'),
     'srv-explain-send_group' : TT('Send group command before requesting articles.'),
+    'srv-categories' : TT('Categories'),
+    'srv-explain-categories' : TT('Only use this server for these categories.'),
 
 # Config->Scheduling
     'configSchedule' : TT('Scheduling configuration'), #:Config->Scheduling


### PR DESCRIPTION
Add support to restrict which servers can be used to download items for a specific category by adding categories to the server config.  Selecting "Default" will allow a server to be used in all categories.  Any server created before this change will also default to being allowed by all categories.

![screen shot 2015-06-14 at 5 24 18 pm](https://cloud.githubusercontent.com/assets/10488026/8151168/fce95542-12ba-11e5-931b-1a44c1a74785.png)
