### PR TITLE
Catch failing Windows Notification

### DIFF
--- a/sabnzbd/growler.py
+++ b/sabnzbd/growler.py
@@ -541,5 +541,10 @@ def send_pushbullet(title, msg, gtype, force=False, test=None):
 
 def send_windows(title, msg, gtype):
     if sabnzbd.WINTRAY:
-        sabnzbd.WINTRAY.sendnotification(title, msg)
+        try:
+            sabnzbd.WINTRAY.sendnotification(title, msg)
+        except:
+            logging.info(T('Failed to send Windows notification'))
+            logging.debug("Traceback: ", exc_info=True)
+            return T('Failed to send Windows notification')
     return None


### PR DESCRIPTION
I assumed Windows notifications could not fail, but clearly they can:
http://forums.sabnzbd.org/viewtopic.php?f=11&t=20211&p=104438
When no tray-icon is available, it will fail and in the case of completed NZB notification it will restart the whole of SABnzbd.

Should be in 1.0.0 I think :)