### PR TITLE
Improve CPU usage on Firefox

### DIFF
--- a/interfaces/Glitter/templates/static/stylesheets/glitter.css
+++ b/interfaces/Glitter/templates/static/stylesheets/glitter.css
@@ -1384,6 +1384,46 @@ td.delete label,
 }
 
 /***
+    SPECIAL FOR FIREFOX
+    It uses very high CPU for anything animated (Sep 2015)
+    Disable animations on progress-bar and make the History-'processing' a block animation
+    Can be removed if it's performance gets better in the future..
+***/
+@supports (-moz-transform: translate(0, 0)) {
+    .progress-bar {
+        transform: none !important;
+        animation: none !important;
+        transition: none !important;
+    }
+    
+    @keyframes stretchdelay {
+        0%, 60% {
+            transform: scaleY(0.4);
+        }
+    
+        61%, 100% {
+            transform: scaleY(1.0);
+        }
+    }
+    
+    .processing-download > div {
+        animation: stretchdelay 2s infinite linear;
+    }
+    
+    .processing-download .rect2 {
+        animation-delay: 0.2s;
+    }
+    
+    .processing-download .rect3 {
+        animation-delay: 0.4s;
+    }
+    
+    .processing-download .rect4 {
+        animation-delay: 0.6s;
+    }
+}
+
+/***
     Bootstrap overwrites
 ***/
 


### PR DESCRIPTION
*You were very fast with the previous merge :grin: Was still working on this. Maybe leave this PR open until you build Alpa4, so I can add stuff if I noticed any other bugs etc.*

Firefox uses very high CPU (up to 30%) for anything animated. All the others (IE, Chrome) use much less (max 2-7%).
Disables animations on progress-bar and make the History-'processing' a
block animation.
Can be removed if Firefox animation performance gets better in the future..