### PR TITLE
Dupe - Tag only

### DIFF
--- a/interfaces/Config/templates/config_switches.tmpl
+++ b/interfaces/Config/templates/config_switches.tmpl
@@ -86,6 +86,7 @@
                         <label class="config" for="no_dupes">$T('opt-no_dupes')</label>
                         <select name="no_dupes" id="no_dupes">
                             <option value="0" <!--#if int($no_dupes) == 0 then 'selected="selected"' else ""#--> >$T('nodupes-off')</option>
+                            <option value="4" <!--#if int($no_dupes) == 4 then 'selected="selected"' else ""#--> >$T('nodupes-tag')</option>
                             <option value="2" <!--#if int($no_dupes) == 2 then 'selected="selected"' else ""#--> >$T('nodupes-pause')</option>
                             <option value="3" <!--#if int($no_dupes) == 3 then 'selected="selected"' else ""#--> >$T('nodupes-fail')</option>
                             <option value="1" <!--#if int($no_dupes) == 1 then 'selected="selected"' else ""#--> >$T('nodupes-ignore')</option>
@@ -96,6 +97,7 @@
                         <label class="config" for="no_series_dupes">$T('opt-no_series_dupes')</label>
                         <select name="no_series_dupes" id="no_series_dupes">
                             <option value="0" <!--#if int($no_series_dupes) == 0 then 'selected="selected"' else ""#--> >$T('nodupes-off')</option>
+                            <option value="4" <!--#if int($no_series_dupes) == 4 then 'selected="selected"' else ""#--> >$T('nodupes-tag')</option>
                             <option value="2" <!--#if int($no_series_dupes) == 2 then 'selected="selected"' else ""#--> >$T('nodupes-pause')</option>
                             <option value="3" <!--#if int($no_series_dupes) == 3 then 'selected="selected"' else ""#--> >$T('nodupes-fail')</option>
                             <option value="1" <!--#if int($no_series_dupes) == 1 then 'selected="selected"' else ""#--> >$T('nodupes-ignore')</option>

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -851,17 +851,23 @@ class NzbObject(TryList):
         if duplicate and ((not series and cfg.no_dupes() == 3) or (series and cfg.no_series_dupes() == 3)):
             if cfg.warn_dupl_jobs():
                 logging.warning(T('Failing duplicate NZB "%s"'), filename)
-            # Move to history, utlizing the same code as accept&fail from pre-queue script
+            # Move to history, utilizing the same code as accept&fail from pre-queue script
             self.fail_msg = T('Duplicate NZB')
             accept = 2
             duplicate = False
 
         if duplicate or self.priority == DUP_PRIORITY:
-            if cfg.warn_dupl_jobs():
-                logging.warning(T('Pausing duplicate NZB "%s"'), filename)
-            self.duplicate = True
-            self.pause()
-            self.priority = NORMAL_PRIORITY
+            if cfg.no_dupes() == 4 or cfg.no_series_dupes() == 4:
+                if cfg.warn_dupl_jobs():
+                    logging.warning(T('Tagging duplicate NZB "%s"'), filename)
+                self.duplicate = True
+                self.priority = NORMAL_PRIORITY
+            else:
+                if cfg.warn_dupl_jobs():
+                    logging.warning(T('Pausing duplicate NZB "%s"'), filename)
+                self.duplicate = True
+                self.pause()
+                self.priority = NORMAL_PRIORITY
 
         if self.priority == PAUSED_PRIORITY:
             self.pause()

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -437,9 +437,10 @@ SKIN_TEXT = {
     'opt-no_series_dupes' : TT('Detect duplicate episodes in series'),
     'explain-no_series_dupes' : TT('Detect identical episodes in series (based on "name/season/episode" of items in your History)'),
     'nodupes-off' : TT('Off'), #: Three way switch for duplicates
-    'nodupes-ignore' : TT('Discard'), #: Three way switch for duplicates
-    'nodupes-pause' : TT('Pause'), #: Three way switch for duplicates
-    'nodupes-fail' : TT('Fail job (move to History)'), #: Three way switch for duplicates
+    'nodupes-ignore' : TT('Discard'), #: Four way switch for duplicates
+    'nodupes-pause' : TT('Pause'), #: Four way switch for duplicates
+    'nodupes-fail' : TT('Fail job (move to History)'), #: Four way switch for duplicates
+    'nodupes-tag' : TT('Tag job'), #: Four way switch for duplicates
     'abort' : TT('Abort'), #: Three way switch for encrypted posts
     'opt-action_on_unwanted_extensions' : TT('Action when unwanted extension detected'),
     'explain-action_on_unwanted_extensions' : TT('Action when an unwanted extension is detected in RAR files'),


### PR DESCRIPTION
User requested a way to track dupes but not have sab block/discard/pause the items (as he doesnt want to have to manually unpause). Figured we could add a 'Tag' switch for the Dupe detection. Works same way as Pause (shows duplicate tag in queue/adds warning/internally tags it) but does not pause the item.

Once the file is done downloading and makes it to the queue, you have no idea it was a duplicate.
You would have to use the 'Warning' and search for that.. and then assume the newer one was the dupe... we really should expose in the History that an item was a duplicate. Right now the 'search' box only looks at the name.. and I dont think we should be messing with the name to add duplicate there. I'd rather us just add a tag/flag whatever to notate this.. and can filter/sort on it. We also should do the same to the Queue as well.. since changing the name of the item to be `DUPLICATE / XXXXX` is a little jarring.

Now if we just exposed the dupe flag in the history, then the whole 'tag' option really isnt needed as it was just a means to an end.