### PR TITLE
retry nscript

### DIFF
--- a/sabnzbd/notifier.py
+++ b/sabnzbd/notifier.py
@@ -540,7 +540,13 @@ def send_nscript(title, msg, gtype, force=False, test=None):
     if force or check_classes(gtype, 'nscript'):
         script_path = make_script_path(script)
         if script_path:
-            output, ret = external_script(script_path, gtype, title, msg, parameters)
+            # retry calling the script up to 5 times
+            for i in range(5):
+                output, ret = external_script(script_path, gtype, title, msg, parameters)
+                if ret:
+                    continue
+                else:
+                    break
             if ret:
                 logging.error(T('Script returned exit code %s and output "%s"') % (ret, output))
                 return T('Script returned exit code %s and output "%s"') % (ret, output)


### PR DESCRIPTION
When using sabnzbd inside a docker container it ocassionally happens that external scripts cannot be run because of some resource pressure inside docker. It terminates then with exit code -11, which indicates a segmentation fault. you cannot catch that error with a wrapper script.

Retrying the call from within notifier.py succeeds, though.
