### PR TITLE
Add HTML login page

### DIFF
--- a/interfaces/Config/templates/config_general.tmpl
+++ b/interfaces/Config/templates/config_general.tmpl
@@ -34,6 +34,11 @@
                     <span class="desc">$T('explain-web_password')</span>
                 </div>
                 <div class="field-pair">
+                    <label class="config" for="html_login">$T('opt-html_login')</label>
+                    <input type="checkbox" name="html_login" id="html_login" value="1" <!--#if int($html_login) > 0 then 'checked="checked"' else ""#--> />
+                    <span class="desc">$T('explain-html_login')</span>
+                </div>
+                <div class="field-pair">
                     <label class="config" for="web_dir">$T('opt-web_dir')</label>
                         <select name="web_dir" id="web_dir">
                         <!--#for $webline in $web_list#-->

--- a/interfaces/Config/templates/config_general.tmpl
+++ b/interfaces/Config/templates/config_general.tmpl
@@ -72,12 +72,7 @@
                     <label class="config" for="password">$T('opt-web_password')</label>
                     <input type="text" name="password" id="password" value="$password" />
                     <span class="desc">$T('explain-web_password')</span>
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="html_login">$T('opt-html_login')</label>
-                    <input type="checkbox" name="html_login" id="html_login" value="1" <!--#if int($html_login) > 0 then 'checked="checked"' else ""#--> />
-                    <span class="desc">$T('explain-html_login')</span>
-                </div>   
+                </div>  
                 <div class="field-pair">
                     <label class="config" for="inet_exposure">$T('opt-inet_exposure')</label>
                         <select name="inet_exposure" id="inet_exposure" class="select">

--- a/interfaces/Config/templates/config_general.tmpl
+++ b/interfaces/Config/templates/config_general.tmpl
@@ -24,21 +24,6 @@
                     <span class="desc">$T('explain-port')</span>
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="username">$T('opt-web_username')</label>
-                    <input type="text" name="username" id="username" value="$username" />
-                    <span class="desc">$T('explain-web_username')</span>
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="password">$T('opt-web_password')</label>
-                    <input type="text" name="password" id="password" value="$password" />
-                    <span class="desc">$T('explain-web_password')</span>
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="html_login">$T('opt-html_login')</label>
-                    <input type="checkbox" name="html_login" id="html_login" value="1" <!--#if int($html_login) > 0 then 'checked="checked"' else ""#--> />
-                    <span class="desc">$T('explain-html_login')</span>
-                </div>
-                <div class="field-pair">
                     <label class="config" for="web_dir">$T('opt-web_dir')</label>
                         <select name="web_dir" id="web_dir">
                         <!--#for $webline in $web_list#-->
@@ -79,10 +64,20 @@
                     <span class="desc">$T('explain-language')</span>
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="local_ranges">$T('opt-local_ranges')</label>
-                    <input type="text" name="local_ranges" id="local_ranges" value="$local_ranges" />
-                    <span class="desc">$T('explain-local_ranges')</span>
+                    <label class="config" for="username">$T('opt-web_username')</label>
+                    <input type="text" name="username" id="username" value="$username" />
+                    <span class="desc">$T('explain-web_username')</span>
                 </div>
+                <div class="field-pair">
+                    <label class="config" for="password">$T('opt-web_password')</label>
+                    <input type="text" name="password" id="password" value="$password" />
+                    <span class="desc">$T('explain-web_password')</span>
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="html_login">$T('opt-html_login')</label>
+                    <input type="checkbox" name="html_login" id="html_login" value="1" <!--#if int($html_login) > 0 then 'checked="checked"' else ""#--> />
+                    <span class="desc">$T('explain-html_login')</span>
+                </div>   
                 <div class="field-pair">
                     <label class="config" for="inet_exposure">$T('opt-inet_exposure')</label>
                         <select name="inet_exposure" id="inet_exposure" class="select">
@@ -91,8 +86,14 @@
                             <option value="2" <!--#if $inet_exposure == 2 then 'selected="selected"' else ""#-->>$T('inet-api')</option>
                             <option value="3" <!--#if $inet_exposure == 3 then 'selected="selected"' else ""#-->>$T('inet-fullapi')</option>
                             <option value="4" <!--#if $inet_exposure == 4 then 'selected="selected"' else ""#-->>$T('inet-ui')</option>
+                            <option value="5" <!--#if $inet_exposure == 5 then 'selected="selected"' else ""#-->>$T('inet-ui') - $T('inet-external_login')</option>
                         </select>
                     <span class="desc">$T('explain-inet_exposure')</span>
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="local_ranges">$T('opt-local_ranges')</label>
+                    <input type="text" name="local_ranges" id="local_ranges" value="$local_ranges" />
+                    <span class="desc">$T('explain-local_ranges')</span>
                 </div>
                 <div class="field-pair">
                     <label class="config" for="disable_api_key">$T('opt-disableApikey')</label>

--- a/interfaces/Config/templates/login/main.tmpl
+++ b/interfaces/Config/templates/login/main.tmpl
@@ -1,0 +1,37 @@
+<html lang="$active_lang">
+<head>
+    <title>SABnzbd</title>
+    
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="apple-mobile-web-app-title" content="SABnzbd" />
+    
+    <link rel="apple-touch-icon" sizes="76x76" href="../staticcfg/ico/apple-touch-icon-76x76-precomposed.png" />
+    <link rel="apple-touch-icon" sizes="120x120" href="../staticcfg/ico/apple-touch-icon-120x120-precomposed.png" />
+    <link rel="apple-touch-icon" sizes="152x152" href="../staticcfg/ico/apple-touch-icon-152x152-precomposed.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="../staticcfg/ico/apple-touch-icon-180x180-precomposed.png" />  
+    <link rel="shortcut icon" href="../staticcfg/ico/favicon.ico" />      
+
+    <link rel="stylesheet" type="text/css" href="../staticcfg/bootstrap/css/bootstrap.min.css" /> 
+    <link rel="stylesheet" type="text/css" href="../staticcfg/css/style.css?p=$pid" />
+    <link rel="stylesheet" type="text/css" href="../staticcfg/css/login.css?p=$pid" />
+</head>
+<html>
+	<body>
+        <div class="account-wall">
+            <div class="text-center logo-header">
+                <img src="../staticcfg/images/logo.png" alt="SABnzbd">
+            </div>
+            <form class="form-signin" action="./" method="post">
+                <!--#if $error#-->
+                <div class="alert alert-danger" role="alert">$error</div>
+                <!--#end if#-->
+                
+                <input type="text" class="form-control" name="username" placeholder="$T('srv-username')" required autofocus>
+                <input type="password" class="form-control" name="password" placeholder="$T('srv-password')" required>
+                
+                <button class="btn btn-default"><span class="glyphicon glyphicon-ok"></span> $T('send') </button>
+            </form>
+        </div>
+    </body>
+ </html>

--- a/interfaces/Config/templates/login/main.tmpl
+++ b/interfaces/Config/templates/login/main.tmpl
@@ -23,6 +23,9 @@
         <div class="account-wall">
             <div class="text-center logo-header">
                 <img src="../staticcfg/images/logo.png" alt="SABnzbd">
+                <a href="http://wiki.sabnzbd.org/faq#why-login" target="_blank">
+                    <span class="glyphicon glyphicon-question-sign"></span>
+                </a>
             </div>
             <form class="form-signin" action="./" method="post">
                 <!--#if $error#-->
@@ -32,7 +35,7 @@
                 <input type="text" class="form-control" name="username" placeholder="$T('srv-username')" required autofocus>
                 <input type="password" class="form-control" name="password" placeholder="$T('srv-password')" required>
                 
-                <button class="btn btn-default"> $T('login') <span class="glyphicon glyphicon-circle-arrow-right"></span></button>
+                <button class="btn btn-default"><span class="glyphicon glyphicon-circle-arrow-right"></span> $T('login') </button>
 
                 <div class="checkbox text-center">
                     <label>

--- a/interfaces/Config/templates/login/main.tmpl
+++ b/interfaces/Config/templates/login/main.tmpl
@@ -13,7 +13,6 @@
     <link rel="shortcut icon" href="../staticcfg/ico/favicon.ico" />      
 
     <link rel="stylesheet" type="text/css" href="../staticcfg/bootstrap/css/bootstrap.min.css" /> 
-    <link rel="stylesheet" type="text/css" href="../staticcfg/css/style.css?p=$pid" />
     <link rel="stylesheet" type="text/css" href="../staticcfg/css/login.css?p=$pid" />
 </head>
 <html>
@@ -30,7 +29,13 @@
                 <input type="text" class="form-control" name="username" placeholder="$T('srv-username')" required autofocus>
                 <input type="password" class="form-control" name="password" placeholder="$T('srv-password')" required>
                 
-                <button class="btn btn-default"><span class="glyphicon glyphicon-ok"></span> $T('send') </button>
+                <button class="btn btn-default"> $T('login') <span class="glyphicon glyphicon-circle-arrow-right"></span></button>
+
+                <div class="checkbox text-center">
+                    <label>
+                        <input type="checkbox" name="remember_me" value="1"> $T('rememberme')
+                    </label>
+                  </div>
             </form>
         </div>
     </body>

--- a/interfaces/Config/templates/login/main.tmpl
+++ b/interfaces/Config/templates/login/main.tmpl
@@ -14,6 +14,9 @@
 
     <link rel="stylesheet" type="text/css" href="../staticcfg/bootstrap/css/bootstrap.min.css" /> 
     <link rel="stylesheet" type="text/css" href="../staticcfg/css/login.css?p=$pid" />
+
+    <script type="text/javascript" src="../staticcfg/js/jquery-1.11.2.min.js"></script>
+    <script type="text/javascript" src="../staticcfg/bootstrap/js/bootstrap.min.js"></script>
 </head>
 <html>
 	<body>
@@ -38,5 +41,16 @@
                   </div>
             </form>
         </div>
+        <script type="text/javascript">
+            // Try-catch in case somebody disabled localstorage
+            try {
+                // Set what was done previously
+                \$('input[type="checkbox"]').prop('checked', localStorage.getItem("remember_me") === 'true')
+                // Store if we change something
+                \$('input[type="checkbox"]').on('change', function() {
+                    localStorage.setItem("remember_me", \$(this).is(':checked'));
+                })
+            } catch(err) { }
+        </script>
     </body>
  </html>

--- a/interfaces/Config/templates/staticcfg/css/login.css
+++ b/interfaces/Config/templates/staticcfg/css/login.css
@@ -22,7 +22,19 @@ body {
 	top: 30%;
 	left: 50%;
   	transform: translate(-50%, -30%);
- }
+}
+
+.text-center a {
+	position: absolute; 
+	right: 13px; 
+	top: 12px; 
+	color: #636363; 
+	font-size: 1.2em
+}
+
+.text-center a:hover {
+	color: black !important;
+}
 
 .form-signin .alert {
 	margin: 5px 0px;
@@ -42,7 +54,8 @@ body {
 .btn .glyphicon {
 	margin-left: 3px;	
 	float: right;
-	font-size: 1.1em;
+	top: 1px;
+	font-size: 1.2em;
 }
 
 input[type="checkbox"] {
@@ -52,5 +65,5 @@ input[type="checkbox"] {
 }
 
 label {
-	color: #545454;
+	color: #636363;
 }

--- a/interfaces/Config/templates/staticcfg/css/login.css
+++ b/interfaces/Config/templates/staticcfg/css/login.css
@@ -1,13 +1,33 @@
+body {
+    overflow-y: scroll;
+    background-color: #E4E4E4;
+}
+
+* {
+    border-radius: 0 !important;
+}
+
+.btn, .btn:hover, .btn:active, .btn:focus {
+    box-shadow: 1px 1px 1px rgba(0,0,0,.1) !important;
+    background-color: white !important;
+}
+
 .logo-header {
 	padding-bottom: 10px;
 }
+
 .account-wall {
-	max-width: 300px;
+	width: 300px;
 	position: absolute;
 	top: 30%;
 	left: 50%;
   	transform: translate(-50%, -30%);
  }
+
+.form-signin .alert {
+	margin: 5px 0px;
+}
+
 
 .form-signin input {
 	margin-top: 5px
@@ -15,13 +35,22 @@
 
 .form-signin .btn {
 	width: 100%;
-	margin-top: 10px
+	margin-top: 10px;
+	font-weight: bold;
 }
 
-.form-signin .alert {
-	margin: 5px 0px;
+.btn .glyphicon {
+	margin-left: 3px;	
+	float: right;
+	font-size: 1.1em;
 }
 
-.btn:hover {
-	background-color: white;
+input[type="checkbox"] {
+	width: 16px;
+	height: 16px;
+	margin-top: 2px;
+}
+
+label {
+	color: #545454;
 }

--- a/interfaces/Config/templates/staticcfg/css/login.css
+++ b/interfaces/Config/templates/staticcfg/css/login.css
@@ -1,0 +1,27 @@
+.logo-header {
+	padding-bottom: 10px;
+}
+.account-wall {
+	max-width: 300px;
+	position: absolute;
+	top: 30%;
+	left: 50%;
+  	transform: translate(-50%, -30%);
+ }
+
+.form-signin input {
+	margin-top: 5px
+}
+
+.form-signin .btn {
+	width: 100%;
+	margin-top: 10px
+}
+
+.form-signin .alert {
+	margin: 5px 0px;
+}
+
+.btn:hover {
+	background-color: white;
+}

--- a/interfaces/Config/templates/staticcfg/css/style.css
+++ b/interfaces/Config/templates/staticcfg/css/style.css
@@ -715,6 +715,7 @@ input[type="text"].smaller_input {
 
 select {
     min-width: 200px;
+    max-width: 300px;
 }
 
 input[disabled],

--- a/interfaces/Glitter/templates/include_menu.tmpl
+++ b/interfaces/Glitter/templates/include_menu.tmpl
@@ -91,7 +91,8 @@
                 </a>
                 <ul class="dropdown-menu menu-options">
                     <li><a href="#modal-help" data-toggle="modal"><span class="glyphicon glyphicon-question-sign"></span> $T('menu-help')</a></li>
-                    <!--#if $have_quota or $have_rss_defined or $have_watched_dir or $pp_pause_event#--><li class="divider"></li><!--#end if#-->
+                    <!--#if $have_logout or $have_quota or $have_rss_defined or $have_watched_dir or $pp_pause_event#--><li class="divider"></li><!--#end if#-->
+                    <!--#if $have_logout#--><li><a href="login?logout=1"><span class="glyphicon glyphicon-log-out"></span> $T('logout')</a></li><!--#end if#-->
                     <!--#if $have_quota#--><li><a href="#" data-bind="click: doQueueAction" data-mode="reset_quota">$T('link-resetQuota')</a></li><!--#end if#-->
                     <!--#if $have_rss_defined#--><li><a href="#" data-bind="click: doQueueAction" data-mode="rss_now">$T('button-rssNow')</a></li><!--#end if#-->
                     <!--#if $have_watched_dir#--><li><a href="#" data-bind="click: doQueueAction" data-mode="watched_now">$T('sch-scan_folder')</a></li><!--#end if#-->

--- a/interfaces/Glitter/templates/main.tmpl
+++ b/interfaces/Glitter/templates/main.tmpl
@@ -21,7 +21,7 @@
         <meta name="application-name" content="SABnzbd">
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-title" content="SABnzbd" />
-        <meta name="apple-mobile-web-app-status-bar-style" content="#000000" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="black" />
         <meta name="msapplication-navbutton-color" content="#000000" />
         <meta name="theme-color" content="#000000" />
         

--- a/interfaces/Plush/templates/main.tmpl
+++ b/interfaces/Plush/templates/main.tmpl
@@ -26,6 +26,7 @@
           <li class="main_sprite_container sprite_q_queue">
             <a class="sf-with-ul">$T('menu-queue')</a>
             <ul>
+              <!--#if $have_logout#--><li><a href="login?logout=1">$T('logout')</a></li><!--#end if#-->
               <!--#if $have_quota#--><li><a id="reset_quota_now" class="pointer">$T('link-resetQuota')</a></li><!--#end if#-->
               <!--#if $have_rss_defined#--><li><a id="get_rss_now" class="pointer">$T('button-rssNow')</a></li><!--#end if#-->
               <!--#if $have_watched_dir#--><li><a id="get_watched_now" class="pointer">$T('sch-scan_folder')</a></li><!--#end if#-->

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -254,7 +254,7 @@ nzb_key = OptionStr('misc', 'nzb_key', create_api_key())
 disable_key = OptionBool('misc', 'disable_api_key', False, protect=True)
 api_warnings = OptionBool('misc', 'api_warnings', True, protect=True)
 local_ranges = OptionList('misc', 'local_ranges', protect=True)
-inet_exposure = OptionNumber('misc', 'inet_exposure', 0, protect=True)  # 0=local-only, 1=nzb, 2=api, 3=full_api, 4=webui
+inet_exposure = OptionNumber('misc', 'inet_exposure', 0, protect=True)  # 0=local-only, 1=nzb, 2=api, 3=full_api, 4=webui, 5=webui with login for external
 max_art_tries = OptionNumber('misc', 'max_art_tries', 3, 2)
 max_art_opt = OptionBool('misc', 'max_art_opt', False)
 use_pickle = OptionBool('misc', 'use_pickle', False)

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -210,6 +210,7 @@ else:
 
 username = OptionStr('misc', 'username')
 password = OptionPassword('misc', 'password')
+html_login = OptionBool('misc', 'html_login', True)
 login_realm = OptionStr('misc', 'login_realm', 'SABnzbd')
 bandwidth_perc = OptionNumber('misc', 'bandwidth_perc', 0, 0, 100)
 bandwidth_max = OptionStr('misc', 'bandwidth_max')

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -1493,7 +1493,7 @@ SPECIAL_BOOL_LIST = \
               'queue_complete_pers', 'api_warnings', 'allow_64bit_tools',
               'never_repair', 'allow_streaming', 'ignore_unrar_dates', 'rss_filenames',
               'osx_menu', 'osx_speed', 'win_menu', 'use_pickle', 'allow_incomplete_nzb',
-              'no_ipv6', 'keep_awake', 'empty_postproc',
+              'no_ipv6', 'keep_awake', 'empty_postproc', 'html_login',
               'web_watchdog', 'wait_for_dfolder', 'warn_empty_nzb', 'enable_bonjour',
               'warn_dupl_jobs', 'backup_for_duplicates', 'enable_par_cleanup',
               'enable_https_verification', 'api_logging', 'fixed_ports'
@@ -1553,7 +1553,7 @@ class ConfigSpecial(object):
 
 ##############################################################################
 GENERAL_LIST = (
-    'host', 'port', 'username', 'password', 'html_login', 'disable_api_key',
+    'host', 'port', 'username', 'password', 'disable_api_key',
     'refresh_rate', 'cache_limit', 'local_ranges', 'inet_exposure',
     'enable_https', 'https_port', 'https_cert', 'https_key', 'https_chain'
 )

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -26,7 +26,7 @@ import logging
 import urllib
 import json
 import re
-import base64
+import hashlib
 from random import randint
 from xml.sax.saxutils import escape
 
@@ -170,7 +170,7 @@ def set_login_cookie(remove=False, remember_me=False):
         number, so cookies cannot be re-used 
     """
     salt = randint(1,1000)
-    cherrypy.response.cookie['login_cookie'] = base64.urlsafe_b64encode(str(salt) + cherrypy.request.remote.ip + COOKIE_SECRET)
+    cherrypy.response.cookie['login_cookie'] = hashlib.sha1(str(salt) + cherrypy.request.remote.ip + COOKIE_SECRET).hexdigest()
     cherrypy.response.cookie['login_cookie']['path'] = '/'
     cherrypy.response.cookie['login_salt'] = salt
     cherrypy.response.cookie['login_salt']['path'] = '/'
@@ -190,7 +190,7 @@ def check_login_cookie():
     if 'login_cookie' not in cherrypy.request.cookie or 'login_salt' not in cherrypy.request.cookie:
         return False
 
-    return cherrypy.request.cookie['login_cookie'].value == base64.urlsafe_b64encode(str(cherrypy.request.cookie['login_salt'].value) + cherrypy.request.remote.ip + COOKIE_SECRET)
+    return cherrypy.request.cookie['login_cookie'].value == hashlib.sha1(str(cherrypy.request.cookie['login_salt'].value) + cherrypy.request.remote.ip + COOKIE_SECRET).hexdigest()
 
 def check_login():
     # Not when no authentication required or basic-auth is on

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -163,7 +163,7 @@ def encrypt_pwd(pwd):
 # Create a more unique ID for each instance
 COOKIE_SECRET = str(randint(1000,100000)*os.getpid())
 
-def set_login_cookie(remove=False):
+def set_login_cookie(remove=False, remember_me=False):
     """ We try to set a cookie as unique as possible
         to the current user. Based on it's IP and the 
         current process ID of the SAB instance and a random
@@ -174,6 +174,11 @@ def set_login_cookie(remove=False):
     cherrypy.response.cookie['login_cookie']['path'] = '/'
     cherrypy.response.cookie['login_salt'] = salt
     cherrypy.response.cookie['login_salt']['path'] = '/'
+
+    # If we want to be remembered
+    if remember_me:
+        cherrypy.response.cookie['login_cookie']['max-age'] = 3600*24*14
+        cherrypy.response.cookie['login_salt']['max-age'] = 3600*24*14
 
     # To remove
     if remove:
@@ -575,7 +580,7 @@ class LoginPage(object):
         # Check login info
         if kwargs.get('username') == cfg.username() and kwargs.get('password') == cfg.password():
             # Save login cookie
-            set_login_cookie()
+            set_login_cookie(remember_me=kwargs.get('remember_me', False))
             # Redirect
             raise dcRaiser('../', kwargs)
         elif kwargs.get('username') or kwargs.get('password'):

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -157,9 +157,11 @@ def get_users():
     users[cfg.username()] = cfg.password()
     return users
 
-
 def encrypt_pwd(pwd):
     return pwd
+
+# Create a more unique ID for each instance
+COOKIE_SECRET = str(randint(1000,100000)*os.getpid())
 
 def set_login_cookie(remove=False):
     """ We try to set a cookie as unique as possible
@@ -168,7 +170,7 @@ def set_login_cookie(remove=False):
         number, so cookies cannot be re-used 
     """
     salt = randint(1,1000)
-    cherrypy.response.cookie['login_cookie'] = base64.urlsafe_b64encode(str(salt) + cherrypy.request.remote.ip + str(os.getpid()))
+    cherrypy.response.cookie['login_cookie'] = base64.urlsafe_b64encode(str(salt) + cherrypy.request.remote.ip + COOKIE_SECRET)
     cherrypy.response.cookie['login_cookie']['path'] = '/'
     cherrypy.response.cookie['login_salt'] = salt
     cherrypy.response.cookie['login_salt']['path'] = '/'
@@ -183,7 +185,7 @@ def check_login_cookie():
     if 'login_cookie' not in cherrypy.request.cookie or 'login_salt' not in cherrypy.request.cookie:
         return False
 
-    return cherrypy.request.cookie['login_cookie'].value == base64.urlsafe_b64encode(str(cherrypy.request.cookie['login_salt'].value) + cherrypy.request.remote.ip + str(os.getpid()))
+    return cherrypy.request.cookie['login_cookie'].value == base64.urlsafe_b64encode(str(cherrypy.request.cookie['login_salt'].value) + cherrypy.request.remote.ip + COOKIE_SECRET)
 
 def check_login():
     # Not when basic-auth is one

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -350,7 +350,9 @@ class MainPage(object):
             info['cat_list'] = list_cats(True)
             info['have_rss_defined'] = bool(config.get_rss())
             info['have_watched_dir'] = bool(cfg.dirscan_dir())
-            info['have_logout'] = cfg.html_login() and cfg.username() and cfg.password()
+            
+            # Have logout only with HTML and if inet=5, only when we are external
+            info['have_logout'] = cfg.username() and cfg.password() and (cfg.html_login() and (cfg.inet_exposure() < 5 or (cfg.inet_exposure() == 5 and not check_access(access_type=6))))
 
             bytespersec_list = BPSMeter.do.get_bps_list()
             info['bytespersec_list'] = ','.join(bytespersec_list)

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -363,6 +363,7 @@ SKIN_TEXT = {
     'inet-api' : TT('API (no Config)'), # Selection value for external access
     'inet-fullapi' : TT('Full API'), # Selection value for external access
     'inet-ui' : TT('Full Web interface'), # Selection value for external access
+    'inet-external_login' : TT('Only external access requires login'), # Selection value for external access
 
 # Config->Folders
     'explain-folderConfig' : TT('<em>NOTE:</em> Folders will be created automatically when Saving. You may use absolute paths to save outside of the default folders.'),

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -131,6 +131,7 @@ SKIN_TEXT = {
     'audio' : TT('Audio'),
     'notUsed' : TT('Not used'),
     'orLess' : TT('or less'),
+    'logout' : TT('Log out'),
 
 # General template elements
     'signOn' : TT('The automatic usenet download tool'), #: SABnzbd's theme line
@@ -316,6 +317,8 @@ SKIN_TEXT = {
     'opt-web_username' : TT('SABnzbd Username'),
     'explain-web_username' : TT('Optional authentication username.'),
     'opt-web_password' : TT('SABnzbd Password'),
+    'explain-html_login' : TT('Use HTML login page instead of basic authentication.'),
+    'opt-html_login' : TT('Login page'),
     'explain-web_password' : TT('Optional authentication password.'),
     'httpsSupport' : TT('HTTPS Support'),
     'opt-enable_https' : TT('Enable HTTPS'),

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -319,8 +319,6 @@ SKIN_TEXT = {
     'opt-web_username' : TT('SABnzbd Username'),
     'explain-web_username' : TT('Optional authentication username.'),
     'opt-web_password' : TT('SABnzbd Password'),
-    'explain-html_login' : TT('Use HTML login page instead of basic authentication.'),
-    'opt-html_login' : TT('Login page'),
     'explain-web_password' : TT('Optional authentication password.'),
     'httpsSupport' : TT('HTTPS Support'),
     'opt-enable_https' : TT('Enable HTTPS'),

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -131,7 +131,9 @@ SKIN_TEXT = {
     'audio' : TT('Audio'),
     'notUsed' : TT('Not used'),
     'orLess' : TT('or less'),
+    'login' : TT('Log in'),
     'logout' : TT('Log out'),
+    'rememberme' : TT('Remember me'),
 
 # General template elements
     'signOn' : TT('The automatic usenet download tool'), #: SABnzbd's theme line


### PR DESCRIPTION
Based on cookies, not CherryPy-sessions. We create an unique cookie based on user-IP, SAB-process-ID and a salt to facilitate log-out functionality (#369).
Yes, this cookie can be stolen when on a public wifi-network (same IP) when not on HTTPS, but when not on HTTPS basic-auth or API-requests (which have the API-key) can also easily be intercepted. Any restart of SAB would in-validate the cookie.

Could also add a 'Remember-me' option if you guys like my implementation.
If it would replace basic-auth we don't need any new translations (except 'Log out', but this can automatically be translated from other packages on Launchpad).

@shypike Since it's a new feature, I understand this is not anymore for the 0.8.0 release :)

![image](https://cloud.githubusercontent.com/assets/5703454/12548101/59d37518-c354-11e5-8d5d-2b82e9b495aa.png)

