### PR TITLE
Fix for hover problems in Plush

### DIFF
--- a/interfaces/Plush/templates/static/javascripts/plush.js
+++ b/interfaces/Plush/templates/static/javascripts/plush.js
@@ -560,17 +560,6 @@ jQuery(function($){
     function(){ $.plush.skipRefresh=false; } // out
   );
 
-  // refresh on mouseout after deletion
-  $('#queue').hover(  // $.mouseout was triggering too often
-    function(){}, // over
-    function(){   // out
-      if ($.plush.pendingQueueRefresh) {
-        $.plush.pendingQueueRefresh = false;
-        $.plush.RefreshQueue();
-      }
-    }
-  );
-
   // NZB pause/resume individual toggle
   $('#queue').delegate('.nzb_status','click',function(event){
     var pid = $(this).parent().parent().attr('id');


### PR DESCRIPTION
This fixes #86 (a problem which also occurred for me in Chrome, not just FF and is horribly annoying).
Why was this function added? 
I tried many scenarios in FF/IE/Chrome and deleted stuff with short and long refresh-times but it always seemed to continue refreshing when the hover was off the queue again.