### PR TITLE
If file occurs twice in NZB, only add the larger

### DIFF
--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -391,6 +391,7 @@ history_limit = OptionNumber('misc', 'history_limit', 10, 0)
 show_sysload = OptionNumber('misc', 'show_sysload', 2, 0, 2)
 web_watchdog = OptionBool('misc', 'web_watchdog', False)
 enable_bonjour = OptionBool('misc', 'enable_bonjour', True)
+allow_duplicate_files = OptionBool('misc', 'allow_duplicate_files', False)
 warn_dupl_jobs = OptionBool('misc', 'warn_dupl_jobs', True)
 new_nzb_on_failure = OptionBool('misc', 'new_nzb_on_failure', False)
 

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -1501,7 +1501,7 @@ SPECIAL_BOOL_LIST = \
               'osx_menu', 'osx_speed', 'win_menu', 'use_pickle', 'allow_incomplete_nzb',
               'no_ipv6', 'keep_awake', 'empty_postproc', 'html_login',
               'web_watchdog', 'wait_for_dfolder', 'warn_empty_nzb', 'enable_bonjour',
-              'warn_dupl_jobs', 'backup_for_duplicates', 'enable_par_cleanup',
+              'allow_duplicate_files', 'warn_dupl_jobs', 'backup_for_duplicates', 'enable_par_cleanup', 
               'enable_https_verification', 'api_logging', 'fixed_ports'
      )
 SPECIAL_VALUE_LIST = \


### PR DESCRIPTION
Usually it's an error by the NZB creator or some NZB search website like binsearch.info.
So we only keep the larger (inspired by NZBGet's behavior).
There have also been reported cases where SABnzbd burps an error when duplicate files are present and some of them get removed by par2's repair. SABnzbd then still tries to extract the ```.1``` files, but since some files are missing it fails the whole NZB.