### PR TITLE
Allow 7zip to detect archive type

### DIFF
--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -1020,8 +1020,7 @@ def seven_extract_core(sevenset, extensions, extraction_path, one_folder, delete
     if not os.path.exists(name):
         return 1, T('7ZIP set "%s" is incomplete, cannot unpack') % unicoder(sevenset)
 
-    command = [SEVEN_COMMAND, method, '-y', '-aou', '-t7z', case, password,
-               '-o%s' % extraction_path, name]
+    command = [SEVEN_COMMAND, method, '-y', '-aou', case, password, '-o%s' % extraction_path, name]
 
     stup, need_shell, command, creationflags = build_command(command)
 


### PR DESCRIPTION
This change fixes an issue with 7zip extraction failing for a supported archive type. The '-t7z' parameter will only allow 7z file types, and excludes others, e.g. Split type (.7z.001). By removing -t7z we allow 7zip to detect the archive type, and prevent 7z from errorring out with a valid archive.