### PR TITLE
Glitter and TryList fixes part 2

### DIFF
--- a/interfaces/Glitter/templates/static/javascripts/glitter.history.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.history.js
@@ -42,6 +42,9 @@ function HistoryListModel(parent) {
             var existingItem = ko.utils.arrayFirst(self.historyItems(), function(i) {
                 return i.historyStatus.nzo_id() == slot.nzo_id;
             });
+            // Set index in the results
+            slot.index = index
+            
             // Update or add?
             if(existingItem) {
                 existingItem.updateFromData(slot);

--- a/interfaces/Glitter/templates/static/javascripts/glitter.history.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.history.js
@@ -207,7 +207,10 @@ function HistoryListModel(parent) {
             // List all the ID's
             var strIDs = '';
             $.each(self.historyItems(), function(index) {
-                strIDs = strIDs + this.nzo_id + ',';
+                // Only append when it's a download that can be deleted
+                if(!this.processingDownload() && !this.processingWaiting()) {
+                    strIDs = strIDs + this.nzo_id + ',';
+                }
             })
             // Send the command
             callAPI({

--- a/interfaces/Glitter/templates/static/javascripts/glitter.main.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.main.js
@@ -130,6 +130,10 @@ function ViewModel() {
 
     // Update main queue
     self.updateQueue = function(response) {
+        // Succesfull API-call, set new one
+        self.interval = setTimeout(self.refresh, parseInt(self.refreshRate()) * 1000);
+
+        // Block in case off dragging
         if(!self.queue.shouldUpdate()) return;
 
         // Make sure we are displaying the interface
@@ -300,9 +304,8 @@ function ViewModel() {
 
     // Refresh function
     self.refresh = function(forceFullHistory) {
-        // Clear previous timeout and set a new one to prevent double-calls
+        // Clear previous timeout to prevent double-calls
         clearTimeout(self.interval);
-        self.interval = setTimeout(self.refresh, parseInt(self.refreshRate()) * 1000);
         
         /**
             Limited refresh
@@ -330,6 +333,9 @@ function ViewModel() {
 
                 // Force the next full update to be full
                 self.history.lastUpdate = 0
+
+                // Set new update
+                self.interval = setTimeout(self.refresh, parseInt(self.refreshRate()) * 1000);
             })
             // Do not continue!
             return;
@@ -368,11 +374,15 @@ function ViewModel() {
             }
             // Show screen
             self.isRestarting(1)
+            // Try again
+            self.interval = setTimeout(self.refresh, parseInt(self.refreshRate()) * 1000);
         });
+
         // Force full history update?
         if(forceFullHistory) {
             self.history.lastUpdate = 0
         }
+
         // History
         callAPI({
             mode: "history",

--- a/interfaces/Glitter/templates/static/javascripts/glitter.main.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.main.js
@@ -130,9 +130,6 @@ function ViewModel() {
 
     // Update main queue
     self.updateQueue = function(response) {
-        // Succesfull API-call, set new one
-        self.interval = setTimeout(self.refresh, parseInt(self.refreshRate()) * 1000);
-
         // Block in case off dragging
         if(!self.queue.shouldUpdate()) return;
 
@@ -302,6 +299,11 @@ function ViewModel() {
         self.history.updateFromData(response.history);
     }
 
+    // Set new update timer
+    self.setNextUpdate = function() {
+        self.interval = setTimeout(self.refresh, parseInt(self.refreshRate()) * 1000);
+    }
+
     // Refresh function
     self.refresh = function(forceFullHistory) {
         // Clear previous timeout to prevent double-calls
@@ -333,10 +335,7 @@ function ViewModel() {
 
                 // Force the next full update to be full
                 self.history.lastUpdate = 0
-
-                // Set new update
-                self.interval = setTimeout(self.refresh, parseInt(self.refreshRate()) * 1000);
-            })
+            }).always(self.setNextUpdate)
             // Do not continue!
             return;
         }
@@ -350,6 +349,7 @@ function ViewModel() {
             self.updateHistory(glitterPreLoadHistory);
             glitterPreLoadQueue = undefined;
             glitterPreLoadHistory = undefined;
+            self.setNextUpdate()
             return;
         }
 
@@ -374,9 +374,7 @@ function ViewModel() {
             }
             // Show screen
             self.isRestarting(1)
-            // Try again
-            self.interval = setTimeout(self.refresh, parseInt(self.refreshRate()) * 1000);
-        });
+        }).always(self.setNextUpdate);
 
         // Force full history update?
         if(forceFullHistory) {

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1876,7 +1876,6 @@ def build_history(start=None, limit=None, verbose=False, verbose_list=None, sear
     items.reverse()
 
     retry_folders = []
-    n = 0
     for item in items:
         for key in item:
             value = item[key]
@@ -1916,9 +1915,6 @@ def build_history(start=None, limit=None, verbose=False, verbose_list=None, sear
             rating = Rating.do.get_rating_by_nzo(item['nzo_id'])
         else:
             rating = None
-
-        item['index'] = n
-        n += 1
 
         item['has_rating'] = rating is not None
         if rating:

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -1228,6 +1228,7 @@ class NzbObject(TryList):
                         logging.info('Prospectively added %s repair blocks to %s', new_nzf.blocks, self.final_name)
                     # Reset all try lists
                     self.reset_all_try_lists()
+                    sabnzbd.NzbQueue.do.reset_try_list()
 
 
     def check_quality(self, req_ratio=0):


### PR DESCRIPTION
The ```NzbQueue``` also needs a reset of the ```TryList```, otherwise it still stalls.
We still don't know why though...

Also found that my previous way of making the History properly sorted in Glitter could easily be done without any API changes and fixed domino effect on slow connections reported by @thezoggy.