### PR TITLE
Adding info message for orphaned folders and updates.Fixing clear-speedlimit and storage/path in history.

### DIFF
--- a/interfaces/Glitter/templates/include_modals.tmpl
+++ b/interfaces/Glitter/templates/include_modals.tmpl
@@ -189,7 +189,6 @@
                         </div>
                     </fieldset>
 
-
                     <fieldset data-bind="visible: (statusInfo.status.folders().length > 0)">
                         <legend>
                             <a href="#" class="hoverbutton" data-bind="click: removeAllOrphaned">$T('Glitter-purgeOrphaned') <span class="glyphicon glyphicon-trash"></span></a> $T('Glitter-orphanedJobs')

--- a/interfaces/Glitter/templates/main.tmpl
+++ b/interfaces/Glitter/templates/main.tmpl
@@ -67,8 +67,9 @@
                                 <li><a href="#" data-time="180" data-bind="click: pauseTime">$T('Glitter-pause3h')</a></li>
                                 <li><a href="#" data-time="360" data-bind="click: pauseTime">$T('Glitter-pause6h')</a></li>
                             </ul>
+                            <span class="btn btn-default navbar-btn navbar-timeleft" data-bind="text: timeLeft"  data-toggle="dropdown">0:00</span>
                         </div>
-                        <span class="btn btn-default navbar-btn  navbar-timeleft" data-bind="text: timeLeft">0:00</span>
+                        
                     </div>
                 </div>
 
@@ -151,13 +152,6 @@
 
         <div class="container main-content">
             <div class="queue">
-                <div class="queue-update-info" data-bind="visible: new_release()" style="display: none;">
-                    <a href="#" target="_blank" data-bind="attr: { href: new_rel_url() }">
-                        <span class="label label-success">$T('Glitter-updateAvailable')</span>
-                        <span class="label label-default" data-bind="text: new_release()"></span>
-                    </a>
-                </div>
-
                 <h2>$T('menu-queue')</h2>
 
                 <div class="info-container" data-bind="visible: diskSpaceLeft1()" style="display: none;">
@@ -213,8 +207,9 @@
                     <tbody class="nodownloads">
                         <tr>
                             <td colspan="5">
-                                <a href="#modal_add_nzb" title="$T('Glitter-dragAndDrop')" class="hoverbutton" data-toggle="modal">
-                                    <span class="glyphicon glyphicon-plus-sign"></span> $T('Glitter-addNZB')</a>
+                                <a href="#modal_add_nzb" class="hoverbutton" data-toggle="modal">
+                                    <span title="$T('Glitter-dragAndDrop')" data-toggle="tooltip"><span class="glyphicon glyphicon-plus-sign"></span> $T('Glitter-addNZB')</span>
+                                </a>
                             </td>
                         </tr>
                     </tbody>
@@ -344,30 +339,43 @@
                 </ul>
             </div>
 
-            <div class="queue-warnings" data-bind="visible: (nrWarnings() > 0)" style="display: none;">
-                <table class="table table-hover table-warnings">
+            <div class="queue-messages" data-bind="visible: hasMessages()" style="display: none;">
+                <table class="table table-hover table-messages">
                     <thead>
                         <tr>
-                            <th class="table-warnings-header-label"></th>
+                            <th class="table-messages-header-label"></th>
                             <th></th>
                             <th style="width: 30px;"></th>
                         </tr>
                     </thead>
                     <tbody>
-                        <tr>
-                            <td colspan="2" class="table-warnings-hide"></td>
-                            <td data-bind="attr: { 'rowspan': parseInt(nrWarnings())+1 }, click: clearWarnings" class="table-warnings-remove">
-                                <a href="#" class="hoverbutton"><span class="glyphicon glyphicon-trash"></span></a>
-                            </td>
-                        </tr>
-                        <!-- ko foreach: allWarnings -->
-                        <tr>
-                            <td class="table-warnings-label">
-                                <span class="label" data-bind="css: 'label-' + css, text: type"></span>
-                                <strong data-bind="text: date"></strong>
-                            </td>
-                            <td><span class="queue-warning-text" data-bind="text: text"></span></td>
-                        </tr>
+                        <!-- ko if: allWarnings().length > 0 -->
+                            <tr>
+                                <td colspan="2" class="table-messages-hide"></td>
+                                <td data-bind="attr: { 'rowspan': parseInt(nrWarnings())+1 }, click: clearWarnings" class="table-messages-remove">
+                                    <a href="#" class="hoverbutton"><span class="glyphicon glyphicon-remove"></span></a>
+                                </td>
+                            </tr>
+                            <!-- ko foreach: allWarnings -->
+                            <tr>
+                                <td class="table-messages-label">
+                                    <span class="label" data-bind="css: 'label-' + css, text: type"></span>
+                                    <strong data-bind="text: date"></strong>
+                                </td>
+                                <td><span class="queue-message-text" data-bind="html: text"></span></td>
+                            </tr>
+                            <!-- /ko -->
+                        <!-- /ko -->
+                        <!-- ko foreach: allMessages -->
+                            <tr>
+                                <td class="table-messages-label-no-date" colspan="2">
+                                    <span class="label" data-bind="css: 'label-' + css, text: type"></span>
+                                    <span class="queue-message-text" data-bind="html: text"></span>
+                                </td>
+                                <td class="table-messages-remove">
+                                    <!-- ko if: \$data.hasOwnProperty("clear") --><a href="#" data-bind="click: clear"  class="hoverbutton"><span class="glyphicon glyphicon-remove"></span></a><!-- /ko -->
+                                </td>
+                            </tr>
                         <!-- /ko -->
                     </tbody>
                 </table>
@@ -603,6 +611,8 @@
         <script type="text/javascript">
             var apiKey = "$session";
             var sabSpeedHistory = [$bytespersec_list];
+            var newRelease = "$new_release";
+            var newReleaseUrl = "$new_rel_url";
         
             var glitterTranslate = new Object();
             glitterTranslate.paused = "$T('post-Paused')";
@@ -619,6 +629,8 @@
             glitterTranslate.noSelect = "$T('Glitter-noSelect')";
             glitterTranslate.sendThanks = "$T('Glitter-sendThanks')";
             glitterTranslate.chooseFile = "$T('Glitter-chooseFile')";
+            glitterTranslate.orphanedJobsMsg = "$T('Glitter-orphanedJobsMsg')";
+            glitterTranslate.updateAvailable = "$T('Glitter-updateAvailable')";
             glitterTranslate.status = [];
 
             glitterTranslate.status['Completed'] = "$T('post-Completed')";

--- a/interfaces/Glitter/templates/main.tmpl
+++ b/interfaces/Glitter/templates/main.tmpl
@@ -79,12 +79,14 @@
                             <div class="btn-group">
                                 <div class="btn-group">
                                     <button type="button" class="btn btn-default navbar-btn navbar-speed" data-toggle="dropdown">
-                                        <span class="glyphicon glyphicon-link" data-bind="click: clearSpeedLimit, visible:(speedLimit() != 100)" style="display: none;"></span>
                                         <span data-bind="text: speedText">0 KB/s</span>
                                     </button>
                                     <button type="button" class="btn btn-default navbar-btn dropdown-toggle" data-toggle="dropdown" onclick="keepOpen(this)">
                                         <span class="caret"></span>
                                     </button>
+                                    <a href="#" class="max-speed-input-clear hoverbutton" data-bind="click: clearSpeedLimit, visible:(speedLimit() != 100)" style="display: none;">
+                                        <span class="glyphicon glyphicon-link"></span>
+                                    </a>
                                     <div class="dropdown-menu max-speed-input">
                                         <div data-bind="visible: !bandwithLimit()">
                                             <a href="config/general/">
@@ -540,10 +542,6 @@
                                             </div>
                                             <div class="row">
                                                 <div class="col-sm-2">$T('msg-path')</div>
-                                                <div class="col-sm-10" data-bind="text: historyStatus.path"></div>
-                                            </div>
-                                            <div class="row">
-                                                <div class="col-sm-2">$T('Glitter-storage')</div>
                                                 <div class="col-sm-10" data-bind="text: historyStatus.storage"></div>
                                             </div>
                                             <!-- ko foreach: historyStatus.stage_log -->

--- a/interfaces/Glitter/templates/static/stylesheets/glitter.css
+++ b/interfaces/Glitter/templates/static/stylesheets/glitter.css
@@ -66,7 +66,7 @@ h2 {
     font-weight: bold;
     min-width: 100px;
     background-color: #F5F5F5;
-    cursor: inherit;
+    border-left: 0;
 }
 
 .navbar-header img {
@@ -323,11 +323,6 @@ tbody>tr>td:last-child {
     color: #474747;
 }
 
-.queue-update-info {
-    margin-bottom: 5px;
-    font-size: 1.1em;
-}
-
 .info-container {
     float: right;
     color: #888;
@@ -407,10 +402,6 @@ td.name .name-ratings .glyphicon {
     margin-left: 2px;
 }
 
-td.name .name-ratings .glyphicon-volume-up {
-    top: 2px;
-}
-
 tbody.nodownloads tr td {
     border: none;
     text-align: center;
@@ -441,7 +432,7 @@ td.delete .dropdown {
     float: left;
 }
 
-td.delete .dropdown a {
+td.delete .dropdown>a {
     display: inline-block;
     padding: 0px 10px;
 }
@@ -455,11 +446,6 @@ td.delete label,
     margin: -5px;
     padding: 5px 12px 5px 10px;
     cursor: pointer;
-}
-
-td.delete span,
-.table-warnings-hide span {
-    top: 2px;
 }
 
 .queueitem-settings {
@@ -598,29 +584,29 @@ td.delete span,
     color: #AAA;
 }
 
-.table-warnings .table-warnings-header-label {
-    width: 220px;
-}
-
 /* WARNINGS */
-
-.queue-warnings {
+.queue-messages {
     clear: both;
     width: 100%;
     overflow: auto;
     max-height: 200px;
+    margin-bottom: 5px;
 }
 
-.table-warnings {
+.table-messages {
     border-collapse: separate !important;
 }
 
-.table-warnings .table-warnings-hide {
+.table-messages .table-messages-header-label {
+    width: 220px;
+}
+
+.table-messages .table-messages-hide {
     padding: 0 !important;
     border: 0 !important;
 }
 
-.table-warnings .table-warnings-remove {
+.table-messages .table-messages-remove {
     border-bottom: 1px solid #F0F0F0 !important;
     text-align: center;
     vertical-align: top !important;
@@ -628,35 +614,57 @@ td.delete span,
     cursor: pointer;
 }
 
-.table-warnings .table-warnings-remove a {
+.table-messages .table-messages-remove a {
     display: block;
 }
 
-.table-warnings .table-warnings-remove:hover a {
+.table-messages .table-messages-remove:hover a {
     opacity: 1;
 }
 
-.table-warnings-label {
+.table-messages-label {
     vertical-align: top !important;
 }
 
-.table-warnings .label {
+.table-messages .label {
     margin-right: 8px;
 }
 
-.table-warnings td {
+.table-messages td {
     padding: 2px !important;
 }
 
-.table-warnings .label {
+.table-messages .label {
     display: inline-block;
     width: 80px;
     padding: 5px;
 }
 
-.table-warnings .queue-warning-text {
+.table-messages .label-info {
+    background-color: #58A9FA;
+}
+
+.table-messages .queue-message-text {
     word-break: break-all;
 }
+
+.table-messages .table-messages-label-no-date .queue-message-text {
+    word-break: normal;
+}
+
+.table-messages .queue-update-sab {
+    font-weight: bold;
+}
+
+.table-messages .glyphicon {
+    top: 2px;
+}
+
+.table-messages .queue-update-sab:hover {
+    text-decoration: underline;
+}
+
+
 
 /***
     History Specific
@@ -1353,6 +1361,11 @@ a:hover,
 a:focus {
     color: black;
     text-decoration: none;
+}
+
+.glyphicon-volume-up,
+.glyphicon-trash {
+    top: 2px;
 }
 
 .navbar-inverse {

--- a/interfaces/Glitter/templates/static/stylesheets/glitter.css
+++ b/interfaces/Glitter/templates/static/stylesheets/glitter.css
@@ -97,12 +97,21 @@ li.dropdown {
     line-height: 18px;
 }
 
-.navbar-speed .glyphicon:hover {
-    opacity: 1;
-}
-
 .caret {
     border-top-color: black !important;
+}
+
+.max-speed-input-clear {
+    position: absolute;
+    top: 16px;
+    text-align: center;
+    right: 30px;
+    z-index: 999;
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    background-color: transparent !important;
+    font-size: 1.1em;
 }
 
 .max-speed-input {
@@ -111,11 +120,6 @@ li.dropdown {
     font-weight: bold;
     width: 190px;
     text-align: center;
-}
-
-.max-speed-input span.glyphicon {
-    float: right;
-    margin-top: 10px;
 }
 
 .max-speed-input a {

--- a/interfaces/Glitter/templates/static/stylesheets/glitter.mobile.css
+++ b/interfaces/Glitter/templates/static/stylesheets/glitter.mobile.css
@@ -155,15 +155,20 @@ h2 {
     margin-left: 0px;
 }
 
-.table-warnings .table-warnings-header-label {
+.table-messages .table-messages-header-label {
     width: 120px;
 }
 
-.table-warnings .label {
+.table-messages-label-no-date .label {
+    width: 113px;
+    margin-right: 2px;
+}
+
+.table-messages-label .label {
     width: 100%;
 }
 
-.table-warnings strong {
+.table-messages strong {
     display: block;
     text-align: center;
 }
@@ -177,7 +182,17 @@ h2 {
 }
 
 .history-table .delete .dropdown-menu {
-    width: 90%;
+    width: 96%;
+    left: 2%;
+    right: inherit;
+    margin-bottom: 10px;
+}
+
+
+.history-table .delete .dropdown-menu .glyphicon {
+    top: -7px;
+    right: -8px;
+    text-shadow: 2px 0px 8px #ccc;
 }
 
 .history-table .status-header {
@@ -191,7 +206,6 @@ h2 {
 #history-table-search input {
     width: 210px !important;
 }
-
 
 /**
     MODALS

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -825,7 +825,7 @@ SKIN_TEXT = {
     'Glitter-pause1h' : TT('Pause for 1 hour'),
     'Glitter-pause3h' : TT('Pause for 3 hours'),
     'Glitter-pause6h' : TT('Pause for 6 hours'),
-    'Glitter-setMaxLinespeed' : TT('Set maximum line speed in configuration'),
+    'Glitter-setMaxLinespeed' : TT('You must set a maximum bandwidth before you can set a bandwidth limit'),
     'Glitter-left' : TT('left'),
     'Glitter-quota' : TT('quota'),
     'Glitter-free' : TT('Free Space'),
@@ -891,6 +891,7 @@ SKIN_TEXT = {
     'Glitter-confirmClear1Download' : TT('Are you sure?'),
     'Glitter-grabbing' : TT('Grabbing NZB...'),
     'Glitter-updateAvailable' : TT('Update Available!'),
+    'Glitter-orphanedJobsMsg' : TT('There are orphaned job folders, click on ICON_PLACEHOLDER to take care of them'), #: Don't translate ICON_PLACEHOLDER 
     'Glitter-sortAgeAsc' : TT('Sort by Age <small>Oldest&rarr;Newest</small>'),
     'Glitter-sortAgeDesc' : TT('Sort by Age <small>Newest&rarr;Oldest</small>'),
     'Glitter-sortNameAsc' : TT('Sort by Name <small>A&rarr;Z</small>'),

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -839,7 +839,6 @@ SKIN_TEXT = {
     'Glitter-onFinish' : TT('On queue finish'),
     'Glitter-statusInterfaceOptions' : TT('Status and interface options'),
     'Glitter-dragAndDrop' : TT('Or drag and drop files in the window!'),
-    'Glitter-storage' : TT('Storage'),
     'Glitter-today' : TT('Today'),
     'Glitter-thisMonth' : TT('This month'),
     'Glitter-total' : TT('Total'),


### PR DESCRIPTION
1. Fixing clear-speedlimit and storage/path in history
2. If more than 3 orphaned folders are found, display a message. Check this
every other day. 
3. If update is found, it is now also displayed in the messages-box.

More message-types can be added later, if wanted.