### PR TITLE
Improve interpreting of custom pause time for plain numeric input

### DIFF
--- a/interfaces/Glitter/templates/static/javascripts/glitter.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.js
@@ -536,6 +536,12 @@ $(function() {
         
         // Update on changes
         self.pauseCustom.subscribe(function(newValue) {
+            // Is it plain numbers?
+            if(newValue.match(/^\s*\d+\s*$/)) {
+                // Treat it as a number of minutes
+                newValue += " minutes";
+            }
+
             // At least 3 charaters
             if(newValue.length < 3) {
                 $('#customPauseOutput').text('').data('time', 0)


### PR DESCRIPTION
Treat ambiguous numeric values as number of minutes for custom pause time.

Currently if you just type "100" into the custom pause field it'll think you want 143015 minutes, that's useless. A lot of people are probably used to the old Plush behaviour of entering the number of minutes you want to pause for, it's also a much saner default. So in the case that the user just enters some numbers and nothing else, this assumes they want to pause for that many minutes.