### PR TITLE
Config refactoring

### DIFF
--- a/ABOUT.txt
+++ b/ABOUT.txt
@@ -1,5 +1,5 @@
 *******************************************
-*** This is SABnzbd 1.1.x               ***
+*** This is SABnzbd 1.2.x               ***
 *******************************************
 SABnzbd is an open-source cross-platform binary newsreader.
 It simplifies the process of downloading from Usenet dramatically,

--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,7 +1,7 @@
 Metadata-Version: 1.0
 Name: SABnzbd
-Version: 1.2.0
-Summary: SABnzbd-1.2.0
+Version: 1.2.0Beta1
+Summary: SABnzbd-1.2.0Beta1
 Home-page: http://sabnzbd.org
 Author: The SABnzbd Team
 Author-email: team@sabnzbd.org

--- a/README.mkd
+++ b/README.mkd
@@ -1,5 +1,5 @@
-Release Notes  -  SABnzbd 1.2.0
-===============================
+Release Notes  -  SABnzbd 1.2.0Beta1
+====================================
 
 ## What's new in 1.2.0
 - New SSL engine:
@@ -25,10 +25,11 @@ Release Notes  -  SABnzbd 1.2.0
 - Duplicates can now be marked as Failed (to notify external tools)
 
 ## Changes:
+- Python post/pre/notification-scripts now require execute (+x) permissions
 - Dropped dependency on PyOpenSSL, now only requires cryptography package
 - Update 7zip to 16.04 and UnRar to 5.40 for Windows/macOS
-- Python post/pre/notification-scripts require execute permissions
-- Removed web_watchdog
+- Update Python to 2.7.13 on Windows and macOS binaries
+- Dropped support for macOS 10.9 (Mavericks)
 
 ## Bug fixes
 - Re-use IP-address for new connections when a server has open connections

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1083,24 +1083,25 @@ def main():
         except:
             Bail_Out(browserhost, cherryport, '49')
 
-    # NonSSL
-    try:
-        cherrypy.process.servers.check_port(browserhost, cherryport, timeout=0.1)
-    except IOError, error:
-        if str(error) == 'Port not bound.':
-            pass
-        else:
-            if not url:
-                url = 'http://%s:%s/sabnzbd/api?' % (browserhost, cherryport)
-            if not sabnzbd.cfg.fixed_ports():
-                if new_instance or not check_for_sabnzbd(url, upload_nzbs, autobrowser):
-                    port = find_free_port(browserhost, cherryport)
-                    if port > 0:
-                        sabnzbd.cfg.cherryport.set(port)
-                        notify_port_change = True
-                        cherryport = port
-    except:
-        Bail_Out(browserhost, cherryport, '49')
+    # NonSSL check if there's no HTTPS or we only use 1 port
+    if not (enable_https and not https_port):
+        try:
+            cherrypy.process.servers.check_port(browserhost, cherryport, timeout=0.1)
+        except IOError, error:
+            if str(error) == 'Port not bound.':
+                pass
+            else:
+                if not url:
+                    url = 'http://%s:%s/sabnzbd/api?' % (browserhost, cherryport)
+                if not sabnzbd.cfg.fixed_ports():
+                    if new_instance or not check_for_sabnzbd(url, upload_nzbs, autobrowser):
+                        port = find_free_port(browserhost, cherryport)
+                        if port > 0:
+                            sabnzbd.cfg.cherryport.set(port)
+                            notify_port_change = True
+                            cherryport = port
+        except:
+            Bail_Out(browserhost, cherryport, '49')
 
     if cherrypylogging is None:
         cherrypylogging = sabnzbd.cfg.log_web()

--- a/interfaces/Config/templates/config_general.tmpl
+++ b/interfaces/Config/templates/config_general.tmpl
@@ -99,11 +99,6 @@
                     <span class="desc">$T('explain-local_ranges')</span>
                 </div>
                 <div class="field-pair">
-                    <label class="config" for="disable_api_key">$T('opt-disableApikey')</label>
-                    <input type="checkbox" name="disable_api_key" id="disable_api_key" value="1" <!--#if int($disable_api_key) > 0 then 'checked="checked"' else ""#--> />
-                    <span class="desc">$T('explain-disableApikey')</span>
-                </div>
-                <div class="field-pair">
                     <label class="config" for="apikey">$T('opt-apikey')</label>
                     <input type="text" id="apikey" class="fileBrowserField" value="$session" readonly />
                     <button class="btn btn-default show_qrcode" title="$T('explain-qr-code')" rel="$session" ><span class="glyphicon glyphicon-qrcode"></span></button>

--- a/interfaces/Config/templates/config_general.tmpl
+++ b/interfaces/Config/templates/config_general.tmpl
@@ -66,6 +66,56 @@
                        $T('explain-ask-language') <a href="https://sabnzbd.org/wiki/translate" target="_blank" class="alert-link">https://sabnzbd.org/wiki/translate</a>
                     </div>
                 </div>
+                <div class="field-pair <!--#if int($have_ssl) == 0 then "disabled" else ""#-->">
+                    <label class="config" for="enable_https">$T('opt-enable_https')</label>
+                    <input type="checkbox" name="enable_https" id="enable_https" value="1" <!--#if int($enable_https) > 0 then 'checked="checked"' else ""#--> <!--#if int($have_ssl) == 0 then "disabled" else ""#--> />
+                    <span class="desc">$T('explain-enable_https')</span>
+                </div>
+                <div id="enable_https_options" <!--#if int($enable_https) < 1 then 'style="display:none"' else ""#-->>
+                    <div class="field-pair">
+                        <h5 class="darkred nomargin">$T('base-folder'): <span class="path">$my_lcldata</span></h5>
+                    </div>
+                    <div class="field-pair">
+                        <label class="config" for="https_port">$T('opt-https_port')</label>
+                        <input type="number" name="https_port" id="https_port" value="$https_port" size="8" data-original="$https_port" />
+                        <span class="desc">$T('explain-https_port')</span>
+                    </div>
+
+                    <div class="field-pair">
+                        <label class="config" for="https_cert">$T('opt-https_cert')</label>
+                        <input type="text" name="https_cert" id="https_cert" value="$https_cert" />
+                        <button class="btn btn-default generate_cert" title="$T('explain-new-cert')" <!--#if int($have_cryptography) == 0 then "disabled" else ""#-->>
+                            <span class="glyphicon glyphicon-repeat"></span>
+                        </button>
+                        <span class="desc">$T('explain-https_cert')</span>
+                    </div>
+                    <div class="field-pair">
+                        <label class="config" for="https_key">$T('opt-https_key')</label>
+                        <input type="text" name="https_key" id="https_key" value="$https_key" />
+                        <button class="btn btn-default generate_cert" title="$T('explain-new-cert')" <!--#if int($have_cryptography) == 0 then "disabled" else ""#-->>
+                            <span class="glyphicon glyphicon-repeat"></span>
+                        </button>
+                        <span class="desc">$T('explain-https_key')</span>
+                    </div>
+                    <div class="field-pair">
+                        <label class="config" for="https_chain">$T('opt-https_chain')</label>
+                        <input type="text" name="https_chain" id="https_chain" value="$https_chain" />
+                        <span class="desc">$T('explain-https_chain')</span>
+                    </div>
+                </div>
+                <div class="field-pair">
+                    <button class="btn btn-default saveButton"><span class="glyphicon glyphicon-ok"></span> $T('button-saveChanges')</button>
+                    <button class="btn btn-default sabnzbd_restart"><span class="glyphicon glyphicon-refresh"></span> $T('button-restart') SABnzbd</button>
+                </div>
+            </fieldset>
+        </div>
+    </div>
+    <div class="section">
+        <div class="col2">
+            <h3>$T('security') <a href="$helpuri$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+        </div><!-- /col2 -->
+        <div class="col1">
+            <fieldset>
                 <!-- Tricks to avoid browser auto-fill, fixed on-submit with javascript -->
                 <div class="field-pair">
                     <label class="config" for="${pid}_wu">$T('opt-web_username')</label>
@@ -114,55 +164,6 @@
                 </div>
                 <div class="field-pair">
                     <button class="btn btn-default saveButton"><span class="glyphicon glyphicon-ok"></span> $T('button-saveChanges')</button>
-                    <button class="btn btn-default sabnzbd_restart"><span class="glyphicon glyphicon-refresh"></span> $T('button-restart') SABnzbd</button>
-                </div>
-            </fieldset>
-        </div><!-- /col1 -->
-    </div><!-- /section -->
-    <div class="section">
-        <div class="col2">
-            <h3>$T('httpsSupport') <a href="$helpuri$help_uri#toc1" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
-            <p><b>$T('restartRequired')</b></p>
-        </div><!-- /col2 -->
-        <div class="col1 <!--#if int($have_ssl) == 0 then "disabled" else ""#-->">
-            <fieldset>
-                <div class="field-pair">
-                    <h5 class="darkred nomargin">$T('base-folder'): <span class="path">$my_lcldata</span></h5>
-                </div>
-                <div class="field-pair <!--#if int($have_ssl) == 0 then "disabled" else ""#-->">
-                    <label class="config" for="enable_https">$T('opt-enable_https')</label>
-                    <input type="checkbox" name="enable_https" id="enable_https" value="1" <!--#if int($enable_https) > 0 then 'checked="checked"' else ""#--> <!--#if int($have_ssl) == 0 then "disabled" else ""#--> />
-                    <span class="desc">$T('explain-enable_https')</span>
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="https_port">$T('opt-https_port')</label>
-                    <input type="number" name="https_port" id="https_port" value="$https_port" size="8" data-original="$https_port" />
-                    <span class="desc">$T('explain-https_port')</span>
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="https_cert">$T('opt-https_cert')</label>
-                    <input type="text" name="https_cert" id="https_cert" value="$https_cert" />
-                    <button class="btn btn-default generate_cert" title="$T('explain-new-cert')" <!--#if int($have_cryptography) == 0 then "disabled" else ""#-->>
-                        <span class="glyphicon glyphicon-repeat"></span>
-                    </button>
-                    <span class="desc">$T('explain-https_cert')</span>
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="https_key">$T('opt-https_key')</label>
-                    <input type="text" name="https_key" id="https_key" value="$https_key" />
-                    <button class="btn btn-default generate_cert" title="$T('explain-new-cert')" <!--#if int($have_cryptography) == 0 then "disabled" else ""#-->>
-                        <span class="glyphicon glyphicon-repeat"></span>
-                    </button>
-                    <span class="desc">$T('explain-https_key')</span>
-                </div>
-                <div class="field-pair">
-                    <label class="config" for="https_chain">$T('opt-https_chain')</label>
-                    <input type="text" name="https_chain" id="https_chain" value="$https_chain" />
-                    <span class="desc">$T('explain-https_chain')</span>
-                </div>
-                <div class="field-pair">
-                    <button class="btn btn-default saveButton"><span class="glyphicon glyphicon-ok"></span> $T('button-saveChanges')</button>
-                    <button class="btn btn-default sabnzbd_restart"><span class="glyphicon glyphicon-refresh"></span> $T('button-restart') SABnzbd</button>
                 </div>
             </fieldset>
         </div><!-- /col1 -->

--- a/interfaces/Config/templates/config_general.tmpl
+++ b/interfaces/Config/templates/config_general.tmpl
@@ -170,6 +170,37 @@
     </div><!-- /section -->
     <div class="section">
         <div class="col2">
+            <h3>$T('cmenu-switches') <a href="$helpuri$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+        </div><!-- /col2 -->
+        <div class="col1">
+            <fieldset>
+                <div class="field-pair">
+                    <label class="config" for="auto_browser">$T('opt-auto_browser')</label>
+                    <input type="checkbox" name="auto_browser" id="auto_browser" value="1" <!--#if int($auto_browser) > 0 then 'checked="checked"' else ""#--> />
+                    <span class="desc">$T('explain-auto_browser')</span>
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="check_new_rel">$T('opt-check_new_rel')</label>
+                    <select name="check_new_rel" id="check_new_rel">
+                        <option value="0" <!--#if $check_new_rel == 0 then 'selected="selected"' else ""#--> >$T('off')</option>
+                        <option value="1" <!--#if $check_new_rel == 1 then 'selected="selected"' else ""#--> >$T('on')</option>
+                        <option value="2" <!--#if $check_new_rel == 2 then 'selected="selected"' else ""#--> >$T('also-test')</option>
+                    </select>
+                    <span class="desc">$T('explain-check_new_rel')</span>
+                </div>
+                <div class="field-pair <!--#if int($have_ssl_context) == 0 then "disabled" else ""#-->">
+                    <label class="config" for="enable_https_verification">$T('opt-enable_https_verification')</label>
+                    <input type="checkbox" name="enable_https_verification" id="enable_https_verification" value="1" <!--#if int($enable_https_verification) > 0 then 'checked="checked"' else ""#--> <!--#if int($have_ssl_context) == 0 then "disabled=\"disabled\"" else ""#--> />
+                    <span class="desc">$T('explain-enable_https_verification')</span>
+                </div>
+                <div class="field-pair">
+                    <button class="btn btn-default saveButton"><span class="glyphicon glyphicon-ok"></span> $T('button-saveChanges')</button>
+                </div>
+            </fieldset>
+        </div><!-- /col1 -->
+    </div><!-- /section -->
+    <div class="section">
+        <div class="col2">
             <h3>$T('tuning') <a href="$helpuri$help_uri#toc2" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
         </div><!-- /col2 -->
         <div class="col1">
@@ -200,6 +231,7 @@
             </fieldset>
         </div><!-- /col1 -->
     </div><!-- /section -->
+
     </form>
 </div><!-- /colmask -->
 

--- a/interfaces/Config/templates/config_server.tmpl
+++ b/interfaces/Config/templates/config_server.tmpl
@@ -27,7 +27,12 @@
                 </div>
                 <div class="field-pair">
                     <label class="config" for="port">$T('srv-port')</label>
-                    <input type="number" name="port" id="port" size="8" />
+                    <input type="number" name="port" id="port" size="8" value="119" />
+                </div>
+                <div class="field-pair <!--#if int($have_ssl) == 0 then "disabled" else ""#-->">
+                    <label class="config" for="ssl">$T('srv-ssl')</label>
+                    <input type="checkbox" name="ssl" id="ssl" value="1" <!--#if int($have_ssl) == 0 then "disabled=\"disabled\"" else ""#--> />
+                    <span class="desc">$T('explain-ssl')</span>
                 </div>
                 <!-- Tricks to avoid browser auto-fill, fixed on-submit with javascript -->
                 <div class="field-pair">
@@ -40,26 +45,21 @@
                 </div>
                 <div class="field-pair">
                     <label class="config" for="connections">$T('srv-connections')</label>
-                    <input type="number" name="connections" id="connections" min="0" max="100" />
+                    <input type="number" name="connections" id="connections" min="0" max="100" value="8" />
                 </div>
                 <div class="field-pair">
                     <label class="config" for="priority">$T('srv-priority')</label>
                     <input type="number" name="priority" id="priority" min="0" max="100" /> <i>$T('explain-svrprio')</i>
                 </div>
-                <div class="field-pair">
+                <div class="field-pair advanced-settings">
                     <label class="config" for="retention">$T('srv-retention')</label>
                     <input type="number" name="retention" id="retention" min="0" /> <i>$T('days')</i>
                 </div>
-                <div class="field-pair">
+                <div class="field-pair advanced-settings">
                     <label class="config" for="timeout">$T('srv-timeout')</label>
                     <input type="number" name="timeout" id="timeout" min="30" /> <i>$T('seconds')</i>
                 </div>
-                <div class="field-pair <!--#if int($have_ssl) == 0 then "disabled" else ""#-->">
-                    <label class="config" for="ssl">$T('srv-ssl')</label>
-                    <input type="checkbox" name="ssl" id="ssl" value="1" <!--#if int($have_ssl) == 0 then "disabled=\"disabled\"" else ""#--> />
-                    <span class="desc">$T('explain-ssl')</span>
-                </div>
-                <div class="field-pair <!--#if int($have_ssl_context) == 0 then "disabled" else ""#-->">
+                <div class="field-pair <!--#if int($have_ssl_context) == 0 then "disabled" else ""#--> advanced-settings">
                     <label class="config" for="ssl_verify">$T('opt-ssl_verify')</label>
                     <select name="ssl_verify" id="ssl_verify" <!--#if int($have_ssl_context) == 0 then "disabled=\"disabled\"" else ""#-->>
                           <option value="0">$T('ssl_verify-disabled')</option>
@@ -68,17 +68,17 @@
                     </select>
                     <span class="desc">$T('explain-ssl_verify').replace('. ', '.<br/>')</span>
                 </div>
-                <div class="field-pair">
+                <div class="field-pair advanced-settings">
                     <label class="config" for="send_group">$T('srv-send_group')</label>
                     <input type="checkbox" name="send_group" id="send_group" value="1" />
                     <span class="desc">$T('srv-explain-send_group')</span>
                 </div>
-                <div class="field-pair">
+                <div class="field-pair advanced-settings">
                     <label class="config" for="optional">$T('srv-optional')</label>
                     <input type="checkbox" name="optional" id="optional" value="1" />
                     <span class="desc">$T('explain-optional')</span>
                 </div>
-                <div class="field-pair">
+                <div class="field-pair advanced-settings">
                     <label class="config" for="categories">$T('srv-categories')</label>
                     <select name="categories" id="categories" multiple>
                     <!--#for $cat in $cats#-->
@@ -89,16 +89,17 @@
                     </select>
                     <span class="desc">$T('srv-explain-categories')</span>
                 </div>
-                <div class="field-pair">
+                <div class="field-pair advanced-settings">
                     <label class="config" for="displayname">$T('srv-displayname')</label>
                     <input type="text" name="displayname" id="displayname" />
                 </div>
-                <div class="field-pair">
+                <div class="field-pair advanced-settings">
                     <label class="config" for="notes">$T('srv-notes')</label>
                     <textarea name="notes" id="notes" rows="3" cols="50"></textarea>
                 </div>
                 <div class="field-pair">
                     <button class="btn btn-default"><span class="glyphicon glyphicon-plus"></span> $T('button-addServer')</button>
+                    <button class="btn btn-default advancedButton"><span class="glyphicon glyphicon-cog"></span> $T('button-advanced')</button>
                     <button class="btn btn-default testServer" type="button"><span class="glyphicon glyphicon-sort"></span> $T('button-testServer')</button>
                 </div>
                 <div class="field-pair result-box">
@@ -143,6 +144,11 @@
                     <label class="config" for="port$cur">$T('srv-port')</label>
                     <input type="number" name="port" id="port$cur" value="$server['port']" size="8" />
                 </div>
+                <div class="field-pair <!--#if int($have_ssl) == 0 then "disabled" else ""#-->">
+                    <label class="config" for="ssl$cur">$T('srv-ssl')</label>
+                    <input type="checkbox" name="ssl" id="ssl$cur" value="1" <!--#if int($server['ssl']) != 0 and int($have_ssl) == 1 then 'checked="checked"' else ""#--> <!--#if int($have_ssl) == 0 then "disabled=\"disabled\"" else ""#--> />
+                    <span class="desc">$T('explain-ssl')</span>
+                </div>
                 <!-- Tricks to avoid browser auto-fill, fixed on-submit with javascript -->
                 <div class="field-pair">
                     <label class="config" for="${pid}_${cur}0">$T('srv-username')</label>
@@ -160,20 +166,16 @@
                     <label class="config" for="priority$cur">$T('srv-priority')</label>
                     <input type="number" name="priority" id="priority$cur" value="$server['priority']" min="0" max="100" /> <i>$T('explain-svrprio')</i>
                 </div>
-                <div class="field-pair">
+                <div class="field-pair advanced-settings">
                     <label class="config" for="retention$cur">$T('srv-retention')</label>
                     <input type="number" name="retention" id="retention$cur" value="$server['retention']" min="0" /> <i>$T('days')</i>
                 </div>
-                <div class="field-pair">
+                <div class="field-pair advanced-settings">
                     <label class="config" for="timeout$cur">$T('srv-timeout')</label>
                     <input type="number" name="timeout" id="timeout$cur" value="$server['timeout']" min="30" /> <i>$T('seconds')</i>
                 </div>
-                <div class="field-pair <!--#if int($have_ssl) == 0 then "disabled" else ""#-->">
-                    <label class="config" for="ssl$cur">$T('srv-ssl')</label>
-                    <input type="checkbox" name="ssl" id="ssl$cur" value="1" <!--#if int($server['ssl']) != 0 and int($have_ssl) == 1 then 'checked="checked"' else ""#--> <!--#if int($have_ssl) == 0 then "disabled=\"disabled\"" else ""#--> />
-                    <span class="desc">$T('explain-ssl')</span>
-                </div>
-                <div class="field-pair <!--#if int($have_ssl_context) == 0 then "disabled" else ""#-->">
+
+                <div class="field-pair <!--#if int($have_ssl_context) == 0 then "disabled" else ""#--> advanced-settings">
                     <label class="config" for="ssl_verify$cur">$T('opt-ssl_verify')</label>
                     <select name="ssl_verify" id="ssl_verify$cur" <!--#if int($have_ssl_context) == 0 then "disabled=\"disabled\"" else ""#-->>
                           <option value="0" <!--#if $server['ssl_verify'] == 0 then 'selected="selected"' else ""#--> >$T('ssl_verify-disabled')</option>
@@ -182,17 +184,17 @@
                     </select>
                     <span class="desc">$T('explain-ssl_verify').replace('. ', '.<br/>')</span>
                 </div>
-                <div class="field-pair">
+                <div class="field-pair advanced-settings">
                     <label class="config" for="optional$cur">$T('srv-optional')</label>
                     <input type="checkbox" name="optional" id="optional$cur" value="1" <!--#if int($server['optional']) != 0 then 'checked="checked"' else ""#--> />
                     <span class="desc">$T('explain-optional')</span>
                 </div>
-                <div class="field-pair">
+                <div class="field-pair advanced-settings">
                     <label class="config" for="send_group$cur">$T('srv-send_group')</label>
                     <input type="checkbox" name="send_group" id="send_group$cur" value="1" <!--#if int($server['send_group']) != 0 then 'checked="checked"' else ""#--> />
                     <span class="desc">$T('srv-explain-send_group')</span>
                 </div>
-                <div class="field-pair">
+                <div class="field-pair advanced-settings">
                     <label class="config" for="categories$cur">$T('srv-categories')</label>
                     <select name="categories" id="categories$cur" multiple>
                     <!--#for $cat in $cats#-->
@@ -207,16 +209,17 @@
                         $T('srv-explain-no-categories')
                     </div>
                 </div>
-                <div class="field-pair">
+                <div class="field-pair advanced-settings">
                     <label class="config" for="displayname$cur">$T('srv-displayname')</label>
                     <input type="text" name="displayname" id="displayname$cur" value="$server['displayname']" />
                 </div>
-                <div class="field-pair">
+                <div class="field-pair advanced-settings">
                     <label class="config" for="notes$cur">$T('srv-notes')</label>
                     <textarea name="notes" id="notes$cur" rows="3" cols="50">$server['notes']</textarea>
                 </div>
                 <div class="field-pair">
                     <button class="btn btn-default saveButton"><span class="glyphicon glyphicon-ok"></span> $T('button-saveChanges')</button>
+                    <button class="btn btn-default advancedButton"><span class="glyphicon glyphicon-cog"></span> $T('button-advanced')</button>
                     <button class="btn btn-default testServer" type="button"><span class="glyphicon glyphicon-sort"></span> $T('button-testServer')</button>
                     <button class="btn btn-default delServer"><span class="glyphicon glyphicon-trash"></span> $T('button-delServer')</button>
                 </div>
@@ -310,10 +313,36 @@
             \$(this).attr("value", "$T('showDetails')");
         }
     });
+
     \$('#addServerButton').click(function(){
         \$('#addServer').hide();
         \$('#addServerContent').show();
     });
+
+    \$('[name="ssl"]').click(function() {
+        // Use CSS transitions to do some highlighting
+        var portBox = \$(this).parent().parent().find('[name="port"]')
+        if(this.checked) {
+            // Enabled SSL change port when not already a custom port
+            if(portBox.val() == '119') {
+                portBox.val('563')
+                portBox.addClass('port-highlight')
+            }
+        } else {
+            // Remove SSL port
+            if(portBox.val() == '563') {
+                portBox.val('119')
+                portBox.addClass('port-highlight')
+            }
+        }
+        setTimeout(function() { portBox.removeClass('port-highlight') }, 2000)
+    })
+
+    \$('.advancedButton').click(function(event){
+        \$('.advanced-settings').toggle()
+        return false;
+    })
+
     \$('.testServer').click(function(event){
         removeObfuscation()
         var theButton = \$(this)
@@ -341,6 +370,7 @@
             }
         });
     });
+
     \$('.delServer').click(function(){
         if( confirm("$T('Plush-confirm')") ) {
             \$(this).parents('form:first').attr('action','delServer').submit();
@@ -351,6 +381,7 @@
         }
         return false;
     });
+
     \$('.clrServer').click(function(){
         if( confirm("$T('Plush-confirm')") ) {
             \$(this).parents('form:first').attr('action','clrServer').submit();
@@ -361,6 +392,7 @@
         }
         return false;
     });
+
     \$('.toggleServerCheckbox').click(function(){
         var whichServer = \$(this).attr("name");
         \$.ajax({

--- a/interfaces/Config/templates/config_switches.tmpl
+++ b/interfaces/Config/templates/config_switches.tmpl
@@ -7,38 +7,6 @@
         <input type="hidden" id="session" name="session" value="$session" />
         <div class="section">
             <div class="col2">
-                <h3>$T('swtag-general') <a href="$helpuri$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
-            </div><!-- /col2 -->
-            <div class="col1">
-                <fieldset>
-                    <div class="field-pair">
-                        <label class="config" for="auto_browser">$T('opt-auto_browser')</label>
-                        <input type="checkbox" name="auto_browser" id="auto_browser" value="1" <!--#if int($auto_browser) > 0 then 'checked="checked"' else ""#--> />
-                        <span class="desc">$T('explain-auto_browser')</span>
-                    </div>
-                    <div class="field-pair">
-                        <label class="config" for="check_new_rel">$T('opt-check_new_rel')</label>
-                        <select name="check_new_rel" id="check_new_rel">
-                            <option value="0" <!--#if $check_new_rel == 0 then 'selected="selected"' else ""#--> >$T('off')</option>
-                            <option value="1" <!--#if $check_new_rel == 1 then 'selected="selected"' else ""#--> >$T('on')</option>
-                            <option value="2" <!--#if $check_new_rel == 2 then 'selected="selected"' else ""#--> >$T('also-test')</option>
-                        </select>
-                        <span class="desc">$T('explain-check_new_rel')</span>
-                    </div>
-                    <div class="field-pair <!--#if int($have_ssl_context) == 0 then "disabled" else ""#-->">
-                        <label class="config" for="enable_https_verification">$T('opt-enable_https_verification')</label>
-                        <input type="checkbox" name="enable_https_verification" id="enable_https_verification" value="1" <!--#if int($enable_https_verification) > 0 then 'checked="checked"' else ""#--> <!--#if int($have_ssl_context) == 0 then "disabled=\"disabled\"" else ""#--> />
-                        <span class="desc">$T('explain-enable_https_verification')</span>
-                    </div>
-                    <div class="field-pair">
-                        <button class="btn btn-default saveButton"><span class="glyphicon glyphicon-ok"></span> $T('button-saveChanges')</button>
-                        <button class="btn btn-default restoreDefaults"><span class="glyphicon glyphicon-asterisk"></span> $T('button-restoreDefaults')</button>
-                    </div>
-                </fieldset>
-            </div><!-- /col1 -->
-        </div><!-- /section -->
-        <div class="section">
-            <div class="col2">
                 <h3>$T('swtag-server') <a href="$helpuri$help_uri#toc1" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
             </div><!-- /col2 -->
             <div class="col1">

--- a/interfaces/Config/templates/staticcfg/css/style.css
+++ b/interfaces/Config/templates/staticcfg/css/style.css
@@ -955,6 +955,14 @@ input[type="checkbox"] {
     opacity: 0.7;
 }
 
+.Servers .advanced-settings {
+    display: none;
+}
+
+.Servers .port-highlight {
+    animation: highlight-fade 1s ease-in 1;
+}
+
 .Servers .col2 label,
 .Email .col2 label {
     margin: 0;
@@ -1049,6 +1057,11 @@ input[type="checkbox"] {
     0% { opacity: 0; }
     50% { opacity: 0; }
     100% { opacity: 1; }
+}
+
+@keyframes highlight-fade {
+   0% { background: #FEFEDA; }
+   100% { background: none; }
 }
 
 .spin-glyphicon {

--- a/interfaces/Config/templates/staticcfg/js/script.js
+++ b/interfaces/Config/templates/staticcfg/js/script.js
@@ -370,16 +370,12 @@ $(document).ready(function () {
 
     // Disable sections
     var checkDisabled = '#enable_https, #rating_enable, #enable_tv_sorting, #enable_movie_sorting, #enable_date_sorting'
-    var checkEnabled = '#disable_api_key'
 
-    $(checkDisabled + ','+ checkEnabled).on('change', function() {
+    $(checkDisabled).on('change', function() {
         $(this).parent().nextAll().toggleClass('disabled')
     })
     if(!$(checkDisabled).is(':checked')) {
         $(checkDisabled).parent().nextAll().addClass('disabled')
-    }
-    if($(checkEnabled).is(':checked')) {
-        $(checkEnabled).parent().nextAll().addClass('disabled')
     }
 });
 

--- a/interfaces/Config/templates/staticcfg/js/script.js
+++ b/interfaces/Config/templates/staticcfg/js/script.js
@@ -377,6 +377,11 @@ $(document).ready(function () {
     if(!$(checkDisabled).is(':checked')) {
         $(checkDisabled).parent().nextAll().addClass('disabled')
     }
+
+    // Hide or show HTTPS
+    $('#enable_https').on('change', function() {
+        $('#enable_https_options').toggle()
+    })
 });
 
 /*

--- a/interfaces/Config/templates/staticcfg/js/script.js
+++ b/interfaces/Config/templates/staticcfg/js/script.js
@@ -207,18 +207,19 @@ function do_restart() {
     // What template
     var arrPath = window.location.pathname.split('/');
     var urlPath = (arrPath[1] == "m" || arrPath[2] == "m") ? '/sabnzbd/m/' : '/sabnzbd/';
+    var switchedHTTPS = !$('#enable_https').is(':checked') && window.location.protocol == 'https:'
 
     // Are we on settings page?
     if(!$('body').hasClass('General')) {
         // Same as before, with fall-back in case location.origin is not supported (<IE9)
         var urlTotal = window.location.origin ? (window.location.origin + urlPath) : window.location;
-    } else if (($('#port').val() == $('#port').data('original')) && ($('#https_port ').val() == $('#https_port ').data('original'))) {
+    } else if (!switchedHTTPS && ($('#port').val() == $('#port').data('original')) && ($('#https_port').val() == $('#https_port').data('original'))) {
         // If the http/https port config didn't change, don't try and guess the URL/port to redirect to
         // This solves some incorrect behavior if running behind a reverse proxy
         var urlTotal = window.location.origin ? (window.location.origin + urlPath) : window.location;
     } else {
         // Protocol and port depend on http(s) setting
-        if($('#enable_https').is(':checked') && window.location.protocol == 'https:') {
+        if($('#enable_https').is(':checked') && (window.location.protocol == 'https:' || !$('#https_port').val())) {
             // Https on and we visited this page from HTTPS
             var urlProtocol = 'https:';
             var urlPort = $('#https_port').val() ? $('#https_port').val() : $('#port').val();
@@ -369,7 +370,7 @@ $(document).ready(function () {
     $('input[type="checkbox"]').parents('label').addClass('config-hover')
 
     // Disable sections
-    var checkDisabled = '#enable_https, #rating_enable, #enable_tv_sorting, #enable_movie_sorting, #enable_date_sorting'
+    var checkDisabled = '#rating_enable, #enable_tv_sorting, #enable_movie_sorting, #enable_date_sorting'
 
     $(checkDisabled).on('change', function() {
         $(this).parent().nextAll().toggleClass('disabled')

--- a/interfaces/wizard/one.html
+++ b/interfaces/wizard/one.html
@@ -49,7 +49,7 @@
                             <div class="col-sm-4"></div>
                             <div class="col-sm-8">
                                 <a href="#" onclick="\$('#server-hidden-settings').removeClass('hidden');\$(this).parent().parent().hide()">
-                                    <span class="glyphicon glyphicon-cog"></span> $T('showAllHis')
+                                    <span class="glyphicon glyphicon-cog"></span> $T('button-advanced')
                                 </a>
                             </div>
                         </div>
@@ -63,7 +63,7 @@
                             <div class="form-group">
                                 <label for="connections" class="col-sm-4 control-label">$T('srv-connections')</label>
                                 <div class="col-sm-8">
-                                    <input type="number" class="form-control" name="connections" id="connections" value="<!--#if $connections then $connections else '6'#-->" data-toggle="tooltip" data-placement="right" title="$T('wizard-server-con-explain') $T('wizard-server-con-eg')" />
+                                    <input type="number" class="form-control" name="connections" id="connections" value="<!--#if $connections then $connections else '8'#-->" data-toggle="tooltip" data-placement="right" title="$T('wizard-server-con-explain') $T('wizard-server-con-eg')" />
                                 </div>
                             </div>
                         </div>

--- a/po/main/en.po
+++ b/po/main/en.po
@@ -80,14 +80,6 @@ msgstr "API key incorrect, Use the API key from Config->General in your 3rd part
 msgid "HTTPS Chain Certifcates"
 msgstr "HTTPS Chain Certificates"
 
-#: sabnzbd/skintext.py:336
-msgid "Highest possible linespeed in Bytes/second, e.g. 2M."
-msgstr "Highest possible line speed in Bytes/second, e.g. 2M."
-
-#: sabnzbd/skintext.py:338
-msgid "Which percentage of the linespeed should SABnzbd use, e.g. 50"
-msgstr "Which percentage of the line speed should SABnzbd use, e.g. 50"
-
 #: sabnzbd/skintext.py:465
 msgid "Replace Spaces in Foldername"
 msgstr "Replace spaces in folder name"
@@ -132,18 +124,6 @@ msgstr "Web interface"
 msgid "Script returned exit code %s and output \"%s\""
 msgstr "Notification script returned exit code %s and output \"%s\""
 
-#: sabnzbd/skintext.py:390
-msgid "Post-Processing Scripts Folder"
-msgstr "Scripts Folder"
-
-#: sabnzbd/skintext.py:391
-msgid "Folder containing user scripts for post-processing."
-msgstr "Folder containing user scripts."
-
-#: sabnzbd/skintext.py:520
-msgid "Enable OZnzb Integration"
-msgstr "Enable Indexer Integration"
-
 #: sabnzbd/skintext.py:521
 msgid ""
 "Enhanced functionality including ratings and extra status information is "
@@ -153,36 +133,8 @@ msgstr ""
 "using the settings below to provide ratings and extra status information. "
 "<br>The Server address and API key settings can be left blank, depending on your indexer. "
 
-#: sabnzbd/skintext.py:523
-msgid ""
-"This key provides identity to indexer. Refer to "
-"https://www.oznzb.com/profile."
-msgstr ""
-"This key provides identity to indexer. Check "
-"your profile on the indexer's website."
-
-#: sabnzbd/assembler.py:117 [Warning message]
-msgid "WARNING: Paused job \"%s\" because of encrypted RAR file"
-msgstr "WARNING: Paused job \"%s\" because of encrypted RAR file (if supplied, all passwords were tried)"
-
 #: sabnzbd/skintext.py:333
 msgid "If empty, the standard port will only listen to HTTPS."
 msgstr "If empty, the SABnzbd Port set above will only listen to HTTPS."
-
-#: sabnzbd/skintext.py:439
-msgid "Detect identical episodes in series (based on \"name/season/episode\")"
-msgstr "Detect identical episodes in series (based on \"name/season/episode\" of items in your History)"
-
-#: sabnzbd/skintext.py:436
-msgid "Detect identical NZB files (based on NZB content)"
-msgstr "Detect identical NZB files (based on items in your History or files in .nzb Backup Folder)"
-
-#: sabnzbd/assembler.py:120 [Warning message]
-msgid "WARNING: Aborted job \"%s\" because of encrypted RAR file"
-msgstr "WARNING: Aborted job \"%s\" because of encrypted RAR file (if supplied, all passwords were tried)"
-
-#: sabnzbd/skintext.py:368
-msgid "You can set access rights for systems outside your local network"
-msgstr "You can set access rights for systems outside your local network. Requires List of local network ranges to be defined."
 
 

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -543,7 +543,7 @@ def add_url(url, pp=None, script=None, cat=None, priority=None, nzbname=None):
     """ Add NZB based on a URL, attributes optional """
     if 'http' not in url:
         return
-    if pp and pp == "-1":
+    if not pp or pp == "-1":
         pp = None
     if script and script.lower() == 'default':
         script = None

--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -114,10 +114,10 @@ class Assembler(Thread):
                     rar_encrypted, unwanted_file = check_encrypted_and_unwanted_files(nzo, filepath)
                     if rar_encrypted:
                         if cfg.pause_on_pwrar() == 1:
-                            logging.warning(T('WARNING: Paused job "%s" because of encrypted RAR file'), nzo.final_name)
+                            logging.warning(T('WARNING: Paused job "%s" because of encrypted RAR file (if supplied, all passwords were tried)'), nzo.final_name)
                             nzo.pause()
                         else:
-                            logging.warning(T('WARNING: Aborted job "%s" because of encrypted RAR file'), nzo.final_name)
+                            logging.warning(T('WARNING: Aborted job "%s" because of encrypted RAR file (if supplied, all passwords were tried)'), nzo.final_name)
                             nzo.fail_msg = T('Aborted, encryption detected')
                             import sabnzbd.nzbqueue
                             sabnzbd.nzbqueue.NzbQueue.do.end_job(nzo)

--- a/sabnzbd/config.py
+++ b/sabnzbd/config.py
@@ -912,9 +912,18 @@ def get_categories(cat=0):
     if 'categories' not in database:
         database['categories'] = {}
     cats = database['categories']
+
+    # Add Default categories
     if '*' not in cats:
         ConfigCat('*', {'pp': old_def('dirscan_opts', '3'), 'script': old_def('dirscan_script', 'None'),
                         'priority': old_def('dirscan_priority', NORMAL_PRIORITY)})
+        # Add some categorie suggestions
+        ConfigCat('movies', {})
+        ConfigCat('tv', {})
+        ConfigCat('audio', {})
+        ConfigCat('software', {})
+
+        # Save config for future use
         save_config(True)
     if not isinstance(cat, int):
         try:

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -2224,8 +2224,6 @@ class ConfigRss(object):
         if msg:
             return msg
         if 'feed' in kwargs:
-            feed = kwargs['feed']
-            self.__refresh_readout = feed
             self.__refresh_download = False
             self.__refresh_force = False
             self.__refresh_ignore = False

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -1415,10 +1415,10 @@ class ConfigFolders(object):
 ##############################################################################
 SWITCH_LIST = \
     ('par2_multicore', 'par_option', 'overwrite_files', 'top_only', 'ssl_ciphers',
-             'auto_sort', 'propagation_delay', 'check_new_rel', 'auto_disconnect', 'flat_unpack',
-             'safe_postproc', 'no_dupes', 'replace_spaces', 'replace_dots', 'replace_illegal', 'auto_browser',
+             'auto_sort', 'propagation_delay', 'auto_disconnect', 'flat_unpack',
+             'safe_postproc', 'no_dupes', 'replace_spaces', 'replace_dots', 'replace_illegal',
              'ignore_samples', 'pause_on_post_processing', 'quick_check', 'nice', 'ionice',
-             'pre_script', 'pause_on_pwrar', 'sfv_check', 'folder_rename',
+             'pre_script', 'pause_on_pwrar', 'sfv_check', 'folder_rename', 'load_balancing',
              'unpack_check', 'quota_size', 'quota_day', 'quota_resume', 'quota_period',
              'pre_check', 'max_art_tries', 'max_art_opt', 'fail_hopeless_jobs', 'enable_all_par',
              'enable_recursive', 'no_series_dupes', 'script_can_fail', 'new_nzb_on_failure',
@@ -1429,8 +1429,7 @@ SWITCH_LIST = \
              'rating_filter_abort_downvoted', 'rating_filter_abort_keywords',
              'rating_filter_pause_audio', 'rating_filter_pause_video', 'rating_filter_pause_encrypted',
              'rating_filter_pause_encrypted_confirm', 'rating_filter_pause_spam', 'rating_filter_pause_spam_confirm',
-             'rating_filter_pause_downvoted', 'rating_filter_pause_keywords',
-             'load_balancing', 'enable_https_verification'
+             'rating_filter_pause_downvoted', 'rating_filter_pause_keywords'
      )
 
 
@@ -1560,7 +1559,8 @@ class ConfigSpecial(object):
 GENERAL_LIST = (
     'host', 'port', 'username', 'password', 'refresh_rate', 'cache_limit',
     'local_ranges', 'inet_exposure', 'enable_https', 'https_port',
-    'https_cert', 'https_key', 'https_chain'
+    'https_cert', 'https_key', 'https_chain', 'enable_https_verification',
+    'auto_browser', 'check_new_rel'
 )
 
 
@@ -1608,6 +1608,7 @@ class ConfigGeneral(object):
         conf['restart_req'] = sabnzbd.RESTART_REQ
 
         conf['have_ssl'] = sabnzbd.HAVE_SSL
+        conf['have_ssl_context'] = sabnzbd.HAVE_SSL_CONTEXT
         conf['have_cryptography'] = sabnzbd.HAVE_CRYPTOGRAPHY
 
         wlist = []
@@ -1640,24 +1641,13 @@ class ConfigGeneral(object):
             lang_list = []
         conf['lang_list'] = lang_list
 
-        conf['host'] = cfg.cherryhost()
-        conf['port'] = cfg.cherryport()
-        conf['https_port'] = cfg.https_port()
-        conf['https_cert'] = cfg.https_cert()
-        conf['https_key'] = cfg.https_key()
-        conf['https_chain'] = cfg.https_chain()
-        conf['enable_https'] = cfg.enable_https()
-        conf['username'] = cfg.username()
-        conf['password'] = cfg.password.get_stars()
-        conf['html_login'] = cfg.html_login()
+        for kw in GENERAL_LIST:
+            conf[kw] = config.get_config('misc', kw)()
+
         conf['bandwidth_max'] = cfg.bandwidth_max()
         conf['bandwidth_perc'] = cfg.bandwidth_perc()
-        conf['refresh_rate'] = cfg.refresh_rate()
-        conf['cache_limit'] = cfg.cache_limit()
-        conf['cleanup_list'] = cfg.cleanup_list.get_string()
         conf['nzb_key'] = cfg.nzb_key()
         conf['local_ranges'] = cfg.local_ranges.get_string()
-        conf['inet_exposure'] = cfg.inet_exposure()
         conf['my_lcldata'] = cfg.admin_dir.get_path()
         conf['caller_url1'] = cherrypy.request.base + '/sabnzbd/'
         conf['caller_url2'] = cherrypy.request.base + '/sabnzbd/m/'

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -1500,8 +1500,8 @@ SPECIAL_BOOL_LIST = \
               'osx_menu', 'osx_speed', 'win_menu', 'use_pickle', 'allow_incomplete_nzb',
               'rss_filenames', 'ipv6_hosting', 'keep_awake', 'empty_postproc', 'html_login',
               'wait_for_dfolder', 'warn_empty_nzb', 'enable_bonjour','allow_duplicate_files',
-              'warn_dupl_jobs', 'backup_for_duplicates', 'enable_par_cleanup', 'api_logging',
-              'fixed_ports'
+              'warn_dupl_jobs', 'backup_for_duplicates', 'enable_par_cleanup', 'disable_api_key',
+              'api_logging', 'fixed_ports'
      )
 SPECIAL_VALUE_LIST = \
     ('size_limit', 'folder_max_length', 'fsys_type', 'movie_rename_limit', 'nomedia_marker',
@@ -1558,9 +1558,9 @@ class ConfigSpecial(object):
 
 ##############################################################################
 GENERAL_LIST = (
-    'host', 'port', 'username', 'password', 'disable_api_key',
-    'refresh_rate', 'cache_limit', 'local_ranges', 'inet_exposure',
-    'enable_https', 'https_port', 'https_cert', 'https_key', 'https_chain'
+    'host', 'port', 'username', 'password', 'refresh_rate', 'cache_limit',
+    'local_ranges', 'inet_exposure', 'enable_https', 'https_port',
+    'https_cert', 'https_key', 'https_chain'
 )
 
 
@@ -1640,7 +1640,6 @@ class ConfigGeneral(object):
             lang_list = []
         conf['lang_list'] = lang_list
 
-        conf['disable_api_key'] = cfg.disable_key()
         conf['host'] = cfg.cherryhost()
         conf['port'] = cfg.cherryport()
         conf['https_port'] = cfg.https_port()

--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -716,11 +716,20 @@ def _get_link(uri, entry):
         except:
             pass
 
+    # Try newznab attribute first, this is the correct one
     try:
         # Convert it to format that calc_age understands
-        age = datetime.datetime(*entry.published_parsed[:6])
+        age = datetime.datetime(*entry['newznab']['usenetdate_parsed'][:6])
     except:
-        pass
+        # Date from feed (usually lags behind)
+        try:
+            # Convert it to format that calc_age understands
+            age = datetime.datetime(*entry.published_parsed[:6])
+        except:
+            pass
+    finally:
+        # We need to convert it to local timezone, feedparser always returns UTC
+        age = age - datetime.timedelta(seconds=time.timezone)
 
     if link and 'http' in link.lower():
         try:

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -371,7 +371,7 @@ SKIN_TEXT = {
     'opt-local_ranges' : TT('List of local network ranges'),
     'explain-local_ranges' : TT('All local network addresses start with these prefixes (often "192.168.1.")'),
     'opt-inet_exposure' : TT('External internet access'),
-    'explain-inet_exposure' : TT('You can set access rights for systems outside your local network'),
+    'explain-inet_exposure' : TT('You can set access rights for systems outside your local network. Requires List of local network ranges to be defined.'),
     'inet-local' : TT('No access'), # Selection value for external access
     'inet-nzb' : TT('Add NZB files '), # Selection value for external access
     'inet-api' : TT('API (no Config)'), # Selection value for external access
@@ -396,8 +396,8 @@ SKIN_TEXT = {
     'explain-dirscan_dir' : TT('Folder to monitor for .nzb files.<br /><i>Also scans .zip .rar and .tar.gz archives for .nzb files.</i>'),
     'opt-dirscan_speed' : TT('Watched Folder Scan Speed'),
     'explain-dirscan_speed' : TT('Number of seconds between scans for .nzb files.'),
-    'opt-script_dir' : TT('Post-Processing Scripts Folder'),
-    'explain-script_dir' : TT('Folder containing user scripts for post-processing.'),
+    'opt-script_dir' : TT('Scripts Folder'),
+    'explain-script_dir' : TT('Folder containing user scripts.'),
     'opt-email_dir' : TT('Email Templates Folder'),
     'explain-email_dir' : TT('Folder containing user-defined email templates.'),
     'opt-password_file' : TT('Password file'),
@@ -430,9 +430,9 @@ SKIN_TEXT = {
     'opt-pause_on_pwrar' : TT('Action when encrypted RAR is downloaded'),
     'explain-pause_on_pwrar' : TT('In case of "Pause", you\'ll need to set a password and resume the job.'),
     'opt-no_dupes' : TT('Detect Duplicate Downloads'),
-    'explain-no_dupes' : TT('Detect identical NZB files (based on NZB content)'),
+    'explain-no_dupes' : TT('Detect identical NZB files (based on items in your History or files in .nzb Backup Folder)'),
     'opt-no_series_dupes' : TT('Detect duplicate episodes in series'),
-    'explain-no_series_dupes' : TT('Detect identical episodes in series (based on "name/season/episode")'),
+    'explain-no_series_dupes' : TT('Detect identical episodes in series (based on "name/season/episode" of items in your History)'),
     'nodupes-off' : TT('Off'), #: Three way switch for duplicates
     'nodupes-ignore' : TT('Discard'), #: Three way switch for duplicates
     'nodupes-pause' : TT('Pause'), #: Three way switch for duplicates
@@ -516,11 +516,11 @@ SKIN_TEXT = {
     'explain-max_art_opt' : TT('Apply maximum retries only to optional servers'),
     'opt-fail_hopeless_jobs' : TT('Abort jobs that cannot be completed'),
     'explain-fail_hopeless_jobs' : TT('When during download it becomes clear that too much data is missing, abort the job'),
-    'opt-rating_enable' : TT('Enable OZnzb Integration'),
+    'opt-rating_enable' : TT('Enable Indexer Integration'),
     'explain-rating_enable' : TT('Enhanced functionality including ratings and extra status information is available when connected to OZnzb indexer.'),
     'opt-rating_api_key' : TT('API Key'),
     'opt-rating_host' : TT('Server address'),
-    'explain-rating_api_key' : TT('This key provides identity to indexer. Refer to https://www.oznzb.com/profile.'),
+    'explain-rating_api_key' : TT('This key provides identity to indexer. Check your profile on the indexer\'s website.'),
     'opt-rating_feedback' : TT('Automatic Feedback'),
     'explain-rating_feedback' : TT('Send automatically calculated validation results for downloads to indexer.'),
     'opt-rating_filter_enable' : TT('Enable Filtering'),

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -300,6 +300,7 @@ SKIN_TEXT = {
     'cache' : TT('Used cache'), #: Main config page, how much cache is in use
     'explain-Restart' : TT('This will restart SABnzbd.<br />Use it when you think the program has a stability problem.<br />Downloading will be paused before the restart and resume afterwards.') + TT('<br />If authentication is enabled, you will need to login again.'),
     'explain-needNewLogin' : TT('<br />If authentication is enabled, you will need to login again.'),
+    'button-advanced' : TT('Advanced'),
     'button-restart' : TT('Restart'),
     'explain-orphans' : TT('There are orphaned jobs in the download folder.<br />You can choose to delete them (including files) or send them back to the queue.'),
     'button-repair' : TT('Repair'),

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -332,6 +332,7 @@ SKIN_TEXT = {
     'explain-web_username' : TT('Optional authentication username.'),
     'opt-web_password' : TT('SABnzbd Password'),
     'explain-web_password' : TT('Optional authentication password.'),
+    'security' : TT('Security'),
     'httpsSupport' : TT('HTTPS Support'),
     'opt-enable_https' : TT('Enable HTTPS'),
     'opt-notInstalled' : TT('not installed'),

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -365,8 +365,6 @@ SKIN_TEXT = {
     'opt-nzbkey' : TT('NZB Key'),
     'explain-nzbkey' : TT('This key will allow 3rd party programs to add NZBs to SABnzbd.'),
     'button-apikey' : TT('Generate New Key'),
-    'opt-disableApikey' : TT('Disable API-key'),
-    'explain-disableApikey' : TT('Do not require the API key.'),
     'explain-qr-code' : TT('API Key QR Code'), #: Explanation for QR code of APIKEY
     'opt-local_ranges' : TT('List of local network ranges'),
     'explain-local_ranges' : TT('All local network addresses start with these prefixes (often "192.168.1.")'),

--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -26,6 +26,7 @@ import re
 import logging
 import Queue
 import urllib2
+from httplib import IncompleteRead
 from threading import Thread
 
 import sabnzbd
@@ -209,7 +210,10 @@ class URLGrabber(Thread):
                 if gzipped:
                     filename += '.gz'
                 if not data:
-                    data = fn.read()
+                    try:
+                        data = fn.read()
+                    except IncompleteRead, e:
+                        bad_fetch(future_nzo, url, T('Server could not complete request'))
                 fn.close()
 
                 if '<nzb' in data and misc.get_ext(filename) != '.nzb':

--- a/sabnzbd/utils/feedparser.py
+++ b/sabnzbd/utils/feedparser.py
@@ -527,6 +527,8 @@ class _FeedParserMixin:
         'http://www.w3.org/1999/xhtml':                          'xhtml',
         'http://www.w3.org/1999/xlink':                          'xlink',
         'http://www.w3.org/XML/1998/namespace':                  'xml',
+        'http://www.newznab.com/DTD/2010/feeds/attributes/':     'nZEDb',
+        'http://www.newznab.com/DTD/2010/feeds/attributes/':     'newznab',
     }
     _matchnamespaces = {}
 
@@ -1766,6 +1768,19 @@ class _FeedParserMixin:
         if context is not self.feeddata:
             return
         context['newlocation'] = _makeSafeAbsoluteURI(self.baseuri, url.strip())
+
+    def _start_newznab_attr(self, attrsD):
+        context = self._getContext()
+        # Add the dict
+        if 'newznab' not in context:
+            context['newznab'] = {}
+        # Add keys
+        context['newznab'][attrsD['name']] = attrsD['value']
+        # Try to get date-object
+        if attrsD['name'] == 'usenetdate':
+            context['newznab'][attrsD['name'] + '_parsed'] = _parse_date(attrsD['value'])
+    _start_nZEDb_attr = _start_newznab_attr
+    _start_nzedb_attr = _start_nZEDb_attr
 
 if _XML_AVAILABLE:
     class _StrictFeedParser(_FeedParserMixin, xml.sax.handler.ContentHandler):


### PR DESCRIPTION
In collaboration partly with @sanderjo some re-working of the Config:

- Changed the General page, making a separate _Security_ section and move things like _Update check_ setting there since these are General settings. HTTPS in the _SABnzbd Web Server_ settings (collapsed when not enabled), since it's about the Web Server.
- The Servers page had become way too long with many confusing settings. Now only the things that actually matter er show, and rest is hidden behind a new 'Advanced' button. Just like in the Wizard, enabling SSL will auto-change the port setting from 119 to 563 and vica versa.
- Add 4 default Categories for new users: `tv`, `movies`, `software`  and `audio`. So users can get an idea of what categories can be used for. These are also Newznab categories that SAB now auto-matches.
- Moved disabled_api_key to Specials, but also removed the texts and some Javascript that was used for it (a bit more than @shypike put in #756 😉 )
