### PR TITLE
Log "Preferred Encoding", useful for debugging Unicode problems

### DIFF
--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1342,6 +1342,8 @@ def main():
 
     logging.debug('Unwanted extensions are ... %s', sabnzbd.cfg.unwanted_extensions())
 
+    logging.info('Preferred encoding = %s', locale.getpreferredencoding())    # Useful for debugging Unicode problems
+
     if fork and not sabnzbd.WIN32:
         daemonize()
 


### PR DESCRIPTION
As discussed here: https://github.com/sabnzbd/sabnzbd/issues/543
This is only logging (no warning)

Useful for Linux and *BSD, thus possibly for OSX too.

Examples from sabnzbd.log:

With UTF-8 in LANG environment setting (good):
`2016-04-30 12:45:40,577::INFO::[SABnzbd:1345] Preferred encoding = UTF-8
`

Without UTF-8 in LANG environment setting (not good):
`2016-04-30 12:46:04,124::INFO::[SABnzbd:1345] Preferred encoding = ANSI_X3.4-1968
`