### PR TITLE
Airplane-mode fixes

### DIFF
--- a/ABOUT.txt
+++ b/ABOUT.txt
@@ -15,28 +15,17 @@ https://sabnzbd.org/wiki/
 IMPORTANT INFORMATION about release 1.0.0:
 https://sabnzbd.org/wiki/introducing-1-0
 
-
 Please also read the file "ISSUES.txt"
-
-
-*******************************************
-*** Upgrading from 0.7.x or 0.6.x       ***
-*******************************************
-Empty your current queue
-Stop SABnzbd.
-Install new version
-Start SABnzbd.
-
-
-*******************************************
-*** Upgrading from 0.5.x                ***
-*******************************************
-Stop SABnzbd.
-Uninstall current version, keeping the data.
-Install new version
-Start SABnzbd.
 
 The organization of the download queue is different from 0.7.x (and older).
 1.0.0 will not finish downloading an existing queue.
 Also, your sabnzbd.ini file will be upgraded, making it
 incompatible with older releases.
+
+*******************************************
+*** Upgrading from 0.7.x and below      ***
+*******************************************
+Empty your current queue
+Stop SABnzbd.
+Install new version
+Start SABnzbd.

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1332,10 +1332,6 @@ def main():
     sabnzbd.WEB_COLOR2 = CheckColor(sabnzbd.cfg.web_color2(), web_dir2)
     sabnzbd.cfg.web_color2.set(sabnzbd.WEB_COLOR2)
 
-    logging.debug('Unwanted extensions are ... %s', sabnzbd.cfg.unwanted_extensions())
-
-    logging.info('Preferred encoding = %s', locale.getpreferredencoding())    # Useful for debugging Unicode problems
-
     if fork and not sabnzbd.WIN32:
         daemonize()
 

--- a/interfaces/Config/templates/config.tmpl
+++ b/interfaces/Config/templates/config.tmpl
@@ -3,115 +3,114 @@
 <!--#include $webdir + "/_inc_header_uc.tmpl"#-->
 
 <!--#from sabnzbd.newswrapper import HAVE_SSL#-->
+<!--#from locale import getpreferredencoding#-->
 <!--#import sabnzbd.utils.sslinfo#-->
 <!--#from sabnzbd.decoder import HAVE_YENC#-->
-<!--#from sabnzbd.newsunpack import PAR2_COMMAND, PAR2C_COMMAND, RAR_COMMAND, ZIP_COMMAND, SEVEN_COMMAND, NICE_COMMAND, IONICE_COMMAND#-->
-
-    <div class="colmask">
-        <div class="section padTable">
-            <table class="table table-striped">
-                <tbody>
-                    <tr>
-                        <th scope="row">$T('version'): </th>
-                        <td>$version [$build]</td>
-                    </tr>
-                    <tr>
-                        <th scope="row">$T('uptime'): </th>
-                        <td>$uptime</td>
-                    </tr>
-                    <tr>
-                        <th scope="row">$T('confgFile'): </th>
-                        <td>$configfn</td>
-                    </tr>
-                    <tr>
-                        <th scope="row">$T('cache').capitalize(): </th>
-                        <td><!--#set $msg=$T('ft-buffer@2')%($cache_art, $cache_size)#-->$msg</td>
-                    </tr>
-                    <tr>
-                        <th scope="row">$T('parameters'): </th>
-                        <td>$cmdline</td>
-                    </tr>
-                    <tr>
-                        <th scope="row">$T('pythonVersion'): </th>
-                        <td>$sys.version[:120]</td>
-                    </tr>
-                    <tr>
-                        <th scope="row">OpenSSL:</th>
-                        <td>
-                            <!--#if HAVE_SSL#--> 
-                                <!--#set $sslversions = ', '.join(sabnzbd.utils.sslinfo.ssl_protocols())#-->
-                                $sabnzbd.utils.sslinfo.ssl_version() &nbsp; [$sslversions]
-                            <!--#else#-->
-                                <span class="label label-warning">$T('notAvailable')</span>
-                                <a href="$helpuri$help_uri#no_ssl" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a>
-                            <!--#end if#-->
-                        </td>
-                    </tr>
-                    <tr>
-                        <th scope="row">pyOpenSSL:</th>
-                        <td>
-                            <!--#if HAVE_SSL#--> 
-                                $sabnzbd.utils.sslinfo.pyopenssl_version()
-                            <!--#else#-->
-                                <span class="label label-warning">$T('notAvailable')</span>
-                                <a href="$helpuri$help_uri#no_ssl" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a>
-                            <!--#end if#-->
-                        </td>
-                    </tr>
-                    <tr>
-                        <th scope="row">yEnc:</th>
-                        <td>
-                            <!--#if HAVE_YENC#--> 
-                                <span class="glyphicon glyphicon-ok"></span>
-                            <!--#else#-->
-                                <span class="label label-warning">$T('notAvailable')</span>
-                                <a href="$helpuri$help_uri#no_yenc" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a>
-                            <!--#end if#-->
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
+<div class="colmask">
+    <div class="section padTable">
+        <table class="table table-striped">
+            <tbody>
+                <tr>
+                    <th scope="row">$T('version'): </th>
+                    <td>$version [$build]</td>
+                </tr>
+                <tr>
+                    <th scope="row">$T('uptime'): </th>
+                    <td>$uptime</td>
+                </tr>
+                <tr>
+                    <th scope="row">$T('confgFile'): </th>
+                    <td>$configfn</td>
+                </tr>
+                <tr>
+                    <th scope="row">$T('cache').capitalize(): </th>
+                    <td><!--#set $msg=$T('ft-buffer@2')%($cache_art, $cache_size)#-->$msg</td>
+                </tr>
+                <tr>
+                    <th scope="row">$T('parameters'): </th>
+                    <td>$cmdline</td>
+                </tr>
+                <tr>
+                    <th scope="row">$T('pythonVersion'): </th>
+                    <td>$sys.version[:120] [$getpreferredencoding()]</td>
+                </tr>
+                <tr>
+                    <th scope="row">OpenSSL:</th>
+                    <td>
+                        <!--#if HAVE_SSL#--> 
+                            <!--#set $sslversions = ', '.join(sabnzbd.utils.sslinfo.ssl_protocols())#-->
+                            $sabnzbd.utils.sslinfo.ssl_version() &nbsp; [$sslversions]
+                        <!--#else#-->
+                            <span class="label label-warning">$T('notAvailable')</span>
+                            <a href="$helpuri$help_uri#no_ssl" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a>
+                        <!--#end if#-->
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row">pyOpenSSL:</th>
+                    <td>
+                        <!--#if HAVE_SSL#--> 
+                            $sabnzbd.utils.sslinfo.pyopenssl_version()
+                        <!--#else#-->
+                            <span class="label label-warning">$T('notAvailable')</span>
+                            <a href="$helpuri$help_uri#no_ssl" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a>
+                        <!--#end if#-->
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row">yEnc:</th>
+                    <td>
+                        <!--#if HAVE_YENC#--> 
+                            <span class="glyphicon glyphicon-ok"></span>
+                        <!--#else#-->
+                            <span class="label label-warning">$T('notAvailable')</span>
+                            <a href="$helpuri$help_uri#no_yenc" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a>
+                        <!--#end if#-->
+                    </td>
+                </tr>
+            </tbody>
+        </table>
     </div>
-    <div class="colmask">
-        <div class="section padTable">
-            <table class="table table-striped">
-                <tbody>
-                    <tr>
-                        <th scope="row">$T('homePage') </th>
-                        <td><a href="http://sabnzbd.org/" target="_blank">http://sabnzbd.org/</a></td>
-                    </tr>
-                    <tr>
-                        <th scope="row">$T('menu-wiki') </th>
-                        <td><a href="https://sabnzbd.org/wiki/" target="_blank">https://sabnzbd.org/wiki/</a></td>
-                    </tr>
-                    <tr>
-                        <th scope="row">$T('menu-forums') </th>
-                        <td><a href="http://forums.sabnzbd.org/" target="_blank">http://forums.sabnzbd.org/</a></td>
-                    </tr>
-                    <tr>
-                        <th scope="row">$T('source') </th>
-                        <td><a href="https://github.com/sabnzbd/sabnzbd" target="_blank">https://github.com/sabnzbd/sabnzbd</a></td>
-                    </tr>
-                    <tr>
-                        <th scope="row">$T('menu-irc') </th>
-                        <td><a href="irc://irc.synirc.net/#sabnzbd"><i>#sabnzbd</i> on <i>irc.synirc.net</i></a> $T('or') (<a href="http://sabnzbd.org/live-chat/" target="_blank">webchat</a>)</td>
-                    </tr>
-                    <tr>
-                        <th scope="row">$T('menu-issues') </th>
-                        <td><a href="https://sabnzbd.org/wiki/introduction/known-issues" target="_blank">https://sabnzbd.org/wiki/introduction/known-issues</a></td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
+</div>
+<div class="colmask">
+    <div class="section padTable">
+        <table class="table table-striped">
+            <tbody>
+                <tr>
+                    <th scope="row">$T('homePage') </th>
+                    <td><a href="http://sabnzbd.org/" target="_blank">http://sabnzbd.org/</a></td>
+                </tr>
+                <tr>
+                    <th scope="row">$T('menu-wiki') </th>
+                    <td><a href="https://sabnzbd.org/wiki/" target="_blank">https://sabnzbd.org/wiki/</a></td>
+                </tr>
+                <tr>
+                    <th scope="row">$T('menu-forums') </th>
+                    <td><a href="http://forums.sabnzbd.org/" target="_blank">http://forums.sabnzbd.org/</a></td>
+                </tr>
+                <tr>
+                    <th scope="row">$T('source') </th>
+                    <td><a href="https://github.com/sabnzbd/sabnzbd" target="_blank">https://github.com/sabnzbd/sabnzbd</a></td>
+                </tr>
+                <tr>
+                    <th scope="row">$T('menu-irc') </th>
+                    <td><a href="irc://irc.synirc.net/#sabnzbd"><i>#sabnzbd</i> on <i>irc.synirc.net</i></a> $T('or') (<a href="http://sabnzbd.org/live-chat/" target="_blank">webchat</a>)</td>
+                </tr>
+                <tr>
+                    <th scope="row">$T('menu-issues') </th>
+                    <td><a href="https://sabnzbd.org/wiki/introduction/known-issues" target="_blank">https://sabnzbd.org/wiki/introduction/known-issues</a></td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<div class="colmask">
+    <div class="padding alt">
+        <h5 class="copyright">Copyright &copy; 2008-2016 The SABnzbd Team &lt;<a href="mailto:team@sabnzbd.org">team@sabnzbd.org</a>&gt;</h5>
+        <p class="copyright"><small>$T('yourRights')</small></p>
     </div>
 
-    <div class="colmask">
-        <div class="padding alt">
-            <h5 class="copyright">Copyright &copy; 2008-2016 The SABnzbd Team &lt;<a href="mailto:team@sabnzbd.org">team@sabnzbd.org</a>&gt;</h5>
-            <p class="copyright"><small>$T('yourRights')</small></p>
-        </div>
-
-    </div>
+</div>
 
 <!--#include $webdir + "/_inc_footer_uc.tmpl"#-->

--- a/interfaces/Config/templates/config.tmpl
+++ b/interfaces/Config/templates/config.tmpl
@@ -83,7 +83,7 @@
                     </tr>
                     <tr>
                         <th scope="row">$T('menu-wiki') </th>
-                        <td><a href="https://sabnzbd.org/wiki/faq" target="_blank">https://sabnzbd.org/wiki/faq</a></td>
+                        <td><a href="https://sabnzbd.org/wiki/" target="_blank">https://sabnzbd.org/wiki/</a></td>
                     </tr>
                     <tr>
                         <th scope="row">$T('menu-forums') </th>

--- a/interfaces/Config/templates/config.tmpl
+++ b/interfaces/Config/templates/config.tmpl
@@ -38,7 +38,7 @@
                     <th scope="row">OpenSSL:</th>
                     <td>
                         <!--#if HAVE_SSL#--> 
-                            <!--#set $sslversions = ', '.join(sabnzbd.utils.sslinfo._SSL_PROTOCOLS_LABELS)#-->
+                            <!--#set $sslversions = ', '.join(sabnzbd.utils.sslinfo.ssl_protocols_labels())#-->
                             $sabnzbd.utils.sslinfo.ssl_version() &nbsp; [$sslversions]
                         <!--#else#-->
                             <span class="label label-warning">$T('notAvailable')</span>

--- a/interfaces/Config/templates/config.tmpl
+++ b/interfaces/Config/templates/config.tmpl
@@ -38,7 +38,7 @@
                     <th scope="row">OpenSSL:</th>
                     <td>
                         <!--#if HAVE_SSL#--> 
-                            <!--#set $sslversions = ', '.join(sabnzbd.utils.sslinfo.ssl_protocols())#-->
+                            <!--#set $sslversions = ', '.join(sabnzbd.utils.sslinfo._SSL_PROTOCOLS_LABELS)#-->
                             $sabnzbd.utils.sslinfo.ssl_version() &nbsp; [$sslversions]
                         <!--#else#-->
                             <span class="label label-warning">$T('notAvailable')</span>

--- a/interfaces/Config/templates/config_general.tmpl
+++ b/interfaces/Config/templates/config_general.tmpl
@@ -208,7 +208,6 @@
 \$(document).ready(function(){
     // Show the message about translating when it's non-English
     function hideOrShowTranslate() {
-        console.log(\$('#language').val())
         if(\$('#language').val() == 'en') {
             \$('.alert-translate').hide()
         } else {

--- a/interfaces/Config/templates/config_general.tmpl
+++ b/interfaces/Config/templates/config_general.tmpl
@@ -26,20 +26,20 @@
                 </div>
                 <div class="field-pair">
                     <label class="config" for="web_dir">$T('opt-web_dir')</label>
-                        <select name="web_dir" id="web_dir">
-                        <!--#for $webline in $web_list#-->
-                            <!--#if $webline.lower() == $web_dir.lower()#-->
-                                <option value="$webline" selected="selected">$webline</option>
-                            <!--#else#-->
-                                <option value="$webline">$webline</option>
-                            <!--#end if#-->
-                        <!--#end for#-->
+                    <select name="web_dir" id="web_dir">
+                    <!--#for $webline in $web_list#-->
+                        <!--#if $webline.lower() == $web_dir.lower()#-->
+                            <option value="$webline" selected="selected">$webline</option>
+                        <!--#else#-->
+                            <option value="$webline">$webline</option>
+                        <!--#end if#-->
+                    <!--#end for#-->
                     </select>
                     <span class="desc">$T('explain-web_dir')&nbsp;&nbsp;<a href="$caller_url1">$caller_url1</a></span>
                 </div>
                 <div class="field-pair">
                     <label class="config" for="web_dir2">$T('opt-web_dir2')</label>
-                        <select name="web_dir2" id="web_dir2">
+                    <select name="web_dir2" id="web_dir2">
                         <option value="None" selected="selected">$T("None")</option>
                         <!--#for $webline in $web_list#-->
                             <!--#if $webline.lower() == $web_dir2.lower()#-->
@@ -53,16 +53,19 @@
                 </div>
                 <div class="field-pair">
                     <label class="config" for="language">$T('opt-language')</label>
-                        <select name="language" id="language" class="select">
-                        <!--#for $webline in $lang_list#-->
-                            <!--#if $webline[0].lower() == $language.lower()#-->
-                                <option value="$webline[0]" selected="selected">$webline[1]</option>
-                            <!--#else#-->
-                                <option value="$webline[0]">$webline[1]</option>
-                            <!--#end if#-->
-                        <!--#end for#-->
-                        </select>
+                    <select name="language" id="language" class="select">
+                    <!--#for $webline in $lang_list#-->
+                        <!--#if $webline[0].lower() == $language.lower()#-->
+                            <option value="$webline[0]" selected="selected">$webline[1]</option>
+                        <!--#else#-->
+                            <option value="$webline[0]">$webline[1]</option>
+                        <!--#end if#-->
+                    <!--#end for#-->
+                    </select>
                     <span class="desc">$T('explain-language')</span>
+                    <div class="alert alert-info alert-translate">
+                       $T('explain-ask-language') <a href="https://sabnzbd.org/wiki/translate" target="_blank" class="alert-link">https://sabnzbd.org/wiki/translate</a>
+                    </div>
                 </div>
                 <div class="field-pair">
                     <!-- Here we add "search" to the ID as an exception to stop Password Managers (like LastPass)! -->
@@ -203,7 +206,20 @@
 
 <script type="text/javascript">
 \$(document).ready(function(){
+    // Show the message about translating when it's non-English
+    function hideOrShowTranslate() {
+        console.log(\$('#language').val())
+        if(\$('#language').val() == 'en') {
+            \$('.alert-translate').hide()
+        } else {
+            \$('.alert-translate').show()
+        }
+    }
+    \$('#language').on('change', hideOrShowTranslate)
+    hideOrShowTranslate()
+
     \$('#apikey, #nzbkey').click(function () { \$(this).select() });
+    
     \$('#generate_new_apikey').click(function () {
       if (confirm("$T('Plush-confirm')")) {
         $.ajax({

--- a/interfaces/Config/templates/config_switches.tmpl
+++ b/interfaces/Config/templates/config_switches.tmpl
@@ -25,11 +25,6 @@
                         </select>
                         <span class="desc">$T('explain-check_new_rel')</span>
                     </div>
-                    <div class="field-pair <!--#if not $have_ampm then "disabled" else "" #-->">
-                        <label class="config" for="ampm">$T('opt-ampm')</label>
-                        <input type="checkbox" name="ampm" id="ampm" value="1" <!--#if int($ampm) > 0 then 'checked="checked"' else ""#--> <!--#if not $have_ampm then 'readonly="readonly" disabled="disabled"' else "" #--> />
-                        <span class="desc">$T('explain-ampm')</span>
-                    </div>
                     <div class="field-pair">
                         <label class="config" for="enable_https_verification">$T('opt-enable_https_verification')</label>
                         <input type="checkbox" name="enable_https_verification" id="enable_https_verification" value="1" <!--#if int($enable_https_verification) > 0 then 'checked="checked"' else ""#--> />

--- a/interfaces/Config/templates/config_switches.tmpl
+++ b/interfaces/Config/templates/config_switches.tmpl
@@ -180,7 +180,7 @@
                     <div class="field-pair">
                         <label class="config" for="enable_all_par">$T('opt-enable_all_par')</label>
                         <input type="checkbox" name="enable_all_par" id="enable_all_par" value="1" <!--#if int($enable_all_par) > 0 then 'checked="checked"' else ""#--> />
-                        <span class="desc">$T('explain-enable_all_par')</span>
+                        <span class="desc">$T('explain-enable_all_par').replace('.', '<br/>')</span>
                     </div>
                     <div class="field-pair">
                         <label class="config" for="quick_check">$T('opt-quick_check')</label>
@@ -318,11 +318,13 @@
                         <input type="checkbox" name="replace_illegal" id="replace_illegal" value="1" <!--#if int($replace_illegal) > 0 then 'checked="checked"' else ""#--> />
                         <span class="desc">$T('explain-replace_illegal')</span>
                     </div>
+                    <!--#if not $nt#-->
                     <div class="field-pair">
                         <label class="config" for="sanitize_safe">$T('opt-sanitize_safe')</label>
                         <input type="checkbox" name="sanitize_safe" id="sanitize_safe" value="1" <!--#if int($sanitize_safe) > 0 then 'checked="checked"' else ""#--> />
                         <span class="desc">$T('explain-sanitize_safe')</span>
                     </div>
+                    <!--#end if#-->
                     <div class="field-pair">
                         <label class="config" for="enable_meta">$T('opt-enable_meta')</label>
                         <input type="checkbox" name="enable_meta" id="enable_meta" value="1" <!--#if int($enable_meta) > 0 then 'checked="checked"' else ""#--> />

--- a/interfaces/Config/templates/staticcfg/css/style.css
+++ b/interfaces/Config/templates/staticcfg/css/style.css
@@ -915,7 +915,8 @@ input[type="checkbox"] {
     display: none;
 }
 
-.alert-no-category {
+.alert-no-category,
+.alert-translate {
     display: none;
     margin: 5px 0px 0px;
 }

--- a/interfaces/Glitter/templates/main.tmpl
+++ b/interfaces/Glitter/templates/main.tmpl
@@ -77,6 +77,7 @@
             glitterTranslate.orphanedJobsMsg = "$T('explain-orphans')";
             glitterTranslate.useCache = "$T('explain-cache_limitstr').replace("64M", "256M").replace("128M", "512M")";
             glitterTranslate.noLocalStorage = "$T('Glitter-noLocalStorage')";
+            glitterTranslate.glitterTips = "$T('Glitter-glitterTips')";
             glitterTranslate.updateAvailable = "$T('Glitter-updateAvailable')";
             glitterTranslate.defaultText = "$T('default')";
             glitterTranslate.noneText = "$T('None')";

--- a/interfaces/Glitter/templates/static/javascripts/glitter.main.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.main.js
@@ -1056,6 +1056,17 @@ function ViewModel() {
         });
     }
 
+    // Message about tips and tricks, only once
+    if(!localStorageGetItem('TipsMsgV110')*1) {
+        self.allMessages.push({
+            index: 'TipsMsgV110',
+            type: glitterTranslate.status['INFO'],
+            text: glitterTranslate.glitterTips + ' <a class="queue-update-sab" href="https://sabnzbd.org/wiki/extra/glitter-tips-and-tricks" target="_blank">Glitter Tips and Tricks <span class="glyphicon glyphicon-new-window"></span></a>',
+            css: 'info',
+            clear: function() { self.clearMessages('TipsMsgV110')}
+        });
+    }
+
     /***
         Date-stuff
     ***/

--- a/po/main/en.po
+++ b/po/main/en.po
@@ -131,3 +131,12 @@ msgstr "Web interface"
 #: sabnzbd/notifier.py
 msgid "Script returned exit code %s and output \"%s\""
 msgstr "Notification script returned exit code %s and output \"%s\""
+
+#: sabnzbd/skintext.py:390
+msgid "Post-Processing Scripts Folder"
+msgstr "Scripts Folder"
+
+#: sabnzbd/skintext.py:391
+msgid "Folder containing user scripts for post-processing."
+msgstr "Folder containing user scripts."
+

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -153,20 +153,6 @@ __SHUTTING_DOWN__ = False
 
 
 ##############################################################################
-# Table to map 0.5.x style language code to new style
-##############################################################################
-LANG_MAP = {
-    'de-de': 'de',
-    'dk-da': 'da',  # Should have been "da-dk"
-    'fr-fr': 'fr',
-    'nl-du': 'nl',  # Should have been "du-nl"
-    'no-no': 'nb',  # Norsk Bokmal
-    'sv-se': 'sv',
-    'us-en': 'en'  # Should have been "en-us"
-}
-
-
-##############################################################################
 # Signal Handler
 ##############################################################################
 def sig_handler(signum=None, frame=None):
@@ -283,9 +269,6 @@ def initialize(pause_downloader=False, clean_up=False, evalSched=False, repair=0
     ArticleCache.do.new_limit(cfg.cache_limit.get_int())
 
     check_incomplete_vs_complete()
-
-    # Handle language upgrade from 0.5.x to 0.6.x
-    cfg.language.set(LANG_MAP.get(cfg.language(), cfg.language()))
 
     # Set language files
     lang.set_locale_info('SABnzbd', DIR_LANGUAGE)

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -106,7 +106,7 @@ par2_multicore = OptionBool('misc', 'par2_multicore', True)
 allow_64bit_tools = OptionBool('misc', 'allow_64bit_tools', True)
 allow_streaming = OptionBool('misc', 'allow_streaming', False)
 pre_check = OptionBool('misc', 'pre_check', False)
-fail_hopeless = OptionBool('misc', 'fail_hopeless', False)
+fail_hopeless = OptionBool('misc', 'fail_hopeless', True)
 req_completion_rate = OptionNumber('misc', 'req_completion_rate', 100.2, 100, 200)
 
 rating_enable = OptionBool('misc', 'rating_enable', False)

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -1459,7 +1459,6 @@ class ConfigSwitches(object):
         conf['unwanted_extensions'] = cfg.unwanted_extensions.get_string()
 
         conf['script_list'] = list_scripts() or ['None']
-        conf['have_ampm'] = HAVE_AMPM
 
         template = Template(file=os.path.join(self.__web_dir, 'config_switches.tmpl'),
                             filter=FILTER, searchList=[conf], compilerSettings=DIRECTIVES)
@@ -1492,7 +1491,7 @@ class ConfigSwitches(object):
 ##############################################################################
 SPECIAL_BOOL_LIST = \
     ('start_paused', 'no_penalties', 'ignore_wrong_unrar', 'create_group_folders',
-              'queue_complete_pers', 'api_warnings', 'allow_64bit_tools',
+              'queue_complete_pers', 'api_warnings', 'allow_64bit_tools', 'ampm',
               'prospective_par_download', 'never_repair', 'allow_streaming', 'ignore_unrar_dates',
               'osx_menu', 'osx_speed', 'win_menu', 'use_pickle', 'allow_incomplete_nzb',
               'rss_filenames', 'ipv6_hosting', 'keep_awake', 'empty_postproc', 'html_login',

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -492,7 +492,7 @@ SKIN_TEXT = {
     'explain-ignore_samples' : TT('Filter out sample files (e.g. video samples).'),
     'igsam-off' : TT('Off'),
     'igsam-del' : TT('Delete after download'),
-    'opt-enable_https_verification' : TT('Enable HTTPS verification'),
+    'opt-enable_https_verification' : TT('HTTPS certificate verification'),
     'explain-enable_https_verification' : TT('Verify certificates when connecting to indexers and RSS-sources using HTTPS.'),
     'swtag-general' : TT('General'),
     'swtag-server' : TT('Server'),

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -353,6 +353,7 @@ SKIN_TEXT = {
     'explain-restoreDefaults' : TT('Reset'),
     'opt-language' : TT('Language'),
     'explain-language' : TT('Select a web interface language.'),
+    'explain-ask-language': TT('Help us translate SABnzbd in your language! <br/>Add untranslated texts or improved existing translations here:'), # Link to sabnzbd.org follows this text
     'opt-apikey' : TT('API Key'),
     'explain-apikey' : TT('This key will give 3rd party programs full access to SABnzbd.'),
     'opt-nzbkey' : TT('NZB Key'),

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -831,6 +831,7 @@ SKIN_TEXT = {
     'Glitter-confirmClear1Download' : TT('Are you sure?'),
     'Glitter-updateAvailable' : TT('Update Available!'),
     'Glitter-noLocalStorage' : TT('LocalStorage (cookies) are disabled in your browser, interface settings will be lost after you close the browser!'), #: Don't translate LocalStorage
+    'Glitter-glitterTips' : TT('Glitter has some (new) features you might like!'), 
     'Glitter-custom' : TT('Custom'),
     'Glitter-displayCompact' : TT('Compact layout'),
     'Glitter-displayTabbed' : TT('Tabbed layout <br/>(separate queue and history)'),

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -492,8 +492,6 @@ SKIN_TEXT = {
     'explain-ignore_samples' : TT('Filter out sample files (e.g. video samples).'),
     'igsam-off' : TT('Off'),
     'igsam-del' : TT('Delete after download'),
-    'opt-ampm' : TT('Use 12 hour clock (AM/PM)'),
-    'explain-ampm' : TT('Show times in AM/PM notation (does not affect scheduler).'),
     'opt-enable_https_verification' : TT('Enable HTTPS verification'),
     'explain-enable_https_verification' : TT('Verify certificates when connecting to indexers and RSS-sources using HTTPS.'),
     'swtag-general' : TT('General'),

--- a/sabnzbd/utils/sslinfo.py
+++ b/sabnzbd/utils/sslinfo.py
@@ -71,6 +71,11 @@ def ssl_protocols():
     return [p for p in _ALL_PROTOCOLS if p in _SSL_PROTOCOLS]
 
 
+def ssl_protocols_labels():
+    ''' Return human readable labels for SSL protocols, highest quality first '''
+    return _SSL_PROTOCOLS_LABELS
+
+
 def ssl_version():
     if SSL:
         try:

--- a/sabnzbd/utils/sslinfo.py
+++ b/sabnzbd/utils/sslinfo.py
@@ -1,5 +1,8 @@
-_ALL_PROTOCOLS = ('t12', 't11', 't1', 'v23', 'v3', 'v2')
+# v23 indicates "negotiate highest possible"
+_ALL_PROTOCOLS = ('v23', 't12', 't11', 't1', 'v3', 'v2')
 _SSL_PROTOCOLS = {}
+_SSL_PROTOCOLS_LABELS = []
+
 def ssl_potential():
     ''' Return a list of potentially supported SSL protocols'''
     try:
@@ -13,33 +16,38 @@ try:
 
     _potential = ssl_potential()
     try:
-        if 'TLSv1_2' in _potential:
-            _SSL_PROTOCOLS['t12'] = SSL.TLSv1_2_METHOD
-    except AttributeError:
-        pass
-    try:
-        if 'TLSv1_1' in _potential:
-            _SSL_PROTOCOLS['t11'] = SSL.TLSv1_1_METHOD
-    except AttributeError:
-        pass
-    try:
-        if 'TLSv1' in _potential:
-            _SSL_PROTOCOLS['t1'] = SSL.TLSv1_METHOD
-    except AttributeError:
-        pass
-    try:
         if 'SSLv23' in _potential:
             _SSL_PROTOCOLS['v23'] = SSL.SSLv23_METHOD
     except AttributeError:
         pass
     try:
+        if 'TLSv1_2' in _potential:
+            _SSL_PROTOCOLS['t12'] = SSL.TLSv1_2_METHOD
+            _SSL_PROTOCOLS_LABELS.append('TLS v1.2')
+    except AttributeError:
+        pass
+    try:
+        if 'TLSv1_1' in _potential:
+            _SSL_PROTOCOLS['t11'] = SSL.TLSv1_1_METHOD
+            _SSL_PROTOCOLS_LABELS.append('TLS v1.1')
+    except AttributeError:
+        pass
+    try:
+        if 'TLSv1' in _potential:
+            _SSL_PROTOCOLS['t1'] = SSL.TLSv1_METHOD
+            _SSL_PROTOCOLS_LABELS.append('TLS v1')
+    except AttributeError:
+        pass
+    try:
         if 'SSLv3' in _potential:
             _SSL_PROTOCOLS['v3'] = SSL.SSLv3_METHOD
+            _SSL_PROTOCOLS_LABELS.append('SSL v3')
     except AttributeError:
         pass
     try:
         if 'SSLv2' in _potential:
             _SSL_PROTOCOLS['v2'] = SSL.SSLv2_METHOD
+            _SSL_PROTOCOLS_LABELS.append('SSL v2')
     except AttributeError:
         pass
 except ImportError:


### PR DESCRIPTION
Long wait in an airport without internet and in the airplane made me find number of small improvements, mostly in the Config

* Display message to help translate when user selects non-English in the Config
* Update text to Scripts Folder (removed the 'post-processing' from the label)
* fail_hopeless=True by default (it has proven itself and is very usefull in the current age of DCMA-every-day)
* Move AM/PM switch to Specials (only applies to SMPL really)
* Don't show Sanatize for Windows, on Windows. Format AllPar2 explain text
* Fix Wiki link on first page of Config (linked to FAQ, instead of Wiki-main)
* Encoding was logged twice during startup, due to @sanderjo and @shypike both adding it
* Show Encoding on first Config page (so people don't have to check the log when we need that info)
* Human readable SSL labels on first Config page
* Remove code for v0.5.x (it's 2016)
* Change text to 'HTTPS certificate verification'