### PR TITLE
Prevent a failed job from saving new admin files.

### DIFF
--- a/sabnzbd/articlecache.py
+++ b/sabnzbd/articlecache.py
@@ -79,7 +79,7 @@ class ArticleCache(object):
         nzf = article.nzf
         nzo = nzf.nzo
 
-        if nzo.status in (Status.COMPLETED, Status.DELETED):
+        if nzo.status in (Status.COMPLETED, Status.DELETED, Status.FAILED):
             # Do not discard this article because the
             # file might still be processed at this moment!!
             if sabnzbd.LOG_ALL:
@@ -161,7 +161,7 @@ class ArticleCache(object):
         nzf = article.nzf
         nzo = nzf.nzo
 
-        if nzo.status in (Status.COMPLETED, Status.DELETED):
+        if nzo.status in (Status.COMPLETED, Status.DELETED, Status.FAILED):
             # Do not discard this article because the
             # file might still be processed at this moment!!
             if sabnzbd.LOG_ALL:

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -806,7 +806,7 @@ class NzbQueue(TryList):
         if reset:
             self.reset_try_list()
 
-        if nzo.status in (Status.COMPLETED, Status.DELETED):
+        if nzo.status in (Status.COMPLETED, Status.DELETED, Status.FAILED):
             logging.debug('Discarding file completion %s for deleted job', filename)
         else:
             if file_done:

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -1581,7 +1581,7 @@ class NzbObject(TryList):
     def save_to_disk(self):
         """ Save job's admin to disk """
         self.save_attribs()
-        if self.nzo_id and self.status not in (Status.COMPLETED, Status.DELETED):
+        if self.nzo_id and self.status not in (Status.COMPLETED, Status.DELETED, Status.FAILED):
             sabnzbd.save_data(self, self.nzo_id, self.workpath)
 
     def save_attribs(self):


### PR DESCRIPTION
This should fix the re-creation of the NZO admin file.
#647 