### PR TITLE
fixed faulty dict iteration

### DIFF
--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -1638,7 +1638,7 @@ class NzbObject(TryList):
         for nzf in self.files:
             sabnzbd.remove_data(nzf.nzf_id, wpath)
 
-        for _set in self.extrapars:
+        for _set in list(self.extrapars):
             for nzf in self.extrapars[_set]:
                 sabnzbd.remove_data(nzf.nzf_id, wpath)
 


### PR DESCRIPTION
Just saw this stacktrace:

> Traceback (most recent call last):
  File "/usr/share/sabnzbdplus/cherrypy/_cprequest.py", line 670, in respond
    response.body = self.handler()
  File "/usr/share/sabnzbdplus/cherrypy/lib/encoding.py", line 220, in __call__
    self.body = self.oldhandler(*args, **kwargs)
  File "/usr/share/sabnzbdplus/cherrypy/_cpdispatch.py", line 60, in __call__
    return self.callable(*self.args, **self.kwargs)
  File "/usr/share/sabnzbdplus/sabnzbd/interface.py", line 451, in tapi
    return api_handler(kwargs)
  File "/usr/share/sabnzbdplus/sabnzbd/api.py", line 115, in api_handler
    response = _api_table.get(mode, (_api_undefined, 2))[0](name, output, kwargs)
  File "/usr/share/sabnzbdplus/sabnzbd/api.py", line 174, in _api_queue
    return _api_queue_table.get(name, (_api_queue_default, 2))[0](output, value, kwargs)
  File "/usr/share/sabnzbdplus/sabnzbd/api.py", line 276, in _api_queue_default
    info, pnfo_list, bytespersec = build_queue(start=start, limit=limit, output=output, search=search)
  File "/usr/share/sabnzbdplus/sabnzbd/api.py", line 1299, in build_queue
    info, pnfo_list, bytespersec, q_size, bytes_left_previous_page = build_queue_header(search=search, start=start, limit=limit, output=output)
  File "/usr/share/sabnzbdplus/sabnzbd/api.py", line 1693, in build_queue_header
    qnfo = NzbQueue.do.queue_info(search=search, start=start, limit=limit)
  File "/usr/share/sabnzbdplus/sabnzbd/nzbqueue.py", line 815, in queue_info
    b_left = nzo.remaining()
  File "/usr/share/sabnzbdplus/sabnzbd/nzbstuff.py", line 1614, in remaining
    for _set in self.extrapars:
RuntimeError: dictionary changed size during iteration

Looks like someone was naughty and [iterated over the items of a dict instead the keys](https://stackoverflow.com/questions/11941817/how-to-avoid-runtimeerror-dictionary-changed-size-during-iteration-error) ;-)

Keep up the good work!