### PR TITLE
PEP8 cleanup

### DIFF
--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -217,7 +217,6 @@ def connect_db(thread_index=0):
     return cherrypy.thread_data.history_db
 
 
-
 @synchronized(INIT_LOCK)
 def initialize(pause_downloader=False, clean_up=False, evalSched=False, repair=0):
     global __INITIALIZED__, __SHUTTING_DOWN__,\
@@ -441,7 +440,6 @@ def halt():
         except:
             logging.error(T('Fatal error at saving state'), exc_info=True)
 
-
         # The Scheduler cannot be stopped when the stop was scheduled.
         # Since all warm-restarts have been removed, it's not longer
         # needed to stop the scheduler.
@@ -516,6 +514,7 @@ def guard_quota_dp():
 def guard_fsys_type():
     """ Callback for change of file system naming type """
     sabnzbd.encoding.change_fsys(cfg.fsys_type())
+
 
 def set_https_verification(value):
     prev = False
@@ -1148,11 +1147,12 @@ def wait_for_download_folder():
         logging.debug('Waiting for "incomplete" folder')
         time.sleep(2.0)
 
+
 def check_old_queue():
     """ Check for old queue (when a new queue is not present) """
     old = False
     if not os.path.exists(os.path.join(cfg.admin_dir.get_path(), QUEUE_FILE_NAME)):
-        for ver in (QUEUE_VERSION -1 , QUEUE_VERSION - 2, QUEUE_VERSION - 3):
+        for ver in (QUEUE_VERSION - 1, QUEUE_VERSION - 2, QUEUE_VERSION - 3):
             data = load_admin(QUEUE_FILE_TMPL % str(ver))
             if data:
                 break
@@ -1160,8 +1160,7 @@ def check_old_queue():
             old = bool(data and isinstance(data, tuple) and len(data[1]))
         except (TypeError, IndexError):
             pass
-        if old and sabnzbd.WIN32 and ver < 10 and sabnzbd.DIR_LCLDATA != sabnzbd.DIR_HOME \
-            and misc.is_relative_path(cfg.download_dir()):
+        if old and sabnzbd.WIN32 and ver < 10 and sabnzbd.DIR_LCLDATA != sabnzbd.DIR_HOME and misc.is_relative_path(cfg.download_dir()):
             # For Windows and when version < 10: adjust old default location
             cfg.download_dir.set('Documents/' + cfg.download_dir())
     return old

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -97,6 +97,7 @@ else:
 # Flag for using the fast json encoder, unless it fails
 FAST_JSON = True
 
+
 def api_handler(kwargs):
     """ API Dispatcher """
     mode = kwargs.get('mode', '')
@@ -105,7 +106,7 @@ def api_handler(kwargs):
     callback = kwargs.get('callback', '')
 
     # Extend the timeout of API calls to 10minutes
-    cherrypy.response.timeout = 60*10
+    cherrypy.response.timeout = 600
 
     if isinstance(mode, list):
         mode = mode[0]
@@ -138,6 +139,7 @@ def _api_set_config(name, output, kwargs):
     config.save_config()
     res, data = config.get_dconfig(kwargs.get('section'), kwargs.get('keyword'))
     return report(output, keyword='config', data=data)
+
 
 def _api_set_config_default(name, output, kwargs):
     """ API: Reset requested config variables back to defaults. Currently only for misc-section """
@@ -385,6 +387,7 @@ def _api_retry(name, output, kwargs):
     else:
         return report(output, _MSG_NO_ITEM)
 
+
 def _api_cancel_pp(name, output, kwargs):
     """ API: accepts name, output, value(=nzo_id) """
     nzo_id = kwargs.get('value')
@@ -392,6 +395,7 @@ def _api_cancel_pp(name, output, kwargs):
         return report(output, keyword='', data={'status': True, 'nzo_id': nzo_id})
     else:
         return report(output, _MSG_NO_ITEM)
+
 
 def _api_addlocalfile(name, output, kwargs):
     """ API: accepts name, output, pp, script, cat, priority, nzbname """
@@ -756,11 +760,13 @@ def _api_test_email(name, output, kwargs):
         res = None
     return report(output, error=res)
 
+
 def _api_test_windows(name, output, kwargs):
     """ API: send a test to Windows, return result """
     logging.info("Sending test notification")
     res = sabnzbd.notifier.send_windows('SABnzbd', T('Test Notification'), 'other')
     return report(output, error=res)
+
 
 def _api_test_notif(name, output, kwargs):
     """ API: send a test to Notification Center, return result """
@@ -803,11 +809,13 @@ def _api_test_pushbullet(name, output, kwargs):
     res = sabnzbd.notifier.send_pushbullet('SABnzbd', T('Test Notification'), 'other', force=True, test=kwargs)
     return report(output, error=res)
 
+
 def _api_test_nscript(name, output, kwargs):
     """ API: execute a test notification script, return result """
     logging.info("Executing notification script")
     res = sabnzbd.notifier.send_nscript('SABnzbd', T('Test Notification'), 'other', force=True, test=kwargs)
     return report(output, error=res)
+
 
 def _api_undefined(name, output, kwargs):
     """ API: accepts output """
@@ -1295,6 +1303,7 @@ def build_status(skip_dashboard=False, output=None):
 
     return info
 
+
 def build_queue(start=0, limit=0, trans=False, output=None, search=None):
     if output:
         converter = unicoder
@@ -1366,7 +1375,8 @@ def build_queue(start=0, limit=0, trans=False, output=None, search=None):
                 slot['status'] = Status.DOWNLOADING
         else:
             # ensure compatibility of API status
-            if status in (Status.DELETED, ): status = Status.DOWNLOADING
+            if status in (Status.DELETED, ):
+                status = Status.DOWNLOADING
             slot['status'] = "%s" % (status)
 
         if (Downloader.do.paused or Downloader.do.postproc or is_propagating or  \
@@ -1516,6 +1526,7 @@ def build_file_list(nzo_id):
 
     return jobs
 
+
 def rss_qstatus():
     """ Return a RSS feed with the queue status """
     qnfo = NzbQueue.do.queue_info()
@@ -1595,7 +1606,8 @@ def retry_job(job, new_nzb, password):
         history_db = sabnzbd.connect_db()
         futuretype, url, pp, script, cat = history_db.get_other(job)
         if futuretype:
-            if pp == 'X': pp = None
+            if pp == 'X':
+                pp = None
             sabnzbd.add_url(url, pp, script, cat)
             history_db.remove_history(job)
         else:
@@ -1735,7 +1747,6 @@ def build_header(webdir=''):
         header['new_rel_url'] = ''
 
     return header
-
 
 
 def build_queue_header(search=None, start=0, limit=0):
@@ -1984,8 +1995,8 @@ def get_active_history(queue=None, items=None):
     return items
 
 
-def format_bytes(bytes):
-    b = to_units(bytes)
+def format_bytes(rawbytes):
+    b = to_units(rawbytes)
     if b == '':
         return b
     else:

--- a/sabnzbd/articlecache.py
+++ b/sabnzbd/articlecache.py
@@ -25,7 +25,7 @@ import threading
 
 import sabnzbd
 from sabnzbd.decorators import synchronized
-from sabnzbd.constants import GIGI, ANFO, Status
+from sabnzbd.constants import GIGI, ANFO
 
 
 ARTICLE_LOCK = threading.Lock()
@@ -59,7 +59,7 @@ class ArticleCache(object):
     @synchronized(ARTICLE_LOCK)
     def reserve_space(self, data):
         """ Is there space left in the set limit? """
-        data_size = sys.getsizeof(data)*64
+        data_size = sys.getsizeof(data) * 64
         self.__cache_size += data_size
         if self.__cache_size + data_size > self.__cache_limit:
             return False
@@ -69,10 +69,9 @@ class ArticleCache(object):
     @synchronized(ARTICLE_LOCK)
     def free_reserve_space(self, data):
         """ Remove previously reserved space """
-        data_size = sys.getsizeof(data)*64
+        data_size = sys.getsizeof(data) * 64
         self.__cache_size -= data_size
         return self.__cache_size + data_size < self.__cache_limit
-
 
     @synchronized(ARTICLE_LOCK)
     def save_article(self, article, data):
@@ -148,7 +147,7 @@ class ArticleCache(object):
     @synchronized(ARTICLE_LOCK)
     def purge_articles(self, articles):
         if sabnzbd.LOG_ALL:
-            logging.debug("Purgable articles -> %s", articles)
+            logging.debug("Purgeable articles -> %s", articles)
         for article in articles:
             if article in self.__article_list:
                 self.__article_list.remove(article)

--- a/sabnzbd/bpsmeter.py
+++ b/sabnzbd/bpsmeter.py
@@ -22,7 +22,6 @@ sabnzbd.bpsmeter - bpsmeter
 import time
 import logging
 import re
-from math import floor
 
 import sabnzbd
 from sabnzbd.constants import BYTES_FILE_NAME, BYTES_FILE_NAME_OLD, KIBI
@@ -333,15 +332,15 @@ class BPSMeter(object):
             return None
 
         # Calculate the variance in the speed
-        avg = sum(self.bps_list[-timespan:])/timespan
+        avg = sum(self.bps_list[-timespan:]) / timespan
         vari = 0
         for bps in self.bps_list[-timespan:]:
             vari += abs(bps - avg)
-        vari = vari/timespan
+        vari = vari / timespan
 
         try:
             # See if the variance is less than 5%
-            if (vari / (self.bps/KIBI)) < 0.05:
+            if (vari / (self.bps / KIBI)) < 0.05:
                 return avg
             else:
                 return False
@@ -349,7 +348,6 @@ class BPSMeter(object):
             # Probably one of the values was 0
             pass
         return None
-
 
     def reset_quota(self, force=False):
         """ Check if it's time to reset the quota, optionally resuming

--- a/sabnzbd/config.py
+++ b/sabnzbd/config.py
@@ -93,6 +93,7 @@ class Option(object):
 
     def set_dict(self, dict):
         """ Set value based on dictionary """
+        # TODO: Review if `dict` is actually correct or typo
         if self.__protect:
             return False
         try:
@@ -377,7 +378,7 @@ class ConfigServer(object):
         self.password = OptionPassword(name, 'password', '', add=False)
         self.connections = OptionNumber(name, 'connections', 1, 0, 100, add=False)
         self.ssl = OptionBool(name, 'ssl', False, add=False)
-        self.ssl_verify = OptionNumber(name, 'ssl_verify', 2, add=False) # 0=No, 1=Normal, 2=Strict (hostname verification)
+        self.ssl_verify = OptionNumber(name, 'ssl_verify', 2, add=False)  # 0=No, 1=Normal, 2=Strict (hostname verification)
         self.enable = OptionBool(name, 'enable', True, add=False)
         self.optional = OptionBool(name, 'optional', False, add=False)
         self.retention = OptionNumber(name, 'retention', add=False)
@@ -813,9 +814,11 @@ def save_config(force=False):
                 except KeyError:
                     CFG[sec] = {}
                 value = database[section][option]()
-                if type(value) == type(True):
+                # bool is a subclass of int, check first
+                if isinstance(value, bool):
+                    # convert bool to int when saving so we store 0 or 1
                     CFG[sec][kw] = str(int(value))
-                elif type(value) == type(0):
+                elif isinstance(value, int):
                     CFG[sec][kw] = str(value)
                 else:
                     CFG[sec][kw] = value

--- a/sabnzbd/config.py
+++ b/sabnzbd/config.py
@@ -783,7 +783,7 @@ def _read_config(path, try_backup=False):
 def save_config(force=False):
     """ Update Setup file with current option values """
     global CFG, database, modified
-    if 0: assert isinstance(CFG, configobj.ConfigObj)
+    if 0: assert isinstance(CFG, configobj.ConfigObj) # debug purpose @IgnorePep8
 
     if not (modified or force):
         return True

--- a/sabnzbd/constants.py
+++ b/sabnzbd/constants.py
@@ -102,7 +102,7 @@ PAUSED_PRIORITY = -2
 DUP_PRIORITY = -3
 STOP_PRIORITY = -4
 
-STAGES = { 'Source' : 0, 'Download' : 1, 'Servers' : 2, 'Repair' : 3, 'Filejoin' : 4, 'Unpack' : 5, 'Script' : 6 }
+STAGES = {'Source': 0, 'Download': 1, 'Servers': 2, 'Repair': 3, 'Filejoin': 4, 'Unpack': 5, 'Script': 6}
 
 VALID_ARCHIVES = ('.zip', '.rar', '.7z')
 
@@ -134,7 +134,7 @@ class Status():
     COMPLETED = 'Completed'         # PP: Job is finished
     CHECKING = 'Checking'           # Q:  Pre-check is running
     DOWNLOADING = 'Downloading'     # Q:  Normal downloading
-    EXTRACTING = 'Extracting'       # PP: Archives are being extraced
+    EXTRACTING = 'Extracting'       # PP: Archives are being extracted
     FAILED = 'Failed'               # PP: Job has failed, now in History
     FETCHING = 'Fetching'           # Q:  Job is downloading extra par2 files
     GRABBING = 'Grabbing'           # Q:  Getting an NZB from an external site

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -90,7 +90,7 @@ class Server(object):
         self.errormsg = ''
         self.warning = ''
         self.info = None     # Will hold getaddrinfo() list
-        self.ssl_info = '' # Will hold the type and cipher of SSL connection
+        self.ssl_info = ''  # Will hold the type and cipher of SSL connection
         self.request = False  # True if a getaddrinfo() request is pending
         self.have_body = 'free.xsusenet.com' not in host
         self.have_stat = True  # Assume server has "STAT", until proven otherwise
@@ -107,7 +107,7 @@ class Server(object):
             2 - and self.info has more than 1 entry (read: IP address): Return the quickest IP based on the happyeyeballs algorithm
             In case of problems: return the host name itself
         """
-        # Check if already a succesfull ongoing connection
+        # Check if already a successful ongoing connection
         if self.busy_threads and self.busy_threads[0].nntp:
             # Re-use that IP
             logging.debug('%s: Re-using address %s', self.host, self.busy_threads[0].nntp.host)
@@ -423,7 +423,7 @@ class Downloader(Thread):
 
         while 1:
             for server in self.servers:
-                if 0: assert isinstance(server, Server) # Assert only for debug purposes
+                if 0: assert isinstance(server, Server) # Assert only for debug purposes @IgnorePep8
                 for nw in server.busy_threads[:]:
                     if (nw.nntp and nw.nntp.error_msg) or (nw.timeout and time.time() > nw.timeout):
                         if nw.nntp and nw.nntp.error_msg:
@@ -447,7 +447,7 @@ class Downloader(Thread):
                         # Restart pending, don't add new articles
                         continue
 
-                if 0: assert isinstance(server, Server) # Assert only for debug purposes
+                if 0: assert isinstance(server, Server) # Assert only for debug purposes @IgnorePep8
                 if not server.idle_threads or server.restart or self.is_paused() or self.shutdown or self.delayed or self.postproc:
                     continue
 
@@ -455,7 +455,7 @@ class Downloader(Thread):
                     continue
 
                 for nw in server.idle_threads[:]:
-                    if 0: assert isinstance(nw, NewsWrapper) # Assert only for debug purposes
+                    if 0: assert isinstance(nw, NewsWrapper) # Assert only for debug purposes @IgnorePep8
                     if nw.timeout:
                         if time.time() < nw.timeout:
                             continue
@@ -531,17 +531,17 @@ class Downloader(Thread):
             if readkeys or writekeys:
                 read, write, error = select.select(readkeys, writekeys, (), 1.0)
 
-                # Why check so often when so few things happend?
+                # Why check so often when so few things happened?
                 if self.can_be_slowed and len(readkeys) >= 8 and len(read) <= 2:
                     time.sleep(0.05)
 
-                # Need to initalize the check during first 20 seconds
+                # Need to initialize the check during first 20 seconds
                 if self.can_be_slowed is None or self.can_be_slowed_timer:
                     # Wait for stable speed to start testing
                     if not self.can_be_slowed_timer and BPSMeter.do.get_stable_speed(timespan=10):
                         self.can_be_slowed_timer = time.time()
 
-                    # Check 10 seconds after enabeling slowdown
+                    # Check 10 seconds after enabling slowdown
                     if self.can_be_slowed_timer and time.time() > self.can_be_slowed_timer + 10:
                         # Now let's check if it was stable in the last 10 seconds
                         self.can_be_slowed = (BPSMeter.do.get_stable_speed(timespan=10) > 0)

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -49,6 +49,7 @@ socket.setdefaulttimeout(DEF_TIMEOUT)
 # to delayed starts and timeouts on connections.
 # Because of this, the results will be cached in the server object.
 
+
 def _retrieve_info(server):
     """ Async attempt to run getaddrinfo() for specified server """
     info = GetServerParms(server.host, server.port)
@@ -113,7 +114,7 @@ def get_ssl_version(sock):
 
 
 def con(sock, host, port, sslenabled, write_fds, nntp):
-    if 0: assert isinstance(nntp, NNTP) # Assert only for debug purposes
+    if 0: assert isinstance(nntp, NNTP) # Assert only for debug purposes @IgnorePep8
     try:
         sock.connect((host, port))
         sock.setblocking(0)
@@ -148,8 +149,6 @@ def con(sock, host, port, sslenabled, write_fds, nntp):
             nntp.error(e)
 
 
-
-
 def probablyipv4(ip):
     if ip.count('.') == 3 and re.sub('[0123456789.]', '', ip) == '':
         return True
@@ -167,7 +166,7 @@ def probablyipv6(ip):
 class NNTP(object):
 
     def __init__(self, host, port, info, sslenabled, send_group, nw, user=None, password=None, block=False, write_fds=None):
-        if 0: assert isinstance(nw, NewsWrapper) # Assert only for debug purposes
+        if 0: assert isinstance(nw, NewsWrapper) # Assert only for debug purposes @IgnorePep8
         self.host = host
         self.port = port
         self.nw = nw
@@ -247,7 +246,6 @@ class NNTP(object):
                     pass
             finally:
                 self.error(e)
-
 
     def error(self, error):
         if 'SSL23_GET_SERVER_HELLO' in str(error) or 'SSL3_GET_RECORD' in str(error):
@@ -419,7 +417,7 @@ class NewsWrapper(object):
             # Append so we can do 1 join(), much faster than multiple!
             self.data.append(chunk)
 
-            # Offical end-of-article is ".\r\n" but sometimes it can get lost between 2 chunks
+            # Official end-of-article is ".\r\n" but sometimes it can get lost between 2 chunks
             chunk_len = len(chunk)
             if chunk[-5:] == '\r\n.\r\n':
                 return (chunk_len, True, False)
@@ -464,10 +462,10 @@ class NewsWrapper(object):
         self.data = []
         self.lines = []
 
-    def hard_reset(self, wait=True, quit=True):
+    def hard_reset(self, wait=True, resetConnection=True):
         if self.nntp:
             try:
-                if quit:
+                if resetConnection:
                     self.nntp.sock.sendall('QUIT\r\n')
                     time.sleep(0.1)
                 self.nntp.sock.close()
@@ -484,11 +482,11 @@ class NewsWrapper(object):
             # Reset for internal reasons, just wait 5 sec
             self.timeout = time.time() + 5
 
-    def terminate(self, quit=False):
+    def terminate(self, quitConnection=False):
         """ Close connection and remove nntp object """
         if self.nntp:
             try:
-                if quit:
+                if quitConnection:
                     self.nntp.sock.sendall('QUIT\r\n')
                     time.sleep(0.1)
                 self.nntp.sock.close()

--- a/sabnzbd/notifier.py
+++ b/sabnzbd/notifier.py
@@ -53,7 +53,7 @@ try:
     # PyNotify will not work with Python 2.5 (due to next three lines)
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        import pynotify
+        import pynotify  # @UnresolvedImport
     _HAVE_NTFOSD = True
 except:
     _HAVE_NTFOSD = False
@@ -120,6 +120,7 @@ def check_classes(gtype, section):
         logging.debug('Incorrect Notify option %s:%s_prio_%s', section, section, gtype)
         return False
 
+
 def get_prio(gtype, section):
     """ Check if `gtype` is enabled in `section` """
     try:
@@ -176,6 +177,7 @@ def send_notification(title, msg, gtype):
     # NTFOSD
     if have_ntfosd() and sabnzbd.cfg.ntfosd_enable() and check_classes(gtype, 'ntfosd'):
         send_notify_osd(title, msg)
+
 
 def reset_growl():
     """ Reset Growl (after changing language) """
@@ -249,7 +251,7 @@ def send_growl(title, msg, gtype, test=None):
         if not _GROWL:
             _GROWL, error = register_growl(growl_server, growl_password)
         if _GROWL:
-            if 0: assert isinstance(_GROWL, GrowlNotifier) # Assert only for debug purposes
+            if 0: assert isinstance(_GROWL, GrowlNotifier) # Assert only for debug purposes @IgnorePep8
             _GROWL_REG = True
             if isinstance(msg, unicode):
                 msg = msg.decode('utf-8')
@@ -516,6 +518,7 @@ def send_nscript(title, msg, gtype, force=False, test=None):
         else:
             return T('Notification script "%s" does not exist') % script_path
     return ''
+
 
 def send_windows(title, msg, gtype):
     if sabnzbd.WINTRAY and not sabnzbd.WINTRAY.terminate:

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -281,7 +281,7 @@ class NzbQueue:
     @synchronized(NZBQUEUE_LOCK)
     def insert_future(self, future, filename, data, pp=None, script=None, cat=None, priority=NORMAL_PRIORITY, nzbname=None, nzo_info=None):
         """ Refresh a placeholder nzo with an actual nzo """
-        if 0: assert isinstance(future, NzbObject) # Assert only for debug purposes
+        if 0: assert isinstance(future, NzbObject) # Assert only for debug purposes @IgnorePep8
         if nzo_info is None:
             nzo_info = {}
         nzo_id = future.nzo_id
@@ -380,7 +380,7 @@ class NzbQueue:
 
     @synchronized(NZBQUEUE_LOCK)
     def add(self, nzo, save=True, quiet=False):
-        if 0: assert isinstance(nzo, NzbObject)  # Assert only for debug purposes
+        if 0: assert isinstance(nzo, NzbObject)  # Assert only for debug purposes @IgnorePep8
         if not nzo.nzo_id:
             nzo.nzo_id = sabnzbd.get_new_id('nzo', nzo.workpath, self.__nzo_table)
 
@@ -441,6 +441,7 @@ class NzbQueue:
             nzo = self.__nzo_table.pop(nzo_id)
             nzo.deleted = True
             if cleanup and nzo.status not in (Status.COMPLETED, Status.FAILED):
+                # TODO: Use nzo.is_gone() ?
                 nzo.status = Status.DELETED
             self.__nzo_list.remove(nzo)
 
@@ -900,7 +901,7 @@ class NzbQueue:
                     bytes_left_previous_page += b_left
 
             if (not search) or search in nzo.final_name_pw_clean.lower():
-                if (not limit) or (start <= n < start+limit):
+                if (not limit) or (start <= n < start + limit):
                     pnfo_list.append(nzo.gather_info())
                 n += 1
 

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -344,7 +344,7 @@ class NzbParser(xml.sax.handler.ContentHandler):
 
     def __init__(self, nzo, remove_samples=False):
         self.nzo = nzo
-        if 0: assert isinstance(self.nzo, NzbObject) # Assert only for debug purposes
+        if 0: assert isinstance(self.nzo, NzbObject) # Assert only for debug purposes @IgnorePep8
         self.in_nzb = False
         self.in_file = False
         self.in_groups = False
@@ -909,7 +909,6 @@ class NzbObject(TryList):
             # Raise error, so it's not added
             raise TypeError
 
-
     def check_for_dupe(self, nzf):
         filename = nzf.filename
 
@@ -935,7 +934,6 @@ class NzbObject(TryList):
         else:
             self.servercount[serverid] = bytes
         self.bytes_downloaded += bytes
-
 
     @synchronized(IO_LOCK)
     def remove_nzf(self, nzf):
@@ -1034,7 +1032,7 @@ class NzbObject(TryList):
                 # set the nzo status to return "Queued"
                 self.status = Status.QUEUED
                 self.set_download_report()
-                self.fail_msg = T('Aborted, cannot be completed') +  ' - https://sabnzbd.org/not-complete'
+                self.fail_msg = T('Aborted, cannot be completed') + ' - https://sabnzbd.org/not-complete'
                 self.set_unpack_info('Download', self.fail_msg, unique=False)
                 logging.debug('Abort job "%s", due to impossibility to complete it', self.final_name_pw_clean)
                 # Update the last check time
@@ -1153,8 +1151,8 @@ class NzbObject(TryList):
             if dif > 0:
                 prefix += T('WAIT %s sec') % dif + ' / '  # : Queue indicator for waiting URL fetch
         if (self.avg_stamp + float(cfg.propagation_delay() * 60)) > time.time() and self.priority != TOP_PRIORITY:
-            wait_time = int((self.avg_stamp + float(cfg.propagation_delay() * 60) - time.time())/60 + 0.5)
-            prefix += T('PROPAGATING %s min') % wait_time + ' / '  # : Queue indicator while waiting for propagtion of post
+            wait_time = int((self.avg_stamp + float(cfg.propagation_delay() * 60) - time.time()) / 60 + 0.5)
+            prefix += T('PROPAGATING %s min') % wait_time + ' / '  # : Queue indicator while waiting for propagation of post
         return '%s%s' % (prefix, self.final_name)
 
     @property
@@ -1222,7 +1220,6 @@ class NzbObject(TryList):
 
     __re_quick_par2_check = re.compile(r'\.par2\W*', re.I)
 
-
     @synchronized(IO_LOCK)
     def prospective_add(self, nzf):
         """ Add par2 files to compensate for missing articles
@@ -1258,7 +1255,6 @@ class NzbObject(TryList):
                     # Reset all try lists
                     self.reset_all_try_lists()
 
-
     def check_quality(self, req_ratio=0):
         """ Determine amount of articles present on servers
             and return (gross available, nett) bytes
@@ -1269,7 +1265,7 @@ class NzbObject(TryList):
         anypars = False
         for nzf_id in self.files_table:
             nzf = self.files_table[nzf_id]
-            if 0: assert isinstance(nzf, NzbFile) # Assert only for debug purposes
+            if 0: assert isinstance(nzf, NzbFile) # Assert only for debug purposes @IgnorePep8
             if nzf.deleted:
                 short += nzf.bytes_left
             if self.__re_quick_par2_check.search(nzf.subject):
@@ -1350,7 +1346,7 @@ class NzbObject(TryList):
         nzf_remove_list = []
 
         for nzf in self.files:
-            if 0: assert isinstance(nzf, NzbFile) # Assert only for debug purposes
+            if 0: assert isinstance(nzf, NzbFile) # Assert only for debug purposes @IgnorePep8
             if nzf.deleted:
                 logging.debug('Skipping existing file %s', nzf.filename or nzf.subject)
             else:
@@ -1817,7 +1813,7 @@ def scan_password(name):
         # Is it maybe in 'name / password' notation?
         if slash == name.find(' / ') + 1:
             # Remove the extra space after name and before password
-            return name[:slash-1].strip('. '), name[slash + 2:]
+            return name[:slash - 1].strip('. '), name[slash + 2:]
         return name[:slash].strip('. '), name[slash + 1:]
 
     # Look for "name password=password"

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -176,7 +176,7 @@ class PostProcessor(Thread):
 
             try:
                 nzo = self.queue.get(timeout=1)
-                if 0: assert isinstance(nzo, sabnzbd.nzbstuff.NzbObject)
+                if 0: assert isinstance(nzo, sabnzbd.nzbstuff.NzbObject) # debug purpose @IgnorePep8
             except Queue.Empty:
                 if check_eoq:
                     check_eoq = False
@@ -220,7 +220,7 @@ class PostProcessor(Thread):
 
 def process_job(nzo):
     """ Process one job """
-    if 0: assert isinstance(nzo, sabnzbd.nzbstuff.NzbObject) # Assert only for debug purposes
+    if 0: assert isinstance(nzo, sabnzbd.nzbstuff.NzbObject) # Assert only for debug purposes @IgnorePep8
     start = time.time()
 
     # keep track of whether we can continue
@@ -513,7 +513,6 @@ def process_job(nzo):
                 # No '(more)' button needed
                 nzo.set_unpack_info('Script', u'%s%s ' % (script_ret, script_line), unique=True)
 
-
         # Cleanup again, including NZB files
         if all_ok:
             cleanup_list(workdir_complete, False)
@@ -613,7 +612,7 @@ def is_parfile(fn):
 
 def parring(nzo, workdir):
     """ Perform par processing. Returns: (par_error, re_add) """
-    if 0: assert isinstance(nzo, sabnzbd.nzbstuff.NzbObject) # Assert only for debug purposes
+    if 0: assert isinstance(nzo, sabnzbd.nzbstuff.NzbObject) # Assert only for debug purposes @IgnorePep8
     filename = nzo.final_name
     notifier.send_notification(T('Post-processing'), filename, 'pp')
     logging.info('Starting verification and repair of %s', filename)
@@ -679,7 +678,7 @@ def parring(nzo, workdir):
                         par2_filename = nzf_path
 
                     # Rename so handle_par2() picks it up
-                    newpath = '%s.vol%d+%d.par2' % (par2_filename, par2_vol, par2_vol+1)
+                    newpath = '%s.vol%d+%d.par2' % (par2_filename, par2_vol, par2_vol + 1)
                     renamer(nzf_path, newpath)
                     nzf_try.filename = os.path.split(newpath)[1]
 
@@ -792,7 +791,7 @@ def try_rar_check(nzo, workdir, setname):
             return True
         except rarfile.Error as e:
             nzo.fail_msg = T('RAR files failed to verify')
-            msg = T('[%s] RAR-based verification failed: %s') % (unicoder(os.path.basename(rars[0])), unicoder(e.message.replace('\r\n',' ')))
+            msg = T('[%s] RAR-based verification failed: %s') % (unicoder(os.path.basename(rars[0])), unicoder(e.message.replace('\r\n', ' ')))
             nzo.set_unpack_info('Repair', msg, set=setname)
             logging.info(msg)
             return False


### PR DESCRIPTION
Normally I wouldn't try to mess with import cleanup since the IDE is untrustworthy due to our less than optimal import practice (circular imports/having to do some to make freeze/py2exe happy).. but found two that are safe.

* articlecache

Status was added under:
https://github.com/sabnzbd/sabnzbd/commit/a8788da698dd73f9529ccf42e214f3955a36bfc7

No longer needed due to:
https://github.com/sabnzbd/sabnzbd/commit/12a622a21fbaf69dac4e554b40a08494a983048b

* bpsmeter

floor import was last touched under:
https://github.com/sabnzbd/sabnzbd/commit/2811e5ae7de0075039295965ebafab2cc564746d

floor was removed when you cleaned it up under:
https://github.com/sabnzbd/sabnzbd/commit/5c77f9d9b3d759120edc6b0cb652312096d9fcde
> not sure if this the reason of the rounding error/difference from glitter vs actual?

