### PR TITLE
panic - fixed ports

### DIFF
--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -671,7 +671,8 @@ def find_free_port(host, currentport):
     """ Return a free port if allowed, 0 when nothing is free """
     if sabnzbd.cfg.fixed_ports():
         # Port found before, so we bail out
-        raise IOError
+        panic('Initialization Error', 'Unable to bind to ' + str(host) + ':' + str(currentport))
+        exit_sab(1)
 
     n = 0
     while n < 10 and currentport <= 49151:


### PR DESCRIPTION
Panic when attempting to bind to host:port when using fixed ports and its used.
This way user gets a webpage with the info and console shows the message vs the user having to try and guess what the traceback + IOError means.