### PR TITLE
systemd service: add wiki link, remove group handling, housekeeping

### DIFF
--- a/linux/sabnzbd@.service
+++ b/linux/sabnzbd@.service
@@ -12,16 +12,15 @@
 
 [Unit]
 Description=SABnzbd binary newsreader
+Documentation=http://wiki.sabnzbd.org
 Wants=network-online.target
 After=network-online.target
 
 [Service]
 ExecStart=/opt/sabnzbd/SABnzbd.py --logging 1 --browser 0
 User=%I
-Group=%I
-Type = simple
-Restart = on-failure
-
+Type=simple
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Removing Group=%I because it (wrongly) assumes every username always has a matching groupname. Not specifying a group will simply make systemd use the default group for the given user.