### PR TITLE
Safer limits for CPU limitation in Downloader

### DIFF
--- a/interfaces/Glitter/templates/static/stylesheets/glitter.css
+++ b/interfaces/Glitter/templates/static/stylesheets/glitter.css
@@ -229,7 +229,7 @@ li.dropdown {
 .rss-icon-svg {
     display: inline-block;
     margin-top: 1px;
-    margin-bottom: -1px;
+    margin-bottom: -3px;
     width: 1.2em;
     height: 1.2em;
 }

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -484,8 +484,8 @@ class Downloader(Thread):
                 read, write, error = select.select(readkeys, writekeys, (), 1.0)
                 
                 # Why check so often when so few things happend?
-                if len(readkeys) >= 8 and len(read) < len(readkeys)/4:
-                    time.sleep(0.05)
+                if len(readkeys) >= 8 and len(read) <= 2:
+                    time.sleep(0.01)
 
             else:
                 read, write, error = ([], [], [])

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -66,7 +66,7 @@ from sabnzbd.api import list_scripts, list_cats, del_from_section, \
     api_handler, build_queue, remove_callable, rss_qstatus, build_status, \
     retry_job, retry_all_jobs, build_header, build_history, del_job_files, \
     format_bytes, calc_age, std_time, report, del_hist_job, Ttemplate, \
-    _api_test_email, _api_test_notif
+    build_queue_header, _api_test_email, _api_test_notif
 
 ##############################################################################
 # Global constants
@@ -647,8 +647,7 @@ class NzoPage(object):
 
         nzo = NzbQueue.do.get_nzo(nzo_id)
         if nzo_id and nzo:
-            info = build_header(self.__prim, self.__web_dir)
-            pnfo_list = [nzo.gather_info(full=True)]
+            info, pnfo_list, bytespersec, q_size, bytes_left_previous_page = build_queue_header(self.__prim, self.__web_dir)
 
             # /SABnzbd_nzo_xxxxx/bulk_operation
             if 'bulk_operation' in args:

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -375,7 +375,13 @@ class NewsWrapper(object):
         self.timeout = time.time() + self.server.timeout
         while 1:
             try:
-                chunk = self.recv(32768)
+                if self.nntp.nw.server.ssl:
+                    # SSL chunks come in 16K frames
+                    # Setting higher limits results in slowdown
+                    chunk = self.recv(16384)
+                else:
+                    # Get as many bytes as possible
+                    chunk = self.recv(1048576)
                 break
             except WantReadError:
                 # SSL connections will block until they are ready.


### PR DESCRIPTION
Soms users experienced slowdowns due to the CPU-usage limiting features in 1.1.0.
These limits have been tested with users that reported problems.