### PR TITLE
Print applied permissions in octal

### DIFF
--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -1461,7 +1461,7 @@ def starts_with_path(path, prefix):
 def set_chmod(path, permissions, report):
     """ Set 'permissions' on 'path', report any errors when 'report' is True """
     try:
-        logging.debug('Applying %s to %s', permissions, path)
+        logging.debug('Applying permissions %s (octal) to %s', oct(permissions), path)
         os.chmod(path, permissions)
     except:
         lpath = path.lower()


### PR DESCRIPTION
See https://github.com/sabnzbd/sabnzbd/issues/968

Old format:
```
2017-07-14 07:55:34,253::DEBUG::[misc:1474] Applying 493 to /home/sander/Downloads/incomplete
```
New format:
```
2017-07-20 20:57:29,134::DEBUG::[misc:1464] Applying permissions 0755 (octal) to /home/sander/Downloads/incomplete
```
