### PR TITLE
Glitter history fix

### DIFF
--- a/interfaces/Glitter/templates/static/javascripts/glitter.history.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.history.js
@@ -71,12 +71,6 @@ function HistoryListModel(parent) {
         if(newItems.length > 0) {
             ko.utils.arrayPushAll(self.historyItems, newItems);
             self.historyItems.valueHasMutated();
-            
-            // Only now sort so newest on top. completed is updated every time while download is waiting
-            // so doing the sorting every time would cause it to bounce around
-            self.historyItems.sort(function(a, b) {
-                return a.historyStatus.completed() > b.historyStatus.completed() ? -1 : 1;
-            });
 
             // We also check if it might be in the Multi-edit
             if(self.parent.queue.multiEditItems().length > 0) {
@@ -86,6 +80,11 @@ function HistoryListModel(parent) {
                 })
             }
         }
+
+        // Sort every time (takes just few msec)
+        self.historyItems.sort(function(a, b) {
+            return a.index < b.index ? -1 : 1;
+        });
 
         /***
             History information
@@ -247,6 +246,7 @@ function HistoryModel(parent, data) {
     // The Status/Actionline/scriptline/completed we do update every time
     // When clicked on the more-info button we load the rest again
     self.nzo_id = data.nzo_id;
+    self.index = data.index;
     self.updateAllHistory = false;
     self.hasDropdown = ko.observable(false);
     self.historyStatus = ko.mapping.fromJS(data);
@@ -260,6 +260,7 @@ function HistoryModel(parent, data) {
     // Update function
     self.updateFromData = function(data) {
         // Fill all the basic info
+        self.index = data.index
         self.status(data.status)
         self.action_line(data.action_line)
         self.script_line(data.script_line)

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1876,6 +1876,7 @@ def build_history(start=None, limit=None, verbose=False, verbose_list=None, sear
     items.reverse()
 
     retry_folders = []
+    n = 0
     for item in items:
         for key in item:
             value = item[key]
@@ -1915,6 +1916,10 @@ def build_history(start=None, limit=None, verbose=False, verbose_list=None, sear
             rating = Rating.do.get_rating_by_nzo(item['nzo_id'])
         else:
             rating = None
+
+        item['index'] = n
+        n += 1
+
         item['has_rating'] = rating is not None
         if rating:
             item['rating_avg_video'] = rating.avg_video


### PR DESCRIPTION
Added ```index```-field to history-API because in Glitter items that were post-processing used to be in a weird order, because it only had the ```completed```-timing field to use, which was updated while a job was waiting to be post-processed. Now the ordering is normal.
I should have fixed this months and months ago :-1: 