### PR TITLE
Move 'disable_api_key' from General to Specials.

### DIFF
--- a/interfaces/Config/templates/config_general.tmpl
+++ b/interfaces/Config/templates/config_general.tmpl
@@ -99,11 +99,6 @@
                     <span class="desc">$T('explain-local_ranges')</span>
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="disable_api_key">$T('opt-disableApikey')</label>
-                    <input type="checkbox" name="disable_api_key" id="disable_api_key" value="1" <!--#if int($disable_api_key) > 0 then 'checked="checked"' else ""#--> />
-                    <span class="desc">$T('explain-disableApikey')</span>
-                </div>
-                <div class="field-pair">
                     <label class="config" for="apikey">$T('opt-apikey')</label>
                     <input type="text" id="apikey" class="fileBrowserField" value="$session" readonly />
                     <button class="btn btn-default show_qrcode" title="$T('explain-qr-code')" rel="$session" ><span class="glyphicon glyphicon-qrcode"></span></button>

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -1501,7 +1501,7 @@ SPECIAL_BOOL_LIST = \
               'rss_filenames', 'ipv6_hosting', 'keep_awake', 'empty_postproc', 'html_login',
               'wait_for_dfolder', 'warn_empty_nzb', 'enable_bonjour','allow_duplicate_files',
               'warn_dupl_jobs', 'backup_for_duplicates', 'enable_par_cleanup', 'api_logging',
-              'fixed_ports'
+              'fixed_ports', 'disable_api_key'
      )
 SPECIAL_VALUE_LIST = \
     ('size_limit', 'folder_max_length', 'fsys_type', 'movie_rename_limit', 'nomedia_marker',
@@ -1558,7 +1558,7 @@ class ConfigSpecial(object):
 
 ##############################################################################
 GENERAL_LIST = (
-    'host', 'port', 'username', 'password', 'disable_api_key',
+    'host', 'port', 'username', 'password',
     'refresh_rate', 'cache_limit', 'local_ranges', 'inet_exposure',
     'enable_https', 'https_port', 'https_cert', 'https_key', 'https_chain'
 )
@@ -1640,7 +1640,6 @@ class ConfigGeneral(object):
             lang_list = []
         conf['lang_list'] = lang_list
 
-        conf['disable_api_key'] = cfg.disable_key()
         conf['host'] = cfg.cherryhost()
         conf['port'] = cfg.cherryport()
         conf['https_port'] = cfg.https_port()


### PR DESCRIPTION
Move an option that shouldn't be used lightly to Specials.
