### PR TITLE
Fix aborting active direct unpack

### DIFF
--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -503,6 +503,8 @@ def rar_unpack(nzo, workdir, workdir_complete, delete, one_folder, rars):
                     if wait_count > 60:
                         # We abort after 2 minutes of no changes
                         nzo.direct_unpacker.abort()
+                else:
+                    wait_count = 0
                 last_stats = nzo.direct_unpacker.get_formatted_stats()
 
         # Did we already direct-unpack it? Not when recursive-unpacking


### PR DESCRIPTION
Downloads with directunpack are sometimes aborting while they are not "hanging".

This happens when the total time needed to unpack is > 2 min and the time to unpack a single item is > 4 sec.