### PR TITLE
Add Special option to ignore empty file definitions in NZB

### DIFF
--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -262,6 +262,7 @@ api_warnings = OptionBool('misc', 'api_warnings', True, protect=True)
 disable_key = OptionBool('misc', 'disable_api_key', False, protect=True)
 no_penalties = OptionBool('misc', 'no_penalties', False)
 debug_log_decoding = OptionBool('misc', 'debug_log_decoding', False)
+ignore_empty_files = OptionBool('misc', 'ignore_empty_files', False)
 
 # Text values
 rss_odd_titles = OptionList('misc', 'rss_odd_titles', ['nzbindex.nl/', 'nzbindex.com/', 'nzbclub.com/'])

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -1380,6 +1380,7 @@ SPECIAL_BOOL_LIST = \
               'rss_filenames', 'ipv6_hosting', 'keep_awake', 'empty_postproc', 'html_login', 'wait_for_dfolder',
               'max_art_opt', 'warn_empty_nzb', 'enable_bonjour', 'reject_duplicate_files', 'warn_dupl_jobs',
               'replace_illegal', 'backup_for_duplicates', 'disable_api_key', 'api_logging',
+              'ignore_empty_files'
      )
 SPECIAL_VALUE_LIST = \
     ('size_limit', 'folder_max_length', 'fsys_type', 'movie_rename_limit', 'nomedia_marker',

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -493,7 +493,11 @@ class NzbParser(xml.sax.handler.ContentHandler):
             # Create an NZF
             self.in_file = False
             if not self.article_db:
-                logging.warning(T('File %s is empty, skipping'), self.filename)
+                msg = T('File %s is empty, skipping')
+                if cfg.ignore_empty_files():
+                    logging.info(msg, self.filename)
+                else:
+                    logging.warning(msg, self.filename)
                 return
             try:
                 tm = datetime.datetime.fromtimestamp(self.file_date)


### PR DESCRIPTION
Called "ignore_empty_files".
In response to https://forums.sabnzbd.org/viewtopic.php?f=2&t=23151

