### PR TITLE
SFV verification fixes

### DIFF
--- a/interfaces/Glitter/templates/static/javascripts/knockout-extensions.js
+++ b/interfaces/Glitter/templates/static/javascripts/knockout-extensions.js
@@ -36,7 +36,7 @@ ko.bindingHandlers.longText = {
         // Any <br>'s?
         if(value.length > 4) {
             // Inital 3, then the button, then the closing
-            outputText += value.pop() + '<br />' + value.pop() + '<br />' + value.pop() + ' ';
+            outputText += value.shift() + '<br />' + value.shift() + '<br />' + value.shift() + ' ';
             outputText += '<a href="#" class="history-status-more">(' + glitterTranslate.moreText + ')</a><br />';
             outputText += '<span class="history-status-hidden">';
             outputText += value.join('<br />');

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -649,11 +649,14 @@ def try_sfv_check(nzo, workdir, setname):
     for sfv in sfvs:
         if setname.lower() in os.path.basename(sfv).lower():
             found = True
+            nzo.status = Status.VERIFYING
             nzo.set_unpack_info('Repair', T('Trying SFV verification'))
+            nzo.set_action_line(T('Trying SFV verification'), '...')
+
             failed = sfv_check(sfv)
             if failed:
-                msg = T('Some files failed to verify against "%s"') % unicoder(os.path.basename(sfv))
-                msg += '; '
+                fail_msg = T('Some files failed to verify against "%s"') % unicoder(os.path.basename(sfv))
+                msg = fail_msg + '; '
                 msg += '; '.join(failed)
                 nzo.set_unpack_info('Repair', msg)
                 par_error = True
@@ -661,6 +664,10 @@ def try_sfv_check(nzo, workdir, setname):
                 nzo.set_unpack_info('Repair', T('Verified successfully using SFV files'))
             if setname:
                 break
+    # Show error in GUI
+    if found and par_error:
+        nzo.status = Status.FAILED
+        nzo.fail_msg = fail_msg
     return (found or not setname) and not par_error
 
 


### PR DESCRIPTION
Noticed today that when a download doesn't have par2 set, but does have SFV it doesn't tell the user anything in the interface: 
SABnzbd doesn't show that it is doing the SFV verification, it just says ```Waiting``` (as if it's queued for post-processing).
And when the verification fails, the action-line is just blank. No information at all.

Also turns out Glitter was messing up long texts of the stage-log, so that the bottom 4 lines were displayed before the rest. 
Fixed all that.