### PR TITLE
Fixes and adding sabnzbd.ini to logging

### DIFF
--- a/ABOUT.txt
+++ b/ABOUT.txt
@@ -10,10 +10,10 @@ SABnzbd also has a fully customizable user interface,
 and offers a complete API for third-party applications to hook into.
 
 There is an extensive Wiki on the use of SABnzbd.
-http://wiki.sabnzbd.org/
+https://sabnzbd.org/wiki/
 
 IMPORTANT INFORMATION about release 1.0.0:
-http://wiki.sabnzbd.org/introducing-1-0-0
+https://sabnzbd.org/wiki/introducing-1-0
 
 
 Please also read the file "ISSUES.txt"

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -129,7 +129,7 @@ may help you solve problems easier.
 -------------------------------------------------------------------------------
 
 Visit the WIKI site:
-    http://wiki.sabnzbd.org/
+    https://sabnzbd.org/wiki/
 
 
 -------------------------------------------------------------------------------

--- a/ISSUES.txt
+++ b/ISSUES.txt
@@ -24,13 +24,13 @@
   For these the server blocking method is not very favourable.
   There is an INI-only option that will limit blocks to 1 minute.
       no_penalties = 1
-  See: http://wiki.sabnzbd.org/configure-special-1-0
+  See: https://sabnzbd.org/wiki/configuration/1.0/special
 
 - Some third-party utilties try to probe SABnzbd API in such a way that you will
   often see warnings about unauthenticated access.
   If you are sure these probes are harmless, you can suppress the warnings by
   setting the option "api_warnings" to 0.
-  See: http://wiki.sabnzbd.org/configure-special-1-0
+  See: https://sabnzbd.org/wiki/configuration/1.0/special
 
 - On OSX you may encounter downloaded files with foreign characters.
   The par2 repair may fail when the files were created on a Windows system.
@@ -41,7 +41,7 @@
   You will see this only when downloaded files contain accented characters.
   You need to fix it yourself by running the convmv utility (available for most Linux platforms).
   Possible the file system override setting 'fsys_type' might be solve things:
-  See: http://wiki.sabnzbd.org/configure-special-1-0
+  See: https://sabnzbd.org/wiki/configuration/1.0/special
 
 - The "Watched Folder" sometimes fails to delete the NZB files it has
   processed. This happens when other software still accesses these files.
@@ -81,4 +81,4 @@
   - Squeeze Linux
   There is a "special" option that will allow you to select an alternative library.
       use_pickle = 1
-  See: http://wiki.sabnzbd.org/configure-special-1-0
+  See: https://sabnzbd.org/wiki/configuration/1.0/special

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you want multi-language support, run:
 python tools/make_mo.py
 ```
 
-Our many other command line options are explained in depth [here](http://wiki.sabnzbd.org/command-line-parameters).
+Our many other command line options are explained in depth [here](https://sabnzbd.org/wiki/advanced/command-line-parameters).
 
 ## About Our Repo
 

--- a/README.mkd
+++ b/README.mkd
@@ -33,7 +33,7 @@ Release Notes  -  SABnzbd 1.1.0Beta1
 
 
 ### IMPORTANT INFORMATION about release 1.0.0
-<http://wiki.sabnzbd.org/introducing-1-0-0>
+<https://sabnzbd.org/wiki/introducing-1-0>
 
 ### Known problems and solutions
 - Read the file "ISSUES.txt"

--- a/interfaces/Config/templates/config.tmpl
+++ b/interfaces/Config/templates/config.tmpl
@@ -1,5 +1,5 @@
 <!--#set global $pane="Config"#-->
-<!--#set global $help_uri="configure-1-0"#-->
+<!--#set global $help_uri="configuration/1.0/configure"#-->
 <!--#include $webdir + "/_inc_header_uc.tmpl"#-->
 
 <!--#from sabnzbd.newswrapper import HAVE_SSL#-->
@@ -83,7 +83,7 @@
                     </tr>
                     <tr>
                         <th scope="row">$T('menu-wiki') </th>
-                        <td><a href="http://wiki.sabnzbd.org/faq" target="_blank">http://wiki.sabnzbd.org/faq</a></td>
+                        <td><a href="https://sabnzbd.org/wiki/faq" target="_blank">https://sabnzbd.org/wiki/faq</a></td>
                     </tr>
                     <tr>
                         <th scope="row">$T('menu-forums') </th>
@@ -99,7 +99,7 @@
                     </tr>
                     <tr>
                         <th scope="row">$T('menu-issues') </th>
-                        <td><a href="http://wiki.sabnzbd.org/issues-1-0-0" target="_blank">http://wiki.sabnzbd.org/issues-1-0-0</a></td>
+                        <td><a href="https://sabnzbd.org/wiki/introduction/known-issues" target="_blank">https://sabnzbd.org/wiki/introduction/known-issues</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/interfaces/Config/templates/config_cat.tmpl
+++ b/interfaces/Config/templates/config_cat.tmpl
@@ -1,5 +1,5 @@
 <!--#set global $pane="Categories"#-->
-<!--#set global $help_uri="configure-categories-1-0"#-->
+<!--#set global $help_uri="configuration/1.0/categories"#-->
 <!--#include $webdir + "/_inc_header_uc.tmpl"#-->
 <div class="colmask">
     <div class="section">

--- a/interfaces/Config/templates/config_folders.tmpl
+++ b/interfaces/Config/templates/config_folders.tmpl
@@ -1,5 +1,5 @@
 <!--#set global $pane="Folders"#-->
-<!--#set global $help_uri="configure-folders-1-0"#-->
+<!--#set global $help_uri="configuration/1.0/folders"#-->
 <!--#include $webdir + "/_inc_header_uc.tmpl"#-->
 
 <div class="colmask">

--- a/interfaces/Config/templates/config_general.tmpl
+++ b/interfaces/Config/templates/config_general.tmpl
@@ -1,5 +1,5 @@
 <!--#set global $pane="General"#-->
-<!--#set global $help_uri="configure-general-1-0"#-->
+<!--#set global $help_uri="configuration/1.0/general"#-->
 <!--#include $webdir + "/_inc_header_uc.tmpl"#-->
 
 <div class="colmask">

--- a/interfaces/Config/templates/config_notify.tmpl
+++ b/interfaces/Config/templates/config_notify.tmpl
@@ -1,5 +1,5 @@
 <!--#set global $pane="Email"#-->
-<!--#set global $help_uri="configure-notifications-1-0"#-->
+<!--#set global $help_uri="configuration/1.0/notifications"#-->
 <!--#include $webdir + "/_inc_header_uc.tmpl"#-->
 
 <div class="colmask">

--- a/interfaces/Config/templates/config_rss.tmpl
+++ b/interfaces/Config/templates/config_rss.tmpl
@@ -1,5 +1,5 @@
 <!--#set global $pane="RSS"#-->
-<!--#set global $help_uri="configure-rss-1-0"#-->
+<!--#set global $help_uri="configuration/1.0/rss"#-->
 <!--#include $webdir + "/_inc_header_uc.tmpl"#-->
 <div class="colmask">
     <!--#if not $active_feed#-->

--- a/interfaces/Config/templates/config_scheduling.tmpl
+++ b/interfaces/Config/templates/config_scheduling.tmpl
@@ -1,5 +1,5 @@
 <!--#set global $pane="Scheduling"#-->
-<!--#set global $help_uri="configure-scheduling-1-0"#-->
+<!--#set global $help_uri="configuration/1.0/scheduling"#-->
 <!--#include $webdir + "/_inc_header_uc.tmpl"#-->
 
 <%

--- a/interfaces/Config/templates/config_server.tmpl
+++ b/interfaces/Config/templates/config_server.tmpl
@@ -1,5 +1,5 @@
 <!--#set global $pane="Servers"#-->
-<!--#set global $help_uri="configure-servers-1-0"#-->
+<!--#set global $help_uri="configuration/1.0/servers"#-->
 <!--#include $webdir + "/_inc_header_uc.tmpl"#-->
 
 <div class="colmask">

--- a/interfaces/Config/templates/config_sorting.tmpl
+++ b/interfaces/Config/templates/config_sorting.tmpl
@@ -1,5 +1,5 @@
 <!--#set global $pane="Sorting"#-->
-<!--#set global $help_uri="configure-sorting-1-0"#-->
+<!--#set global $help_uri="configuration/1.0/sorting"#-->
 <!--#include $webdir + "/_inc_header_uc.tmpl"#-->
 
 <div class="colmask">

--- a/interfaces/Config/templates/config_special.tmpl
+++ b/interfaces/Config/templates/config_special.tmpl
@@ -1,5 +1,5 @@
 <!--#set global $pane="Special"#-->
-<!--#set global $help_uri="configure-special-1-0"#-->
+<!--#set global $help_uri="configuration/1.0/special"#-->
 <!--#include $webdir + "/_inc_header_uc.tmpl"#-->
 
 <div class="colmask">

--- a/interfaces/Config/templates/config_switches.tmpl
+++ b/interfaces/Config/templates/config_switches.tmpl
@@ -1,5 +1,5 @@
 <!--#set global $pane="Switches"#-->
-<!--#set global $help_uri="configure-switches-1-0"#-->
+<!--#set global $help_uri="configuration/1.0/switches"#-->
 <!--#include $webdir + "/_inc_header_uc.tmpl"#-->
 
 <div class="colmask">

--- a/interfaces/Config/templates/login/main.tmpl
+++ b/interfaces/Config/templates/login/main.tmpl
@@ -24,7 +24,7 @@
         <div class="account-wall">
             <div class="text-center logo-header">
                 <!--#include $webdir + "/staticcfg/images/logo-full.svg"#-->
-                <a href="http://wiki.sabnzbd.org/faq#why-login" target="_blank">
+                <a href="https://sabnzbd.org/wiki/faq#why-login" target="_blank">
                     <span class="glyphicon glyphicon-question-sign"></span>
                 </a>
             </div>

--- a/interfaces/Glitter/templates/include_overlays.tmpl
+++ b/interfaces/Glitter/templates/include_overlays.tmpl
@@ -202,18 +202,17 @@
                                 <div class="row" data-bind="visible: servererror()">
                                     <div class="col-sm-12">
                                         <div class="alert alert-danger">
-                                        <a href="#" data-bind="visible: !serveractive(), click: function() { \$parent.unblockServer(servername()) }" class="btn btn-default"><span class="glyphicon glyphicon-share-alt"></span> $T('Glitter-unblockServer')</a>
-                                        <span class="glyphicon glyphicon-exclamation-sign"></span>
-                                        <span data-bind="text: servererror()"></span>
+                                            <a href="#" data-bind="visible: !serveractive(), click: function() { \$parent.unblockServer(servername()) }" class="btn btn-default"><span class="glyphicon glyphicon-share-alt"></span> $T('Glitter-unblockServer')</a>
+                                            <span class="glyphicon glyphicon-exclamation-sign"></span>
+                                            <span data-bind="text: servererror()"></span>
                                         </div>
                                     </div>
                                 </div>
                                 <div class="row" data-bind="visible: !isFinite(serveractiveconn())">
                                     <div class="col-sm-12">
-                                        <div class="alert alert-warning ">
-                                        <a href="#" data-bind="visible: !serveractive(), click: function() { \$parent.unblockServer(servername()) }" class="btn btn-default"><span class="glyphicon glyphicon-share-alt"></span> $T('Glitter-unblockServer')</a>
-                                        <span class="glyphicon glyphicon-info-sign"></span>
-                                        <span data-bind="text: serveractiveconn()"></span>
+                                        <div class="alert alert-warning">
+                                            <span class="glyphicon glyphicon-info-sign"></span>
+                                            <span data-bind="text: serveractiveconn()"></span>
                                         </div>
                                     </div>
                                 </div>

--- a/interfaces/Glitter/templates/include_overlays.tmpl
+++ b/interfaces/Glitter/templates/include_overlays.tmpl
@@ -195,7 +195,7 @@
                                 <div class="row">
                                     <div class="col-sm-6"># $T('connections')</div>
                                     <div class="col-sm-6">
-                                        <span data-bind="html: isFinite(serveractiveconn()) ? serverconnections().length : serveractiveconn()"></span> / 
+                                        <span data-bind="text: serverconnections().length"></span> / 
                                         <span data-bind="text: servertotalconn"></span>
                                     </div>
                                 </div>
@@ -205,6 +205,15 @@
                                         <a href="#" data-bind="visible: !serveractive(), click: function() { \$parent.unblockServer(servername()) }" class="btn btn-default"><span class="glyphicon glyphicon-share-alt"></span> $T('Glitter-unblockServer')</a>
                                         <span class="glyphicon glyphicon-exclamation-sign"></span>
                                         <span data-bind="text: servererror()"></span>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="row" data-bind="visible: !isFinite(serveractiveconn())">
+                                    <div class="col-sm-12">
+                                        <div class="alert alert-warning ">
+                                        <a href="#" data-bind="visible: !serveractive(), click: function() { \$parent.unblockServer(servername()) }" class="btn btn-default"><span class="glyphicon glyphicon-share-alt"></span> $T('Glitter-unblockServer')</a>
+                                        <span class="glyphicon glyphicon-info-sign"></span>
+                                        <span data-bind="text: serveractiveconn()"></span>
                                         </div>
                                     </div>
                                 </div>

--- a/interfaces/Glitter/templates/include_overlays.tmpl
+++ b/interfaces/Glitter/templates/include_overlays.tmpl
@@ -612,7 +612,7 @@
                     <tbody>
                         <tr>
                             <td><strong>$T('menu-wiki'):</strong></td>
-                            <td><a href="http://wiki.sabnzbd.org/" target="_blank">http://wiki.sabnzbd.org/</a></td>
+                            <td><a href="https://sabnzbd.org/wiki/" target="_blank">https://sabnzbd.org/wiki/</a></td>
                         </tr>
                         <tr>
                             <td><strong>$T('menu-forums'):</strong></td>

--- a/interfaces/Glitter/templates/static/javascripts/glitter.main.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.main.js
@@ -327,6 +327,9 @@ function ViewModel() {
 
                 // Does it contain 'Paused'? Update icon!
                 self.downloadsPaused(data.indexOf(glitterTranslate.paused) > -1)
+
+                // Force the next full update to be full
+                self.history.lastUpdate = 0
             })
             // Do not continue!
             return;
@@ -1081,4 +1084,4 @@ function ViewModel() {
 
     // Activate tooltips
     if(!isMobile) $('[data-tooltip="true"]').tooltip({ trigger: 'hover', container: 'body' })
-    }
+}

--- a/interfaces/smpl/templates/status.tmpl
+++ b/interfaces/smpl/templates/status.tmpl
@@ -33,10 +33,6 @@ $T('logging'):
 <!--#end for#-->
 </ul>
 <!--#end if#-->
-<!--#if $lastmail#-->
-  <h2>$T('emailResult')</h2>
-  $lastmail
-<!--#end if#-->
 <!--#if $warnings#-->
   <h2>$T('lastWarnings') (<a class="config" onClick="lr('status/clearwarnings','', '-1', this.parentNode.id);">$T('clearWarnings')</a>)</h2>
   <!--#for $warn in $warnings#-->

--- a/linux/sabnzbd@.service
+++ b/linux/sabnzbd@.service
@@ -12,7 +12,7 @@
 
 [Unit]
 Description=SABnzbd binary newsreader
-Documentation=http://wiki.sabnzbd.org
+Documentation=https://sabnzbd.org/wiki/
 Wants=network-online.target
 After=network-online.target
 

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1295,7 +1295,7 @@ def build_queue(web_dir=None, root=None, prim=True, webdir='', start=0, limit=0,
         converter = xml_name
 
     # build up header full of basic information
-    info, pnfo_list, bytespersec, q_size = build_queue_header(prim, webdir, search=search, start=start, limit=limit)
+    info, pnfo_list, bytespersec, q_size, bytes_left_previous_page = build_queue_header(prim, webdir, search=search, start=start, limit=limit)
 
     datestart = datetime.datetime.now()
     priorities = {TOP_PRIORITY: 'Force', REPAIR_PRIORITY: 'Repair', HIGH_PRIORITY: 'High', NORMAL_PRIORITY: 'Normal', LOW_PRIORITY: 'Low'}
@@ -1319,7 +1319,7 @@ def build_queue(web_dir=None, root=None, prim=True, webdir='', start=0, limit=0,
         info['queue_details'] = str(int_conv(cherrypy.request.cookie['queue_details'].value))
 
     n = 0
-    running_bytes = 0
+    running_bytes = bytes_left_previous_page
     slotinfo = []
     for pnfo in pnfo_list:
         nzo_id = pnfo.nzo_id
@@ -1775,7 +1775,7 @@ def build_queue_header(prim, webdir='', search=None, start=0, limit=0):
         datestart = datetime.datetime.now()
         header['eta'] = T('unknown')
 
-    return (header, qnfo.list, bytespersec, qnfo.q_fullsize)
+    return (header, qnfo.list, bytespersec, qnfo.q_fullsize, qnfo.bytes_left_previous_page)
 
 
 def build_history(start=None, limit=None, verbose=False, verbose_list=None, search=None, failed_only=0,

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1176,8 +1176,6 @@ def build_status(web_dir=None, root=None, prim=True, skip_dashboard=False, outpu
     info['loglevel'] = str(cfg.log_level())
     info['folders'] = [xml_name(item) for item in sabnzbd.nzbqueue.scan_jobs(all=False, action=False)]
     info['configfn'] = xml_name(config.get_filename())
-    info['lastmail'] = None  # Obsolete, keep for compatibility
-
 
     # Dashboard: Begin
     if not int_conv(skip_dashboard):

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1689,7 +1689,7 @@ def build_header(prim, webdir=''):
     free1 = diskfree(cfg.download_dir.get_path())
     free2 = diskfree(cfg.complete_dir.get_path())
 
-    header['helpuri'] = 'http://wiki.sabnzbd.org/'
+    header['helpuri'] = 'https://sabnzbd.org/wiki/'
     header['diskspace1'] = "%.2f" % free1
     header['diskspace2'] = "%.2f" % free2
     header['diskspace1_norm'] = to_units(free1 * GIGI)

--- a/sabnzbd/constants.py
+++ b/sabnzbd/constants.py
@@ -28,7 +28,7 @@ PNFO = namedtuple('PNFO', 'repair unpack delete script nzo_id filename password 
                           'unpackstrht msgid category url bytes_left bytes avg_stamp '
                           'avg_date finished_files active_files queued_files status priority missing')
 
-QNFO = namedtuple('QNFO', 'bytes bytes_left list q_size_list q_fullsize')
+QNFO = namedtuple('QNFO', 'bytes bytes_left bytes_left_previous_page list q_size_list q_fullsize')
 
 ANFO = namedtuple('ANFO', 'article_sum cache_size cache_limit')
 

--- a/sabnzbd/decoder.py
+++ b/sabnzbd/decoder.py
@@ -213,6 +213,7 @@ class Decoder(Thread):
                                     new_nzf = extrapars_sorted.pop()
                                     nzo.add_parfile(new_nzf)
                                     nzo.extrapars[parset] = extrapars_sorted
+                                    nzo.reset_try_list()
                                     blocks_already = blocks_already + int_conv(new_nzf.blocks)
                                     logging.info('Prospectively added %s repair blocks to %s', new_nzf.blocks, nzo.final_name)
 

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -2545,6 +2545,7 @@ LOG_API_RE = re.compile(r"(apikey|api)(=|:)[\w]+", re.I)
 LOG_API_JSON_RE = re.compile(r"u'(apikey|api)': u'[\w]+'", re.I)
 LOG_USER_RE = re.compile(r"(user|username)\s?=\s?[\w]+", re.I)
 LOG_PASS_RE = re.compile(r"(password)\s?=\s?[\w]+", re.I)
+LOG_INI_HIDE_RE = re.compile(r"(email_pwd|rating_api_key|pushover_token|pushover_userkey|pushbullet_apikey|prowl_apikey|growl_password|growl_server)\s?=\s?[\w]+", re.I)
 LOG_HASH_RE = re.compile(r"([a-fA-F\d]{25})", re.I)
 
 class Status(object):
@@ -2613,6 +2614,7 @@ class Status(object):
         log_data = LOG_API_JSON_RE.sub("'apikey':<APIKEY>'", log_data)
         log_data = LOG_USER_RE.sub("\g<1>=<USER>", log_data)
         log_data = LOG_PASS_RE.sub("password=<PASSWORD>", log_data)
+        log_data = LOG_INI_HIDE_RE.sub(r"\1 = <REMOVED>", log_data)
         log_data = LOG_HASH_RE.sub("<HASH>", log_data)
 
         # Try to replace the username

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -2543,8 +2543,8 @@ class ConfigSorting(object):
 ##############################################################################
 LOG_API_RE = re.compile(r"(apikey|api)(=|:)[\w]+", re.I)
 LOG_API_JSON_RE = re.compile(r"u'(apikey|api)': u'[\w]+'", re.I)
-LOG_USER_RE = re.compile(r"(user|username)=[\w]+", re.I)
-LOG_PASS_RE = re.compile(r"(password)=[\w]+", re.I)
+LOG_USER_RE = re.compile(r"(user|username)\s?=\s?[\w]+", re.I)
+LOG_PASS_RE = re.compile(r"(password)\s?=\s?[\w]+", re.I)
 LOG_HASH_RE = re.compile(r"([a-fA-F\d]{25})", re.I)
 
 class Status(object):
@@ -2601,13 +2601,20 @@ class Status(object):
         except:
             pass
 
-        # To remove all API-keys we need to open the file and serve it ourselves
-        log_data = open(sabnzbd.LOGFILE, "r").read()
+        # Fetch the INI and the log-data and add a message at the top
+        log_data  = '--------------------------------\n\n'
+        log_data += 'The log includes a copy of your sabnzbd.ini with\nall usernames, passwords and API-keys removed.'
+        log_data += '\n\n--------------------------------\n'
+        log_data += open(sabnzbd.LOGFILE, "r").read()
+        log_data += open(config.get_filename(), 'r').read()
+
+        # We need to remove all passwords/usernames/api-keys
         log_data = LOG_API_RE.sub("apikey=<APIKEY>", log_data)
         log_data = LOG_API_JSON_RE.sub("'apikey':<APIKEY>'", log_data)
         log_data = LOG_USER_RE.sub("\g<1>=<USER>", log_data)
         log_data = LOG_PASS_RE.sub("password=<PASSWORD>", log_data)
-        log_data = LOG_HASH_RE.sub("<HIDE-HASH>", log_data)
+        log_data = LOG_HASH_RE.sub("<HASH>", log_data)
+
         # Try to replace the username
         try:
             import getpass

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -877,6 +877,7 @@ class NzbQueue(TryList):
             search = search.lower()
         bytes_left = 0
         bytes_total = 0
+        bytes_left_previous_page = 0
         q_size = 0
         pnfo_list = []
         n = 0
@@ -887,6 +888,9 @@ class NzbQueue(TryList):
                 bytes_total += b
                 bytes_left += b_left
                 q_size += 1
+                # We need the number of bytes before the current page
+                if n < start:
+                    bytes_left_previous_page += b_left
 
             if (not search) or search in nzo.final_name_pw_clean.lower():
                 if (not limit) or (start <= n < start+limit):
@@ -895,7 +899,7 @@ class NzbQueue(TryList):
 
         if not search:
             n = len(self.__nzo_list)
-        return QNFO(bytes_total, bytes_left, pnfo_list, q_size, n)
+        return QNFO(bytes_total, bytes_left, bytes_left_previous_page, pnfo_list, q_size, n)
 
     @synchronized(NZBQUEUE_LOCK)
     def remaining(self):

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -1016,6 +1016,8 @@ class NzbObject(TryList):
                 self.fail_msg = T('Aborted, cannot be completed')
                 self.set_unpack_info('Download', self.fail_msg, unique=False)
                 logging.debug('Abort job "%s", due to impossibility to complete it', self.final_name_pw_clean)
+                # Update the last check time
+                sabnzbd.LAST_HISTORY_UPDATE = time.time()
                 return True, True, True
 
         if reset:

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -1594,7 +1594,7 @@ class NzbObject(TryList):
         self.pp_active = False
         self.avg_stamp = time.mktime(self.avg_date.timetuple())
         self.wait = None
-        self.to_be_removed= False
+        self.to_be_removed = False
         if self.meta is None:
             self.meta = {}
         if self.servercount is None:

--- a/sabnzbd/wizard.py
+++ b/sabnzbd/wizard.py
@@ -135,7 +135,7 @@ class Wizard(object):
 
         # Show Restart screen
         info = self.info.copy()
-        info['helpuri'] = 'http://wiki.sabnzbd.org/'
+        info['helpuri'] = 'https://sabnzbd.org/wiki/'
         info['session'] = cfg.api_key()
 
         info['access_url'], info['urls'] = self.get_access_info()


### PR DESCRIPTION
Sometimes a bug is caused or only present in a very specific combination of settings, but without information about those settings bug-hunting take much longer.
Therefore it seemed like a good idea to attach the ```sabnzbd.ini``` to the end of the log when a user download's it on the status page.
The usernames/passwords/api-keys get cleared using the same routines as used to clear the log.
Added a message to the top of the log to inform users that their settings-file is attached.

Also fixed some bugs and made the server warnings displayed better (#606).