### PR TITLE
Improved network stuff: unresponsive DNS and HappyEyeballs-with-memory

### DIFF
--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -99,6 +99,7 @@ import sabnzbd.api
 from sabnzbd.decorators import synchronized, synchronized_CV, IO_LOCK
 from sabnzbd.constants import NORMAL_PRIORITY, VALID_ARCHIVES, GIGI, \
      REPAIR_REQUEST, QUEUE_FILE_NAME, QUEUE_VERSION, QUEUE_FILE_TMPL
+import sabnzbd.getipaddress as getipaddress
 
 LINUX_POWER = powersup.HAVE_DBUS
 
@@ -1143,7 +1144,7 @@ def test_ipv6():
         # User disabled the test, assume active IPv6
         return True
     try:
-        info = socket.getaddrinfo(cfg.selftest_host(), 443, socket.AF_INET6, socket.SOCK_STREAM, socket.IPPROTO_IP, socket.AI_CANONNAME)
+        info = getipaddress.addresslookup6(cfg.selftest_host())
     except:
         logging.debug("Test IPv6: Disabling IPv6, because it looks like it's not available. Reason: %s", sys.exc_info()[0] )
         return False

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -68,6 +68,7 @@ from sabnzbd.database import build_history_info, unpack_history_info, HistoryDB
 import sabnzbd.notifier
 import sabnzbd.rss
 import sabnzbd.emailer
+import sabnzbd.getipaddress as getipaddress
 
 
 ##############################################################################
@@ -1185,7 +1186,7 @@ def build_status(web_dir=None, root=None, prim=True, skip_dashboard=False, outpu
         info['ipv6'] = ipv6()
         # Dashboard: DNS-check
         try:
-            socket.gethostbyname(cfg.selftest_host())
+            getipaddress.addresslookup(cfg.selftest_host())
             info['dnslookup'] = "OK"
         except:
             info['dnslookup'] = None

--- a/sabnzbd/utils/happyeyeballs.py
+++ b/sabnzbd/utils/happyeyeballs.py
@@ -64,6 +64,7 @@ def do_socket_connect(queue, ip, PORT, SSL, ipv4delay):
 
 
 def happyeyeballs(HOST, **kwargs):
+    # Fill out the parameters into the variables
     try:
         PORT = kwargs['port']
     except:
@@ -77,6 +78,28 @@ def happyeyeballs(HOST, **kwargs):
     except:
         preferipv6 = True     # prefer IPv6, so give IPv6 connects a head start by delaying IPv4
 
+
+    # Find out if a result is available, and recent enough:
+    timecurrent = int(time.time())    # current time in seconds since epoch
+    retentionseconds = 100
+    hostkey = (HOST, PORT, SSL, preferipv6)	# Example key: (u'ssl.astraweb.com', 563, True, True)
+    try:
+        happyeyeballs.happylist[hostkey]	# just to check: does it exist?
+        # No exception, so entry exists, so let's check the time:
+        timefound = happyeyeballs.happylist[hostkey][1]
+        if timecurrent - timefound <= retentionseconds:
+            if DEBUG: logging.debug("existing result recent enough")
+            return happyeyeballs.happylist[hostkey][0]
+        else:
+            if DEBUG: logging.debug("existing result too old. Find a new one")
+            # Continue a few lines down
+    except:
+        # Exception, so entry not there, so we have to fill it out
+        if DEBUG: logging.debug("Host not yet known. Find entry")
+        pass
+    # we only arrive here if the entry has to be determined. So let's do that:
+
+    # We have to determine the (new) best IP address
     start = time.clock()
     if DEBUG: logging.debug("\n\n%s %s %s %s", HOST, PORT, SSL, preferipv6)
 
@@ -111,7 +134,15 @@ def happyeyeballs(HOST, **kwargs):
     logging.info("Quickest IP address for %s (port %s, ssl %s, preferipv6 %s) is %s", HOST, PORT, SSL, preferipv6, result)
     delay = int(1000 * (time.clock() - start))
     logging.debug("Happy Eyeballs lookup and port connect took %s ms", delay)
+
+    # We're done. Store and return the result
+    if result:
+        happyeyeballs.happylist[hostkey] = ( result, timecurrent )
+    print "Determined new result for", hostkey, "with result:", happyeyeballs.happylist[hostkey]
     return result
+
+
+happyeyeballs.happylist = {}    # this static variable must be after the def happy()
 
 
 


### PR DESCRIPTION
Solve delays in case of non-responding DNS

Delays were in:
- startup of SABnzbd: 2 times 20 seconds
- Status screen (with the wrench symbol): no status-screen at all.

Thank you @Safihre for the decorator approach.