### PR TITLE
Update sabnzbd@.service with network requirements

### DIFF
--- a/linux/sabnzbd@.service
+++ b/linux/sabnzbd@.service
@@ -12,11 +12,16 @@
 
 [Unit]
 Description=SABnzbd binary newsreader
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 ExecStart=/opt/sabnzbd/SABnzbd.py --logging 1 --browser 0
 User=%I
 Group=%I
+Type = simple
+Restart = on-failure
+
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
1. Added requirement for network to be up before sab starts.
2. Explicitly set service type to simple.
3. Enabled sabnzbd restart on service failure via systemd.