### PR TITLE
Prospective par2 was broken

### DIFF
--- a/interfaces/Config/templates/config_folders.tmpl
+++ b/interfaces/Config/templates/config_folders.tmpl
@@ -59,9 +59,8 @@
                     <span class="desc">$T('explain-email_dir')</span>
                 </div>
                 <div class="field-pair">
-                    <!-- Here we add "search" to the ID as an exception to stop Password Managers (like LastPass)! --> 
-                    <label class="config" for="password_file-search">$T('opt-password_file')</label>
-                    <input type="text" name="password_file" id="password_file-search" value="$password_file" />
+                    <label class="config" for="password_file">$T('opt-password_file')</label>
+                    <input type="text" name="password_file" id="password_file" value="$password_file" />
                     <span class="desc">$T('explain-password_file')</span>
                 </div>
                 <div class="field-pair">

--- a/interfaces/Config/templates/config_general.tmpl
+++ b/interfaces/Config/templates/config_general.tmpl
@@ -14,9 +14,8 @@
         <div class="col1">
             <fieldset>
                 <div class="field-pair">
-                    <!-- Here we add "search" to the ID as an exception to stop Password Managers (like LastPass)! -->
-                    <label class="config" for="host-search">$T('opt-host')</label>
-                    <input type="text" name="host" id="host-search" value="$host" />
+                    <label class="config" for="host">$T('opt-host')</label>
+                    <input type="text" name="host" id="host" value="$host" />
                     <span class="desc">$T('explain-host')</span>
                 </div>
                 <div class="field-pair">
@@ -67,16 +66,15 @@
                        $T('explain-ask-language') <a href="https://sabnzbd.org/wiki/translate" target="_blank" class="alert-link">https://sabnzbd.org/wiki/translate</a>
                     </div>
                 </div>
+                <!-- Tricks to avoid browser auto-fill, fixed on-submit with javascript -->
                 <div class="field-pair">
-                    <!-- Here we add "search" to the ID as an exception to stop Password Managers (like LastPass)! -->
-                    <label class="config" for="username-search">$T('opt-web_username')</label>
-                    <input type="text" name="username" id="username-search" value="$username" />
+                    <label class="config" for="${pid}_wu">$T('opt-web_username')</label>
+                    <input type="text" name="${pid}_wu" id="${pid}_wu" value="$username" data-hide="username" />
                     <span class="desc">$T('explain-web_username')</span>
                 </div>
                 <div class="field-pair">
-                    <!-- Here we add "search" to the ID as an exception to stop Password Managers (like LastPass)! -->
-                    <label class="config" for="password-search">$T('opt-web_password')</label>
-                    <input type="text" name="password" id="password-search" value="$password" />
+                    <label class="config" for="${pid}_wp">$T('opt-web_password')</label>
+                    <input type="text" name="${pid}_wp" id="${pid}_wp" value="$password" data-hide="password" />
                     <span class="desc">$T('explain-web_password')</span>
                 </div>  
                 <div class="field-pair">

--- a/interfaces/Config/templates/config_server.tmpl
+++ b/interfaces/Config/templates/config_server.tmpl
@@ -3,7 +3,7 @@
 <!--#include $webdir + "/_inc_header_uc.tmpl"#-->
 
 <div class="colmask">
-    <form action="addServer" method="post" autocomplete="off" novalidate>
+    <form action="addServer" method="post" autocomplete="off" onsubmit="removeObfuscation();" novalidate>
     <input type="hidden" name="session" value="$session" />
     <div id="addServer">
         <div class="padding alt">
@@ -29,14 +29,14 @@
                     <label class="config" for="port">$T('srv-port')</label>
                     <input type="number" name="port" id="port" size="8" />
                 </div>
+                <!-- Tricks to avoid browser auto-fill, fixed on-submit with javascript -->
                 <div class="field-pair">
-                    <!-- Here we add "search" to the ID as an exception to stop Password Managers (like LastPass)! -->
-                    <label class="config" for="username-search">$T('srv-username')</label>
-                    <input type="text" name="username" id="username-search" />
+                    <label class="config" for="${pid}_00">$T('srv-username')</label>
+                    <input type="text" name="${pid}_00" id="${pid}_00" data-hide="username" />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="password-search">$T('srv-password')</label>
-                    <input type="text" name="password" id="password-search" />
+                    <label class="config" for="${pid}_01">$T('srv-password')</label>
+                    <input type="text" name="${pid}_01" id="${pid}_01" data-hide="password" />
                 </div>
                 <div class="field-pair">
                     <label class="config" for="connections">$T('srv-connections')</label>
@@ -158,14 +158,14 @@
                     <label class="config" for="port$cur">$T('srv-port')</label>
                     <input type="number" name="port" id="port$cur" value="$server['port']" size="8" />
                 </div>
+                <!-- Tricks to avoid browser auto-fill, fixed on-submit with javascript -->
                 <div class="field-pair">
-                    <!-- Here we add "search" to the ID as an exception to stop Password Managers (like LastPass)! -->
-                    <label class="config" for="username$cur-search">$T('srv-username')</label>
-                    <input type="text" name="username" id="username$cur-search" value="$server['username']" />
+                    <label class="config" for="${pid}_${cur}0">$T('srv-username')</label>
+                    <input type="text" name="${pid}_${cur}0" id="${pid}_${cur}0" value="$server['username']" data-hide="username" />
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="password$cur-search">$T('srv-password')</label>
-                    <input type="text" name="password" id="password$cur-search" value="$server['password']" />
+                    <label class="config" for="${pid}_${cur}1">$T('srv-password')</label>
+                    <input type="text" name="${pid}_${cur}1" id="${pid}_${cur}1" value="$server['password']" data-hide="password" />
                 </div>
                 <div class="field-pair">
                     <label class="config" for="connections$cur">$T('srv-connections')</label>

--- a/interfaces/Config/templates/staticcfg/js/script.js
+++ b/interfaces/Config/templates/staticcfg/js/script.js
@@ -273,6 +273,14 @@ function do_restart() {
     });
 }
 
+// Remove obfusication
+function removeObfuscation() {
+    $('input[data-hide]').each(function(index, objInput) {
+        $(objInput).attr('name', $(objInput).data('hide'))
+    })
+    return true
+}
+
 $(document).ready(function () {
     /**
         Restart function
@@ -298,6 +306,8 @@ $(document).ready(function () {
     **/
     $('.fullform').ajaxForm({
         datatype: 'json',
+        // But first remove Obfuscation!
+        beforeSerialize: removeObfuscation,
         beforeSubmit: function () {
             $('.saveButton').each(function () {
                 $(this).attr("disabled", "disabled").removeClass('btn-danger').html('<span class="glyphicon glyphicon-transfer"></span> ' + configTranslate.saving);

--- a/interfaces/Glitter/templates/static/javascripts/glitter.queue.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.queue.js
@@ -422,9 +422,8 @@ function QueueListModel(parent) {
                 if(response.status) {
                     // Make sure the queue doesnt flicker and then fade-out
                     self.isLoading(true)
-                    $('.delete input:checked').parents('tr').fadeOut(fadeOnDeleteDuration, function() {
-                        self.parent.refresh();
-                    })
+                    $('.delete input:checked').parents('tr').fadeOut(fadeOnDeleteDuration)
+                    self.parent.refresh()
                     // Empty it
                     self.multiEditItems.removeAll();
                     // Hide notification

--- a/sabnzbd/decoder.py
+++ b/sabnzbd/decoder.py
@@ -188,7 +188,7 @@ class Decoder(Thread):
             if logme or not found:
                 # Add extra parfiles when there was a damaged article
                 if cfg.prospective_par_download() and nzo.extrapars:
-                    nzo.prospective_add()
+                    nzo.prospective_add(nzf)
 
             if data:
                 ArticleCache.do.save_article(article, data)

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -1061,7 +1061,16 @@ def par2_repair(parfile_nzf, nzo, workdir, setname, single):
     # set the current nzo status to "Repairing". Used in History
 
     assert isinstance(nzo, sabnzbd.nzbstuff.NzbObject)
+
+    # Check if file exists, otherwise see if another is done
     parfile = os.path.join(workdir, parfile_nzf.filename)
+    if not os.path.exists(parfile) and parfile_nzf.extrapars:
+        for new_par in parfile_nzf.extrapars:
+            test_parfile = os.path.join(workdir, new_par.filename)
+            if os.path.exists(test_parfile):
+                parfile = test_parfile
+                break
+    
     parfile = short_path(parfile)
     workdir = short_path(workdir)
 

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -1364,7 +1364,6 @@ def PAR_Verify(parfile, parfile_nzf, nzo, setname, joinables, classic=False, sin
 
                     # Move from extrapar list to files to be downloaded
                     nzo.add_parfile(nzf)
-                    extrapars.remove(nzf)
                     # Now set new par2 file as primary par2
                     nzo.partable[setname] = nzf
                     nzf.extrapars = extrapars

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -890,8 +890,8 @@ class NzbQueue(TryList):
 
         for nzo in self.__nzo_list:
             if nzo.status != 'Paused':
-                b, b_left = nzo.total_and_remaining()
-                bytes_total += b
+                b_left = nzo.remaining()
+                bytes_total += nzo.bytes
                 bytes_left += b_left
                 q_size += 1
                 # We need the number of bytes before the current page

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -889,7 +889,7 @@ class NzbQueue(TryList):
         n = 0
 
         for nzo in self.__nzo_list:
-            if nzo.status != 'Paused':
+            if nzo.status not in (Status.PAUSED, Status.CHECKING):
                 b_left = nzo.remaining()
                 bytes_total += nzo.bytes
                 bytes_left += b_left

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -1194,6 +1194,7 @@ class NzbObject(TryList):
             self.files.append(parfile)
         if parfile.extrapars and parfile in parfile.extrapars:
             parfile.extrapars.remove(parfile)
+        self.remove_extrapar(parfile)
 
     @synchronized(IO_LOCK)
     def remove_parset(self, setname):
@@ -1205,6 +1206,8 @@ class NzbObject(TryList):
         for _set in self.extrapars:
             if parfile in self.extrapars[_set]:
                 self.extrapars[_set].remove(parfile)
+            if self.partable and self.partable[_set] and parfile in self.partable[_set].extrapars:
+                self.partable[_set].extrapars.remove(parfile)
 
     __re_quick_par2_check = re.compile(r'\.par2\W*', re.I)
 

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -1089,6 +1089,7 @@ class NzbObject(TryList):
                     self.remove_nzf(nzf)
                     nzfs.remove(nzf)
                     files.remove(filename)
+                    self.bytes_tried += nzf.bytes
                     break
 
         try:

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -1210,7 +1210,7 @@ class NzbObject(TryList):
 
 
     @synchronized(IO_LOCK)
-    def prospective_add(self):
+    def prospective_add(self, nzf):
         """ Add par2 files to compensate for missing articles
         """
         # How many do we need?
@@ -1221,15 +1221,14 @@ class NzbObject(TryList):
         total_need = bad + miss + killed + dups
 
         # How many do we already have?
-        nzf = None
         blocks_already = 0
-        for nzf in self.files:
+        for nzf_check in self.files:
             # Only par2 files have a blocks attribute
-            if nzf.blocks:
-                blocks_already = blocks_already + int_conv(nzf.blocks)
+            if nzf_check.blocks:
+                blocks_already = blocks_already + int_conv(nzf_check.blocks)
 
         # Need more?
-        if nzf and blocks_already < total_need:
+        if not nzf.is_par2 and blocks_already < total_need:
             # We have to find the right par-set
             for parset in self.extrapars.keys():
                 if parset in nzf.filename and self.extrapars[parset]:


### PR DESCRIPTION
Always wondered why my prospective par2 was **not** doing very well when there were multiple sets in a job. Turns out the for-loop above it changed the ```nzf``` reference to the last one in the list.
This was highlighted by moving it to nzbstuff.py after which PyLint added that ```nzf=None```.

Now it works the way it was intended, but this also means I have to re-test (tomorrow) with a lot of jobs to make sure there's still no stalling issues.