### PR TITLE
Obfuscated parset detection

### DIFF
--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -114,26 +114,6 @@ def get_files_by_file_size(path, reverse=False):
     return filepaths
 
 
-def replace_extension(filename, newExt):
-    """ Replace the extension with desired extension when applicable
-        >>> replace_extension('foo.avi', 'mkv')
-        'foo.mkv'
-        >>> replace_extension('.vimrc', 'arglebargle')
-        '.vimrc'
-        >>> replace_extension('a.b.c', 'd')
-        'a.b.d'
-        >>> replace_extension('', 'a')
-        ''
-        >>> replace_extension('foo.bar', '')
-        'foo.'
-    """
-    sepFile = filename.rpartition(".")
-    if sepFile[0] == "":
-        return filename
-    else:
-        return sepFile[0] + "." + newExt
-
-
 def cat_to_opts(cat, pp=None, script=None, priority=None):
     """ Derive options from category, if options not already defined.
         Specified options have priority over category-options.

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -87,6 +87,53 @@ def globber_full(path, pattern=u'*'):
         return []
 
 
+def get_files_by_file_size(path, reverse=False):
+    """ Return list of file paths in directory sorted by file size """
+
+    # Get list of files
+    filepaths = []
+    if os.path.exists(path):
+        try:
+            filepaths = [os.path.join(path, f) for f in os.listdir(path) if os.path.isfile(os.path.join(path, f))]
+        except UnicodeDecodeError:
+            # This happens on Linux when names are incorrectly encoded, retry using a non-Unicode path
+            path = path.encode('utf-8')
+            filepaths = [os.path.join(path, f) for f in os.listdir(path) if os.path.isfile(os.path.join(path, f))]
+
+    # Re-populate list with filename, size tuples
+    for i in xrange(len(filepaths)):
+        filepaths[i] = (filepaths[i], os.path.getsize(filepaths[i]))
+
+    # Sort list by file size (reverse=False results in smallest to largest)
+    filepaths.sort(key=lambda filename: filename[1], reverse=reverse)
+
+    # Re-populate list with just filenames
+    for i in xrange(len(filepaths)):
+        filepaths[i] = filepaths[i][0]
+
+    return filepaths
+
+
+def replace_extension(filename, newExt):
+    """ Replace the extension with desired extension when applicable
+        >>> replace_extension('foo.avi', 'mkv')
+        'foo.mkv'
+        >>> replace_extension('.vimrc', 'arglebargle')
+        '.vimrc'
+        >>> replace_extension('a.b.c', 'd')
+        'a.b.d'
+        >>> replace_extension('', 'a')
+        ''
+        >>> replace_extension('foo.bar', '')
+        'foo.'
+    """
+    sepFile = filename.rpartition(".")
+    if sepFile[0] == "":
+        return filename
+    else:
+        return sepFile[0] + "." + newExt
+
+
 def cat_to_opts(cat, pp=None, script=None, priority=None):
     """ Derive options from category, if options not already defined.
         Specified options have priority over category-options.

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -87,33 +87,6 @@ def globber_full(path, pattern=u'*'):
         return []
 
 
-def get_files_by_file_size(path, reverse=False):
-    """ Return list of file paths in directory sorted by file size """
-
-    # Get list of files
-    filepaths = []
-    if os.path.exists(path):
-        try:
-            filepaths = [os.path.join(path, f) for f in os.listdir(path) if os.path.isfile(os.path.join(path, f))]
-        except UnicodeDecodeError:
-            # This happens on Linux when names are incorrectly encoded, retry using a non-Unicode path
-            path = path.encode('utf-8')
-            filepaths = [os.path.join(path, f) for f in os.listdir(path) if os.path.isfile(os.path.join(path, f))]
-
-    # Re-populate list with filename, size tuples
-    for i in xrange(len(filepaths)):
-        filepaths[i] = (filepaths[i], os.path.getsize(filepaths[i]))
-
-    # Sort list by file size (reverse=False results in smallest to largest)
-    filepaths.sort(key=lambda filename: filename[1], reverse=reverse)
-
-    # Re-populate list with just filenames
-    for i in xrange(len(filepaths)):
-        filepaths[i] = filepaths[i][0]
-
-    return filepaths
-
-
 def cat_to_opts(cat, pp=None, script=None, priority=None):
     """ Derive options from category, if options not already defined.
         Specified options have priority over category-options.

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -619,7 +619,7 @@ class NzbObject(TryList):
         self.files = []             # List of all NZFs
         self.files_table = {}       # Dictionary of NZFs indexed using NZF_ID
 
-        self.finished_files = []    # List of al finished NZFs
+        self.finished_files = []    # List of all finished NZFs
 
         # the current status of the nzo eg:
         # Queued, Downloading, Repairing, Unpacking, Failed, Complete
@@ -1746,7 +1746,7 @@ def nzf_cmp_name(nzf1, nzf2, name=True):
     if is_par2 and not is_par1:
         return -1
 
-    # Anything with a priority extention goes first
+    # Anything with a priority extension goes first
     ext_list = get_ext_list()
     if ext_list:
         onlist1 = ext_on_list(name1, ext_list)
@@ -1757,7 +1757,7 @@ def nzf_cmp_name(nzf1, nzf2, name=True):
             return 1
 
     if name:
-        # Prioritise .rar files above any other type of file (other than vol-par)
+        # Prioritize .rar files above any other type of file (other than vol-par)
         # Useful for nzb streaming
         RE_RAR = re.compile(r'(\.rar|\.r\d\d|\.s\d\d|\.t\d\d|\.u\d\d|\.v\d\d)$', re.I)
         m1 = RE_RAR.search(name1)
@@ -1773,7 +1773,7 @@ def nzf_cmp_name(nzf1, nzf2, name=True):
             name2 = name2.replace('.rar', '.r//')
         return cmp(name1, name2)
     else:
-        # Do date comparision
+        # Do date comparison
         return cmp(nzf1.date, nzf2.date)
 
 

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -34,7 +34,7 @@ from sabnzbd.misc import real_path, get_unique_path, create_dirs, move_to_path, 
     make_script_path, short_path, long_path, clip_path, \
     on_cleanup_list, renamer, remove_dir, remove_all, globber, globber_full, \
     set_permissions, cleanup_empty_directories, check_win_maxpath, fix_unix_encoding, \
-    sanitize_and_trim_path
+    sanitize_and_trim_path, get_files_by_file_size, replace_extension
 from sabnzbd.tvsort import Sorter
 from sabnzbd.constants import REPAIR_PRIORITY, TOP_PRIORITY, POSTPROC_QUEUE_FILE_NAME, \
     POSTPROC_QUEUE_VERSION, sample_match, JOB_ADMIN, Status, VERIFIED_FILE
@@ -597,6 +597,18 @@ def process_job(nzo):
     return True
 
 
+def is_parfile(fn):
+    """ Check quickly whether file has par2 signature """
+    PAR_ID = "PAR2\x00PKT"
+    try:
+        with open(fn, "rb") as f:
+            buf = f.read(8)
+            return buf.startswith(PAR_ID)
+    except:
+        pass
+    return False
+
+
 def parring(nzo, workdir):
     """ Perform par processing. Returns: (par_error, re_add) """
     if 0: assert isinstance(nzo, sabnzbd.nzbstuff.NzbObject) # Assert only for debug purposes
@@ -644,21 +656,43 @@ def parring(nzo, workdir):
                     continue
                 par_error = par_error or not res
     else:
-        logging.info("No par2 sets for %s", filename)
-        nzo.set_unpack_info('Repair', T('[%s] No par2 sets') % unicoder(filename))
+        # obfuscated par2 check
+        logging.info('No par2 sets found, running obfuscated check on %s', workdir)
+        sorted_files = get_files_by_file_size(workdir, False)
+        for path in sorted_files:
+            # run through list of files, looking for par2 signature..
+            logging.debug("Checking par2 signature on %s", path)
+            if(is_parfile(path)):
+                # rename file on first match (should be head par2)
+                newpath = replace_extension(path, 'par2')
+                renamer(path, newpath)
+                # need to update nzf to reflect name change... and that its a par2 so we can repair?
+                # handle_par2(nzf, file_done=True)
+                # remove_nzf(nzf)
 
-        if not verified.get('', False):
-            # Try SFV
-            if cfg.sfv_check():
+                # repair then tell sab to re-process?
+                # parfile_nzf = {}
+                # dummy, parfile_nzf.filename = os.path.split(long_path(newpath))
+                # setname = os.path.split(parfile_nzf.filename)[1]
+                # re_add, res = par2_repair(parfile_nzf, nzo, workdir, setname, single=True)
+
+                # tell sab to readd to re-process once filenames are fixed?
+                re_add = True
+                break
+
+        # if re_add gets set (obfuscated par found), skip next code block
+        if not re_add:
+            logging.info("No par2 sets for %s", filename)
+            nzo.set_unpack_info('Repair', T('[%s] No par2 sets') % unicoder(filename))
+            if cfg.sfv_check() and not verified.get('', False):
                 par_error = not try_sfv_check(nzo, workdir, '')
                 verified[''] = not par_error
             # If still no success, do RAR-check
             if not par_error and cfg.enable_unrar():
                 par_error = not try_rar_check(nzo, workdir, '')
                 verified[''] = not par_error
-
     if re_add:
-        logging.info('Readded %s to queue', filename)
+        logging.info('Re-added %s to queue', filename)
         if nzo.priority != TOP_PRIORITY:
             nzo.priority = REPAIR_PRIORITY
         sabnzbd.nzbqueue.add_nzo(nzo)


### PR DESCRIPTION
As described in #440 by @thezoggy, some posts nowadays are so obfuscated that even all extensions are removed and thus SAB will not detect par2 files and fails the job because there are no par2 or rar files.
With these changes, if no par2-sets are detected we will do a quick scan of all the files and detect if files might be par2's based on a few bytes at the start of the file.
If so, we try to repair the job using the just found files.

Credits to @thezoggy!