### PR TITLE
Real bytes counter

### DIFF
--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -890,8 +890,8 @@ class NzbQueue(TryList):
 
         for nzo in self.__nzo_list:
             if nzo.status != 'Paused':
-                b, b_left = nzo.total_and_remaining()
-                bytes_total += b
+                b_left = nzo.remaining()
+                bytes_total += nzo.bytes
                 bytes_left += b_left
                 q_size += 1
                 # We need the number of bytes before the current page

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -1089,6 +1089,7 @@ class NzbObject(TryList):
                     self.remove_nzf(nzf)
                     nzfs.remove(nzf)
                     files.remove(filename)
+                    self.bytes_tried += nzf.bytes
                     break
 
         try:


### PR DESCRIPTION
Fixing #664 and improving API speed even a bit more, this seems to me the way the bytes counter should have always been: a true account of the bytes tried and the bare minimum of loops required.

Timings also improve, ```queue_info()``` averaged over 1 minute with 120 jobs in the queue:

Branch | Time
------------ | -------------
This PR + PR #663   |  2.45ms
Old | 9.43ms
1.0.x | 24.33ms

**Important:** it does need fix d597fbc from my other PR #663, to make sure par2's are removed properly from all the lists that they are on.