### PR TITLE
SSL client side system info in SAB

### DIFF
--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1283,7 +1283,7 @@ def main():
         cpumodel = getcpu()  # Linux only
         if cpumodel:
             logging.debug('CPU model name is %s', cpumodel)
-
+            
     # OSX 10.5 I/O priority setting
     if sabnzbd.DARWIN:
         logging.info('[osx] IO priority setting')
@@ -1353,6 +1353,10 @@ def main():
                 logging.info("pygtk2 not found. No SysTray.")
 
     print_modules()
+    
+    from sabnzbd.utils.sslinfo import sslversion, sslprotocols
+    logging.info("SSL version %s", sslversion())
+    logging.info("SSL supported protocols %s", str(sslprotocols()))
 
     cherrylogtoscreen = False
     sabnzbd.WEBLOGFILE = None

--- a/sabnzbd/utils/sslinfo.py
+++ b/sabnzbd/utils/sslinfo.py
@@ -3,19 +3,27 @@ import logging
 DEBUG = False
 
 def sslversion():
-    return ssl.OPENSSL_VERSION
-    
+    try:
+        return ssl.OPENSSL_VERSION
+    except:
+        return None
+        
 def sslversioninfo():
-    return ssl.OPENSSL_VERSION_INFO    
+    try:
+        return ssl.OPENSSL_VERSION_INFO
+    except:
+        return None
 
 def sslprotocols():
     protocollist = []   
-    for i in dir(ssl):
-        #print i
-        if i.find('PROTOCOL_') == 0:
-            protocollist.append(i)
-    return protocollist
-
+    try:
+        for i in dir(ssl):
+            #print i
+            if i.find('PROTOCOL_') == 0:
+                protocollist.append(i[9:])
+        return protocollist
+    except:
+        return None
 
 if __name__ == '__main__':
 

--- a/sabnzbd/utils/sslinfo.py
+++ b/sabnzbd/utils/sslinfo.py
@@ -1,0 +1,32 @@
+import ssl
+import logging
+DEBUG = False
+
+def sslversion():
+    return ssl.OPENSSL_VERSION
+    
+def sslversioninfo():
+    return ssl.OPENSSL_VERSION_INFO    
+
+def sslprotocols():
+    protocollist = []   
+    for i in dir(ssl):
+        #print i
+        if i.find('PROTOCOL_') == 0:
+            protocollist.append(i)
+    return protocollist
+
+
+if __name__ == '__main__':
+
+    logger = logging.getLogger('')
+    logger.setLevel(logging.INFO)
+    if DEBUG: logger.setLevel(logging.DEBUG)
+    
+    print sslversion()
+    print sslversioninfo()
+    print sslprotocols()
+    print str(sslprotocols())
+
+
+

--- a/sabnzbd/utils/sslinfo.py
+++ b/sabnzbd/utils/sslinfo.py
@@ -1,24 +1,24 @@
 import ssl
 import logging
-DEBUG = False
 
 def sslversion():
     try:
         return ssl.OPENSSL_VERSION
     except:
+        logging.info("ssl.OPENSSL_VERSION not defined")
         return None
         
 def sslversioninfo():
     try:
         return ssl.OPENSSL_VERSION_INFO
     except:
+        logging.info("ssl.OPENSSL_VERSION_INFO not defined")
         return None
 
 def sslprotocols():
     protocollist = []   
     try:
         for i in dir(ssl):
-            #print i
             if i.find('PROTOCOL_') == 0:
                 protocollist.append(i[9:])
         return protocollist
@@ -29,12 +29,8 @@ if __name__ == '__main__':
 
     logger = logging.getLogger('')
     logger.setLevel(logging.INFO)
-    if DEBUG: logger.setLevel(logging.DEBUG)
-    
+
     print sslversion()
     print sslversioninfo()
     print sslprotocols()
-    print str(sslprotocols())
-
-
 


### PR DESCRIPTION
Will print something like

```
2015-10-19 23:40:34,211::INFO::[SABnzbd:1358] SSL version OpenSSL 1.0.1f 6 Jan 2014
2015-10-19 23:40:34,212::INFO::[SABnzbd:1359] SSL supported protocols ['SSLv23', 'SSLv3', 'TLSv1', 'TLSv1_1', 'TLSv1_2']
```
Useful to find mismatches between client system running SABnzbd and SSL enabled newsservers and indexers