### PR TITLE
Improve handling of passwords embedded in the NZB.

### DIFF
--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -866,6 +866,10 @@ class NzbObject(TryList):
             if not self.nzo_info.get(kw):
                 self.nzo_info[kw] = self.meta[kw][0]
 
+        # Show first meta-password (if any), when there's no explicit password
+        if not self.password and self.meta.get('password'):
+            self.password = self.meta.get('password', [None])[0]
+
         # Set nzo save-delay to 6 sec per GB with a max of 5 min
         self.save_timeout = min(6.0 * float(self.bytes) / GIGI, 300.0)
 


### PR DESCRIPTION
Show first password from NZB in the title of the user hasn't set one.
Try them all: user password, NZB-passwords, from password file.