### PR TITLE
Fix locale compilation in Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ SABnzbd*.dmg
 # WingIDE project files
 *.wp[ru]
 
+# PyCharm project files
+.idea/
+
 # Testing folders
 .cache
 .xprocess

--- a/tools/make_mo.py
+++ b/tools/make_mo.py
@@ -21,7 +21,6 @@ make_mo - Compile PO files to MO files
 """
 
 import glob
-import locale
 import os
 import re
 import sys

--- a/tools/make_mo.py
+++ b/tools/make_mo.py
@@ -164,9 +164,10 @@ def process_po_folder(domain, folder, extra=''):
         # Create the MO file
         mo_file = os.path.join(mo_path, mo_name)
         print(('Compile %s' % mo_file))
-        cmd = [TOOL, '-o', mo_file,  fname]
-        if extra != '':
-            cmd.insert(1, extra)
+        if extra:
+            cmd = TOOL + [extra, '-o', mo_file,  fname]
+        else:
+            cmd = TOOL + ['-o', mo_file, fname]
         ret, output = run(cmd)
         if ret != 0:
             print(('\nMissing %s. Please install this package first.' % TOOL))
@@ -270,9 +271,9 @@ path, py = os.path.split(sys.argv[0])
 tl = os.path.abspath(os.path.normpath(os.path.join(path, 'msgfmt.py')))
 if os.path.exists(tl):
     if os.name == 'nt':
-        TOOL = 'python3 %s' % tl
+        TOOL = [sys.executable, tl]
     else:
-        TOOL = tl
+        TOOL = [tl]
 
 result = True
 if len(sys.argv) > 1 and sys.argv[1] == 'all':


### PR DESCRIPTION
This pull request fixes the locale compilation tools for Python 3, a small contribution towards the ongoing effort to make sabnzbd ready for Python 3 (issue #933).

Successfully tested with Python 3.6.5 on Linux with an UTF-8 system locale, so any verification on other operating systems (and locales) would be appreciated.