### PR TITLE
Add test-download shortcuts

### DIFF
--- a/interfaces/Glitter/templates/include_overlays.tmpl
+++ b/interfaces/Glitter/templates/include_overlays.tmpl
@@ -137,6 +137,13 @@
                             </div>
                             <div class="col-sm-6 col-loading" data-bind="visible: !hasPerformanceInfo()">$T('Glitter-loading')<span class="loader-dot-one">.</span><span class="loader-dot-two">.</span><span class="loader-dot-three">.</span></div>
                         </div>
+                        <div class="row test-download">
+                            <div class="col-sm-6">$T('dashboard-testDownload')</div>
+                            <div class="col-sm-6">
+                                <a href="#" class="btn btn-default" data-bind="click: testDownload" data-size="100MB" data-tooltip="true" data-placement="top" title="$T('dashboard-testDownload-explain')"><span class="glyphicon glyphicon-download-alt"></span> 100 MB</a>
+                                <a href="#" class="btn btn-default" data-bind="click: testDownload" data-size="1000MB" data-tooltip="true" data-placement="top" title="$T('dashboard-testDownload-explain')"><span class="glyphicon glyphicon-download-alt"></span> 1000 MB</a>
+                            </div>
+                        </div>
                         <hr />
                         <div class="row options-function-box">
                             <div class="col-sm-6">

--- a/interfaces/Glitter/templates/static/javascripts/glitter.main.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.main.js
@@ -849,6 +849,24 @@ function ViewModel() {
         })
     }
 
+    // Download a test-NZB
+    self.testDownload = function(data, event) {
+        var nzbSize = $(event.target).data('size')
+        // Build request
+        var theCall = {
+            mode: "addurl",
+            name: "https://sabnzbd.org/tests/test_download_" + nzbSize + ".nzb",
+            priority: self.queue.priorityName["Force"]
+        }
+
+        // Add
+        callAPI(theCall).then(function(r) {
+            // Hide and reset/refresh
+            self.refresh()
+            $("#modal-options").modal("hide");
+        });
+    }
+
     // Unblock server
     self.unblockServer = function(servername) {
         callSpecialAPI("./status/unblock_server/", {

--- a/interfaces/Glitter/templates/static/stylesheets/glitter.css
+++ b/interfaces/Glitter/templates/static/stylesheets/glitter.css
@@ -1419,6 +1419,14 @@ tr.queue-item>td:first-child>a {
     margin: 5px 0px 10px;
 }
 
+#modal-options .test-download .btn {
+    padding: 1px 5px;
+}
+
+#modal-options #options-status .test-download .btn .glyphicon {
+    margin-right: 2px;
+}
+
 #modal-options .options-function-box {
     margin-top: 5px;
 }

--- a/po/main/SABnzbd.pot
+++ b/po/main/SABnzbd.pot
@@ -12,7 +12,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=ASCII\n"
 "Content-Transfer-Encoding: 7bit\n"
-"POT-Creation-Date: 2018-11-28 09:21+W. Europe Standard Time\n"
+"POT-Creation-Date: 2018-12-24 17:40+W. Europe Standard Time\n"
 "Generated-By: pygettext.py 1.5\n"
 
 
@@ -2018,7 +2018,7 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: sabnzbd/skintext.py [Main menu item] # sabnzbd/skintext.py
+#: sabnzbd/skintext.py [Main menu item]
 msgid "Categories"
 msgstr ""
 
@@ -3383,14 +3383,6 @@ msgid "Send group command before requesting articles."
 msgstr ""
 
 #: sabnzbd/skintext.py
-msgid "Only use this server for these categories."
-msgstr ""
-
-#: sabnzbd/skintext.py
-msgid "None of the enabled servers have the 'Default' category selected. Jobs in the queue that are not assigned to one of the server's categories will not be downloaded."
-msgstr ""
-
-#: sabnzbd/skintext.py
 msgid "Personal notes"
 msgstr ""
 
@@ -3563,10 +3555,6 @@ msgid "Enable Growl"
 msgstr ""
 
 #: sabnzbd/skintext.py [Don't translate "Growl"]
-msgid "Send notifications to Growl"
-msgstr ""
-
-#: sabnzbd/skintext.py [Don't translate "Growl"]
 msgid "Only use for remote Growl server (host:port)"
 msgstr ""
 
@@ -3582,16 +3570,8 @@ msgstr ""
 msgid "Enable NotifyOSD"
 msgstr ""
 
-#: sabnzbd/skintext.py [Don't translate "NotifyOSD"]
-msgid "Send notifications to NotifyOSD"
-msgstr ""
-
 #: sabnzbd/skintext.py # sabnzbd/skintext.py [Header for OSX Notfication Center section]
 msgid "Notification Center"
-msgstr ""
-
-#: sabnzbd/skintext.py
-msgid "Send notifications to Notification Center"
 msgstr ""
 
 #: sabnzbd/skintext.py

--- a/po/main/SABnzbd.pot
+++ b/po/main/SABnzbd.pot
@@ -12,7 +12,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=ASCII\n"
 "Content-Transfer-Encoding: 7bit\n"
-"POT-Creation-Date: 2018-12-24 17:40+W. Europe Standard Time\n"
+"POT-Creation-Date: 2018-12-26 18:01+W. Europe Standard Time\n"
 "Generated-By: pygettext.py 1.5\n"
 
 
@@ -2412,6 +2412,14 @@ msgstr ""
 
 #: sabnzbd/skintext.py
 msgid "Repeat test"
+msgstr ""
+
+#: sabnzbd/skintext.py
+msgid "Test download"
+msgstr ""
+
+#: sabnzbd/skintext.py
+msgid "Adds a verified test NZB of the specified size, filled with random data. Can be used to verify your setup."
 msgstr ""
 
 #: sabnzbd/skintext.py

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -299,6 +299,8 @@ SKIN_TEXT = {
     'dashboard-speedTestFailed' : TT('Could not write. Check that the directory is writable.'),
     'dashboard-clickToStart' : TT('Click on Repeat test button below to determine'),
     'dashboard-repeatTest' : TT('Repeat test'),
+    'dashboard-testDownload' : TT('Test download'),
+    'dashboard-testDownload-explain' : TT('Adds a verified test NZB of the specified size, filled with random data. Can be used to verify your setup.'),
 
 # Configuration
     'confgFile' : TT('Config File'),

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -312,7 +312,6 @@ SKIN_TEXT = {
     'explain-Repair' : TT('The "Repair" button will restart SABnzbd and do a complete<br />reconstruction of the queue content, preserving already downloaded files.<br />This will modify the queue order.'),
     'confirmWithoutSavingPrompt' : TT('Changes have not been saved, and will be lost.'),
     'explain-sessionExpire': TT('When your IP address changes or SABnzbd is restarted the session will expire.'),
-    #'explain-Shutdown' : TT('This will end the SABnzbd process. <br />You will be unable to access SABnzbd and no downloading will take place until the service is started again.'),
     'opt-enable_unzip' : TT('Enable Unzip'),
     'opt-enable_7zip' : TT('Enable 7zip'),
     'opt-multicore-par2' : TT('Multicore Par2'),
@@ -577,9 +576,6 @@ SKIN_TEXT = {
     'srv-bandwidth' : TT('Bandwidth'),
     'srv-send_group' : TT('Send Group'),
     'srv-explain-send_group' : TT('Send group command before requesting articles.'),
-    'srv-categories' : TT('Categories'),
-    'srv-explain-categories' : TT('Only use this server for these categories.'),
-    'srv-explain-no-categories' : TT('None of the enabled servers have the \'Default\' category selected. Jobs in the queue that are not assigned to one of the server\'s categories will not be downloaded.'),
     'srv-notes' : TT('Personal notes'),
 
 # Config->Scheduling
@@ -639,15 +635,12 @@ SKIN_TEXT = {
     'explain-email_pwd' : TT('For authenticated email, password.'),
     'growlSettings' : TT('Growl'), #: Header Growl section
     'opt-growl_enable' : TT('Enable Growl'), #: Don't translate "Growl"
-    'explain-growl_enable' : TT('Send notifications to Growl'), #: Don't translate "Growl"
     'opt-growl_server' : TT('Server address'), #: Address of Growl server
     'explain-growl_server' : TT('Only use for remote Growl server (host:port)'), #: Don't translate "Growl"
     'opt-growl_password' : TT('Server password'), #: Growl server password
     'explain-growl_password' : TT('Optional password for Growl server'), #: Don't translate "Growl"
     'opt-ntfosd_enable' : TT('Enable NotifyOSD'), #: Don't translate "NotifyOSD"
-    'explain-ntfosd_enable' : TT('Send notifications to NotifyOSD'), #: Don't translate "NotifyOSD"
     'opt-ncenter_enable' : TT('Notification Center'),
-    'explain-ncenter_enable' : TT('Send notifications to Notification Center'),
     'opt-acenter_enable' : TT('Enable Windows Notifications'),
     'testNotify' : TT('Test Notification'),
     'section-NC' : TT('Notification Center'), #: Header for OSX Notfication Center section


### PR DESCRIPTION
Initiated by @sanderjo, we introduce 2 new buttons in the _Status and Interface settings_ window.
This allows users to quickly add a test NZB filled with a random `.bin` file of 100MB or 1000MB, split over the usual RAR files and par2 files.
With this they can check if their setup is fine, for users that complain that SABnzbd fails all their downloads so something must be wrong with SABnzbd (instead of just DMCA takedowns).
Or people can use it for speed testing their connection.

We host the 2 NZB's at https://sabnzbd.org/tests, so that we can always [update them easily](https://github.com/sabnzbd/sabnzbd.github.io/tree/master/tests) later.
