### PR TITLE
Fix breaking Glitter bug with large script_log

### DIFF
--- a/sabnzbd/database.py
+++ b/sabnzbd/database.py
@@ -495,7 +495,7 @@ def unpack_history_info(item):
         item['stage_log'] = [x for x in lst if x is not None]
 
     if item['script_log']:
-        item['script_log'] = zlib.decompress(item['script_log'][:])
+        del item['script_log']
     # The action line is only available for items in the postproc queue
     if not item.has_key('action_line'):
         item['action_line'] = ''


### PR DESCRIPTION
If large chunks of HTML are put into the script_log by (for example) the old NZBDrone script, the ```preload_history``` and API call become so large that Glitter fails to load and chokes.

There is no need to have ```script_log``` in the API call, since all skins retrieve it using the ```/scriptlog?name=SABnzbd_nzo_lxyg7a``` call and it can make the API call way too large.

@shypike I verified the fix using the history.db of 2 of people that reported it!
Will you also put this in develop branch?