### PR TITLE
Enable Windows Notifications

### DIFF
--- a/interfaces/Config/templates/config_notify.tmpl
+++ b/interfaces/Config/templates/config_notify.tmpl
@@ -73,52 +73,58 @@
     <div class="section">
         <div class="col2">
             <h3>$T('section-NC')</h3>
+            <table>
+                <tr>
+                    <td><input type="checkbox" name="ncenter_enable" id="ncenter_enable" value="1" <!--#if int($ncenter_enable) > 0 then 'checked="checked"' else ""#--> /></td>
+                    <td><label for="ncenter_enable"> $T('opt-ncenter_enable')</label></td>
+                </tr>
+            </table>
         </div><!-- /col2 -->
-        <div class="col1">
+        <div class="col1" <!--#if int($ncenter_enable) > 0 then '' else 'style="display:none"'#-->>
             <fieldset>
                 <div class="field-pair">
-                    <label class="config" for="ncenter_enable">$T('opt-ncenter_enable')</label>
+                    <label class="config wide" for="ncenter_enable">$T('opt-ncenter_enable')</label>
                     <input type="checkbox" name="ncenter_enable" id="ncenter_enable" value="1" <!--#if int($ncenter_enable) > 0 then 'checked="checked"' else ""#--> />
                     <span class="desc">$T('explain-ncenter_enable')</span>
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="ncenter_prio_startup">$T($notify_texts['startup'])</label>
+                    <label class="config wide" for="ncenter_prio_startup">$T($notify_texts['startup']).replace('/', ' / ')</label>
                     <input type="checkbox" name="ncenter_prio_startup" id="ncenter_prio_startup" value="1" <!--#if int($ncenter_prio_startup) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="ncenter_prio_download">$T($notify_texts['download'])</label>
+                    <label class="config wide" for="ncenter_prio_download">$T($notify_texts['download']) / $T('link-pause') / $T('link-resume')</label>
                     <input type="checkbox" name="ncenter_prio_download" id="ncenter_prio_download" value="1" <!--#if int($ncenter_prio_download) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="ncenter_prio_pp">$T($notify_texts['pp'])</label>
+                    <label class="config wide" for="ncenter_prio_pp">$T($notify_texts['pp'])</label>
                     <input type="checkbox" name="ncenter_prio_pp" id="ncenter_prio_pp" value="1" <!--#if int($ncenter_prio_pp) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="ncenter_prio_complete">$T($notify_texts['complete'])</label>
+                    <label class="config wide" for="ncenter_prio_complete">$T($notify_texts['complete'])</label>
                     <input type="checkbox" name="ncenter_prio_complete" id="ncenter_prio_complete" value="1" <!--#if int($ncenter_prio_complete) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="ncenter_prio_failed">$T($notify_texts['failed'])</label>
+                    <label class="config wide" for="ncenter_prio_failed">$T($notify_texts['failed'])</label>
                     <input type="checkbox" name="ncenter_prio_failed" id="ncenter_prio_failed" value="1" <!--#if int($ncenter_prio_failed) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="ncenter_prio_queue_done">$T($notify_texts['queue_done'])</label>
+                    <label class="config wide" for="ncenter_prio_queue_done">$T($notify_texts['queue_done'])</label>
                     <input type="checkbox" name="ncenter_prio_queue_done" id="ncenter_prio_queue_done" value="1" <!--#if int($ncenter_prio_queue_done) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="ncenter_prio_disk_full">$T($notify_texts['disk_full'])</label>
+                    <label class="config wide" for="ncenter_prio_disk_full">$T($notify_texts['disk_full'])</label>
                     <input type="checkbox" name="ncenter_prio_disk_full" id="ncenter_prio_disk_full" value="1" <!--#if int($ncenter_prio_disk_full) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="ncenter_prio_warning">$T($notify_texts['warning'])</label>
+                    <label class="config wide" for="ncenter_prio_warning">$T($notify_texts['warning'])</label>
                     <input type="checkbox" name="ncenter_prio_warning" id="ncenter_prio_warning" value="1" <!--#if int($ncenter_prio_warning) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="ncenter_prio_error">$T($notify_texts['error'])</label>
+                    <label class="config wide" for="ncenter_prio_error">$T($notify_texts['error'])</label>
                     <input type="checkbox" name="ncenter_prio_error" id="ncenter_prio_error" value="1" <!--#if int($ncenter_prio_error) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="ncenter_prio_other">$T($notify_texts['other'])</label>
+                    <label class="config wide" for="ncenter_prio_other">$T($notify_texts['other'])</label>
                     <input type="checkbox" name="ncenter_prio_other" id="ncenter_prio_other" value="1" <!--#if int($ncenter_prio_other) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
@@ -134,51 +140,53 @@
     <div class="section">
         <div class="col2">
             <h3>$T('section-AC')</h3>
+            <table>
+                <tr>
+                    <td><input type="checkbox" name="acenter_enable" id="acenter_enable" value="1" <!--#if int($acenter_enable) > 0 then 'checked="checked"' else ""#--> /></td>
+                    <td><label for="acenter_enable"> $T('opt-acenter_enable')</label></td>
+                </tr>
+            </table>
         </div><!-- /col2 -->
-        <div class="col1">
+        <div class="col1" <!--#if int($acenter_enable) > 0 then '' else 'style="display:none"'#-->>
             <fieldset>
                 <div class="field-pair">
-                    <label class="config" for="acenter_enable">$T('opt-acenter_enable')</label>
-                    <input type="checkbox" name="acenter_enable" id="acenter_enable" value="1" <!--#if int($acenter_enable) > 0 then 'checked="checked"' else ""#--> />
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="acenter_prio_startup">$T($notify_texts['startup'])</label>
+                    <label class="config wide" for="acenter_prio_startup">$T($notify_texts['startup']).replace('/', ' / ')</label>
                     <input type="checkbox" name="acenter_prio_startup" id="acenter_prio_startup" value="1" <!--#if int($acenter_prio_startup) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="acenter_prio_download">$T($notify_texts['download'])</label>
+                    <label class="config wide" for="acenter_prio_download">$T($notify_texts['download']) / $T('link-pause') / $T('link-resume')</label>
                     <input type="checkbox" name="acenter_prio_download" id="acenter_prio_download" value="1" <!--#if int($acenter_prio_download) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="acenter_prio_pp">$T($notify_texts['pp'])</label>
+                    <label class="config wide" for="acenter_prio_pp">$T($notify_texts['pp'])</label>
                     <input type="checkbox" name="acenter_prio_pp" id="acenter_prio_pp" value="1" <!--#if int($acenter_prio_pp) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="acenter_prio_complete">$T($notify_texts['complete'])</label>
+                    <label class="config wide" for="acenter_prio_complete">$T($notify_texts['complete'])</label>
                     <input type="checkbox" name="acenter_prio_complete" id="acenter_prio_complete" value="1" <!--#if int($acenter_prio_complete) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="acenter_prio_failed">$T($notify_texts['failed'])</label>
+                    <label class="config wide" for="acenter_prio_failed">$T($notify_texts['failed'])</label>
                     <input type="checkbox" name="acenter_prio_failed" id="acenter_prio_failed" value="1" <!--#if int($acenter_prio_failed) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="acenter_prio_queue_done">$T($notify_texts['queue_done'])</label>
+                    <label class="config wide" for="acenter_prio_queue_done">$T($notify_texts['queue_done'])</label>
                     <input type="checkbox" name="acenter_prio_queue_done" id="acenter_prio_queue_done" value="1" <!--#if int($acenter_prio_queue_done) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="acenter_prio_disk_full">$T($notify_texts['disk_full'])</label>
+                    <label class="config wide" for="acenter_prio_disk_full">$T($notify_texts['disk_full'])</label>
                     <input type="checkbox" name="acenter_prio_disk_full" id="acenter_prio_disk_full" value="1" <!--#if int($acenter_prio_disk_full) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="acenter_prio_warning">$T($notify_texts['warning'])</label>
+                    <label class="config wide" for="acenter_prio_warning">$T($notify_texts['warning'])</label>
                     <input type="checkbox" name="acenter_prio_warning" id="acenter_prio_warning" value="1" <!--#if int($acenter_prio_warning) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="acenter_prio_error">$T($notify_texts['error'])</label>
+                    <label class="config wide" for="acenter_prio_error">$T($notify_texts['error'])</label>
                     <input type="checkbox" name="acenter_prio_error" id="acenter_prio_error" value="1" <!--#if int($acenter_prio_error) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="acenter_prio_other">$T($notify_texts['other'])</label>
+                    <label class="config wide" for="acenter_prio_other">$T($notify_texts['other'])</label>
                     <input type="checkbox" name="acenter_prio_other" id="acenter_prio_other" value="1" <!--#if int($acenter_prio_other) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
@@ -194,52 +202,53 @@
     <div class="section">
         <div class="col2">
             <h3>$T('section-OSD') <a href="$helpuri$help_uri#toc4" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+            <table>
+                <tr>
+                    <td><input type="checkbox" name="ntfosd_enable" id="ntfosd_enable" value="1" <!--#if int($ntfosd_enable) > 0 then 'checked="checked"' else ""#--> /></td>
+                    <td><label for="ntfosd_enable"> $T('opt-ntfosd_enable')</label></td>
+                </tr>
+            </table>
         </div><!-- /col2 -->
-        <div class="col1">
+        <div class="col1" <!--#if int($ntfosd_enable) > 0 then '' else 'style="display:none"'#-->>
             <fieldset>
                 <div class="field-pair">
-                    <label class="config" for="ntfosd_enable">$T('opt-ntfosd_enable')</label>
-                    <input type="checkbox" name="ntfosd_enable" id="ntfosd_enable" value="1" <!--#if int($ntfosd_enable) > 0 then 'checked="checked"' else ""#--> <!--#if not $have_ntfosd then 'readonly="readonly" disabled="disabled"' else "" #--> />
-                    <span class="desc">$T('explain-ntfosd_enable')</span>
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="ntfosd_prio_startup">$T($notify_texts['startup'])</label>
+                    <label class="config wide" for="ntfosd_prio_startup">$T($notify_texts['startup']).replace('/', ' / ')</label>
                     <input type="checkbox" name="ntfosd_prio_startup" id="ntfosd_prio_startup" value="1" <!--#if int($ntfosd_prio_startup) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="ntfosd_prio_download">$T($notify_texts['download'])</label>
+                    <label class="config wide" for="ntfosd_prio_download">$T($notify_texts['download']) / $T('link-pause') / $T('link-resume')</label>
                     <input type="checkbox" name="ntfosd_prio_download" id="ntfosd_prio_download" value="1" <!--#if int($ntfosd_prio_download) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="ntfosd_prio_pp">$T($notify_texts['pp'])</label>
+                    <label class="config wide" for="ntfosd_prio_pp">$T($notify_texts['pp'])</label>
                     <input type="checkbox" name="ntfosd_prio_pp" id="ntfosd_prio_pp" value="1" <!--#if int($ntfosd_prio_pp) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="ntfosd_prio_complete">$T($notify_texts['complete'])</label>
+                    <label class="config wide" for="ntfosd_prio_complete">$T($notify_texts['complete'])</label>
                     <input type="checkbox" name="ntfosd_prio_complete" id="ntfosd_prio_complete" value="1" <!--#if int($ntfosd_prio_complete) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="ntfosd_prio_failed">$T($notify_texts['failed'])</label>
+                    <label class="config wide" for="ntfosd_prio_failed">$T($notify_texts['failed'])</label>
                     <input type="checkbox" name="ntfosd_prio_failed" id="ntfosd_prio_failed" value="1" <!--#if int($ntfosd_prio_failed) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="ntfosd_prio_queue_done">$T($notify_texts['queue_done'])</label>
+                    <label class="config wide" for="ntfosd_prio_queue_done">$T($notify_texts['queue_done'])</label>
                     <input type="checkbox" name="ntfosd_prio_queue_done" id="ntfosd_prio_queue_done" value="1" <!--#if int($ntfosd_prio_queue_done) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="ntfosd_prio_disk_full">$T($notify_texts['disk_full'])</label>
+                    <label class="config wide" for="ntfosd_prio_disk_full">$T($notify_texts['disk_full'])</label>
                     <input type="checkbox" name="ntfosd_prio_disk_full" id="ntfosd_prio_disk_full" value="1" <!--#if int($ntfosd_prio_disk_full) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="ntfosd_prio_warning">$T($notify_texts['warning'])</label>
+                    <label class="config wide" for="ntfosd_prio_warning">$T($notify_texts['warning'])</label>
                     <input type="checkbox" name="ntfosd_prio_warning" id="ntfosd_prio_warning" value="1" <!--#if int($ntfosd_prio_warning) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="ntfosd_prio_error">$T($notify_texts['error'])</label>
+                    <label class="config wide" for="ntfosd_prio_error">$T($notify_texts['error'])</label>
                     <input type="checkbox" name="ntfosd_prio_error" id="ntfosd_prio_error" value="1" <!--#if int($ntfosd_prio_error) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="ntfosd_prio_other">$T($notify_texts['other'])</label>
+                    <label class="config wide" for="ntfosd_prio_other">$T($notify_texts['other'])</label>
                     <input type="checkbox" name="ntfosd_prio_other" id="ntfosd_prio_other" value="1" <!--#if int($ntfosd_prio_other) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
@@ -251,17 +260,18 @@
        </div><!-- /col1 -->
     </div><!-- /section -->
     <!--#end if#-->
-        <div class="section" id="growl">
+    <div class="section" id="growl">
         <div class="col2">
             <h3>$T('growlSettings') <a href="$helpuri$help_uri#toc3" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+            <table>
+                <tr>
+                    <td><input type="checkbox" name="growl_enable" id="growl_enable" value="1" <!--#if int($growl_enable) > 0 then 'checked="checked"' else ""#--> /></td>
+                    <td><label for="growl_enable"> $T('opt-growl_enable')</label></td>
+                </tr>
+            </table>
         </div><!-- /col2 -->
-        <div class="col1">
+        <div class="col1" <!--#if int($growl_enable) > 0 then '' else 'style="display:none"'#-->>
             <fieldset>
-                <div class="field-pair" >
-                    <label class="config" for="growl_enable">$T('opt-growl_enable')</label>
-                    <input type="checkbox" name="growl_enable" id="growl_enable" value="1" <!--#if int($growl_enable) > 0 then 'checked="checked"' else ""#--> />
-                    <span class="desc">$T('explain-growl_enable')</span>
-                </div>
                 <div class="field-pair">
                     <label class="config" for="growl_server">$T('opt-growl_server')</label>
                     <input type="text" name="growl_server" id="growl_server" value="$growl_server" />
@@ -273,43 +283,43 @@
                     <span class="desc">$T('explain-growl_password')</span>
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="growl_prio_startup">$T($notify_texts['startup'])</label>
+                    <label class="config wide" for="growl_prio_startup">$T($notify_texts['startup']).replace('/', ' / ')</label>
                     <input type="checkbox" name="growl_prio_startup" id="growl_prio_startup" value="1" <!--#if int($growl_prio_startup) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="growl_prio_download">$T($notify_texts['download'])</label>
+                    <label class="config wide" for="growl_prio_download">$T($notify_texts['download']) / $T('link-pause') / $T('link-resume')</label>
                     <input type="checkbox" name="growl_prio_download" id="growl_prio_download" value="1" <!--#if int($growl_prio_download) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="growl_prio_pp">$T($notify_texts['pp'])</label>
+                    <label class="config wide" for="growl_prio_pp">$T($notify_texts['pp'])</label>
                     <input type="checkbox" name="growl_prio_pp" id="growl_prio_pp" value="1" <!--#if int($growl_prio_pp) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="growl_prio_complete">$T($notify_texts['complete'])</label>
+                    <label class="config wide" for="growl_prio_complete">$T($notify_texts['complete'])</label>
                     <input type="checkbox" name="growl_prio_complete" id="growl_prio_complete" value="1" <!--#if int($growl_prio_complete) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="growl_prio_failed">$T($notify_texts['failed'])</label>
+                    <label class="config wide" for="growl_prio_failed">$T($notify_texts['failed'])</label>
                     <input type="checkbox" name="growl_prio_failed" id="growl_prio_failed" value="1" <!--#if int($growl_prio_failed) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="growl_prio_queue_done">$T($notify_texts['queue_done'])</label>
+                    <label class="config wide" for="growl_prio_queue_done">$T($notify_texts['queue_done'])</label>
                     <input type="checkbox" name="growl_prio_queue_done" id="growl_prio_queue_done" value="1" <!--#if int($growl_prio_queue_done) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="growl_prio_disk_full">$T($notify_texts['disk_full'])</label>
+                    <label class="config wide" for="growl_prio_disk_full">$T($notify_texts['disk_full'])</label>
                     <input type="checkbox" name="growl_prio_disk_full" id="growl_prio_disk_full" value="1" <!--#if int($growl_prio_disk_full) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="growl_prio_warning">$T($notify_texts['warning'])</label>
+                    <label class="config wide" for="growl_prio_warning">$T($notify_texts['warning'])</label>
                     <input type="checkbox" name="growl_prio_warning" id="growl_prio_warning" value="1" <!--#if int($growl_prio_warning) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="growl_prio_error">$T($notify_texts['error'])</label>
+                    <label class="config wide" for="growl_prio_error">$T($notify_texts['error'])</label>
                     <input type="checkbox" name="growl_prio_error" id="growl_prio_error" value="1" <!--#if int($growl_prio_error) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="growl_prio_other">$T($notify_texts['other'])</label>
+                    <label class="config wide" for="growl_prio_other">$T($notify_texts['other'])</label>
                     <input type="checkbox" name="growl_prio_other" id="growl_prio_other" value="1" <!--#if int($growl_prio_other) > 0 then 'checked="checked"' else ""#--> />
                 </div>
                 <div class="field-pair">
@@ -323,21 +333,23 @@
     <div class="section" id="prowl">
         <div class="col2">
             <h3>$T('section-Prowl')</h3>
+            <table>
+                <tr>
+                    <td><input type="checkbox" name="prowl_enable" id="prowl_enable" value="1" <!--#if int($prowl_enable) > 0 then 'checked="checked"' else ""#--> /></td>
+                    <td><label for="prowl_enable"> $T('opt-prowl_enable')</label></td>
+                </tr>
+            </table>
+            <em>$T('explain-prowl_enable')</em>
         </div><!-- /col2 -->
-        <div class="col1">
+        <div class="col1" <!--#if int($prowl_enable) > 0 then '' else 'style="display:none"'#-->>
             <fieldset>
-                <div class="field-pair" >
-                    <label class="config" for="prowl_enable">$T('opt-prowl_enable')</label>
-                    <input type="checkbox" name="prowl_enable" id="prowl_enable" value="1" <!--#if int($prowl_enable) > 0 then 'checked="checked"' else ""#--> />
-                    <span class="desc">$T('explain-prowl_enable')</span>
-                </div>
                 <div class="field-pair">
                     <label class="config" for="prowl_apikey">$T('opt-prowl_apikey')</label>
                     <input type="text" name="prowl_apikey" id="prowl_apikey" value="$prowl_apikey" />
                     <span class="desc">$T('explain-prowl_apikey')</span>
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="prowl_prio_startup">$T($notify_texts['startup'])</label>
+                    <label class="config" for="prowl_prio_startup">$T($notify_texts['startup']).replace('/', ' / ')</label>
                     <select name="prowl_prio_startup" id="prowl_prio_startup">
                         <option value="-3" <!--#if $prowl_prio_startup == -3 then 'selected="selected"' else ""#--> >$T('prowl-off')</option>
                         <option value="-2" <!--#if $prowl_prio_startup == -2 then 'selected="selected"' else ""#--> >$T('prowl-very-low')</option>
@@ -348,7 +360,7 @@
                     </select>
                </div>
                 <div class="field-pair">
-                    <label class="config" for="prowl_prio_download">$T($notify_texts['download'])</label>
+                    <label class="config" for="prowl_prio_download">$T($notify_texts['download']) / $T('link-pause') / $T('link-resume')</label>
                     <select name="prowl_prio_download" id="prowl_prio_download">
                         <option value="-3" <!--#if $prowl_prio_download == -3 then 'selected="selected"' else ""#--> >$T('prowl-off')</option>
                         <option value="-2" <!--#if $prowl_prio_download == -2 then 'selected="selected"' else ""#--> >$T('prowl-very-low')</option>
@@ -458,14 +470,16 @@
 	<div class="section" id="pushover">
 		<div class="col2">
 			<h3>$T('section-Pushover')</h3>
-		</div><!-- /col2 -->
-		<div class="col1">
+            <table>
+                <tr>
+                    <td><input type="checkbox" name="pushover_enable" id="pushover_enable" value="1" <!--#if int($pushover_enable) > 0 then 'checked="checked"' else ""#--> /></td>
+                    <td><label for="pushover_enable"> $T('opt-pushover_enable')</label></td>
+                </tr>
+            </table>
+            <em>$T('explain-pushover_enable')</em>
+        </div><!-- /col2 -->
+        <div class="col1" <!--#if int($pushover_enable) > 0 then '' else 'style="display:none"'#-->>
 			<fieldset>
-				<div class="field-pair" >
-					<label class="config" for="pushover_enable">$T('opt-pushover_enable')</label>
-					<input type="checkbox" name="pushover_enable" id="pushover_enable" value="1" <!--#if int($pushover_enable) > 0 then 'checked="checked"' else ""#--> />
-					<span class="desc">$T('explain-pushover_enable')</span>
-				</div>
 				<div class="field-pair">
 					<label class="config" for="pushover_token">$T('opt-pushover_token')</label>
 					<input type="text" name="pushover_token" id="pushover_token" value="$pushover_token" />
@@ -482,7 +496,7 @@
 					<span class="desc">$T('explain-pushover_device')</span>
 				</div>
 				<div class="field-pair">
-					<label class="config" for="pushover_prio_startup">$T($notify_texts['startup'])</label>
+					<label class="config" for="pushover_prio_startup">$T($notify_texts['startup']).replace('/', ' / ')</label>
 					<select name="pushover_prio_startup" id="pushover_prio_startup">
 						<option value="-2" <!--#if $pushover_prio_startup == -2 then 'selected="selected"' else ""#--> >$T('pushover-off')</option>
 						<option value="-1" <!--#if $pushover_prio_startup == -1 then 'selected="selected"' else ""#--> >$T('pushover-low')</option>
@@ -491,7 +505,7 @@
 					</select>
 			   </div>
 				<div class="field-pair">
-					<label class="config" for="pushover_prio_download">$T($notify_texts['download'])</label>
+					<label class="config" for="pushover_prio_download">$T($notify_texts['download']) / $T('link-pause') / $T('link-resume')</label>
 					<select name="pushover_prio_download" id="pushover_prio_download">
 						<option value="-2" <!--#if $pushover_prio_download == -2 then 'selected="selected"' else ""#--> >$T('pushover-off')</option>
 						<option value="-1" <!--#if $pushover_prio_download == -1 then 'selected="selected"' else ""#--> >$T('pushover-low')</option>
@@ -583,14 +597,16 @@
 	<div class="section" id="pushbullet">
 		<div class="col2">
 			<h3>$T('section-Pushbullet')</h3>
-		</div><!-- /col2 -->
-		<div class="col1">
+            <table>
+                <tr>
+                    <td><input type="checkbox" name="pushbullet_enable" id="pushbullet_enable" value="1" <!--#if int($pushbullet_enable) > 0 then 'checked="checked"' else ""#--> /></td>
+                    <td><label for="pushbullet_enable"> $T('opt-pushbullet_enable')</label></td>
+                </tr>
+            </table>
+            <em>$T('explain-pushbullet_enable')</em>
+        </div><!-- /col2 -->
+        <div class="col1" <!--#if int($pushbullet_enable) > 0 then '' else 'style="display:none"'#-->>
 			<fieldset>
-				<div class="field-pair">
-					<label class="config" for="pushbullet_enable">$T('opt-pushbullet_enable')</label>
-					<input type="checkbox" name="pushbullet_enable" id="pushbullet_enable" value="1" <!--#if int($pushbullet_enable) > 0 then 'checked="checked"' else ""#--> />
-					<span class="desc">$T('explain-pushbullet_enable')</span>
-				</div>
 				<div class="field-pair">
 					<label class="config" for="pushbullet_apikey">$T('opt-pushbullet_apikey')</label>
 					<input type="text" name="pushbullet_apikey" id="pushbullet_apikey" value="$pushbullet_apikey" />
@@ -604,43 +620,43 @@
 				</div>
 				<!--#end if#-->
 				<div class="field-pair">
-					<label class="config" for="pushbullet_prio_startup">$T($notify_texts['startup'])</label>
+					<label class="config wide" for="pushbullet_prio_startup">$T($notify_texts['startup']).replace('/', ' / ')</label>
 					<input type="checkbox" name="pushbullet_prio_startup" id="pushbullet_prio_startup" value="1" <!--#if int($pushbullet_prio_startup) > 0 then 'checked="checked"' else ""#--> />
 				</div>
 				<div class="field-pair">
-					<label class="config" for="pushbullet_prio_download">$T($notify_texts['download'])</label>
+					<label class="config wide" for="pushbullet_prio_download">$T($notify_texts['download']) / $T('link-pause') / $T('link-resume')</label>
 					<input type="checkbox" name="pushbullet_prio_download" id="pushbullet_prio_download" value="1" <!--#if int($pushbullet_prio_download) > 0 then 'checked="checked"' else ""#--> />
 				</div>
 				<div class="field-pair">
-					<label class="config" for="pushbullet_prio_pp">$T($notify_texts['pp'])</label>
+					<label class="config wide" for="pushbullet_prio_pp">$T($notify_texts['pp'])</label>
 					<input type="checkbox" name="pushbullet_prio_pp" id="pushbullet_prio_pp" value="1" <!--#if int($pushbullet_prio_pp) > 0 then 'checked="checked"' else ""#--> />
 				</div>
 				<div class="field-pair">
-					<label class="config" for="pushbullet_prio_complete">$T($notify_texts['complete'])</label>
+					<label class="config wide" for="pushbullet_prio_complete">$T($notify_texts['complete'])</label>
 					<input type="checkbox" name="pushbullet_prio_complete" id="pushbullet_prio_complete" value="1" <!--#if int($pushbullet_prio_complete) > 0 then 'checked="checked"' else ""#--> />
 				</div>
 				<div class="field-pair">
-					<label class="config" for="pushbullet_prio_failed">$T($notify_texts['failed'])</label>
+					<label class="config wide" for="pushbullet_prio_failed">$T($notify_texts['failed'])</label>
 					<input type="checkbox" name="pushbullet_prio_failed" id="pushbullet_prio_failed" value="1" <!--#if int($pushbullet_prio_failed) > 0 then 'checked="checked"' else ""#--> />
 				</div>
 				<div class="field-pair">
-					<label class="config" for="pushbullet_prio_queue_done">$T($notify_texts['queue_done'])</label>
+					<label class="config wide" for="pushbullet_prio_queue_done">$T($notify_texts['queue_done'])</label>
 					<input type="checkbox" name="pushbullet_prio_queue_done" id="pushbullet_prio_queue_done" value="1" <!--#if int($pushbullet_prio_queue_done) > 0 then 'checked="checked"' else ""#--> />
 				</div>
 				<div class="field-pair">
-					<label class="config" for="pushbullet_prio_disk_full">$T($notify_texts['disk_full'])</label>
+					<label class="config wide" for="pushbullet_prio_disk_full">$T($notify_texts['disk_full'])</label>
 					<input type="checkbox" name="pushbullet_prio_disk_full" id="pushbullet_prio_disk_full" value="1" <!--#if int($pushbullet_prio_disk_full) > 0 then 'checked="checked"' else ""#--> />
 				</div>
 				<div class="field-pair">
-					<label class="config" for="pushbullet_prio_warning">$T($notify_texts['warning'])</label>
+					<label class="config wide" for="pushbullet_prio_warning">$T($notify_texts['warning'])</label>
 					<input type="checkbox" name="pushbullet_prio_warning" id="pushbullet_prio_warning" value="1" <!--#if int($pushbullet_prio_warning) > 0 then 'checked="checked"' else ""#--> />
 				</div>
 				<div class="field-pair">
-					<label class="config" for="pushbullet_prio_error">$T($notify_texts['error'])</label>
+					<label class="config wide" for="pushbullet_prio_error">$T($notify_texts['error'])</label>
 					<input type="checkbox" name="pushbullet_prio_error" id="pushbullet_prio_error" value="1" <!--#if int($pushbullet_prio_error) > 0 then 'checked="checked"' else ""#--> />
 				</div>
 				<div class="field-pair">
-					<label class="config" for="pushbullet_prio_other">$T($notify_texts['other'])</label>
+					<label class="config wide" for="pushbullet_prio_other">$T($notify_texts['other'])</label>
 					<input type="checkbox" name="pushbullet_prio_other" id="pushbullet_prio_other" value="1" <!--#if int($pushbullet_prio_other) > 0 then 'checked="checked"' else ""#--> />
 				</div>
 				<div class="field-pair">
@@ -654,10 +670,20 @@
     </form>
 </div><!-- /colmask -->
 
-<script>
+<script type="text/javascript">
 \$(document).ready(function(){
     // Autocomplete and filebrowser
     \$('#email_dir').typeahead().fileBrowser();
+    
+    // Expand on enable
+    \$('.col2 input[name$="enable"]').change(function() {
+        if(this.checked) {
+            \$(this).parents('.section').find('.col1').show()
+        } else {
+            \$(this).parents('.section').find('.col1').hide()
+        }
+        \$('form').submit()
+    })
     
     /**
         Testing functions

--- a/interfaces/Config/templates/config_notify.tmpl
+++ b/interfaces/Config/templates/config_notify.tmpl
@@ -69,7 +69,189 @@
             </fieldset>
         </div><!-- /col1 -->
     </div><!-- /section -->
-    <div class="section" id="growl">
+    <!--#if $have_ncenter#-->
+    <div class="section">
+        <div class="col2">
+            <h3>$T('section-NC')</h3>
+        </div><!-- /col2 -->
+        <div class="col1">
+            <fieldset>
+                <div class="field-pair">
+                    <label class="config" for="ncenter_enable">$T('opt-ncenter_enable')</label>
+                    <input type="checkbox" name="ncenter_enable" id="ncenter_enable" value="1" <!--#if int($ncenter_enable) > 0 then 'checked="checked"' else ""#--> />
+                    <span class="desc">$T('explain-ncenter_enable')</span>
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="ncenter_prio_startup">$T($notify_texts['startup'])</label>
+                    <input type="checkbox" name="ncenter_prio_startup" id="ncenter_prio_startup" value="1" <!--#if int($ncenter_prio_startup) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="ncenter_prio_download">$T($notify_texts['download'])</label>
+                    <input type="checkbox" name="ncenter_prio_download" id="ncenter_prio_download" value="1" <!--#if int($ncenter_prio_download) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="ncenter_prio_pp">$T($notify_texts['pp'])</label>
+                    <input type="checkbox" name="ncenter_prio_pp" id="ncenter_prio_pp" value="1" <!--#if int($ncenter_prio_pp) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="ncenter_prio_complete">$T($notify_texts['complete'])</label>
+                    <input type="checkbox" name="ncenter_prio_complete" id="ncenter_prio_complete" value="1" <!--#if int($ncenter_prio_complete) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="ncenter_prio_failed">$T($notify_texts['failed'])</label>
+                    <input type="checkbox" name="ncenter_prio_failed" id="ncenter_prio_failed" value="1" <!--#if int($ncenter_prio_failed) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="ncenter_prio_queue_done">$T($notify_texts['queue_done'])</label>
+                    <input type="checkbox" name="ncenter_prio_queue_done" id="ncenter_prio_queue_done" value="1" <!--#if int($ncenter_prio_queue_done) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="ncenter_prio_disk_full">$T($notify_texts['disk_full'])</label>
+                    <input type="checkbox" name="ncenter_prio_disk_full" id="ncenter_prio_disk_full" value="1" <!--#if int($ncenter_prio_disk_full) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="ncenter_prio_warning">$T($notify_texts['warning'])</label>
+                    <input type="checkbox" name="ncenter_prio_warning" id="ncenter_prio_warning" value="1" <!--#if int($ncenter_prio_warning) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="ncenter_prio_error">$T($notify_texts['error'])</label>
+                    <input type="checkbox" name="ncenter_prio_error" id="ncenter_prio_error" value="1" <!--#if int($ncenter_prio_error) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="ncenter_prio_other">$T($notify_texts['other'])</label>
+                    <input type="checkbox" name="ncenter_prio_other" id="ncenter_prio_other" value="1" <!--#if int($ncenter_prio_other) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                   <button class="btn btn-default saveButton"><span class="glyphicon glyphicon-ok"></span> $T('button-saveChanges')</button>
+                   <button class="btn btn-default" type="button" id="test_notification"><span class="glyphicon glyphicon-comment"></span> $T('testNotify')</button>
+                   <span id="testnotice-result" class="icon path darkred">&nbsp;</span>
+               </div>
+           </fieldset>
+       </div><!-- /col1 -->
+    </div><!-- /section -->
+    <!--#end if#-->
+    <!--#if $nt#-->
+    <div class="section">
+        <div class="col2">
+            <h3>$T('section-AC')</h3>
+        </div><!-- /col2 -->
+        <div class="col1">
+            <fieldset>
+                <div class="field-pair">
+                    <label class="config" for="acenter_enable">$T('opt-acenter_enable')</label>
+                    <input type="checkbox" name="acenter_enable" id="acenter_enable" value="1" <!--#if int($acenter_enable) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="acenter_prio_startup">$T($notify_texts['startup'])</label>
+                    <input type="checkbox" name="acenter_prio_startup" id="acenter_prio_startup" value="1" <!--#if int($acenter_prio_startup) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="acenter_prio_download">$T($notify_texts['download'])</label>
+                    <input type="checkbox" name="acenter_prio_download" id="acenter_prio_download" value="1" <!--#if int($acenter_prio_download) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="acenter_prio_pp">$T($notify_texts['pp'])</label>
+                    <input type="checkbox" name="acenter_prio_pp" id="acenter_prio_pp" value="1" <!--#if int($acenter_prio_pp) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="acenter_prio_complete">$T($notify_texts['complete'])</label>
+                    <input type="checkbox" name="acenter_prio_complete" id="acenter_prio_complete" value="1" <!--#if int($acenter_prio_complete) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="acenter_prio_failed">$T($notify_texts['failed'])</label>
+                    <input type="checkbox" name="acenter_prio_failed" id="acenter_prio_failed" value="1" <!--#if int($acenter_prio_failed) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="acenter_prio_queue_done">$T($notify_texts['queue_done'])</label>
+                    <input type="checkbox" name="acenter_prio_queue_done" id="acenter_prio_queue_done" value="1" <!--#if int($acenter_prio_queue_done) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="acenter_prio_disk_full">$T($notify_texts['disk_full'])</label>
+                    <input type="checkbox" name="acenter_prio_disk_full" id="acenter_prio_disk_full" value="1" <!--#if int($acenter_prio_disk_full) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="acenter_prio_warning">$T($notify_texts['warning'])</label>
+                    <input type="checkbox" name="acenter_prio_warning" id="acenter_prio_warning" value="1" <!--#if int($acenter_prio_warning) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="acenter_prio_error">$T($notify_texts['error'])</label>
+                    <input type="checkbox" name="acenter_prio_error" id="acenter_prio_error" value="1" <!--#if int($acenter_prio_error) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="acenter_prio_other">$T($notify_texts['other'])</label>
+                    <input type="checkbox" name="acenter_prio_other" id="acenter_prio_other" value="1" <!--#if int($acenter_prio_other) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                   <button class="btn btn-default saveButton"><span class="glyphicon glyphicon-ok"></span> $T('button-saveChanges')</button>
+                   <button class="btn btn-default" type="button" id="test_windows_notification"><span class="glyphicon glyphicon-comment"></span> $T('testNotify')</button>
+                   <span id="testnotice-result" class="icon path darkred">&nbsp;</span>
+               </div>
+           </fieldset>
+       </div><!-- /col1 -->
+    </div><!-- /section -->
+    <!--#end if#-->
+    <!--#if $have_ntfosd#-->
+    <div class="section">
+        <div class="col2">
+            <h3>$T('section-OSD') <a href="$helpuri$help_uri#toc4" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+        </div><!-- /col2 -->
+        <div class="col1">
+            <fieldset>
+                <div class="field-pair">
+                    <label class="config" for="ntfosd_enable">$T('opt-ntfosd_enable')</label>
+                    <input type="checkbox" name="ntfosd_enable" id="ntfosd_enable" value="1" <!--#if int($ntfosd_enable) > 0 then 'checked="checked"' else ""#--> <!--#if not $have_ntfosd then 'readonly="readonly" disabled="disabled"' else "" #--> />
+                    <span class="desc">$T('explain-ntfosd_enable')</span>
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="ntfosd_prio_startup">$T($notify_texts['startup'])</label>
+                    <input type="checkbox" name="ntfosd_prio_startup" id="ntfosd_prio_startup" value="1" <!--#if int($ntfosd_prio_startup) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="ntfosd_prio_download">$T($notify_texts['download'])</label>
+                    <input type="checkbox" name="ntfosd_prio_download" id="ntfosd_prio_download" value="1" <!--#if int($ntfosd_prio_download) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="ntfosd_prio_pp">$T($notify_texts['pp'])</label>
+                    <input type="checkbox" name="ntfosd_prio_pp" id="ntfosd_prio_pp" value="1" <!--#if int($ntfosd_prio_pp) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="ntfosd_prio_complete">$T($notify_texts['complete'])</label>
+                    <input type="checkbox" name="ntfosd_prio_complete" id="ntfosd_prio_complete" value="1" <!--#if int($ntfosd_prio_complete) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="ntfosd_prio_failed">$T($notify_texts['failed'])</label>
+                    <input type="checkbox" name="ntfosd_prio_failed" id="ntfosd_prio_failed" value="1" <!--#if int($ntfosd_prio_failed) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="ntfosd_prio_queue_done">$T($notify_texts['queue_done'])</label>
+                    <input type="checkbox" name="ntfosd_prio_queue_done" id="ntfosd_prio_queue_done" value="1" <!--#if int($ntfosd_prio_queue_done) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="ntfosd_prio_disk_full">$T($notify_texts['disk_full'])</label>
+                    <input type="checkbox" name="ntfosd_prio_disk_full" id="ntfosd_prio_disk_full" value="1" <!--#if int($ntfosd_prio_disk_full) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="ntfosd_prio_warning">$T($notify_texts['warning'])</label>
+                    <input type="checkbox" name="ntfosd_prio_warning" id="ntfosd_prio_warning" value="1" <!--#if int($ntfosd_prio_warning) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="ntfosd_prio_error">$T($notify_texts['error'])</label>
+                    <input type="checkbox" name="ntfosd_prio_error" id="ntfosd_prio_error" value="1" <!--#if int($ntfosd_prio_error) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="ntfosd_prio_other">$T($notify_texts['other'])</label>
+                    <input type="checkbox" name="ntfosd_prio_other" id="ntfosd_prio_other" value="1" <!--#if int($ntfosd_prio_other) > 0 then 'checked="checked"' else ""#--> />
+                </div>
+                <div class="field-pair">
+                   <button class="btn btn-default saveButton"><span class="glyphicon glyphicon-ok"></span> $T('button-saveChanges')</button>
+                   <button class="btn btn-default" type="button" id="test_osd"><span class="glyphicon glyphicon-comment"></span> $T('testNotify')</button>
+                   <span id="testosd-result" class="icon path darkred">&nbsp;</span>
+               </div>
+           </fieldset>
+       </div><!-- /col1 -->
+    </div><!-- /section -->
+    <!--#end if#-->
+        <div class="section" id="growl">
         <div class="col2">
             <h3>$T('growlSettings') <a href="$helpuri$help_uri#toc3" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
         </div><!-- /col2 -->
@@ -138,128 +320,6 @@
            </fieldset>
        </div><!-- /col1 -->
     </div><!-- /section -->
-    <!--#if $have_ncenter#-->
-    <div class="section">
-        <div class="col2">
-            <h3>$T('section-NC')</h3>
-        </div><!-- /col2 -->
-        <div class="col1">
-            <fieldset>
-                <div class="field-pair">
-                    <label class="config" for="ncenter_enable">$T('opt-ncenter_enable')</label>
-                    <input type="checkbox" name="ncenter_enable" id="ncenter_enable" value="1" <!--#if int($ncenter_enable) > 0 then 'checked="checked"' else ""#--> <!--#if not $have_ncenter then 'readonly="readonly" disabled="disabled"' else "" #--> />
-                    <span class="desc">$T('explain-ncenter_enable')</span>
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="ncenter_prio_startup">$T($notify_texts['startup'])</label>
-                    <input type="checkbox" name="ncenter_prio_startup" id="ncenter_prio_startup" value="1" <!--#if int($ncenter_prio_startup) > 0 then 'checked="checked"' else ""#--> />
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="ncenter_prio_download">$T($notify_texts['download'])</label>
-                    <input type="checkbox" name="ncenter_prio_download" id="ncenter_prio_download" value="1" <!--#if int($ncenter_prio_download) > 0 then 'checked="checked"' else ""#--> />
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="ncenter_prio_pp">$T($notify_texts['pp'])</label>
-                    <input type="checkbox" name="ncenter_prio_pp" id="ncenter_prio_pp" value="1" <!--#if int($ncenter_prio_pp) > 0 then 'checked="checked"' else ""#--> />
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="ncenter_prio_complete">$T($notify_texts['complete'])</label>
-                    <input type="checkbox" name="ncenter_prio_complete" id="ncenter_prio_complete" value="1" <!--#if int($ncenter_prio_complete) > 0 then 'checked="checked"' else ""#--> />
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="ncenter_prio_failed">$T($notify_texts['failed'])</label>
-                    <input type="checkbox" name="ncenter_prio_failed" id="ncenter_prio_failed" value="1" <!--#if int($ncenter_prio_failed) > 0 then 'checked="checked"' else ""#--> />
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="ncenter_prio_queue_done">$T($notify_texts['queue_done'])</label>
-                    <input type="checkbox" name="ncenter_prio_queue_done" id="ncenter_prio_queue_done" value="1" <!--#if int($ncenter_prio_queue_done) > 0 then 'checked="checked"' else ""#--> />
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="ncenter_prio_disk_full">$T($notify_texts['disk_full'])</label>
-                    <input type="checkbox" name="ncenter_prio_disk_full" id="ncenter_prio_disk_full" value="1" <!--#if int($ncenter_prio_disk_full) > 0 then 'checked="checked"' else ""#--> />
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="ncenter_prio_warning">$T($notify_texts['warning'])</label>
-                    <input type="checkbox" name="ncenter_prio_warning" id="ncenter_prio_warning" value="1" <!--#if int($ncenter_prio_warning) > 0 then 'checked="checked"' else ""#--> />
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="ncenter_prio_error">$T($notify_texts['error'])</label>
-                    <input type="checkbox" name="ncenter_prio_error" id="ncenter_prio_error" value="1" <!--#if int($ncenter_prio_error) > 0 then 'checked="checked"' else ""#--> />
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="ncenter_prio_other">$T($notify_texts['other'])</label>
-                    <input type="checkbox" name="ncenter_prio_other" id="ncenter_prio_other" value="1" <!--#if int($ncenter_prio_other) > 0 then 'checked="checked"' else ""#--> />
-                </div>
-                <div class="field-pair">
-                   <button class="btn btn-default saveButton"><span class="glyphicon glyphicon-ok"></span> $T('button-saveChanges')</button>
-                   <button class="btn btn-default" type="button" id="test_notification"><span class="glyphicon glyphicon-comment"></span> $T('testNotify')</button>
-                   <span id="testnotice-result" class="icon path darkred">&nbsp;</span>
-               </div>
-           </fieldset>
-       </div><!-- /col1 -->
-    </div><!-- /section -->
-    <!--#end if#-->
-    <!--#if $have_ntfosd#-->
-    <div class="section">
-        <div class="col2">
-            <h3>$T('section-OSD') <a href="$helpuri$help_uri#toc4" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
-        </div><!-- /col2 -->
-        <div class="col1">
-            <fieldset>
-                <div class="field-pair">
-                    <label class="config" for="ntfosd_enable">$T('opt-ntfosd_enable')</label>
-                    <input type="checkbox" name="ntfosd_enable" id="ntfosd_enable" value="1" <!--#if int($ntfosd_enable) > 0 then 'checked="checked"' else ""#--> <!--#if not $have_ntfosd then 'readonly="readonly" disabled="disabled"' else "" #--> />
-                    <span class="desc">$T('explain-ntfosd_enable')</span>
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="ntfosd_prio_startup">$T($notify_texts['startup'])</label>
-                    <input type="checkbox" name="ntfosd_prio_startup" id="ntfosd_prio_startup" value="1" <!--#if int($ntfosd_prio_startup) > 0 then 'checked="checked"' else ""#--> />
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="ntfosd_prio_download">$T($notify_texts['download'])</label>
-                    <input type="checkbox" name="ntfosd_prio_download" id="ntfosd_prio_download" value="1" <!--#if int($ntfosd_prio_download) > 0 then 'checked="checked"' else ""#--> />
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="ntfosd_prio_pp">$T($notify_texts['pp'])</label>
-                    <input type="checkbox" name="ntfosd_prio_pp" id="ntfosd_prio_pp" value="1" <!--#if int($ntfosd_prio_pp) > 0 then 'checked="checked"' else ""#--> />
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="ntfosd_prio_complete">$T($notify_texts['complete'])</label>
-                    <input type="checkbox" name="ntfosd_prio_complete" id="ntfosd_prio_complete" value="1" <!--#if int($ntfosd_prio_complete) > 0 then 'checked="checked"' else ""#--> />
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="ntfosd_prio_failed">$T($notify_texts['failed'])</label>
-                    <input type="checkbox" name="ntfosd_prio_failed" id="ntfosd_prio_failed" value="1" <!--#if int($ntfosd_prio_failed) > 0 then 'checked="checked"' else ""#--> />
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="ntfosd_prio_queue_done">$T($notify_texts['queue_done'])</label>
-                    <input type="checkbox" name="ntfosd_prio_queue_done" id="ntfosd_prio_queue_done" value="1" <!--#if int($ntfosd_prio_queue_done) > 0 then 'checked="checked"' else ""#--> />
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="ntfosd_prio_disk_full">$T($notify_texts['disk_full'])</label>
-                    <input type="checkbox" name="ntfosd_prio_disk_full" id="ntfosd_prio_disk_full" value="1" <!--#if int($ntfosd_prio_disk_full) > 0 then 'checked="checked"' else ""#--> />
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="ntfosd_prio_warning">$T($notify_texts['warning'])</label>
-                    <input type="checkbox" name="ntfosd_prio_warning" id="ntfosd_prio_warning" value="1" <!--#if int($ntfosd_prio_warning) > 0 then 'checked="checked"' else ""#--> />
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="ntfosd_prio_error">$T($notify_texts['error'])</label>
-                    <input type="checkbox" name="ntfosd_prio_error" id="ntfosd_prio_error" value="1" <!--#if int($ntfosd_prio_error) > 0 then 'checked="checked"' else ""#--> />
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="ntfosd_prio_other">$T($notify_texts['other'])</label>
-                    <input type="checkbox" name="ntfosd_prio_other" id="ntfosd_prio_other" value="1" <!--#if int($ntfosd_prio_other) > 0 then 'checked="checked"' else ""#--> />
-                </div>
-                <div class="field-pair">
-                   <button class="btn btn-default saveButton"><span class="glyphicon glyphicon-ok"></span> $T('button-saveChanges')</button>
-                   <button class="btn btn-default" type="button" id="test_osd"><span class="glyphicon glyphicon-comment"></span> $T('testNotify')</button>
-                   <span id="testosd-result" class="icon path darkred">&nbsp;</span>
-               </div>
-           </fieldset>
-       </div><!-- /col1 -->
-    </div><!-- /section -->
-    <!--#end if#-->
     <div class="section" id="prowl">
         <div class="col2">
             <h3>$T('section-Prowl')</h3>
@@ -636,6 +696,29 @@
             beforeSend: function () {
                 \$('#test_notification').attr("disabled", "disabled");
                 \$('#testnotice-result').removeClass("success failure").addClass("loading").html('$T('post-Verifying')');
+            },
+            complete: function () {
+                \$('#test_notification').removeAttr("disabled");
+                \$('#testnotice-result').removeClass("loading");
+            },
+            success: function (data) {
+                if (data.status == true) {
+                  \$('#testnotice-result').addClass("success").html('$T('smpl-notesent')');
+                } else {
+                  \$('#testnotice-result').addClass("failure").html(data.error);
+                }
+            }
+        });
+    });
+    \$('#test_windows_notification').click(function () {
+        \$.ajax({
+            type: "GET",
+            url: "../../tapi",
+            data: {mode: 'test_windows', apikey: '$session', output: 'json' },
+            beforeSend: function () {
+                \$('#test_notification').attr("disabled", "disabled");
+                \$('#testnotice-result').removeClass("success failure").addClass("loading").html('$T('post-Verifying')');
+                console.log('asdas')
             },
             complete: function () {
                 \$('#test_notification').removeAttr("disabled");

--- a/interfaces/Config/templates/config_server.tmpl
+++ b/interfaces/Config/templates/config_server.tmpl
@@ -136,7 +136,7 @@
             
             <table><tr>
               <td><input type="checkbox" class="toggleServerCheckbox" id="enable_$cur" rel="$server['name']" name="q_enable" value="1" <!--#if int($server['enable']) != 0 then 'checked="checked"' else ""#--> /></td>
-              <td><label for="enable_$cur">&nbsp;$T('enabled')</label></td>
+              <td><label for="enable_$cur">$T('enabled')</label></td>
             </tr></table>
 
             <button type="button" class="btn btn-default showserver"><span class="glyphicon glyphicon-pencil"></span> $T('showDetails')</button>

--- a/interfaces/Config/templates/staticcfg/css/style.css
+++ b/interfaces/Config/templates/staticcfg/css/style.css
@@ -155,7 +155,9 @@ input[type="checkbox"]+.desc {
 .infoTableSeperator.alt {
     background-color: #F8F8F8;
 }
-
+.success {
+    color: #5cb85c !important;
+}
 .typeahead.dropdown-menu {
     padding: 0;
     min-width: 300px;

--- a/interfaces/Config/templates/staticcfg/css/style.css
+++ b/interfaces/Config/templates/staticcfg/css/style.css
@@ -806,8 +806,11 @@ input[type="checkbox"] {
     opacity: 0.7;
 }
 
-.Servers .col2 label {
+.Servers .col2 label,
+.Email .col2 label {
     margin: 0;
+    margin-left: 4px;
+    margin-top: 2px;
     cursor: pointer;
 }
 

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -719,6 +719,11 @@ def _api_test_email(name, output, kwargs):
         res = None
     return report(output, error=res)
 
+def _api_test_windows(name, output, kwargs):
+    """ API: send a test to Windows, return result """
+    logging.info("Sending test notification")
+    res = sabnzbd.growler.send_windows('SABnzbd', T('Test Notification'), 'other')
+    return report(output, error=res)
 
 def _api_test_notif(name, output, kwargs):
     """ API: send a test to Notification Center, return result """
@@ -908,6 +913,7 @@ _api_table = {
     'retry_all': (_api_retry_all, 2),
     'reset_quota': (_api_reset_quota, 2),
     'test_email': (_api_test_email, 2),
+    'test_windows': (_api_test_windows, 2),
     'test_notif': (_api_test_notif, 2),
     'test_growl': (_api_test_growl, 2),
     'test_osd': (_api_test_osd, 2),

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -274,7 +274,7 @@ ncenter_prio_other = OptionBool('ncenter', 'ncenter_prio_other', False)
 
 # [acenter]
 acenter_enable = OptionBool('acenter', 'acenter_enable', sabnzbd.WIN32)
-acenter_prio_startup = OptionBool('acenter', 'acenter_prio_startup', True)
+acenter_prio_startup = OptionBool('acenter', 'acenter_prio_startup', False)
 acenter_prio_download = OptionBool('acenter', 'acenter_prio_download', False)
 acenter_prio_pp = OptionBool('acenter', 'acenter_prio_pp', False)
 acenter_prio_complete = OptionBool('acenter', 'acenter_prio_complete', True)

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -272,6 +272,19 @@ ncenter_prio_error = OptionBool('ncenter', 'ncenter_prio_error', False)
 ncenter_prio_queue_done = OptionBool('ncenter', 'ncenter_prio_queue_done', True)
 ncenter_prio_other = OptionBool('ncenter', 'ncenter_prio_other', False)
 
+# [acenter]
+acenter_enable = OptionBool('acenter', 'acenter_enable', sabnzbd.WIN32)
+acenter_prio_startup = OptionBool('acenter', 'acenter_prio_startup', True)
+acenter_prio_download = OptionBool('acenter', 'acenter_prio_download', False)
+acenter_prio_pp = OptionBool('acenter', 'acenter_prio_pp', False)
+acenter_prio_complete = OptionBool('acenter', 'acenter_prio_complete', True)
+acenter_prio_failed = OptionBool('acenter', 'acenter_prio_failed', True)
+acenter_prio_disk_full = OptionBool('acenter', 'acenter_prio_disk_full', True)
+acenter_prio_warning = OptionBool('acenter', 'acenter_prio_warning', False)
+acenter_prio_error = OptionBool('acenter', 'acenter_prio_error', False)
+acenter_prio_queue_done = OptionBool('acenter', 'acenter_prio_queue_done', True)
+acenter_prio_other = OptionBool('acenter', 'acenter_prio_other', False)
+
 # [ntfosd]
 ntfosd_enable = OptionBool('ntfosd', 'ntfosd_enable', not sabnzbd.WIN32 and not sabnzbd.DARWIN)
 ntfosd_prio_startup = OptionBool('ntfosd', 'ntfosd_prio_startup', True)

--- a/sabnzbd/growler.py
+++ b/sabnzbd/growler.py
@@ -123,6 +123,11 @@ def send_notification(title, msg, gtype):
     if sabnzbd.DARWIN_VERSION > 7 and sabnzbd.cfg.ncenter_enable():
         if check_classes(gtype, 'ncenter'):
             send_notification_center(title, msg, gtype)
+            
+    # Windows
+    if sabnzbd.WIN32 and sabnzbd.cfg.acenter_enable():
+        if check_classes(gtype, 'acenter'):
+            send_windows(title, msg, gtype)
 
     # Growl
     if sabnzbd.cfg.growl_enable() and check_classes(gtype, 'growl'):
@@ -153,7 +158,6 @@ def send_notification(title, msg, gtype):
     # NTFOSD
     if have_ntfosd() and sabnzbd.cfg.ntfosd_enable() and check_classes(gtype, 'ntfosd'):
         send_notify_osd(title, msg)
-
 
 def reset_growl():
     """ Reset Growl (after changing language) """
@@ -534,3 +538,7 @@ def send_pushbullet(title, msg, gtype, force=False, test=None):
             logging.info('Traceback: ', exc_info=True)
             return T('Failed to send pushbullet message')
     return ''
+
+def send_windows(title, msg, gtype):
+    sabnzbd.WINTRAY.sendnotification(title, msg)
+    return None

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -2743,6 +2743,10 @@ LIST_NCENTER = ('ncenter_enable',
                 'ncenter_prio_startup', 'ncenter_prio_download', 'ncenter_prio_pp', 'ncenter_prio_complete', 'ncenter_prio_failed',
                 'ncenter_prio_disk_full', 'ncenter_prio_warning', 'ncenter_prio_error', 'ncenter_prio_queue_done', 'ncenter_prio_other'
                 )
+LIST_ACENTER = ('acenter_enable',
+                'acenter_prio_startup', 'acenter_prio_download', 'acenter_prio_pp', 'acenter_prio_complete', 'acenter_prio_failed',
+                'acenter_prio_disk_full', 'acenter_prio_warning', 'acenter_prio_error', 'acenter_prio_queue_done', 'acenter_prio_other'
+                )
 LIST_NTFOSD = ('ntfosd_enable',
                'ntfosd_prio_startup', 'ntfosd_prio_download', 'ntfosd_prio_pp', 'ntfosd_prio_complete', 'ntfosd_prio_failed',
                'ntfosd_prio_disk_full', 'ntfosd_prio_warning', 'ntfosd_prio_error', 'ntfosd_prio_queue_done', 'ntfosd_prio_other'
@@ -2797,6 +2801,8 @@ class ConfigNotify(object):
             conf[kw] = config.get_config('pushbullet', kw)()
         for kw in LIST_NCENTER:
             conf[kw] = config.get_config('ncenter', kw)()
+        for kw in LIST_ACENTER:
+            conf[kw] = config.get_config('acenter', kw)()
         for kw in LIST_NTFOSD:
             conf[kw] = config.get_config('ntfosd', kw)()
         conf['notify_texts'] = sabnzbd.growler.NOTIFICATION
@@ -2822,6 +2828,10 @@ class ConfigNotify(object):
                 return badParameterResponse(T('Incorrect value for %s: %s') % (kw, unicoder(msg)), ajax)
         for kw in LIST_NCENTER:
             msg = config.get_config('ncenter', kw).set(platform_encode(kwargs.get(kw)))
+            if msg:
+                return badParameterResponse(T('Incorrect value for %s: %s') % (kw, unicoder(msg)), ajax)
+        for kw in LIST_ACENTER:
+            msg = config.get_config('acenter', kw).set(platform_encode(kwargs.get(kw)))
             if msg:
                 return badParameterResponse(T('Incorrect value for %s: %s') % (kw, unicoder(msg)), ajax)
         for kw in LIST_NTFOSD:

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -620,8 +620,10 @@ SKIN_TEXT = {
     'explain-ntfosd_enable' : TT('Send notifications to NotifyOSD'), #: Don't translate "NotifyOSD"
     'opt-ncenter_enable' : TT('Notification Center'),
     'explain-ncenter_enable' : TT('Send notifications to Notification Center'),
+    'opt-acenter_enable' : TT('Enable Windows Notifications'),
     'testNotify' : TT('Test Notification'),
     'section-NC' : TT('Notification Center'), #: Header for OSX Notfication Center section
+    'section-AC' : TT('Windows Notifications'),
     'section-OSD' : TT('NotifyOSD'), #: Header for Ubuntu's NotifyOSD notifications section
     'section-Prowl' : TT('Prowl'), #: Header for Prowl notification section
     'opt-prowl_enable' : TT('Enable Prowl notifications'), #: Prowl settings

--- a/sabnzbd/utils/systrayiconthread.py
+++ b/sabnzbd/utils/systrayiconthread.py
@@ -94,6 +94,20 @@ class SysTrayIconThread(Thread):
     # override this
     def doUpdates(self):
         pass
+        
+    # Notification
+    def sendnotification(self, title, msg):
+        hicon = self.get_icon(self.icon)
+        win32gui.Shell_NotifyIcon(win32gui.NIM_MODIFY,
+                                  (self.hwnd, 
+                                   0, 
+                                   win32gui.NIF_INFO,
+                                   win32con.WM_USER+20, 
+                                   hicon,
+                                   "Balloon tooltip", 
+                                   msg, 
+                                   200, 
+                                   title))
 
     def _add_ids_to_menu_options(self, menu_options):
         result = []


### PR DESCRIPTION
I always wondered why this was not embedded into SAB!

![untitled](https://cloud.githubusercontent.com/assets/5703454/11782820/b5e2b686-a273-11e5-9584-3caa71ae9a77.png)

Turns out to be really simple to implement and the PyWin32 code for it is already years old, so fully backwards compatible with older Windows versions.
Unfortunately only Metro-apps seem to be able to create persisting notifications in the Action Center of Windows 10. Could find no Python implementation anywhere that made this possible.
The **a** is because in Windows 10 it's called Action Center.
Next improvement would be to improve the icon for the Windows 10 notification, but documentation is very,very limited so no idea if that's even possible.

Also changed the sorting in notification config pane to be: Email - OS services - External services.

PS: Sorry for including the commits from my other PR, but created a new branch too late..