### PR TITLE
hide password in General Config via use of HTML element type "password"

### DIFF
--- a/interfaces/Config/templates/config_general.tmpl
+++ b/interfaces/Config/templates/config_general.tmpl
@@ -109,7 +109,7 @@
                 </div>
                 <div class="field-pair">
                     <label class="config" for="${pid}_wp">$T('opt-web_password')</label>
-                    <input type="text" name="${pid}_wp" id="${pid}_wp" value="$password" data-hide="password" />
+                    <input type="text" name="${pid}_wp" id="${pid}_wp" value="$password" data-hide="password" type="password" />
                     <span class="desc">$T('explain-web_password')</span>
                 </div>
                 <div class="field-pair">


### PR DESCRIPTION
Changed form text field to HTML type “password” for web interface password in General Config section. Password is currently viewable as it’s by default set to type “text.”