### PR TITLE
URLGrabber fix and password seperate from title

### DIFF
--- a/interfaces/Glitter/templates/include_overlays.tmpl
+++ b/interfaces/Glitter/templates/include_overlays.tmpl
@@ -455,7 +455,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal">&times;</button>
-                <h4 class="modal-title row-wrap-text" data-bind="text: filelist.modalTitle">$T('Glitter-loading')</h4>
+                <h4 class="modal-title row-wrap-text" data-bind="text: filelist.filelist_name">$T('Glitter-loading')</h4>
             </div>
             <div class="modal-body">
                 <div id="modal-item-filelist">
@@ -466,7 +466,7 @@
                                     <span class="glyphicon glyphicon-lock"></span>
                                 <span class="glyphicon glyphicon-floppy-saved"></span>
                                 </span>
-                                <input type="text" class="form-control" id="nzb_password" placeholder="$T('srv-password')" data-bind="value: filelist.modalPassword" />
+                                <input type="text" class="form-control" id="nzb_password" placeholder="$T('srv-password')" data-bind="value: filelist.filelist_password" />
                                 <button type="submit" class="btn btn-default">$T('Glitter-submit')</button>
                             </div>
                         </div>

--- a/interfaces/Glitter/templates/include_queue.tmpl
+++ b/interfaces/Glitter/templates/include_queue.tmpl
@@ -88,7 +88,13 @@
                 </td>
                 <td class="name">
                     <div class="row-wrap-text" data-bind="visible: !editingName()">
-                        <span data-bind="html: displayName, attr: { 'title': name() }"></span>
+                        <span data-bind="text: name, attr: { 'title': name() }"></span>
+                        <!-- ko if: password()  -->
+                        <small class="queue-item-password">
+                            <span class="glyphicon glyphicon-lock"></span>
+                            <span data-bind="text: password"></span>
+                        </small>
+                        <!-- /ko -->
                         <!-- ko if: (rating_avg_video() !== false)  -->
                         <div class="name-ratings hover-button">
                             <span class="glyphicon glyphicon-facetime-video"></span> <span data-bind="text: rating_avg_video"></span>

--- a/interfaces/Glitter/templates/static/javascripts/glitter.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.js
@@ -772,8 +772,10 @@ $(function() {
             // Hide tooltips (otherwise they stay forever..)
             $('#options-status [data-tooltip="true"]').tooltip('hide')
 
-            // Reset
-            self.hasStatusInfo(false)
+            // Reset if not called from a function
+            if(item) {
+                self.hasStatusInfo(false)
+            }
             
             // Full refresh? Only on click and for the status-screen
             var statusFullRefresh = (event != undefined) && $('#options-status').hasClass('active');
@@ -827,6 +829,26 @@ $(function() {
             })
         }
 
+        // Refresh connections page
+        var connectionRefresh
+        $('.nav-tabs a[href="#options_connections"]').click(function() {
+            connectionRefresh = setInterval(function() {
+                // Check if still visible
+                if(!$('#options_connections').is(':visible') && connectionRefresh) {
+                    // Stop refreshing
+                    clearInterval(connectionRefresh)
+                    return
+                }
+                // Only when we show them
+                if(self.showActiveConnections()) {
+                    self.loadStatusInfo()
+                    // Trick to force the interface to refresh
+                    self.hasStatusInfo(false)
+                    self.hasStatusInfo(true)
+                }
+            }, self.refreshRate() * 1000)
+        })
+
         // Orphaned folder processing
         self.folderProcess = function(folder, htmlElement) {
             // Hide tooltips (otherwise they stay forever..)
@@ -847,7 +869,7 @@ $(function() {
                 // Remove item and load status data
                 $(htmlElement.currentTarget).parent().parent().fadeOut(fadeOnDeleteDuration)
                 // Refresh
-                self.loadStatusInfo()
+                self.loadStatusInfo(true, true)
                 // Hide notification
                 hideNotification(true)
             })
@@ -862,7 +884,7 @@ $(function() {
                 callSpecialAPI("./status/delete_all").then(function() {
                     // Remove notifcation and update screen
                     hideNotification(true)
-                    self.loadStatusInfo()
+                    self.loadStatusInfo(true, true)
                 })
             }     
         }

--- a/interfaces/Plush/templates/queue.tmpl
+++ b/interfaces/Plush/templates/queue.tmpl
@@ -56,7 +56,7 @@
   </td>
 
   <td class="download-title" <!--#if $rating_enable#-->style="width:35%"<!--#end if#-->>
-    <a href="nzb/$slot.nzo_id/" title="$T('status'): $T('post-'+$slot.status)<br/>$T('nzo-age'): $slot.avg_age<br/><!--#if $slot.missing#-->$T('missingArt'): $slot.missing<!--#end if#-->">$slot.filename.replace('.', '.&#8203;').replace('_', '_&#8203;')</a>
+    <a href="nzb/$slot.nzo_id/" title="$T('status'): $T('post-'+$slot.status)<br/>$T('nzo-age'): $slot.avg_age<br/><!--#if $slot.missing#-->$T('missingArt'): $slot.missing<!--#end if#-->">$slot.filename.replace('.', '.&#8203;').replace('_', '_&#8203;')<!--#if $slot.password#--> /  $slot.password<!--#end if#--></a>
   </td>
 
   <!--#if $rating_enable#-->

--- a/interfaces/smpl/templates/queue.tmpl
+++ b/interfaces/smpl/templates/queue.tmpl
@@ -70,7 +70,7 @@ $T('smpl-timeleft'): <strong>$timeleft</strong> $T('eta'): <strong>$eta</strong>
             </select>
           </td>
           <td>
-            <span class="filename"><a href="#/nzb/$slot.nzo_id/" onclick="javascript:lr('nzb/$slot.nzo_id/');">$slot.filename</a></span>
+            <span class="filename"><a href="#/nzb/$slot.nzo_id/" onclick="javascript:lr('nzb/$slot.nzo_id/');">$slot.filename<!--#if $slot.password#--> /  $slot.password<!--#end if#--></a></span>
           </td>
           <!--#if $queue_details == '1'#-->
           <td>

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1206,6 +1206,7 @@ def build_queue(web_dir=None, root=None, verbose=False, prim=True, webdir='', ve
         if not cat:
             cat = 'None'
         filename = pnfo.filename
+        password = pnfo.password
         bytesleft = pnfo.bytes_left
         bytes = pnfo.bytes
         average_date = pnfo.avg_date
@@ -1230,6 +1231,7 @@ def build_queue(web_dir=None, root=None, verbose=False, prim=True, webdir='', ve
         else:
             slot['script'] = 'None'
         slot['filename'] = converter(filename)
+        slot['password'] = converter(password) if password else ""
         slot['cat'] = cat
         slot['mbleft'] = "%.2f" % mbleft
         slot['mb'] = "%.2f" % mb

--- a/sabnzbd/constants.py
+++ b/sabnzbd/constants.py
@@ -24,7 +24,7 @@ POSTPROC_QUEUE_VERSION = 2
 
 REC_RAR_VERSION = 500
 
-PNFO = namedtuple('PNFO', 'repair unpack delete script nzo_id filename '
+PNFO = namedtuple('PNFO', 'repair unpack delete script nzo_id filename password '
                           'unpackstrht msgid category url bytes_left bytes '
                           'avg_date finished_files active_files queued_files status priority missing')
 

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -763,11 +763,13 @@ class NzbObject(TryList):
 
         # Pickup backed-up attributes when re-using
         if reuse:
-            cat, pp, script, priority, name, self.url = get_attrib_file(self.workpath, 6)
+            cat, pp, script, priority, name, password, self.url = get_attrib_file(self.workpath, 7)
             cat = unicoder(cat)
             script = unicoder(script)
             if name:
-                self.set_final_name_pw(unicoder(name))
+                self.final_name = unicoder(name)
+            if password:
+                self.password = unicoder(password)
 
         # Determine category and find pp/script values
         self.cat, pp_tmp, self.script, self.priority = cat_to_opts(cat, pp, script, priority)
@@ -1086,10 +1088,7 @@ class NzbObject(TryList):
             dif = int(self.wait - time.time() + 0.5)
             if dif > 0:
                 prefix += T('WAIT %s sec') % dif + ' / '  # : Queue indicator for waiting URL fetch
-        if self.password:
-            return '%s%s / %s' % (prefix, self.final_name, self.password)
-        else:
-            return '%s%s' % (prefix, self.final_name)
+        return '%s%s' % (prefix, self.final_name)
 
     @property
     def final_name_pw_clean(self):
@@ -1463,7 +1462,7 @@ class NzbObject(TryList):
             avg_date = time.mktime(avg_date.timetuple())
 
         return PNFO(self.repair, self.unpack, self.delete, self.script,
-                self.nzo_id, self.final_name_pw, {},
+                self.nzo_id, self.final_name, self.password, {},
                 '', self.cat, self.url,
                 bytes_left_all, self.bytes, avg_date,
                 finished_files, active_files, queued_files, self.status, self.priority,
@@ -1513,7 +1512,7 @@ class NzbObject(TryList):
             sabnzbd.save_data(self, self.nzo_id, self.workpath)
 
     def save_attribs(self):
-        set_attrib_file(self.workpath, (self.cat, self.pp, self.script, self.priority, self.final_name_pw_clean, self.url))
+        set_attrib_file(self.workpath, (self.cat, self.pp, self.script, self.priority, self.final_name, self.password, self.url))
 
     def build_pos_nzf_table(self, nzf_ids):
         pos_nzf_table = {}

--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -201,6 +201,9 @@ class URLGrabber(Thread):
                     data = fn.read()
                 fn.close()
 
+                # Sanatize filename first
+                filename = misc.sanitize_filename(filename)
+
                 # Write data to temp file
                 path = os.path.join(cfg.admin_dir.get_path(), FUTURE_Q_FOLDER)
                 path = os.path.join(path, filename)


### PR DESCRIPTION
Surprisingly the URLGrabber did not sanitize the filename before writing the temporary file. In cases where no filename was specified or for example when the server sends an error message back, the URLGrabber will try to write a file like ```api?t=get&id=9b93b84cf706c07b85505be0b661ae03&apikey=6c60492de2fc5ec11ad7e047bf81cfa6.nzb```
This could possibly be abused through manipulated links in RSS feeds for example, to have SAB overwrite other files on the system.
For now it just causes URLGrabber crashes reported on the forum and Reddit, which is quite unclear for the user which will think SAB is broken instead of the provider of the NZB-URL.

_Rest is not for 1.0.0_
Second part to split the password from the job-title, since this caused some odd behavior when Glitter tries to deduct the password from the title, especially when there is also a label like ```DUPLICATE \``` in front. 
Next part would be to also separate the label from the title, since it is not really the title and would allow for some better styling of the label. But that's for later.
Also made the Connections tab in the Status and Interface settings auto-refresh when _Show active connections_ is turned on.