### PR TITLE
Fix missing trailing-slash in Glitter interface

### DIFF
--- a/interfaces/Glitter/templates/include_menu.tmpl
+++ b/interfaces/Glitter/templates/include_menu.tmpl
@@ -81,7 +81,7 @@
             </li>
             <!--#end if#-->
             <li data-tooltip="true" data-placement="bottom" title="SABnzbd $T('menu-config')">
-                <a href="config"><span class="glyphicon glyphicon-cog"></span></a>
+                <a href="config/"><span class="glyphicon glyphicon-cog"></span></a>
             </li>
             <li class="dropdown main-menu-link" data-bind="css: { 'active-on-queue-finish-menu': onQueueFinish()}">
                 <a href="#" data-toggle="dropdown"  onclick="keepOpen(this)">


### PR DESCRIPTION
The "SABnzbd Config" link on the main screen is missing a trailing slash in (at least) the Glitter interface, causing failures when SABnzbd is accessed via a reverse proxy (tested with Pound and HAProxy)  This one-character change simply provides the missing slash.