### PR TITLE
Log RAR-binary and RAR-file versions

### DIFF
--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -496,7 +496,8 @@ def print_modules():
         logging.info("par2-classic binary... found (%s)", sabnzbd.newsunpack.PAR2C_COMMAND)
 
     if sabnzbd.newsunpack.RAR_COMMAND:
-        logging.info("unrar binary... found (%s)", sabnzbd.newsunpack.RAR_COMMAND)
+        logging.info("UNRAR binary... found (%s)", sabnzbd.newsunpack.RAR_COMMAND)
+
     else:
         logging.warning(T('unrar binary... NOT found'))
 
@@ -1097,9 +1098,6 @@ def main():
         except:
             Bail_Out(browserhost, cherryport, '49')
 
-    # Find external programs
-    sabnzbd.newsunpack.find_programs(sabnzbd.DIR_PROG)
-
     # Windows instance is reachable through registry
     url = None
     if sabnzbd.WIN32 and not new_instance:
@@ -1353,6 +1351,9 @@ def main():
                 sabnzbd.LINUXTRAY = sabnzbd.sabtraylinux.StatusIcon()
             except:
                 logging.info("pygtk2 not found. No SysTray.")
+
+    # Find external programs
+    sabnzbd.newsunpack.find_programs(sabnzbd.DIR_PROG)
 
     print_modules()
 

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -146,10 +146,9 @@ def find_programs(curdir):
         version, original = unrar_check(sabnzbd.newsunpack.RAR_COMMAND)
         sabnzbd.newsunpack.RAR_PROBLEM = not original or version < 380
         sabnzbd.newsunpack.RAR_VERSION = version
-        logging.info('UNRAR version %s', version)
+        logging.info('UNRAR binary version %.2f', (float(version) / 100))
         if sabnzbd.newsunpack.RAR_PROBLEM:
             logging.info('Problematic UNRAR')
-
 
 def external_processing(extern_proc, complete_dir, filename, nicename, cat, group, status, failure_url):
     """ Run a user postproc script, return console output and exit value """
@@ -597,6 +596,7 @@ def rar_extract_core(rarfile, numrars, one_folder, nzo, setname, extraction_path
 
     stup, need_shell, command, creationflags = build_command(command)
 
+    logging.debug("Analyzing rar file ... %s found", is_rarfile(rarfile))
     logging.debug("Running unrar %s", command)
     p = subprocess.Popen(command, shell=need_shell, stdin=subprocess.PIPE,
                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT,

--- a/sabnzbd/utils/rarfile.py
+++ b/sabnzbd/utils/rarfile.py
@@ -108,7 +108,11 @@ def is_rarfile(fn):
     '''Check quickly whether file is rar archive.'''
     try:
         buf = open(fn, "rb").read(50)
-        return buf.startswith(RAR_ID) or buf.startswith(RAR5_ID)
+        if(buf.startswith(RAR5_ID)):
+            return "rar5 signature"
+        if(buf.startswith(RAR_ID)):
+            return "rar4 (or lower) signature"
+        return None
     except:
         return False
 


### PR DESCRIPTION
Everything to make #154 work was already there, but the check of the rar-binary and it's ```log.debug()``` was called before the logger was active, so it would never show the version.
I implemented as @shypike suggested, based on @sanderjo placements!