### PR TITLE
Add .pyd to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 #Compiled python
-*.py[co]
+*.py[cod]
 
 # Working folders for Win build
 build/


### PR DESCRIPTION
This adds .pyd (essentially python .dll files on windows) to the gitignore.