### PR TITLE
Update the ad in the Wizard for Github Pages Future-Proofing

### DIFF
--- a/interfaces/wizard/one.html
+++ b/interfaces/wizard/one.html
@@ -79,7 +79,7 @@
                     </div>
                     <div class="col-md-5">
                         <div class="clearfix"></div>
-                        <iframe style="float: right; width: 315px; height: 315px;" frameborder="0" src="http://sabnzbd.org/resources/wizard/ad/$language"></iframe>
+                        <iframe style="float: right; width: 315px; height: 315px;" frameborder="0" src="https://resources.sabnzbd.org/wizard/ad/$language"></iframe>
                     </div>
                 </div>
                 <input type="hidden" name="session" value="$session" />


### PR DESCRIPTION
We're eventually moving sabnzbd.org's hosting to Github Pages, so I needed to set up a new home for the few bits of utility code presently hosted under the main domain that wouldn't be portable.

The Wizard Ad is written in PHP, so I've relocated it here under the resources.sabnzbd.org subdomain which I'll keep hosting:

https://resources.sabnzbd.org/wizard/ad/en

This PR updates the iframe source in the wizard to point there instead. While I was at it I updated everything in the Wizard Ad to run over SSL.

At some future date when the site is in Github Pages we should evaluate porting this code to a simple JS include which could then be hosted in Pages, but for the moment just updating the URL should be enough.