### PR TITLE
Another try at the Downloader

### DIFF
--- a/interfaces/Glitter/templates/static/javascripts/glitter.main.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.main.js
@@ -168,6 +168,8 @@ function ViewModel() {
         // Same sizes? Then it's all 1 disk!
         if(response.queue.diskspace1 != response.queue.diskspace2) {
             self.diskSpaceLeft2(response.queue.diskspace2_norm)
+        } else {
+            self.diskSpaceLeft2('')
         }
         
         // Did we exceed the space?

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -414,6 +414,10 @@ def halt():
         except:
             logging.error(T('Fatal error at saving state'), exc_info=True)
 
+        # Stop the windows tray icon
+        if sabnzbd.WINTRAY:
+            sabnzbd.WINTRAY.terminate = True
+
         # The Scheduler cannot be stopped when the stop was scheduled.
         # Since all warm-restarts have been removed, it's not longer
         # needed to stop the scheduler.

--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -313,7 +313,7 @@ def check_encrypted_rar(nzo, filepath):
                 nzo.encrypted = 1
             else:
                 # Don't check other files
-                nzo.encrypted = 2
+                nzo.encrypted = -1
                 encrypted = False
             zf.close()
             del zf

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -482,6 +482,10 @@ class Downloader(Thread):
 
             if readkeys or writekeys:
                 read, write, error = select.select(readkeys, writekeys, (), 1.0)
+                
+                # Why check so often when so few things happend?
+                if len(read) < len(readkeys)/4:
+                    time.sleep(0.05)
 
             else:
                 read, write, error = ([], [], [])

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -484,7 +484,7 @@ class Downloader(Thread):
                 read, write, error = select.select(readkeys, writekeys, (), 1.0)
                 
                 # Why check so often when so few things happend?
-                if len(read) < len(readkeys)/4:
+                if len(readkeys) >= 8 and len(read) < len(readkeys)/4:
                     time.sleep(0.05)
 
             else:

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -560,7 +560,7 @@ def rar_extract(rarfile, numrars, one_folder, nzo, setname, extraction_path):
     if nzo.password:
         # If an explicit password was set, add a retry without password, just in case.
         passwords.append('')
-    elif not passwords or not nzo.encrypted:
+    elif not passwords or nzo.encrypted < 1:
         # If we're not sure about encryption, start with empty password
         # and make sure we have at least the empty password
         passwords.insert(0, '')
@@ -973,7 +973,7 @@ def seven_extract(nzo, sevenset, extensions, extraction_path, one_folder, delete
     if nzo.password:
         # If an explicit password was set, add a retry without password, just in case.
         passwords.append('')
-    elif not passwords or not nzo.encrypted:
+    elif not passwords or nzo.encrypted < 1:
         # If we're not sure about encryption, start with empty password
         # and make sure we have at least the empty password
         passwords.insert(0, '')

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -1124,7 +1124,7 @@ class NzbObject(TryList):
         prefix = ''
         if self.duplicate:
             prefix = T('DUPLICATE') + ' / '  # : Queue indicator for duplicate job
-        if self.encrypted and self.status == 'Paused':
+        if self.encrypted > 0 and self.status == 'Paused':
             prefix += T('ENCRYPTED') + ' / '  #: Queue indicator for encrypted job
         if self.oversized and self.status == 'Paused':
             prefix += T('TOO LARGE') + ' / '  # : Queue indicator for oversized job
@@ -1171,7 +1171,7 @@ class NzbObject(TryList):
 
     def resume(self):
         self.status = Status.QUEUED
-        if self.encrypted:
+        if self.encrypted > 0:
             # If user resumes after encryption warning, no more auto-pauses
             self.encrypted = 2
         if self.rating_filtered:

--- a/sabnzbd/sabtray.py
+++ b/sabnzbd/sabtray.py
@@ -109,8 +109,6 @@ class SABTrayThread(SysTrayIconThread):
 
             self.refresh_icon()
             self.counter = 0
-        if sabnzbd.SABSTOP:
-            self.terminate = True
 
     # menu handler
     def opencomplete(self, icon):


### PR DESCRIPTION
I tried (and failed) in most of my endeavours to make SABnzbd download faster, I kind of gave up on it.
But it annoyed me too much that when I am using a 100Mbit connection, SABnzbd will average at about 25% CPU usage (this is 1 core 100%) and download at 11.3MB/s. 
But if I set the speedlimit to 10.5MB/s, the CPU usage will only be 12% or so. That's just too much of a difference and it's all caused by the previously diagnosed hyperactive Downloader-loop on systems where the CPU is not the limiting factor.

Instead of just making the loop always slower (what I tried before and killed performance on high-speed connections), I opted to look at how many of the connections are 'ready'.
If less than 25% of open connections are ready, then we can easily wait a bit before going on.
This works very well! :smiley:  My CPU usage without speedlimit is now 15% on the 100Mbit and it does not effect the speed when I am on the 1Gbit connection. There is a slight increase in max-speed from about 37MB/s to 39MB/s, but this could also be other things.

**Also changed:**  
Bug in RC3 where if you pause a download that already has some files complete, it will show ENCRYPTED.
Moved the logging of 'Decoding article blabla' to only when ```sabnzbd.LOG_ALL``` since it adds no diagnostic information and just pollutes the logs.
