### PR TITLE
Firefox workarounds

### DIFF
--- a/interfaces/Config/templates/config_rss.tmpl
+++ b/interfaces/Config/templates/config_rss.tmpl
@@ -7,7 +7,7 @@
         <div class="padTable"> 
             <a class="main-helplink" href="$helpuri$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a>
             <p>$T('explain-RSS')</p>
-            <form action="add_rss_feed" method="post" novalidate>
+            <form action="add_rss_feed" method="post" autocomplete="off" novalidate>
                 <input type="hidden" name="session" value="$session" />
                 <table class="catTable">
                     <tr>
@@ -37,7 +37,7 @@
     <!--#if $rss#-->
     <div class="section">
         <div class="padTable">
-            <form action="save_rss_feed" method="post" novalidate>
+            <form action="save_rss_feed" method="post" autocomplete="off" novalidate>
                 <input type="hidden" name="session" value="$session" />
                 <table id="subscriptions">
                     <tbody>
@@ -73,7 +73,7 @@
             </form>
             <!--#if $feeds#-->
             <br/>
-            <form action="rss_now" method="post" novalidate>
+            <form action="rss_now" method="post" autocomplete="off" novalidate>
                 <input type="hidden" name="session" value="$session" />
                 <button type="submit" class="btn btn-default readAll"><span class="glyphicon glyphicon-sort"></span> $T('button-rssNow')</button>
             </form>
@@ -82,7 +82,7 @@
     </div>
     <!--#end if#-->
     <div class="section">
-        <form action="save_rss_rate" method="post">
+        <form action="save_rss_rate" method="post" autocomplete="off">
             <input type="hidden" name="session" value="$session" />
             <div class="col1">
                 <fieldset>
@@ -279,7 +279,7 @@
             <!--#set $fnum = 0#-->
             <!--#for $filter in $rss[$feed].filters#-->
                 <!--#set $odd = not $odd#-->
-                <form action="upd_rss_filter" method="post">
+                <form action="upd_rss_filter" method="post" autocomplete="off">
                     <input type="hidden" name="session" value="$session" />
                     <input type="hidden" name="index" value="$fnum" />
                     <input type="hidden" name="feed" value="$feed" />

--- a/interfaces/Config/templates/config_scheduling.tmpl
+++ b/interfaces/Config/templates/config_scheduling.tmpl
@@ -17,7 +17,7 @@ else:
         <div class="col2">
             <h3>$T('addSchedule') <a href="$helpuri$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
         </div><!-- /col2 -->
-        <form action="addSchedule" method="post">
+        <form action="addSchedule" method="post" autocomplete="off">
         <input type="hidden" id="session" name="session" value="$session" />
         <div class="col1">
             <fieldset>

--- a/interfaces/Config/templates/config_server.tmpl
+++ b/interfaces/Config/templates/config_server.tmpl
@@ -316,7 +316,7 @@
             // Let us leave!
             formWasSubmitted = true;
             formHasChanged = false;
-            location.reload();
+            setTimeout(function() { location.reload(); }, 100)
         }
         return false;
     });
@@ -326,7 +326,7 @@
             // Let us leave!
             formWasSubmitted = true;
             formHasChanged = false;
-            location.reload();
+            setTimeout(function() { location.reload(); }, 100)
         }
         return false;
     });
@@ -340,7 +340,7 @@
             // Let us leave!
             formWasSubmitted = true;
             formHasChanged = false;
-            location.reload();
+            setTimeout(function() { location.reload(); }, 100)
         });
     });
 });

--- a/interfaces/Config/templates/config_server.tmpl
+++ b/interfaces/Config/templates/config_server.tmpl
@@ -116,13 +116,13 @@
             </fieldset>
         </div><!-- /col1 -->
     </div><!-- /section -->
-    </form>
+</form>
 
 <!--#set $cur = 0#-->
 <!--#for $server in $servers#-->
     <!--#set $cur = $cur + 1#-->
 
-    <form action="saveServer" method="post" class="fullform" novalidate>
+    <form action="saveServer" method="post" class="fullform" autocomplete="off" novalidate>
     <input type="hidden" name="session" value="$session" />
     <input type="hidden" name="server" value="$server['name']" />
 
@@ -134,7 +134,7 @@
             <span class="label label-primary" data-priority="$server['priority']#-->">$T('srv-priority'):</span>
             <!--#end if#-->
             <table><tr>
-              <td><input type="checkbox" class="toggleServerCheckbox" id="enable_$cur" rel="$server['name']" name="q_enable" value="1" <!--#if int($server['enable']) != 0 then 'checked="checked"' else ""#--> /></td>
+              <td><input type="checkbox" class="toggleServerCheckbox" id="enable_$cur" name="$server['name']" value="1" <!--#if int($server['enable']) != 0 then 'checked="checked"' else ""#--> /></td>
               <td><label for="enable_$cur">$T('enabled')</label></td>
             </tr></table>
 
@@ -331,7 +331,7 @@
         return false;
     });
     \$('.toggleServerCheckbox').click(function(){
-        var whichServer = \$(this).attr("rel");
+        var whichServer = \$(this).attr("name");
         \$.ajax({
             type: "POST",
             url: "toggleServer",

--- a/interfaces/Config/templates/config_sorting.tmpl
+++ b/interfaces/Config/templates/config_sorting.tmpl
@@ -3,7 +3,7 @@
 <!--#include $webdir + "/_inc_header_uc.tmpl"#-->
 
 <div class="colmask">
-    <form action="saveSorting" method="post" name="fullform" class="fullform">
+    <form action="saveSorting" method="post" name="fullform" class="fullform" autocomplete="off">
         <input type="hidden" id="session" name="session" value="$session" />
         <input id="complete_dir" type="hidden" value="$complete_dir" />
         <div class="section">

--- a/interfaces/Config/templates/config_special.tmpl
+++ b/interfaces/Config/templates/config_special.tmpl
@@ -3,7 +3,7 @@
 <!--#include $webdir + "/_inc_header_uc.tmpl"#-->
 
 <div class="colmask">
-    <form action="saveSpecial" method="post">
+    <form action="saveSpecial" method="post" autocomplete="off">
         <input type="hidden" id="session" name="session" value="$session" />
         <div class="padTable">
             <h4 class="darkred nomargin">$T('explain-special')</h4>

--- a/interfaces/Config/templates/config_switches.tmpl
+++ b/interfaces/Config/templates/config_switches.tmpl
@@ -3,7 +3,7 @@
 <!--#include $webdir + "/_inc_header_uc.tmpl"#-->
 
 <div class="colmask">
-    <form action="saveSwitches" method="post" name="fullform" class="fullform">
+    <form action="saveSwitches" method="post" name="fullform" class="fullform" autocomplete="off">
         <input type="hidden" id="session" name="session" value="$session" />
         <div class="section">
             <div class="col2">


### PR DESCRIPTION
The time has come where we have to do more special stuff for FF than for IE..
FF did not like it that on the server page we would submit the form through ajax and immediately also refresh the page, thus we put a small timeout.
Also fixes the weird server-toggle behavior in FF described in #438.  