### PR TITLE
Handle 1/n-1 splitting

### DIFF
--- a/sabnzbd/utils/servertests.py
+++ b/sabnzbd/utils/servertests.py
@@ -21,6 +21,7 @@ sabnzbd.utils.servertests - Debugging server connections. Currently only NNTP se
 
 import socket
 import sys
+import select
 
 from sabnzbd.newswrapper import NewsWrapper
 from sabnzbd.downloader import Server, clues_login, clues_too_many
@@ -84,6 +85,10 @@ def test_nntp_server(host, port, server=None, username=None, password=None, ssl=
         while not nw.connected:
             nw.lines = []
             nw.recv_chunk(block=True)
+            #more ssl related: handle 1/n-1 splitting to prevent Rizzo/Duong-Beast
+            read_sockets, _, _ = select.select([nw.nntp.sock], [], [], 0.1)
+            if read_sockets:
+                nw.recv_chunk(block=True)
             nw.finish_connect(nw.lines[0][:3])
 
     except socket.timeout, e:


### PR DESCRIPTION
Some custom ssl library realization to prevent Rizzo/Duong-Beast attack encode whole data in separate chunks: in first chunk small amount of data(mostly 1 first byte) and append all other data in next chunk. In this case servertests don't work correctly, because **recv_chunk** function receive only first byte, and another chunk still in recv buffer. This situation could also happen in plain tcp when server will make some delay between sending chunks and when Nagle algorithm switched off -- but nobody will do it, so mostly ssl related.

Example:
Erlang ssl library split data into 2 chunk before send operation, for example: "200 welcome", would be sent like: "2" + "00 welcome", so in sabnzbd side(servertests.py) we receive first chunk: "2", and stop trying to receive more and servertests fails with **IndexError**(Server quit during login sequence)

Note:
It is related only to servertests part of functionality, while in downloading part reading from socket occur in infinity loop with select.