### PR TITLE
Lock-less

### DIFF
--- a/interfaces/Config/templates/config_general.tmpl
+++ b/interfaces/Config/templates/config_general.tmpl
@@ -314,14 +314,20 @@
     if(bandwidthLimit) {
         var bandwithLimitNumber = parseFloat(bandwidthLimit)
         var bandwithLimitText = bandwidthLimit.replace(/[^a-zA-Z]+/g, '');
-        \$('#bandwidth_max_value').val(bandwithLimitNumber)
-        \$('#bandwidth_max_dropdown').val(bandwithLimitText)
+        if(bandwithLimitNumber) {
+            \$('#bandwidth_max_value').val(bandwithLimitNumber)
+            \$('#bandwidth_max_dropdown').val(bandwithLimitText)
+        }
     }
 
 
     // Update the value
     \$('#bandwidth_max_value, #bandwidth_max_dropdown').on('change', function() {
-        \$('#bandwidth_max').val(\$('#bandwidth_max_value').val() + \$('#bandwidth_max_dropdown').val())
+        if(\$('#bandwidth_max_value').val()) {
+            \$('#bandwidth_max').val(\$('#bandwidth_max_value').val() + \$('#bandwidth_max_dropdown').val())
+        } else {
+            \$('#bandwidth_max').val('')
+        }
     })
 
 });

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -805,7 +805,6 @@ def change_queue_complete_action(action, new=True):
 
     # keep the name of the action for matching the current select in queue.tmpl
     QUEUECOMPLETE = action
-
     QUEUECOMPLETEACTION = _action
     QUEUECOMPLETEARG = _argument
 
@@ -1167,10 +1166,6 @@ def check_old_queue():
 # Required wrapper because nzbstuff.py cannot import downloader.py
 def highest_server(me):
     return sabnzbd.downloader.Downloader.do.highest_server(me)
-
-
-def proxy_pre_queue(name, pp, cat, script, priority, size, groups):
-    return sabnzbd.newsunpack.pre_queue(name, pp, cat, script, priority, size, groups)
 
 
 def test_ipv6():

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -106,7 +106,7 @@ import sabnzbd.cfg as cfg
 import sabnzbd.database
 import sabnzbd.lang as lang
 import sabnzbd.api
-from sabnzbd.decorators import synchronized, synchronized_CV, IO_LOCK
+from sabnzbd.decorators import synchronized, notify_downloader, IO_LOCK
 from sabnzbd.constants import NORMAL_PRIORITY, VALID_ARCHIVES, GIGI, \
     REPAIR_REQUEST, QUEUE_FILE_NAME, QUEUE_VERSION, QUEUE_FILE_TMPL
 import sabnzbd.getipaddress as getipaddress
@@ -621,9 +621,9 @@ def save_compressed(folder, filename, data):
 
 
 ##############################################################################
-# CV synchronized (notifies downloader)
+# Unsynchronized methods
 ##############################################################################
-@synchronized_CV
+
 def add_nzbfile(nzbfile, pp=None, script=None, cat=None, priority=NORMAL_PRIORITY, nzbname=None, reuse=False, password=None):
     """ Add disk-based NZB file, optional attributes,
         'reuse' flag will suppress duplicate detection
@@ -693,9 +693,6 @@ def add_nzbfile(nzbfile, pp=None, script=None, cat=None, priority=NORMAL_PRIORIT
                                  keep=keep, reuse=reuse, password=password)
 
 
-##############################################################################
-# Unsynchronized methods
-##############################################################################
 def enable_server(server):
     """ Enable server (scheduler only) """
     try:

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -106,7 +106,7 @@ import sabnzbd.cfg as cfg
 import sabnzbd.database
 import sabnzbd.lang as lang
 import sabnzbd.api
-from sabnzbd.decorators import synchronized, notify_downloader, IO_LOCK
+from sabnzbd.decorators import synchronized, notify_downloader
 from sabnzbd.constants import NORMAL_PRIORITY, VALID_ARCHIVES, GIGI, \
     REPAIR_REQUEST, QUEUE_FILE_NAME, QUEUE_VERSION, QUEUE_FILE_TMPL
 import sabnzbd.getipaddress as getipaddress
@@ -857,7 +857,6 @@ def CheckFreeSpace():
 # Data IO                                                                      #
 ################################################################################
 
-@synchronized(IO_LOCK)
 def get_new_id(prefix, folder, check_list=None):
     """ Return unique prefixed admin identifier within folder
         optionally making sure that id is not in the check_list.
@@ -878,7 +877,6 @@ def get_new_id(prefix, folder, check_list=None):
     raise IOError
 
 
-@synchronized(IO_LOCK)
 def save_data(data, _id, path, do_pickle=True, silent=False):
     """ Save data to a diskfile """
     if not silent:
@@ -909,7 +907,6 @@ def save_data(data, _id, path, do_pickle=True, silent=False):
                 time.sleep(0.1)
 
 
-@synchronized(IO_LOCK)
 def load_data(_id, path, remove=True, do_pickle=True, silent=False):
     """ Read data from disk file """
     path = os.path.join(path, _id)
@@ -941,7 +938,6 @@ def load_data(_id, path, remove=True, do_pickle=True, silent=False):
     return data
 
 
-@synchronized(IO_LOCK)
 def remove_data(_id, path):
     """ Remove admin file """
     path = os.path.join(path, _id)
@@ -953,7 +949,6 @@ def remove_data(_id, path):
         logging.debug("Failed to remove %s", path)
 
 
-@synchronized(IO_LOCK)
 def save_admin(data, _id):
     """ Save data in admin folder in specified format """
     path = os.path.join(cfg.admin_dir.get_path(), _id)
@@ -977,7 +972,6 @@ def save_admin(data, _id):
                 time.sleep(0.1)
 
 
-@synchronized(IO_LOCK)
 def load_admin(_id, remove=False, silent=False):
     """ Read data in admin folder in specified format """
     path = os.path.join(cfg.admin_dir.get_path(), _id)

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -47,7 +47,7 @@ from sabnzbd.constants import VALID_ARCHIVES, Status, \
 import sabnzbd.config as config
 import sabnzbd.cfg as cfg
 from sabnzbd.downloader import Downloader
-from sabnzbd.nzbqueue import NzbQueue, set_priority, sort_queue, scan_jobs, repair_job
+from sabnzbd.nzbqueue import NzbQueue
 import sabnzbd.scheduler as scheduler
 from sabnzbd.skintext import SKIN_TEXT
 from sabnzbd.utils.json import JsonWriter
@@ -246,7 +246,7 @@ def _api_queue_priority(output, value, kwargs):
                 priority = int(value2)
             except:
                 return report(output, _MSG_INT_VALUE)
-            pos = set_priority(value, priority)
+            pos = NzbQueue.do.set_priority(value, priority)
             # Returns the position in the queue, -1 is incorrect job-id
             return report(output, keyword='position', data=pos)
         except:
@@ -260,7 +260,7 @@ def _api_queue_sort(output, value, kwargs):
     sort = kwargs.get('sort')
     direction = kwargs.get('dir', '')
     if sort:
-        sort_queue(sort, direction)
+        NzbQueue.do.sort_queue(sort, direction)
         return report(output)
     else:
         return report(output, _MSG_NO_VALUE2)
@@ -679,7 +679,7 @@ def _api_osx_icon(name, output, kwargs):
 
 def _api_rescan(name, output, kwargs):
     """ API: accepts output """
-    scan_jobs(all=False, action=True)
+    NzbQueue.do.scan_jobs(all=False, action=True)
     return report(output)
 
 
@@ -1189,7 +1189,7 @@ def build_status(skip_dashboard=False, output=None):
     info['logfile'] = sabnzbd.LOGFILE
     info['weblogfile'] = sabnzbd.WEBLOGFILE
     info['loglevel'] = str(cfg.log_level())
-    info['folders'] = [xml_name(item) for item in sabnzbd.nzbqueue.scan_jobs(all=False, action=False)]
+    info['folders'] = [xml_name(item) for item in NzbQueue.do.scan_jobs(all=False, action=False)]
     info['configfn'] = xml_name(config.get_filename())
 
     # Dashboard: Speed of System
@@ -1540,7 +1540,7 @@ def retry_job(job, new_nzb, password):
         else:
             path = history_db.get_path(job)
             if path:
-                nzo_id = repair_job(platform_encode(path), new_nzb, password)
+                nzo_id = NzbQueue.do.repair_job(platform_encode(path), new_nzb, password)
                 history_db.remove_history(job)
                 return nzo_id
     return None

--- a/sabnzbd/config.py
+++ b/sabnzbd/config.py
@@ -791,7 +791,6 @@ def _read_config(path, try_backup=False):
 def save_config(force=False):
     """ Update Setup file with current option values """
     global CFG, database, modified
-    if 0: assert isinstance(CFG, configobj.ConfigObj)
 
     if not (modified or force):
         return True

--- a/sabnzbd/decorators.py
+++ b/sabnzbd/decorators.py
@@ -21,7 +21,6 @@
 from threading import RLock, Condition
 
 DOWNLOADER_CV = Condition(RLock())
-IO_LOCK = RLock()
 
 def synchronized(lock):
     def wrap(f):

--- a/sabnzbd/decorators.py
+++ b/sabnzbd/decorators.py
@@ -20,8 +20,7 @@
 ##############################################################################
 from threading import RLock, Condition
 
-NZBQUEUE_LOCK = RLock()
-CV = Condition(NZBQUEUE_LOCK)
+DOWNLOADER_CV = Condition(RLock())
 IO_LOCK = RLock()
 
 def synchronized(lock):
@@ -36,13 +35,13 @@ def synchronized(lock):
     return wrap
 
 
-def synchronized_CV(func):
-    global CV
+def notify_downloader(func):
+    global DOWNLOADER_CV
     def call_func(*params, **kparams):
-        CV.acquire()
+        DOWNLOADER_CV.acquire()
         try:
             return func(*params, **kparams)
         finally:
-            CV.notifyAll()
-            CV.release()
+            DOWNLOADER_CV.notify_all()
+            DOWNLOADER_CV.release()
     return call_func

--- a/sabnzbd/dirscanner.py
+++ b/sabnzbd/dirscanner.py
@@ -99,7 +99,6 @@ def ProcessArchiveFile(filename, path, pp=None, script=None, cat=None, catdir=No
         returns (status, nzo_ids)
             status: -1==Error/Retry, 0==OK, 1==Ignore
     """
-    from sabnzbd.nzbqueue import add_nzo
     nzo_ids = []
     if catdir is None:
         catdir = cat
@@ -145,7 +144,7 @@ def ProcessArchiveFile(filename, path, pp=None, script=None, cat=None, catdir=No
                             sabnzbd.nzbqueue.NzbQueue.do.remove(nzo_id, add_to_history=False)
                             nzo.nzo_id = nzo_id
                             nzo_id = None
-                        nzo_ids.append(add_nzo(nzo))
+                        nzo_ids.append(sabnzbd.nzbqueue.NzbQueue.do.add(nzo))
                         nzo.update_rating()
         zf.close()
         try:
@@ -170,7 +169,6 @@ def ProcessSingleFile(filename, path, pp=None, script=None, cat=None, catdir=Non
         returns (status, nzo_ids)
             status: -2==Error/retry, -1==Error, 0==OK, 1==OK-but-ignorecannot-delete
     """
-    from sabnzbd.nzbqueue import add_nzo
     nzo_ids = []
     if catdir is None:
         catdir = cat
@@ -231,7 +229,7 @@ def ProcessSingleFile(filename, path, pp=None, script=None, cat=None, catdir=Non
             # Re-use existing nzo_id, when a "future" job gets it payload
             sabnzbd.nzbqueue.NzbQueue.do.remove(nzo_id, add_to_history=False)
             nzo.nzo_id = nzo_id
-        nzo_ids.append(add_nzo(nzo, quiet=reuse))
+        nzo_ids.append(sabnzbd.nzbqueue.NzbQueue.do.add(nzo, quiet=reuse))
         nzo.update_rating()
     try:
         if not keep:

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -465,10 +465,11 @@ class Downloader(Thread):
                         break
 
                     if server.retention and article.nzf.nzo.avg_stamp < time.time() - server.retention:
-                        # Article too old for the server, treat as missing
-                        if sabnzbd.LOG_ALL:
+                        # Let's get rid of all the articles for this server at once
+                        while article:
                             logging.debug('Article %s too old for %s', article.article, server.id)
-                        self.decode(article, None, None)
+                            self.decode(article, None, None)
+                            article = article.nzf.nzo.get_article(server, self.servers)
                         break
 
                     server.idle_threads.remove(nw)

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -466,8 +466,8 @@ class Downloader(Thread):
 
                     if server.retention and article.nzf.nzo.avg_stamp < time.time() - server.retention:
                         # Let's get rid of all the articles for this server at once
+                        logging.debug('Job %s too old for %s, moving on', article.nzf.nzo.work_name, server.id)
                         while article:
-                            logging.debug('Article %s too old for %s', article.article, server.id)
                             self.decode(article, None, None)
                             article = article.nzf.nzo.get_article(server, self.servers)
                         break

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -920,7 +920,7 @@ class QueuePage(object):
         msg = check_session(kwargs)
         if msg:
             return msg
-        sabnzbd.nzbqueue.set_priority(kwargs.get('nzo_id'), kwargs.get('priority'))
+        NzbQueue.do.set_priority(kwargs.get('nzo_id'), kwargs.get('priority'))
         raise queueRaiser(self.__root, kwargs)
 
     @cherrypy.expose
@@ -928,7 +928,7 @@ class QueuePage(object):
         msg = check_session(kwargs)
         if msg:
             return msg
-        sabnzbd.nzbqueue.sort_queue('avg_age', kwargs.get('dir'))
+        NzbQueue.do.sort_queue('avg_age', kwargs.get('dir'))
         raise queueRaiser(self.__root, kwargs)
 
     @cherrypy.expose
@@ -936,7 +936,7 @@ class QueuePage(object):
         msg = check_session(kwargs)
         if msg:
             return msg
-        sabnzbd.nzbqueue.sort_queue('name', kwargs.get('dir'))
+        NzbQueue.do.sort_queue('name', kwargs.get('dir'))
         raise queueRaiser(self.__root, kwargs)
 
     @cherrypy.expose
@@ -944,7 +944,7 @@ class QueuePage(object):
         msg = check_session(kwargs)
         if msg:
             return msg
-        sabnzbd.nzbqueue.sort_queue('size', kwargs.get('dir'))
+        NzbQueue.do.sort_queue('size', kwargs.get('dir'))
         raise queueRaiser(self.__root, kwargs)
 
 
@@ -1164,7 +1164,7 @@ class ConfigPage(object):
             new[svr] = {}
         conf['servers'] = new
 
-        conf['folders'] = sabnzbd.nzbqueue.scan_jobs(all=False, action=False)
+        conf['folders'] = NzbQueue.do.scan_jobs(all=False, action=False)
 
         template = Template(file=os.path.join(sabnzbd.WEB_DIR_CONFIG, 'config.tmpl'),
                             filter=FILTER, searchList=[conf], compilerSettings=DIRECTIVES)
@@ -1219,7 +1219,7 @@ def orphan_delete(kwargs):
         remove_all(path, recursive=True)
 
 def orphan_delete_all():
-    paths = sabnzbd.nzbqueue.scan_jobs(all=False, action=False)
+    paths = NzbQueue.do.scan_jobs(all=False, action=False)
     for path in paths:
         kwargs = {'name': path}
         orphan_delete(kwargs)
@@ -1229,10 +1229,10 @@ def orphan_add(kwargs):
     if path:
         path = platform_encode(path)
         path = os.path.join(long_path(cfg.download_dir.get_path()), path)
-        sabnzbd.nzbqueue.repair_job(path, None, None)
+        NzbQueue.do.repair_job(path, None, None)
 
 def orphan_add_all():
-    paths = sabnzbd.nzbqueue.scan_jobs(all=False, action=False)
+    paths = NzbQueue.do.scan_jobs(all=False, action=False)
     for path in paths:
         kwargs = {'name': path}
         orphan_add(kwargs)

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -631,7 +631,7 @@ class NzoPage(object):
         n = 0
         for pnfo in pnfo_list:
             if pnfo.nzo_id == nzo_id:
-                nzo = sabnzbd.nzbqueue.get_nzo(nzo_id)
+                nzo = NzbQueue.do.get_nzo(nzo_id)
                 repair = pnfo.repair
                 unpack = pnfo.unpack
                 delete = pnfo.delete
@@ -704,7 +704,7 @@ class NzoPage(object):
         script = kwargs.get('script', None)
         cat = kwargs.get('cat', None)
         priority = kwargs.get('priority', None)
-        nzo = sabnzbd.nzbqueue.get_nzo(nzo_id)
+        nzo = NzbQueue.do.get_nzo(nzo_id)
 
         if index is not None:
             NzbQueue.do.switch(nzo_id, index)
@@ -752,7 +752,7 @@ class NzoPage(object):
             elif kwargs['action_key'] == 'Bottom':
                 NzbQueue.do.move_bottom_bulk(nzo_id, nzf_ids)
 
-        if sabnzbd.nzbqueue.get_nzo(nzo_id):
+        if NzbQueue.do.get_nzo(nzo_id):
             url = cherrypy.lib.httputil.urljoin(self.__root, nzo_id)
         else:
             url = cherrypy.lib.httputil.urljoin(self.__root, '../queue')

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -970,11 +970,8 @@ def get_filepath(path, nzo, filename):
     # It does no umask setting
     # It uses the dir_lock for the (rare) case that the
     # download_dir is equal to the complete_dir.
-    dirname = nzo.work_name
-    created = nzo.created
-
-    dName = dirname
-    if not created:
+    dName = nzo.work_name
+    if not nzo.created:
         for n in xrange(200):
             dName = dirname
             if n:

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -851,12 +851,9 @@ def get_cache_limit():
 
 
 ##############################################################################
-# Locked directory operations
+# Directory operations
 ##############################################################################
-DIR_LOCK = threading.RLock()
 
-
-@synchronized(DIR_LOCK)
 def get_unique_path(dirpath, n=0, create_dir=True):
     """ Determine a unique folder or filename """
 
@@ -876,7 +873,6 @@ def get_unique_path(dirpath, n=0, create_dir=True):
         return get_unique_path(dirpath, n=n + 1, create_dir=create_dir)
 
 
-@synchronized(DIR_LOCK)
 def get_unique_filename(path):
     """ Check if path is unique. If not, add number like: "/path/name.NUM.ext". """
     num = 1
@@ -889,7 +885,6 @@ def get_unique_filename(path):
     return path
 
 
-@synchronized(DIR_LOCK)
 def create_dirs(dirpath):
     """ Create directory tree, obeying permissions """
     if not os.path.exists(dirpath):
@@ -900,7 +895,6 @@ def create_dirs(dirpath):
     return dirpath
 
 
-@synchronized(DIR_LOCK)
 def move_to_path(path, new_path):
     """ Move a file to a new path, optionally give unique filename
         Return (ok, new_path)
@@ -942,7 +936,6 @@ def move_to_path(path, new_path):
     return ok, new_path
 
 
-@synchronized(DIR_LOCK)
 def cleanup_empty_directories(path):
     """ Remove all empty folders inside (and including) 'path' """
     path = os.path.normpath(path)
@@ -963,7 +956,6 @@ def cleanup_empty_directories(path):
         pass
 
 
-@synchronized(DIR_LOCK)
 def get_filepath(path, nzo, filename):
     """ Create unique filepath """
     # This procedure is only used by the Assembler thread

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -1333,9 +1333,7 @@ def PAR_Verify(parfile, parfile_nzf, nzo, setname, joinables, classic=False, sin
             elif line.startswith('Main packet not found') or 'The recovery file does not exist' in line:
                 # Initialparfile probably didn't decode properly,
                 logging.info(T('Main packet not found...'))
-
                 extrapars = parfile_nzf.extrapars
-
                 logging.info("Extra pars = %s", extrapars)
 
                 # Look for the smallest par2file
@@ -1346,7 +1344,6 @@ def PAR_Verify(parfile, parfile_nzf, nzo, setname, joinables, classic=False, sin
 
                 if block_table:
                     nzf = block_table[min(block_table.keys())]
-
                     logging.info("Found new par2file %s", nzf.filename)
 
                     # Move from extrapar list to files to be downloaded
@@ -1723,7 +1720,6 @@ def MultiPar_Verify(parfile, parfile_nzf, nzo, setname, joinables, classic=False
 
                 # Move from extrapar list to files to be downloaded
                 nzo.add_parfile(nzf)
-                extrapars.remove(nzf)
                 # Now set new par2 file as primary par2
                 nzo.partable[setname] = nzf
                 nzf.extrapars = extrapars

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -113,7 +113,6 @@ def get_ssl_version(sock):
 
 
 def con(sock, host, port, sslenabled, write_fds, nntp):
-    if 0: assert isinstance(nntp, NNTP) # Assert only for debug purposes
     try:
         sock.connect((host, port))
         sock.setblocking(0)
@@ -167,7 +166,6 @@ class NNTP(object):
     __slots__ = ('host', 'port', 'nw', 'blocking', 'error_msg', 'sock')
 
     def __init__(self, host, port, info, sslenabled, send_group, nw, user=None, password=None, block=False, write_fds=None):
-        if 0: assert isinstance(nw, NewsWrapper) # Assert only for debug purposes
         self.host = host
         self.port = port
         self.nw = nw

--- a/sabnzbd/notifier.py
+++ b/sabnzbd/notifier.py
@@ -251,7 +251,6 @@ def send_growl(title, msg, gtype, test=None):
         if not _GROWL:
             _GROWL, error = register_growl(growl_server, growl_password)
         if _GROWL:
-            if 0: assert isinstance(_GROWL, GrowlNotifier) # Assert only for debug purposes
             _GROWL_REG = True
             if isinstance(msg, unicode):
                 msg = msg.decode('utf-8')

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -729,7 +729,7 @@ class NzbQueue(object):
         filename = nzf.filename
 
         if nzo.is_gone():
-            logging.debug('Discarding file completion %s for deleted job', filename)
+            logging.debug('Discarding article %s for deleted job', filename)
         else:
             if file_done:
                 if nzo.next_save is None or time.time() > nzo.next_save:

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -924,20 +924,3 @@ def sort_queue_function(nzo_list, method, reverse):
             new_list.append(item)
 
     return new_list
-
-
-# Wrappers
-def set_priority(nzo_ids, priority):
-    return NzbQueue.do.set_priority(nzo_ids, priority)
-
-
-def sort_queue(field, reverse=False):
-    NzbQueue.do.sort_queue(field, reverse)
-
-
-def repair_job(folder, new_nzb, password):
-    return NzbQueue.do.repair_job(folder, new_nzb, password)
-
-
-def scan_jobs(all=False, action=True):
-    return NzbQueue.do.scan_jobs(all, action)

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -344,7 +344,6 @@ class NzbParser(xml.sax.handler.ContentHandler):
 
     def __init__(self, nzo):
         self.nzo = nzo
-        if 0: assert isinstance(self.nzo, NzbObject) # Assert only for debug purposes
         self.in_nzb = False
         self.in_file = False
         self.in_groups = False
@@ -706,9 +705,6 @@ class NzbObject(TryList):
         # by setting "feature_external_ges" to 0.
 
         if nzb and '<nzb' in nzb:
-            if 'A&A)' in nzb:
-                # Fix needed to compensate for some dumb NZB posters
-                nzb = nzb.replace('A&A)', 'A&amp;A)')
             handler = NzbParser(self)
             parser = xml.sax.make_parser()
             parser.setFeature(xml.sax.handler.feature_external_ges, 0)
@@ -781,8 +777,8 @@ class NzbObject(TryList):
         # Run user pre-queue script if needed
         if not reuse:
             accept, name, pp, cat, script, priority, group = \
-                sabnzbd.proxy_pre_queue(self.final_name_pw_clean, pp, cat, script,
-                                        priority, self.bytes, self.groups)
+                sabnzbd.newsunpack.pre_queue(self.final_name_pw_clean, pp, cat, script,
+                                             priority, self.bytes, self.groups)
             accept = int_conv(accept)
             try:
                 pp = int(pp)
@@ -1248,7 +1244,6 @@ class NzbObject(TryList):
         anypars = False
         for nzf_id in self.files_table:
             nzf = self.files_table[nzf_id]
-            if 0: assert isinstance(nzf, NzbFile) # Assert only for debug purposes
             if nzf.deleted:
                 short += nzf.bytes_left
             if self.__re_quick_par2_check.search(nzf.subject):
@@ -1328,7 +1323,6 @@ class NzbObject(TryList):
         nzf_remove_list = []
 
         for nzf in self.files:
-            if 0: assert isinstance(nzf, NzbFile) # Assert only for debug purposes
             if nzf.deleted:
                 logging.debug('Skipping existing file %s', nzf.filename or nzf.subject)
             else:

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -698,7 +698,7 @@ def parring(nzo, workdir):
         logging.info('Re-added %s to queue', filename)
         if nzo.priority != TOP_PRIORITY:
             nzo.priority = REPAIR_PRIORITY
-        sabnzbd.nzbqueue.add_nzo(nzo)
+        sabnzbd.nzbqueue.NzbQueue.do.add(nzo)
         sabnzbd.downloader.Downloader.do.resume_from_postproc()
 
     sabnzbd.save_data(verified, VERIFIED_FILE, nzo.workpath)

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -186,7 +186,6 @@ class PostProcessor(Thread):
 
             try:
                 nzo = self.queue.get(timeout=1)
-                if 0: assert isinstance(nzo, sabnzbd.nzbstuff.NzbObject)
             except Queue.Empty:
                 if check_eoq:
                     check_eoq = False
@@ -230,7 +229,6 @@ class PostProcessor(Thread):
 
 def process_job(nzo):
     """ Process one job """
-    if 0: assert isinstance(nzo, sabnzbd.nzbstuff.NzbObject) # Assert only for debug purposes
     start = time.time()
 
     # keep track of whether we can continue


### PR DESCRIPTION
To explain the set of changes and possible associated problems, I decided to make a PR to give some background in case anyone is interested.
SABnzbd is riddles with Locks, they make sure that different threads can't simultaneously read or modify a shared variable, for example the Decoder and Assembler changing the cache-counter at the same time. Because a simple operation like `x += 1` is actually 2 operations: read the value of `x` and then increment by 1. 
In the time between those 2, Python might have switched to the other thread that can do a similar operation. So the other thread can read the variable before it's modified and thus make the wrong calculation.

By default the safest is just to lock everything that's shared, and this is what has been done historically in SABnzbd. However, this also causes some threads to have to wait for eachother while this might not be nessecary. 
The clearest example here is when the Assembler is writing the file to the disk, it locks the ArticleCache so the Decoder can't write to it and has to wait. But reading the [list of operations that are atomic](https://docs.python.org/2/faq/library.html#what-kinds-of-global-value-mutation-are-thread-safe) (that can't be interrupted) shows that indeed changing the cache-counter needs to be locked, appending/removing articles from the list doesn't need to be locked.
I analyzed most of the locks and found many places that are actually atomic or lock things that can't actually happen at the same time.

And what's the benefit? **~10%** more speed, at least on my system.
Maybe even more, but I am now hitting ~115MB/s and this might just be the limit of the gigabit connection or newsserver I am using. 
For comparison: that same NZB on SAB 1.0.0 maxes out at 35MB/s!

But it can be that some locks actually were nessecary, which we will find out during Alpha/Beta testing 😨 