### PR TITLE
Added requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+Cheetah>=2.0.1.0
+feedparser
+gntp
+pyOpenSSL>=0.11
+configobj
+pydbus
+support
+-e hg+https://bitbucket.org/dual75/yenc#egg=yenc


### PR DESCRIPTION
I've created a requirements.txt file so sabnzbd can be installed by using pip instead of the packagemanager of the distribution.