### PR TITLE
Parse bandwidth limit as a float instead of an integer

### DIFF
--- a/interfaces/Glitter/templates/static/javascripts/glitter.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.js
@@ -175,7 +175,7 @@ $(function() {
             var bandwithLimitText = self.bandwithLimit().replace(/[^a-zA-Z]+/g, '');
             
             // Only the number
-            var speedLimitNumber = (parseInt(self.bandwithLimit()) * (self.speedLimit() / 100));
+            var speedLimitNumber = (parseFloat(self.bandwithLimit()) * (self.speedLimit() / 100));
             
             // Trick to only get decimal-point when needed
             speedLimitNumber = Math.round(speedLimitNumber*10)/10;


### PR DESCRIPTION
To ensure speed limit value is calculated correctly when non-integer values are used for bandwidth limit.