### PR TITLE
Prevent creating orphan items in "incomplete" when deleting job

### DIFF
--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -933,8 +933,7 @@ def remove_data(_id, path):
             os.remove(path)
             logging.info("%s removed", path)
     except:
-        logging.info("Failed to remove %s", path)
-        logging.info("Traceback: ", exc_info=True)
+        logging.debug("Failed to remove %s", path)
 
 
 @synchronized(IO_LOCK)

--- a/sabnzbd/articlecache.py
+++ b/sabnzbd/articlecache.py
@@ -24,7 +24,7 @@ import threading
 
 import sabnzbd
 from sabnzbd.decorators import synchronized
-from sabnzbd.constants import GIGI, ANFO
+from sabnzbd.constants import GIGI, ANFO, Status
 
 
 ARTICLE_LOCK = threading.Lock()
@@ -60,12 +60,12 @@ class ArticleCache(object):
         nzf = article.nzf
         nzo = nzf.nzo
 
-        if nzf.deleted or nzo.deleted:
+        if nzo.status in (Status.COMPLETED, Status.DELETED):
             # Do not discard this article because the
             # file might still be processed at this moment!!
             if sabnzbd.LOG_ALL:
-                logging.debug("%s would be discarded", article)
-            # return
+                logging.debug("%s is discarded", article)
+            return
 
         saved_articles = article.nzf.nzo.saved_articles
 
@@ -142,12 +142,12 @@ class ArticleCache(object):
         nzf = article.nzf
         nzo = nzf.nzo
 
-        if nzf.deleted or nzo.deleted:
+        if nzo.status in (Status.COMPLETED, Status.DELETED):
             # Do not discard this article because the
             # file might still be processed at this moment!!
             if sabnzbd.LOG_ALL:
-                logging.debug("%s would be discarded", article)
-            # return
+                logging.debug("%s is discarded", article)
+            return
 
         art_id = article.get_art_id()
         if art_id:

--- a/sabnzbd/constants.py
+++ b/sabnzbd/constants.py
@@ -134,6 +134,7 @@ class Status():
     COMPLETED = 'Completed'
     CHECKING = 'Checking'
     DOWNLOADING = 'Downloading'
+    TO_PP = 'ToPP'
     EXTRACTING = 'Extracting'
     FAILED = 'Failed'
     FETCHING = 'Fetching'
@@ -145,5 +146,6 @@ class Status():
     REPAIRING = 'Repairing'
     RUNNING = 'Running'
     VERIFYING = 'Verifying'
+    DELETED = 'Deleted'
 
 NOTIFY_KEYS = ('startup', 'download', 'pp', 'complete', 'failed', 'queue_done', 'disk_full', 'warning', 'error', 'other')

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -477,7 +477,7 @@ class NzbParser(xml.sax.handler.ContentHandler):
 
             nzf = NzbFile(tm, self.filename, self.article_db, self.file_bytes, self.nzo)
 
-            # Check if file was added with same name 
+            # Check if file was added with same name
             if not cfg.allow_duplicate_files():
                 nzo_matches = filter(lambda x: (x.filename == nzf.filename), self.nzo.files)
                 if nzo_matches:
@@ -1133,7 +1133,7 @@ class NzbObject(TryList):
     def pause(self):
         self.status = Status.PAUSED
         # Prevent loss of paused state when terminated
-        if self.nzo_id:
+        if self.nzo_id and self.status not in (Status.COMPLETED, Status.DELETED):
             sabnzbd.save_data(self, self.nzo_id, self.workpath)
 
     def resume(self):
@@ -1533,7 +1533,7 @@ class NzbObject(TryList):
     def save_to_disk(self):
         """ Save job's admin to disk """
         self.save_attribs()
-        if self.nzo_id:
+        if self.nzo_id and self.status not in (Status.COMPLETED, Status.DELETED):
             sabnzbd.save_data(self, self.nzo_id, self.workpath)
 
     def save_attribs(self):


### PR DESCRIPTION
Prevent creating orphan items in "incomplete" when deleting downloading jobs.

Due to previous issues where articles could be lost,
the nzf.deleted and no.deleted flags were not obeyed.
This could lead to creation of orphans when lost articles would be flushed.

Better solution: drop articles only when job is in a final state.
Also prevent NZO files from being saved when job is in "deleted" state.