### PR TITLE
Fix URL grabber crashing on invalid windows file names

### DIFF
--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -228,6 +228,10 @@ class URLGrabber(Thread):
                 f = open(path, 'wb')
                 f.write(data)
                 f.close()
+                # make sure file exists after writing to avoid crashing
+                # the URL grabber
+                if not os.path.exists(path):
+                    raise IOError('Unable to create temp file: ' + path)
                 del data
 
                 # Check if nzb file


### PR DESCRIPTION
When attempting to write an invalid file (such as device files on Windows) the file doesn't get created and the URL grabber stops responding.  As discussed in #494 modifying the filename can lead to other consequences such as issues with unrar.  This raises an IOError instead when the file doesn't get written so the error can propagate but the URL grabber can still continue.

http://superuser.com/questions/613313/why-cant-we-make-con-prn-null-folder-in-windows