### PR TITLE
Optimize queue API

### DIFF
--- a/interfaces/Glitter/templates/static/javascripts/glitter.main.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.main.js
@@ -302,7 +302,7 @@ function ViewModel() {
         // Only update the title when page not visible
         if(!pageIsVisible) {
             // Request new title 
-            callSpecialAPI('./queue/', {}).done(function(data) {
+            callSpecialAPI('./queue/', { limit: 1, start: 0 }).done(function(data) {
                 // Split title & speed
                 var dataSplit = data.split('|||');
 

--- a/interfaces/Plush/templates/_inc_header.tmpl
+++ b/interfaces/Plush/templates/_inc_header.tmpl
@@ -10,7 +10,7 @@
 <html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <title>SABnzbd $version - $T('queued'): $mbleft $T('MB')</title>
+  <title>SABnzbd $version</title>
   <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="${path}rss?mode=history"/>
 
   <link rel="stylesheet" type="text/css" href="${path}static/stylesheets/jqueryui/overcast/jquery-ui-1.8.15.custom.css?$version"/>

--- a/interfaces/smpl/templates/main.tmpl
+++ b/interfaces/smpl/templates/main.tmpl
@@ -25,15 +25,7 @@
   <script type="text/javascript" src="static/PlotKit/PlotKit.js"></script>
   <!--[if IE]><script type="text/javascript" src="static/excanvas/excanvas.js"></script><![endif]-->
 
-<!--#set $mbdone = (float($mb) - float($mbleft))#-->
-<!--#set $mbdonesrt = float($mbdone) #-->
 
-
-<!--#set $kbpersec = float($kbpersec)#-->
-<!--#set $kbpersecrnd = str(int($kbpersec))#-->
-<!--#if $paused #-->
-<!--#set $kbpersecrnd = "0"#-->
-<!--#end if#-->
 
   <script type="text/javascript">
 
@@ -41,8 +33,8 @@
   RefreshTime = 5;
   var jsontimeout;
   var cookietimeout;
-  var speed = '$speed';
-  var kbpersec = $kbpersecrnd;
+  var speed = '';
+  var kbpersec = 0;
   var gDual = 0;
   var gUrl;
 
@@ -274,7 +266,7 @@ if (cook!=null && cook!="")
 }
 else
 {
-setCookie('speedlog2','0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,$kbpersecrnd',1);
+setCookie('speedlog2','0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0',1);
   }
 if (RefreshTime>0) {
   clearTimeout ( cookietimeout );
@@ -445,21 +437,8 @@ function loadtitle() {
 
 </script>
 
-
-<!--#set $statusstr2 = $T('link-pause')#-->
-<!--#set $pau = "0"#-->
-<!--#if $paused #-->
-<!--#set $pau = "1"#-->
-<!--#set $status = "<span class='paused'>"+$T('smpl-paused')+"</span>"#-->
-<!--#set $statusstr2 = $T('link-resume')#-->
-<!--#else if float($kbpersecrnd)>0 #-->
-<!--#set $status = "<span class='downloading'>"+$T('smpl-downloading')+"</span>"#-->
-<!--#else if float($kbpersecrnd) == 0 #-->
-<!--#set $status = "<span class='idle'>"+$T('smpl-idle')+"</span>"#-->
-<!--#end if#-->
-
 <script type="text/javascript">
-  var status2 = $pau;
+  var status2 = 0;
   var timerId2 = 0;
   var timerId3 = 0;
 
@@ -1111,9 +1090,9 @@ function loadingJSON(){
   <div id="Container">
     <div id="Header">
       <p class="status">
-        $T('status'): <span id="status">$status</span><br />
-        $T('smpl-speed'): <span id="speed">$speed</span>B/s<br />
-        $T('menu-queue'): <span id="mbleft">$mbleft</span>/<span id="mbtotal">$mb</span>
+        $T('status'): <span id="status"></span><br />
+        $T('smpl-speed'): <span id="speed"></span>B/s<br />
+        $T('menu-queue'): <span id="mbleft"></span>/<span id="mbtotal"></span>
       </p>
     <div id="logo">
       <a href=""><img id="title" src="static/sabnzbd_small4.png" alt="sabnzbd" /></a>
@@ -1135,7 +1114,7 @@ function loadingJSON(){
         <li><a href="#/status/" onclick="lr('status/','', 1, 0);">$T('menu-cons')</a></li>
         <li><a href="#/status/" onclick="lr('status/','', 1, 0);">$T('smpl-warnings')(<span id="have_warnings">$have_warnings</span>)</a></li>
         <br />
-        <li><a class="bold" id="status2" onclick="toggle_paused()">$statusstr2</a> <a onclick="toggle('hiddenTimedPause','blind',{duration:0.2})"><img src="static/images/bullet_arrow_down.png" border=0 /></a></li>
+        <li><a class="bold" id="status2" onclick="toggle_paused()"></a> <a onclick="toggle('hiddenTimedPause','blind',{duration:0.2})"><img src="static/images/bullet_arrow_down.png" border=0 /></a></li>
         <ul id="hiddenTimedPause" class="secondul">
           <li><a class="config" onclick="javascript:timedPause(5)">5 $T("minutes")</a></li>
           <li><a class="config" onclick="javascript:timedPause(15)">15 $T("minutes")</a></li>

--- a/interfaces/smpl/templates/queue.tmpl
+++ b/interfaces/smpl/templates/queue.tmpl
@@ -3,7 +3,6 @@
 <div class="centerLinks">
 <a onclick="if(confirm('$T('purgeQueueConf')')){lr('queue/purge','limit=$limit&start=$start', -1,-1, this.parentNode.parentNode.id);}">$T('smpl-purgeQueue')</a> |
 <a onclick="setCookie('queue_details','<!--#if $queue_details =='1' then "0" else "1"#-->',30);lr('queue','limit=$limit&start=$start', -1,-1, this.parentNode.parentNode.id);"><!--#if $queue_details == '1' then $T('smpl-hideEdit') else $T('smpl-showEdit')#--></a> |
-<a onclick="lr('queue/tog_verbose','limit=$limit&start=$start', -1,-1, this.parentNode.parentNode.id);"><!--#if $isverbose then $T('link-hideFiles') else $T('link-showFiles')#--></a> |
 $T('onQueueFinish'):
 <select onfocus="pauseQueueDeferer(this.parentNode.parentNode.id)" onblur="javascript:lr('queue/','limit=$limit&start=$start', 1,-1, this.parentNode.parentNode.id);" onChange="javascript:changequeuedetails('queue/change_queue_complete_action?action='+this.options[this.selectedIndex].value, 'limit=$limit&start=$start')">
 <option value=""></option>
@@ -39,7 +38,6 @@ $T('smpl-timeleft'): <strong>$timeleft</strong> $T('eta'): <strong>$eta</strong>
 
   <thead>
   <tr>
-    <th class="expandColumn center"></th>
     <th class="orderColumn center"></th>
     <th>$T('name') <a class="columnLinks" onclick="javascript:lr('queue/sort_by_name','limit=$limit&start=$start&dir=asc', -1,-1, this.parentNode.parentNode.id);"><img src="static/images/up.gif" /></a><a class="columnLinks" onclick="javascript:lr('queue/sort_by_name','limit=$limit&start=$start&dir=desc', -1,-1, this.parentNode.parentNode.id);"><img src="static/images/down.gif" /></a></th>
     <!--#if $queue_details == '1'#-->
@@ -58,9 +56,6 @@ $T('smpl-timeleft'): <strong>$timeleft</strong> $T('eta'): <strong>$eta</strong>
       <!--#set $odd = not $odd#-->
       <tbody id="$slot.nzo_id">
         <tr class="$slot.priority">
-          <td class="expand">
-            <a class="expander" onclick="javascript:toggle_verbosity('$slot.nzo_id', 'limit=$limit&start=$start')"><span id="name_$slot.nzo_id"><!--#if $slot.verbosity then '-' else '+'#--></span></a>
-          </td>
           <td>
             <select onfocus="pauseQueueDeferer(this.parentNode.parentNode.id)" onblur="javascript:lr('queue/','limit=$limit&start=$start', 1,-1, this.parentNode.parentNode.id);" onchange="javascript:changequeuedetails('queue/'+this.options[this.selectedIndex].value, 'limit=$limit&start=$start')">
             <!--#for $i in xrange($noofslots)#-->
@@ -135,20 +130,7 @@ $T('smpl-timeleft'): <strong>$timeleft</strong> $T('eta'): <strong>$eta</strong>
 </td>
 </tr>
 <!--#set $oddLine = False#-->
-<!--#for $line in $slot.finished#-->
-  <!--#set $oddLine = not $oddLine#-->
-  <tr class="finished <!--#if $oddLine then "oddLine" else "evenLine"#--> finished"><td></td><td>Finished</td><td>$line.filename</td><!--#if $queue_details == '1'#--><td></td><!--#end if#--><td class="pre">$line.mbleft/$line.mb MB<td></td><td class="center">$line.age</td><td class="center">$line.size</td><td></td></tr>
-<!--#end for#-->
-<!--#set $oddLine = False#-->
-<!--#for $line in $slot.active#-->
-  <!--#set $oddLine = not $oddLine#-->
-  <tr id="$line.nzf_id" class="active <!--#if $oddLine then "oddLine" else "evenLine"#--> active"><td></td><td>Active</td><td>$line.filename</td><!--#if $queue_details == '1'#--><td></td><!--#end if#--><td class="pre">$line.mbleft/$line.mb MB</td><td></td><td class="center">$line.age</td><td class="center">$line.size</td><td class="right_align"><a onclick="deletenzf('$slot.nzo_id','$line.nzf_id')"><img class="delicon" src="static/images/messagebox_critical.png" /></a></td></tr>
-<!--#end for#-->
-<!--#set $oddLine = False#-->
-<!--#for $line in $slot.queued#-->
-  <!--#set $oddLine = not $oddLine#-->
-  <tr class="waiting <!--#if $oddLine then "oddLine" else "evenLine"#--> waiting"><td></td><td>Waiting</td><td>$line.filename (set: $line.set)</td><!--#if $queue_details == '1'#--><td></td><!--#end if#--><td class="pre">$line.mbleft/$line.mb MB<td></td><td class="center">$line.age</td><td class="center">$line.size</td><td></td></tr>
-<!--#end for#-->
+
 </tbody>
 <!--#end for#-->
 <!--#end if#-->

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1338,159 +1338,159 @@ def build_queue(web_dir=None, root=None, verbose=False, prim=True, webdir='', ve
         info['finish'] = info['noofslots']
 
     for pnfo in pnfo_list:
-        repair = pnfo.repair
-        unpack = pnfo.unpack
-        delete = pnfo.delete
-        script = pnfo.script
-        nzo_id = pnfo.nzo_id
-        cat = pnfo.category
-        if not cat:
-            cat = 'None'
-        filename = pnfo.filename
-        password = pnfo.password
-        bytesleft = pnfo.bytes_left
-        bytes = pnfo.bytes
-        average_date = pnfo.avg_date
-        is_propagating = (pnfo.avg_stamp + float(cfg.propagation_delay() * 60)) > time.time()
-        status = pnfo.status
-        priority = pnfo.priority
-        mbleft = (bytesleft / MEBI)
-        mb = (bytes / MEBI)
-        missing = pnfo.missing
-        if verbose or verbose_list:
-            finished_files = pnfo.finished_files
-            active_files = pnfo.active_files
-            queued_files = pnfo.queued_files
-
-        nzo_ids.append(nzo_id)
-
-        slot = {'index': n, 'nzo_id': str(nzo_id)}
-        unpackopts = sabnzbd.opts_to_pp(repair, unpack, delete)
-
-        slot['unpackopts'] = str(unpackopts)
-        if script:
-            slot['script'] = script
-        else:
-            slot['script'] = 'None'
-        slot['filename'] = converter(filename)
-        slot['password'] = converter(password) if password else ""
-        slot['cat'] = cat
-        slot['mbleft'] = "%.2f" % mbleft
-        slot['mb'] = "%.2f" % mb
-        if not output:
-            slot['mb_fmt'] = locale.format('%d', int(mb), True)
-            slot['mbdone_fmt'] = locale.format('%d', int(mb - mbleft), True)
-        slot['size'] = format_bytes(bytes)
-        slot['sizeleft'] = format_bytes(bytesleft)
-        if not Downloader.do.paused and status not in (Status.PAUSED, Status.FETCHING, Status.GRABBING) and not found_active:
-            if is_propagating:
-                slot['status'] = 'Propagating'
-            elif status == Status.CHECKING:
-                slot['status'] = Status.CHECKING
-            else:
-                slot['status'] = Status.DOWNLOADING
-            found_active = True
-        else:
-            slot['status'] = "%s" % (status)
-        if priority == TOP_PRIORITY:
-            slot['priority'] = 'Force'
-        elif priority == REPAIR_PRIORITY:
-            slot['priority'] = 'Repair'
-        elif priority == HIGH_PRIORITY:
-            slot['priority'] = 'High'
-        elif priority == LOW_PRIORITY:
-            slot['priority'] = 'Low'
-        else:
-            slot['priority'] = 'Normal'
-        if mb == mbleft:
-            slot['percentage'] = "0"
-        else:
-            slot['percentage'] = "%s" % (int(((mb - mbleft) / mb) * 100))
-        slot['missing'] = missing
-
-        if (Downloader.do.paused or Downloader.do.postproc or is_propagating or  \
-           status not in (Status.DOWNLOADING, Status.QUEUED)) and priority != TOP_PRIORITY:
-            slot['timeleft'] = '0:00:00'
-            slot['eta'] = 'unknown'
-        else:
-            running_bytes += bytesleft
-            slot['timeleft'] = calc_timeleft(running_bytes, bytespersec)
-            try:
-                datestart = datestart + datetime.timedelta(seconds=bytesleft / bytespersec)
-                # new eta format: 16:00 Fri 07 Feb
-                slot['eta'] = datestart.strftime(time_format('%H:%M %a %d %b')).decode(codepage)
-            except:
-                datestart = datetime.datetime.now()
-                slot['eta'] = 'unknown'
-
-        if status == Status.GRABBING:
-            slot['avg_age'] = '---'
-        else:
-            slot['avg_age'] = calc_age(average_date, bool(trans))
-
-        rating = Rating.do.get_rating_by_nzo(nzo_id)
-        slot['has_rating'] = rating is not None
-        if rating:
-            slot['rating_avg_video'] = rating.avg_video
-            slot['rating_avg_audio'] = rating.avg_audio
-
-        slot['verbosity'] = ""
-        if web_dir:
-            finished = []
-            active = []
-            queued = []
-            # this will list files in the xml output, wanted yes/no?
-            if verbose or nzo_id in verbose_list:
-                slot['verbosity'] = "True"
-                for tup in finished_files:
-                    bytes_left, bytes, fn, date = tup
-                    fn = converter(fn)
-
-                    age = calc_age(date)
-
-                    line = {'filename': fn,
-                            'mbleft': "%.2f" % (bytes_left / MEBI),
-                            'mb': "%.2f" % (bytes / MEBI),
-                            'size': format_bytes(bytes),
-                            'sizeleft': format_bytes(bytes_left),
-                            'age': age}
-                    finished.append(line)
-
-                for tup in active_files:
-                    bytes_left, bytes, fn, date, nzf_id = tup
-                    fn = converter(fn)
-
-                    age = calc_age(date)
-
-                    line = {'filename': fn,
-                            'mbleft': "%.2f" % (bytes_left / MEBI),
-                            'mb': "%.2f" % (bytes / MEBI),
-                            'size': format_bytes(bytes),
-                            'sizeleft': format_bytes(bytes_left),
-                            'nzf_id': nzf_id,
-                            'age': age}
-                    active.append(line)
-
-                for tup in queued_files:
-                    _set, bytes_left, bytes, fn, date = tup
-                    fn = converter(fn)
-                    _set = converter(_set)
-
-                    age = calc_age(date)
-
-                    line = {'filename': fn, 'set': _set,
-                            'mbleft': "%.2f" % (bytes_left / MEBI),
-                            'mb': "%.2f" % (bytes / MEBI),
-                            'size': format_bytes(bytes),
-                            'sizeleft': format_bytes(bytes_left),
-                            'age': age}
-                    queued.append(line)
-
-            slot['finished'] = finished
-            slot['active'] = active
-            slot['queued'] = queued
-
         if (start <= n and n < start + limit) or not limit:
+            repair = pnfo.repair
+            unpack = pnfo.unpack
+            delete = pnfo.delete
+            script = pnfo.script
+            nzo_id = pnfo.nzo_id
+            cat = pnfo.category
+            if not cat:
+                cat = 'None'
+            filename = pnfo.filename
+            password = pnfo.password
+            bytesleft = pnfo.bytes_left
+            bytes = pnfo.bytes
+            average_date = pnfo.avg_date
+            is_propagating = (pnfo.avg_stamp + float(cfg.propagation_delay() * 60)) > time.time()
+            status = pnfo.status
+            priority = pnfo.priority
+            mbleft = (bytesleft / MEBI)
+            mb = (bytes / MEBI)
+            missing = pnfo.missing
+            if verbose or verbose_list:
+                finished_files = pnfo.finished_files
+                active_files = pnfo.active_files
+                queued_files = pnfo.queued_files
+    
+            nzo_ids.append(nzo_id)
+    
+            slot = {'index': n, 'nzo_id': str(nzo_id)}
+            unpackopts = sabnzbd.opts_to_pp(repair, unpack, delete)
+    
+            slot['unpackopts'] = str(unpackopts)
+            if script:
+                slot['script'] = script
+            else:
+                slot['script'] = 'None'
+            slot['filename'] = converter(filename)
+            slot['password'] = converter(password) if password else ""
+            slot['cat'] = cat
+            slot['mbleft'] = "%.2f" % mbleft
+            slot['mb'] = "%.2f" % mb
+            if not output:
+                slot['mb_fmt'] = locale.format('%d', int(mb), True)
+                slot['mbdone_fmt'] = locale.format('%d', int(mb - mbleft), True)
+            slot['size'] = format_bytes(bytes)
+            slot['sizeleft'] = format_bytes(bytesleft)
+            if not Downloader.do.paused and status not in (Status.PAUSED, Status.FETCHING, Status.GRABBING) and not found_active:
+                if is_propagating:
+                    slot['status'] = 'Propagating'
+                elif status == Status.CHECKING:
+                    slot['status'] = Status.CHECKING
+                else:
+                    slot['status'] = Status.DOWNLOADING
+                found_active = True
+            else:
+                slot['status'] = "%s" % (status)
+            if priority == TOP_PRIORITY:
+                slot['priority'] = 'Force'
+            elif priority == REPAIR_PRIORITY:
+                slot['priority'] = 'Repair'
+            elif priority == HIGH_PRIORITY:
+                slot['priority'] = 'High'
+            elif priority == LOW_PRIORITY:
+                slot['priority'] = 'Low'
+            else:
+                slot['priority'] = 'Normal'
+            if mb == mbleft:
+                slot['percentage'] = "0"
+            else:
+                slot['percentage'] = "%s" % (int(((mb - mbleft) / mb) * 100))
+            slot['missing'] = missing
+    
+            if (Downloader.do.paused or Downloader.do.postproc or is_propagating or  \
+               status not in (Status.DOWNLOADING, Status.QUEUED)) and priority != TOP_PRIORITY:
+                slot['timeleft'] = '0:00:00'
+                slot['eta'] = 'unknown'
+            else:
+                running_bytes += bytesleft
+                slot['timeleft'] = calc_timeleft(running_bytes, bytespersec)
+                try:
+                    datestart = datestart + datetime.timedelta(seconds=bytesleft / bytespersec)
+                    # new eta format: 16:00 Fri 07 Feb
+                    slot['eta'] = datestart.strftime(time_format('%H:%M %a %d %b')).decode(codepage)
+                except:
+                    datestart = datetime.datetime.now()
+                    slot['eta'] = 'unknown'
+    
+            if status == Status.GRABBING:
+                slot['avg_age'] = '---'
+            else:
+                slot['avg_age'] = calc_age(average_date, bool(trans))
+    
+            rating = Rating.do.get_rating_by_nzo(nzo_id)
+            slot['has_rating'] = rating is not None
+            if rating:
+                slot['rating_avg_video'] = rating.avg_video
+                slot['rating_avg_audio'] = rating.avg_audio
+    
+            slot['verbosity'] = ""
+            if web_dir:
+                finished = []
+                active = []
+                queued = []
+                # this will list files in the xml output, wanted yes/no?
+                if verbose or nzo_id in verbose_list:
+                    slot['verbosity'] = "True"
+                    for tup in finished_files:
+                        bytes_left, bytes, fn, date = tup
+                        fn = converter(fn)
+    
+                        age = calc_age(date)
+    
+                        line = {'filename': fn,
+                                'mbleft': "%.2f" % (bytes_left / MEBI),
+                                'mb': "%.2f" % (bytes / MEBI),
+                                'size': format_bytes(bytes),
+                                'sizeleft': format_bytes(bytes_left),
+                                'age': age}
+                        finished.append(line)
+    
+                    for tup in active_files:
+                        bytes_left, bytes, fn, date, nzf_id = tup
+                        fn = converter(fn)
+    
+                        age = calc_age(date)
+    
+                        line = {'filename': fn,
+                                'mbleft': "%.2f" % (bytes_left / MEBI),
+                                'mb': "%.2f" % (bytes / MEBI),
+                                'size': format_bytes(bytes),
+                                'sizeleft': format_bytes(bytes_left),
+                                'nzf_id': nzf_id,
+                                'age': age}
+                        active.append(line)
+    
+                    for tup in queued_files:
+                        _set, bytes_left, bytes, fn, date = tup
+                        fn = converter(fn)
+                        _set = converter(_set)
+    
+                        age = calc_age(date)
+    
+                        line = {'filename': fn, 'set': _set,
+                                'mbleft': "%.2f" % (bytes_left / MEBI),
+                                'mb': "%.2f" % (bytes / MEBI),
+                                'size': format_bytes(bytes),
+                                'sizeleft': format_bytes(bytes_left),
+                                'age': age}
+                        queued.append(line)
+    
+                slot['finished'] = finished
+                slot['active'] = active
+                slot['queued'] = queued
+    
             slotinfo.append(slot)
         n += 1
 

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -267,11 +267,7 @@ def _api_queue_default(output, value, kwargs):
             reverse = direction.lower() == 'desc'
             sort_queue(sort, reverse)
 
-        # &history=1 will show unprocessed items in the history
-        history = bool(kwargs.get('history'))
-
-        info, pnfo_list, bytespersec, verbose_list, dictn = \
-            build_queue(history=history, start=start, limit=limit, output=output, trans=trans, search=search)
+        info, pnfo_list, bytespersec = build_queue(start=start, limit=limit, output=output, trans=trans, search=search)
         info['categories'] = info.pop('cat_list')
         info['scripts'] = info.pop('script_list')
         return report(output, keyword='queue', data=remove_callable(info))
@@ -1279,78 +1275,41 @@ def build_status(web_dir=None, root=None, prim=True, skip_dashboard=False, outpu
 
     return info
 
-def build_queue(web_dir=None, root=None, verbose=False, prim=True, webdir='', verbose_list=None,
-                dictionary=None, history=False, start=0, limit=0, dummy2=None, trans=False, output=None,
-                search=None):
+def build_queue(web_dir=None, root=None, prim=True, webdir='', start=0, limit=0, trans=False, output=None, search=None):
     if output:
         converter = unicoder
     else:
         converter = xml_name
 
-    if not verbose_list:
-        verbose_list = []
-    if dictionary:
-        dictn = dictionary
-    else:
-        dictn = []
     # build up header full of basic information
     info, pnfo_list, bytespersec, q_size = build_queue_header(prim, webdir, search=search, start=start, limit=limit)
-    info['isverbose'] = verbose
-    cookie = cherrypy.request.cookie
-    if 'queue_details' in cookie:
-        info['queue_details'] = str(int_conv(cookie['queue_details'].value))
-    else:
-        info['queue_details'] = '0'
-
-    if cfg.refresh_rate() > 0:
-        info['refresh_rate'] = str(cfg.refresh_rate())
-    else:
-        info['refresh_rate'] = ''
 
     datestart = datetime.datetime.now()
-
-    info['script_list'] = list_scripts()
-    info['cat_list'] = list_cats(output is None)
-
-    info['rating_enable'] = bool(cfg.rating_enable())
-
-    n = 0
-    found_active = False
-    running_bytes = 0
-    slotinfo = []
-    nzo_ids = []
-
+    priorities = {TOP_PRIORITY: 'Force', REPAIR_PRIORITY: 'Repair', HIGH_PRIORITY: 'High', NORMAL_PRIORITY: 'Normal', LOW_PRIORITY: 'Low'}
     limit = int_conv(limit)
     start = int_conv(start)
 
-    if history:
-        # Collect nzo's from the history that are downloaded but not finished (repairing, extracting)
-        slotinfo = format_history_for_queue()
-        # if the specified start value is greater than the amount of history items, do no include the history (used for paging the queue)
-        if len(slotinfo) < start:
-            slotinfo = []
-    else:
-        slotinfo = []
-
-    info['noofslots'] = q_size + len(slotinfo)
-
+    info['refresh_rate'] = str(cfg.refresh_rate()) if cfg.refresh_rate() > 0 else ''
+    info['script_list'] = list_scripts()
+    info['cat_list'] = list_cats(output is None)
+    info['rating_enable'] = bool(cfg.rating_enable())
+    info['noofslots'] = q_size
     info['start'] = start
     info['limit'] = limit
     info['finish'] = info['start'] + info['limit']
+
+    # SMPL-skin specific stuff
     if info['finish'] > info['noofslots']:
         info['finish'] = info['noofslots']
+    info['queue_details'] = '0'
+    if 'queue_details' in cherrypy.request.cookie: 
+        info['queue_details'] = str(int_conv(cherrypy.request.cookie['queue_details'].value)) 
 
+    n = 0
+    running_bytes = 0
+    slotinfo = []
     for pnfo in pnfo_list:
-        repair = pnfo.repair
-        unpack = pnfo.unpack
-        delete = pnfo.delete
-        script = pnfo.script
         nzo_id = pnfo.nzo_id
-        cat = pnfo.category
-        if not cat:
-            cat = 'None'
-        filename = pnfo.filename
-        password = pnfo.password
         bytesleft = pnfo.bytes_left
         bytes = pnfo.bytes
         average_date = pnfo.avg_date
@@ -1360,56 +1319,33 @@ def build_queue(web_dir=None, root=None, verbose=False, prim=True, webdir='', ve
         mbleft = (bytesleft / MEBI)
         mb = (bytes / MEBI)
         missing = pnfo.missing
-        if verbose or verbose_list:
-            finished_files = pnfo.finished_files
-            active_files = pnfo.active_files
-            queued_files = pnfo.queued_files
-
-        nzo_ids.append(nzo_id)
 
         slot = {'index': n, 'nzo_id': str(nzo_id)}
-        unpackopts = sabnzbd.opts_to_pp(repair, unpack, delete)
-
-        slot['unpackopts'] = str(unpackopts)
-        if script:
-            slot['script'] = script
-        else:
-            slot['script'] = 'None'
-        slot['filename'] = converter(filename)
-        slot['password'] = converter(password) if password else ""
-        slot['cat'] = cat
+        slot['unpackopts'] = str(sabnzbd.opts_to_pp(pnfo.repair, pnfo.unpack, pnfo.delete))
+        slot['priority'] = priorities[priority] if priority >= LOW_PRIORITY else priorities[NORMAL_PRIORITY]
+        slot['script'] = pnfo.script if pnfo.script else 'None'
+        slot['filename'] = converter(pnfo.filename)
+        slot['password'] = converter(pnfo.password) if pnfo.password else ''
+        slot['cat'] = converter(pnfo.category) if pnfo.category else 'None'
         slot['mbleft'] = "%.2f" % mbleft
         slot['mb'] = "%.2f" % mb
+        slot['size'] = format_bytes(bytes)
+        slot['sizeleft'] = format_bytes(bytesleft)
+        slot['percentage'] = "%s" % (int(((mb - mbleft) / mb) * 100)) if mb != mbleft else '0'
+        slot['missing'] = pnfo.missing
         if not output:
             slot['mb_fmt'] = locale.format('%d', int(mb), True)
             slot['mbdone_fmt'] = locale.format('%d', int(mb - mbleft), True)
-        slot['size'] = format_bytes(bytes)
-        slot['sizeleft'] = format_bytes(bytesleft)
-        if not Downloader.do.paused and status not in (Status.PAUSED, Status.FETCHING, Status.GRABBING) and not found_active:
+
+        if not Downloader.do.paused and status not in (Status.PAUSED, Status.FETCHING, Status.GRABBING):
             if is_propagating:
                 slot['status'] = 'Propagating'
             elif status == Status.CHECKING:
                 slot['status'] = Status.CHECKING
             else:
                 slot['status'] = Status.DOWNLOADING
-            found_active = True
         else:
             slot['status'] = "%s" % (status)
-        if priority == TOP_PRIORITY:
-            slot['priority'] = 'Force'
-        elif priority == REPAIR_PRIORITY:
-            slot['priority'] = 'Repair'
-        elif priority == HIGH_PRIORITY:
-            slot['priority'] = 'High'
-        elif priority == LOW_PRIORITY:
-            slot['priority'] = 'Low'
-        else:
-            slot['priority'] = 'Normal'
-        if mb == mbleft:
-            slot['percentage'] = "0"
-        else:
-            slot['percentage'] = "%s" % (int(((mb - mbleft) / mb) * 100))
-        slot['missing'] = missing
 
         if (Downloader.do.paused or Downloader.do.postproc or is_propagating or  \
            status not in (Status.DOWNLOADING, Status.QUEUED)) and priority != TOP_PRIORITY:
@@ -1437,62 +1373,6 @@ def build_queue(web_dir=None, root=None, verbose=False, prim=True, webdir='', ve
             slot['rating_avg_video'] = rating.avg_video
             slot['rating_avg_audio'] = rating.avg_audio
 
-        slot['verbosity'] = ""
-        if web_dir:
-            finished = []
-            active = []
-            queued = []
-            # this will list files in the xml output, wanted yes/no?
-            if verbose or nzo_id in verbose_list:
-                slot['verbosity'] = "True"
-                for tup in finished_files:
-                    bytes_left, bytes, fn, date = tup
-                    fn = converter(fn)
-
-                    age = calc_age(date)
-
-                    line = {'filename': fn,
-                            'mbleft': "%.2f" % (bytes_left / MEBI),
-                            'mb': "%.2f" % (bytes / MEBI),
-                            'size': format_bytes(bytes),
-                            'sizeleft': format_bytes(bytes_left),
-                            'age': age}
-                    finished.append(line)
-
-                for tup in active_files:
-                    bytes_left, bytes, fn, date, nzf_id = tup
-                    fn = converter(fn)
-
-                    age = calc_age(date)
-
-                    line = {'filename': fn,
-                            'mbleft': "%.2f" % (bytes_left / MEBI),
-                            'mb': "%.2f" % (bytes / MEBI),
-                            'size': format_bytes(bytes),
-                            'sizeleft': format_bytes(bytes_left),
-                            'nzf_id': nzf_id,
-                            'age': age}
-                    active.append(line)
-
-                for tup in queued_files:
-                    _set, bytes_left, bytes, fn, date = tup
-                    fn = converter(fn)
-                    _set = converter(_set)
-
-                    age = calc_age(date)
-
-                    line = {'filename': fn, 'set': _set,
-                            'mbleft': "%.2f" % (bytes_left / MEBI),
-                            'mb': "%.2f" % (bytes / MEBI),
-                            'size': format_bytes(bytes),
-                            'sizeleft': format_bytes(bytes_left),
-                            'age': age}
-                    queued.append(line)
-
-            slot['finished'] = finished
-            slot['active'] = active
-            slot['queued'] = queued
-
         slotinfo.append(slot)
         n += 1
 
@@ -1500,26 +1380,8 @@ def build_queue(web_dir=None, root=None, verbose=False, prim=True, webdir='', ve
         info['slots'] = slotinfo
     else:
         info['slots'] = []
-        verbose_list = []
 
-    # Paging of the queue using limit and/or start values
-    if limit > 0:
-        try:
-            if start > 0:
-                if start > len(pnfo_list):
-                    pnfo_list = []
-                else:
-                    end = start + limit
-                    if start + limit > len(pnfo_list):
-                        end = len(pnfo_list)
-                    pnfo_list = pnfo_list[start:end]
-            else:
-                if not limit > len(pnfo_list):
-                    pnfo_list = pnfo_list[:limit]
-        except:
-            pass
-
-    return info, pnfo_list, bytespersec, verbose_list, dictn
+    return info, pnfo_list, bytespersec
 
 
 def fast_queue():
@@ -1901,9 +1763,6 @@ def build_queue_header(prim, webdir='', search=None, start=0, limit=0):
     else:
         status = 'Idle'
     header['status'] = status
-
-    header['nzb_quota'] = ''
-
     header['timeleft'] = calc_timeleft(bytesleft, bytespersec)
 
     try:

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -100,6 +100,9 @@ def api_handler(kwargs):
     name = kwargs.get('name', '')
     callback = kwargs.get('callback', '')
 
+    # Extend the timeout of API calls to 10minutes
+    cherrypy.response.timeout = 60*10
+
     if isinstance(mode, list):
         mode = mode[0]
     if isinstance(output, list):

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1460,46 +1460,43 @@ def build_file_list(id):
             queued_files = pnfo.queued_files
 
             n = 0
-            for tup in finished_files:
-                bytes_left, bytes, fn, date = tup
-                fn = xml_name(fn)
+            for nzf in finished_files:
+                fn = xml_name(nzf.filename)
 
-                age = calc_age(date)
+                age = calc_age(nzf.date)
 
-                line = {'filename': fn,
-                        'mbleft': "%.2f" % (bytes_left / MEBI),
-                        'mb': "%.2f" % (bytes / MEBI),
-                        'bytes': "%.2f" % bytes,
+                line = {'filename': nzf.filename,
+                        'mbleft': "%.2f" % (nzf.bytes_left / MEBI),
+                        'mb': "%.2f" % (nzf.bytes / MEBI),
+                        'bytes': "%.2f" % nzf.bytes,
                         'age': age, 'id': str(n), 'status': 'finished'}
                 jobs.append(line)
                 n += 1
 
-            for tup in active_files:
-                bytes_left, bytes, fn, date, nzf_id = tup
-                fn = xml_name(fn)
+            for nzf in active_files:
+                fn = xml_name(nzf.filename)
 
-                age = calc_age(date)
+                age = calc_age(nzf.date)
 
-                line = {'filename': fn,
-                        'mbleft': "%.2f" % (bytes_left / MEBI),
-                        'mb': "%.2f" % (bytes / MEBI),
-                        'bytes': "%.2f" % bytes,
-                        'nzf_id': nzf_id,
+                line = {'filename': nzf.filename,
+                        'mbleft': "%.2f" % (nzf.bytes_left / MEBI),
+                        'mb': "%.2f" % (nzf.bytes / MEBI),
+                        'bytes': "%.2f" % nzf.bytes,
+                        'nzf_id': nzf.nzf_id,
                         'age': age, 'id': str(n), 'status': 'active'}
                 jobs.append(line)
                 n += 1
 
-            for tup in queued_files:
-                _set, bytes_left, bytes, fn, date = tup
-                fn = xml_name(fn)
-                _set = xml_name(_set)
+            for nzf in queued_files:
+                fn = xml_name(nzf.filename)
+                _set = xml_name(nzf.setname)
 
-                age = calc_age(date)
+                age = calc_age(nzf.date)
 
-                line = {'filename': fn, 'set': _set,
-                        'mbleft': "%.2f" % (bytes_left / MEBI),
-                        'mb': "%.2f" % (bytes / MEBI),
-                        'bytes': "%.2f" % bytes,
+                line = {'filename': nzf.filename, 'set': _set,
+                        'mbleft': "%.2f" % (nzf.bytes_left / MEBI),
+                        'mb': "%.2f" % (nzf.bytes / MEBI),
+                        'bytes': "%.2f" % nzf.bytes,
                         'age': age, 'id': str(n), 'status': 'queued'}
                 jobs.append(line)
                 n += 1

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -33,6 +33,7 @@ from sabnzbd.decorators import synchronized, synchronized_CV, CV
 from sabnzbd.decoder import Decoder
 from sabnzbd.utils.sslinfo import ssl_protocols
 from sabnzbd.newswrapper import NewsWrapper, request_server_info
+from sabnzbd.articlecache import ArticleCache
 import sabnzbd.notifier as notifier
 from sabnzbd.constants import *
 import sabnzbd.config as config
@@ -255,7 +256,7 @@ class Downloader(Thread):
             if cfg.autodisconnect():
                 self.disconnect()
             if save:
-                sabnzbd.save_state()
+                ArticleCache.do.flush_articles()
 
     @synchronized_CV
     def delay(self):

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -577,7 +577,6 @@ class LoginPage(object):
     def __init__(self, web_dir, root, prim):
         self.__root = root
         self.__web_dir = web_dir
-        self.__verbose = False
         self.__prim = prim
 
     @cherrypy.expose
@@ -616,7 +615,6 @@ class NzoPage(object):
     def __init__(self, web_dir, root, prim):
         self.__root = root
         self.__web_dir = web_dir
-        self.__verbose = False
         self.__prim = prim
         self.__cached_selection = {}  # None
 
@@ -818,8 +816,6 @@ class QueuePage(object):
     def __init__(self, web_dir, root, prim):
         self.__root = root
         self.__web_dir = web_dir
-        self.__verbose = False
-        self.__verbose_list = []
         self.__prim = prim
 
     @cherrypy.expose
@@ -831,13 +827,9 @@ class QueuePage(object):
 
         start = int_conv(kwargs.get('start'))
         limit = int_conv(kwargs.get('limit'))
-        dummy2 = kwargs.get('dummy2')
         search = kwargs.get('search')
-
-        info, _pnfo_list, _bytespersec, self.__verbose_list, self.__dict__ = build_queue(self.__web_dir, self.__root, self.__verbose,
-                                                                                       self.__prim, self.__web_dir, self.__verbose_list,
-                                                                                       self.__dict__, start=start, limit=limit,
-                                                                                       dummy2=dummy2, trans=True, search=search)
+        info, _pnfo_list, _bytespersec = build_queue(self.__web_dir, self.__root, self.__prim, self.__web_dir,
+                                                     start=start, limit=limit, trans=True, search=search)
 
         template = Template(file=os.path.join(self.__web_dir, 'queue.tmpl'),
                             filter=FILTER, searchList=[info], compilerSettings=DIRECTIVES)
@@ -871,26 +863,6 @@ class QueuePage(object):
         nzf_id = kwargs.get('nzf_id')
         if nzo_id and nzf_id:
             NzbQueue.do.remove_nzf(nzo_id, nzf_id)
-        raise queueRaiser(self.__root, kwargs)
-
-    @cherrypy.expose
-    def tog_verbose(self, **kwargs):
-        msg = check_session(kwargs)
-        if msg:
-            return msg
-        self.__verbose = not self.__verbose
-        raise queueRaiser(self.__root, kwargs)
-
-    @cherrypy.expose
-    def tog_uid_verbose(self, **kwargs):
-        msg = check_session(kwargs)
-        if msg:
-            return msg
-        uid = kwargs.get('uid')
-        if self.__verbose_list.count(uid):
-            self.__verbose_list.remove(uid)
-        else:
-            self.__verbose_list.append(uid)
         raise queueRaiser(self.__root, kwargs)
 
     @cherrypy.expose

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -640,8 +640,10 @@ class NzoPage(object):
                 nzo_id = a
                 break
 
-        if nzo_id and NzbQueue.do.get_nzo(nzo_id):
-            info, pnfo_list, _bytespersec = build_queue_header(self.__prim, self.__web_dir)
+        nzo = NzbQueue.do.get_nzo(nzo_id)
+        if nzo_id and nzo:
+            info = build_header(self.__prim, self.__web_dir)
+            pnfo_list = [nzo.gather_info()]
 
             # /SABnzbd_nzo_xxxxx/bulk_operation
             if 'bulk_operation' in args:
@@ -828,8 +830,8 @@ class QueuePage(object):
         if not check_login():
             raise NeedLogin(self.__root, kwargs)
 
-        start = kwargs.get('start')
-        limit = kwargs.get('limit')
+        start = int_conv(kwargs.get('start'))
+        limit = int_conv(kwargs.get('limit'))
         dummy2 = kwargs.get('dummy2')
         search = kwargs.get('search')
 
@@ -1073,8 +1075,8 @@ class HistoryPage(object):
         if not check_login():
             raise NeedLogin(self.__root, kwargs)
 
-        start = kwargs.get('start')
-        limit = kwargs.get('limit')
+        start = int_conv(kwargs.get('start'))
+        limit = int_conv(kwargs.get('limit'))
         search = kwargs.get('search')
         failed_only = kwargs.get('failed_only')
         if failed_only is None:

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -349,6 +349,7 @@ class MainPage(object):
 
         if kwargs.get('skip_wizard') or config.get_servers():
             info = build_header(self.__prim, self.__web_dir)
+            info['mb'] = info['mbleft'] = info['kbpersec'] = info['speed'] = '0'
 
             info['script_list'] = list_scripts(default=True)
             info['script'] = 'Default'

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -64,7 +64,7 @@ from sabnzbd.lang import list_languages, set_language
 
 from sabnzbd.api import list_scripts, list_cats, del_from_section, \
     api_handler, build_queue, remove_callable, rss_qstatus, build_status, \
-    retry_job, retry_all_jobs, build_header, build_history, del_job_files, \
+    retry_job, retry_all_jobs, build_queue_header, build_header, build_history, del_job_files, \
     format_bytes, calc_age, std_time, report, del_hist_job, Ttemplate, \
     _api_test_email, _api_test_notif
 
@@ -348,7 +348,7 @@ class MainPage(object):
             config.save_config()
 
         if kwargs.get('skip_wizard') or config.get_servers():
-            info, _pnfo_list, _bytespersec = build_header(self.__prim, self.__web_dir, search=kwargs.get('search'))
+            info = build_header(self.__prim, self.__web_dir)
 
             info['script_list'] = list_scripts(default=True)
             info['script'] = 'Default'
@@ -583,7 +583,7 @@ class LoginPage(object):
     @cherrypy.expose
     def index(self, **kwargs):
         # Base output var
-        info, _pnfo_list, _bytespersec = build_header(self.__prim, self.__web_dir)
+        info = build_header(self.__prim, self.__web_dir)
         info['error'] = ''
 
         # Logout?
@@ -640,7 +640,7 @@ class NzoPage(object):
                 break
 
         if nzo_id and NzbQueue.do.get_nzo(nzo_id):
-            info, pnfo_list, _bytespersec = build_header(self.__prim, self.__web_dir)
+            info, pnfo_list, _bytespersec = build_queue_header(self.__prim, self.__web_dir)
 
             # /SABnzbd_nzo_xxxxx/bulk_operation
             if 'bulk_operation' in args:
@@ -1079,7 +1079,7 @@ class HistoryPage(object):
         if failed_only is None:
             failed_only = self.__failed_only
 
-        history, _pnfo_list, _bytespersec = build_header(self.__prim, self.__web_dir)
+        history = build_header(self.__prim, self.__web_dir)
 
         history['isverbose'] = self.__verbose
         history['failed_only'] = failed_only
@@ -1285,7 +1285,7 @@ class ConfigPage(object):
             return Protected()
         if not check_login():
             raise NeedLogin(self.__root, kwargs)
-        conf, _pnfo_list, _bytespersec = build_header(self.__prim, self.__web_dir)
+        conf = build_header(self.__prim, self.__web_dir)
 
         conf['configfn'] = config.get_filename()
         conf['cmdline'] = sabnzbd.CMDLINE
@@ -1391,7 +1391,7 @@ class ConfigFolders(object):
         if not check_login():
             raise NeedLogin(self.__root, kwargs)
 
-        conf, _pnfo_list, _bytespersec = build_header(self.__prim, self.__web_dir)
+        conf = build_header(self.__prim, self.__web_dir)
 
         for kw in LIST_DIRPAGE:
             conf[kw] = config.get_config('misc', kw)()
@@ -1466,7 +1466,7 @@ class ConfigSwitches(object):
         if not check_login():
             raise NeedLogin(self.__root, kwargs)
 
-        conf, _pnfo_list, _bytespersec = build_header(self.__prim, self.__web_dir)
+        conf = build_header(self.__prim, self.__web_dir)
 
         conf['have_multicore'] = sabnzbd.WIN32 or sabnzbd.DARWIN_INTEL
         conf['have_nice'] = bool(sabnzbd.newsunpack.NICE_COMMAND)
@@ -1546,7 +1546,7 @@ class ConfigSpecial(object):
         if not check_login():
             raise NeedLogin(self.__root, kwargs)
 
-        conf, _pnfo_list, _bytespersec = build_header(self.__prim, self.__web_dir)
+        conf = build_header(self.__prim, self.__web_dir)
 
         conf['nt'] = sabnzbd.WIN32
 
@@ -1619,7 +1619,7 @@ class ConfigGeneral(object):
         if not check_login():
             raise NeedLogin(self.__root, kwargs)
 
-        conf, _pnfo_list, _bytespersec = build_header(self.__prim, self.__web_dir)
+        conf = build_header(self.__prim, self.__web_dir)
 
         conf['configfn'] = config.get_filename()
 
@@ -1807,7 +1807,7 @@ class ConfigServer(object):
         if not check_login():
             raise NeedLogin(self.__root, kwargs)
 
-        conf, _pnfo_list, _bytespersec = build_header(self.__prim, self.__web_dir)
+        conf = build_header(self.__prim, self.__web_dir)
 
         new = []
         servers = config.get_servers()
@@ -1977,7 +1977,7 @@ class ConfigRss(object):
         if not check_login():
             raise NeedLogin(self.__root, kwargs)
 
-        conf, _pnfo_list, _bytespersec = build_header(self.__prim, self.__web_dir)
+        conf = build_header(self.__prim, self.__web_dir)
 
         conf['script_list'] = list_scripts(default=True)
         pick_script = conf['script_list'] != []
@@ -2302,7 +2302,7 @@ class ConfigScheduling(object):
         if not check_login():
             raise NeedLogin(self.__root, kwargs)
 
-        conf, _pnfo_list, _bytespersec = build_header(self.__prim, self.__web_dir)
+        conf = build_header(self.__prim, self.__web_dir)
 
         actions = []
         actions.extend(_SCHED_ACTIONS)
@@ -2448,7 +2448,7 @@ class ConfigCats(object):
         if not check_login():
             raise NeedLogin(self.__root, kwargs)
 
-        conf, _pnfo_list, _bytespersec = build_header(self.__prim, self.__web_dir)
+        conf = build_header(self.__prim, self.__web_dir)
 
         conf['script_list'] = list_scripts(default=True)
 
@@ -2525,7 +2525,7 @@ class ConfigSorting(object):
         if not check_login():
             raise NeedLogin(self.__root, kwargs)
 
-        conf, _pnfo_list, _bytespersec = build_header(self.__prim, self.__web_dir)
+        conf = build_header(self.__prim, self.__web_dir)
         conf['complete_dir'] = cfg.complete_dir.get_path()
 
         for kw in SORT_LIST:
@@ -2848,7 +2848,7 @@ class ConfigNotify(object):
         if not check_login():
             raise NeedLogin(self.__root, kwargs)
 
-        conf, _pnfo_list, _bytespersec = build_header(self.__prim, self.__web_dir)
+        conf = build_header(self.__prim, self.__web_dir)
 
         conf['my_home'] = sabnzbd.DIR_HOME
         conf['lastmail'] = self.__lastmail

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -349,7 +349,6 @@ class MainPage(object):
 
         if kwargs.get('skip_wizard') or config.get_servers():
             info = build_header(self.__prim, self.__web_dir)
-            info['mb'] = info['mbleft'] = info['kbpersec'] = info['speed'] = '0'
 
             info['script_list'] = list_scripts(default=True)
             info['script'] = 'Default'

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -722,20 +722,19 @@ class NzoPage(object):
                 info['nzo_id'] = nzo_id
                 info['filename'] = xml_name(pnfo.filename)
 
-                for tup in pnfo.active_files:
-                    bytes_left, bytes, fn, date, nzf_id = tup
+                for nzf in pnfo.active_files:
                     checked = False
-                    if nzf_id in self.__cached_selection and \
-                       self.__cached_selection[nzf_id] == 'on':
+                    if nzf.nzf_id in self.__cached_selection and \
+                       self.__cached_selection[nzf.nzf_id] == 'on':
                         checked = True
 
-                    line = {'filename': xml_name(fn),
-                            'mbleft': "%.2f" % (bytes_left / MEBI),
-                            'mb': "%.2f" % (bytes / MEBI),
-                            'size': format_bytes(bytes),
-                            'sizeleft': format_bytes(bytes_left),
-                            'nzf_id': nzf_id,
-                            'age': calc_age(date),
+                    line = {'filename': xml_name(nzf.filename),
+                            'mbleft': "%.2f" % (nzf.bytes_left / MEBI),
+                            'mb': "%.2f" % (nzf.bytes / MEBI),
+                            'size': format_bytes(nzf.bytes),
+                            'sizeleft': format_bytes(nzf.bytes_left),
+                            'nzf_id': nzf.nzf_id,
+                            'age': calc_age(nzf.date),
                             'checked': checked}
                     active.append(line)
                 break

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -868,7 +868,7 @@ class NzbQueue(TryList):
         return n
 
     @synchronized(NZBQUEUE_LOCK)
-    def queue_info(self, for_cli=False, search=None, start=0, limit=0):
+    def queue_info(self, search=None, start=0, limit=0):
         """ Return list of queued jobs,
             optionally filtered by 'search' and limited by start and limit.
         """
@@ -879,6 +879,7 @@ class NzbQueue(TryList):
         q_size = 0
         pnfo_list = []
         n = 0
+
         for nzo in self.__nzo_list:
             if nzo.status != 'Paused':
                 b, b_left = nzo.total_and_remaining()
@@ -887,13 +888,10 @@ class NzbQueue(TryList):
                 q_size += 1
 
             if (not search) or search in nzo.final_name_pw_clean.lower():
-                try:
-                    if (not limit) or (start <= n < start+limit):
-                        pnfo = nzo.gather_info(for_cli=for_cli)
-                        pnfo_list.append(pnfo)
-                except:
-                    logging.info("Traceback: ", exc_info=True)
+                if (not limit) or (start <= n < start+limit):
+                    pnfo_list.append(nzo.gather_info())
                 n += 1
+     
         if not search:
             n = len(self.__nzo_list)
         return QNFO(bytes_total, bytes_left, pnfo_list, q_size, n)

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -1439,59 +1439,23 @@ class NzbObject(TryList):
             bytes_left += nzf.bytes_left
         return bytes, bytes_left
 
-    def gather_info(self, for_cli=False):
-        bytes_left_all = 0
-
-        active_files = []
+    def gather_info(self):
         queued_files = []
-        finished_files = []
-
-        for nzf in self.finished_files:
-            bytes = nzf.bytes
-            filename = nzf.filename
-            if not filename:
-                filename = nzf.subject
-            date = nzf.date
-            if for_cli:
-                date = time.mktime(date.timetuple())
-            finished_files.append((0, bytes, filename, date))
-
-        for nzf in self.files:
-            bytes_left = nzf.bytes_left
-            bytes = nzf.bytes
-            filename = nzf.filename
-            if not filename:
-                filename = nzf.subject
-            date = nzf.date
-            if for_cli:
-                date = time.mktime(date.timetuple())
-
-            bytes_left_all += bytes_left
-            active_files.append((bytes_left, bytes, filename, date,
-                                 nzf.nzf_id))
-
+        bytes_extrapars = 0
         for _set in self.extrapars:
             for nzf in self.extrapars[_set]:
-                bytes_left = nzf.bytes_left
-                bytes = nzf.bytes
-                filename = nzf.filename
-                if not filename:
-                    filename = nzf.subject
-                date = nzf.date
-                if for_cli:
-                    date = time.mktime(date.timetuple())
+                bytes_extrapars += nzf.bytes
+                nzf.setname = _set
+                queued_files.append(nzf)
 
-                queued_files.append((_set, bytes_left, bytes, filename, date))
-
-        avg_date = self.avg_date
-        if for_cli:
-            avg_date = time.mktime(avg_date.timetuple())
+        # Subtract PAR2 sets and already downloaded bytes
+        bytes_left_all = self.bytes - self.bytes_downloaded - bytes_extrapars
 
         return PNFO(self.repair, self.unpack, self.delete, self.script,
                 self.nzo_id, self.final_name_labeled, self.password, {},
                 '', self.cat, self.url,
-                bytes_left_all, self.bytes, self.avg_stamp, avg_date,
-                finished_files, active_files, queued_files, self.status, self.priority,
+                bytes_left_all, self.bytes, self.avg_stamp, self.avg_date,
+                self.finished_files, self.files, queued_files, self.status, self.priority,
                 len(self.nzo_info.get('missing_art_log', []))
                 )
 

--- a/sabnzbd/osxmenu.py
+++ b/sabnzbd/osxmenu.py
@@ -353,7 +353,7 @@ class SABnzbdDelegate(NSObject):
 
     def queueUpdate(self):
         try:
-            qnfo = NzbQueue.do.queue_info(max_jobs=10)
+            qnfo = NzbQueue.do.queue_info(start=0, limit=10)
             pnfo_list = qnfo.list
 
             bytesleftprogess = 0


### PR DESCRIPTION
While our user in #550 originally used a somewhat unfriendly tone, he pointed out a valid point: SAB's API is slow for large queues.
This triggered @shypike to take a good look at the code and realized there was great room for improvement and already [made changes that drastically improved performance](https://github.com/sabnzbd/sabnzbd/commits/feature/optimize-api).
I also did some more tweaking of those and the results are really great!

Using a queue of 600 items totalling to 1.5TB with the global queue paused, these are the timings of the ```_api_queue_default``` function averaged over 2 minutes:

```Develop``` | @shypike  fixes | + @safihre fixes
------------ | -------------  | -------------
85.58 ms | 12.31 ms | 9.24 ms
- | **6.95x** faster | **9.26x** faster

- Plush also greatly benefits, SMPL not so much because it does 3 simultaneous API requests that slow each other down.
- When pausing the queue it would normally write the whole queue to the disk, this caused a complete freeze of up to 60 seconds with such queues. Now only the article cache is saved to disk.
- Removed the option to view files of a job on the main page in SMPL, this was ugly code that shouldn't be in the back-end functions.

Surely there are more API functions that could be improved, but this is the first one to be tackled!