### PR TITLE
URL Grabber crashes on unhandled socket exceptions

### DIFF
--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -213,7 +213,7 @@ class URLGrabber(Thread):
                 if not data:
                     try:
                         data = fn.read()
-                    except IncompleteRead, e:
+                    except (IncompleteRead, IOError):
                         bad_fetch(future_nzo, url, T('Server could not complete request'))
                 fn.close()
 


### PR DESCRIPTION
URL grabber handles `httplib.IncompleteRequest` exceptions.
This exception is not returned when the HTTP responses closes in the body, rather than the headers.

Handles problem as described un #910 