### PR TITLE
Option require_modern_tls if you want TLS 1.2 or higher for NNTPS

### DIFF
--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -265,6 +265,7 @@ no_penalties = OptionBool('misc', 'no_penalties', False)
 debug_log_decoding = OptionBool('misc', 'debug_log_decoding', False)
 ignore_empty_files = OptionBool('misc', 'ignore_empty_files', False)
 x_frame_options = OptionBool('misc', 'x_frame_options', True)
+require_modern_tls = OptionBool('misc', 'require_modern_tls', False)
 
 # Text values
 rss_odd_titles = OptionList('misc', 'rss_odd_titles', ['nzbindex.nl/', 'nzbindex.com/', 'nzbclub.com/'])

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -1371,7 +1371,7 @@ SPECIAL_BOOL_LIST = \
               'rss_filenames', 'ipv6_hosting', 'keep_awake', 'empty_postproc', 'html_login', 'wait_for_dfolder',
               'max_art_opt', 'warn_empty_nzb', 'enable_bonjour', 'reject_duplicate_files', 'warn_dupl_jobs',
               'replace_illegal', 'backup_for_duplicates', 'disable_api_key', 'api_logging',
-              'ignore_empty_files', 'x_frame_options'
+              'ignore_empty_files', 'x_frame_options', 'require_modern_tls'
      )
 SPECIAL_VALUE_LIST = \
     ('size_limit', 'folder_max_length', 'fsys_type', 'movie_rename_limit', 'nomedia_marker',

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -174,6 +174,10 @@ class NNTP(object):
                 # Setup the SSL socket
                 ctx = ssl.create_default_context()
 
+                if sabnzbd.cfg.require_modern_tls():
+                    # We want a modern TLS (1.2 or higher), so we disallow older protocol versions (<= TLS 1.1)
+                    ctx.options |= ssl.OP_NO_SSLv2 | ssl.OP_NO_SSLv3 | ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
+
                 # Only verify hostname when we're strict
                 if nw.server.ssl_verify < 2:
                     ctx.check_hostname = False


### PR DESCRIPTION
Option require_modern_tls if you want TLS 1.2 or higher for NNTPS

Rationale:

- All 200+ NNTPS servers with a correct TLS setup, speak TLS1.2 or higher. No need to speak TLS1.1 or lower.
- Avoid MITM protocol downgrade attacks
- TLS1 and TLS1.1 are old: 1999 resp 2006. They will depreciated in 2018/2019/2020 by the Big 4 browsers
