### PR TITLE
accept cheetah version newer than 2.x

### DIFF
--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -44,7 +44,7 @@ import re
 
 try:
     import Cheetah
-    if Cheetah.Version[0] != '2':
+    if Cheetah.Version[0] < '2':
         raise ValueError
 except ValueError:
     print "Sorry, requires Python module Cheetah 2.0rc7 or higher."


### PR DESCRIPTION
I'm going to update cheetah to v. 3.x in debian soonish. All seems to work fine with sab in a quick test, apart from this version check.