### PR TITLE
Py3: Should we use Python function annotations

### DIFF
--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -14,7 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
+from pyannotate_runtime import collect_types
+collect_types.init_types_collection()
+collect_types.start()
 import sys
 if sys.hexversion < 0x03050000:
     print("Sorry, requires Python 3.5 or above")
@@ -1505,6 +1507,8 @@ def main():
             os._exit(0)
     else:
         notifier.send_notification('SABnzbd', T('SABnzbd shutdown finished'), 'startup')
+        collect_types.stop()
+        collect_types.dump_stats('type_info.json')
         os._exit(0)
 
 

--- a/sabnzbd/encoding.py
+++ b/sabnzbd/encoding.py
@@ -22,6 +22,7 @@ sabnzbd.encoding - Unicode/byte translation functions
 import locale
 import chardet
 from xml.sax.saxutils import escape
+from typing import Union
 
 
 CODEPAGE = locale.getpreferredencoding()
@@ -34,14 +35,14 @@ def utob(str_in):
     return str_in.encode('utf-8')
 
 
-def ubtou(str_in):
+def ubtou(str_in: Union[bytes, str]) -> str:
     """ Shorthand for converting unicode bytes to UTF-8 """
     if not isinstance(str_in, bytes):
         return str_in
     return str_in.decode('utf-8')
 
 
-def platform_btou(str_in):
+def platform_btou(str_in: bytes) -> str:
     """ Return Unicode, if not already Unicode, decode with locale encoding.
         NOTE: Used for POpen because universal_newlines/text parameter doesn't
         always work! We cannot use encoding-parameter because it's Python 3.7+
@@ -55,7 +56,7 @@ def platform_btou(str_in):
         return str_in
 
 
-def correct_unknown_encoding(str_or_bytes_in):
+def correct_unknown_encoding(str_or_bytes_in: Union[bytes, str]) -> str:
     """ Files created on Windows but unpacked/repaired on
         linux can result in invalid filenames. Try to fix this
         encoding by going to bytes and then back to unicode again.

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -36,6 +36,12 @@ from sabnzbd.constants import DEFAULT_PRIORITY, MEBI, DEF_ARTICLE_CACHE_DEFAULT,
 import sabnzbd.config as config
 import sabnzbd.cfg as cfg
 from sabnzbd.encoding import ubtou, platform_btou
+from datetime import datetime
+from typing import Any
+from typing import Optional
+from typing import Tuple
+from typing import Union
+from mypy_extensions import NoReturn
 
 TAB_UNITS = ("", "K", "M", "G", "T", "P")
 RE_UNITS = re.compile(r"(\d+\.*\d*)\s*([KMGTP]{0,1})", re.I)
@@ -55,7 +61,7 @@ def time_format(fmt):
         return fmt
 
 
-def calc_age(date, trans=False):
+def calc_age(date: datetime, trans: bool = False) -> str:
     """ Calculate the age difference between now and date.
         Value is returned as either days, hours, or minutes.
         When 'trans' is True, time symbols will be translated.
@@ -98,7 +104,7 @@ def monthrange(start, finish):
         yield datetime.date(int(year), int(month), 1)
 
 
-def safe_lower(txt):
+def safe_lower(txt: str) -> str:
     """ Return lowercased string. Return '' for None """
     if txt:
         return txt.lower()
@@ -106,7 +112,7 @@ def safe_lower(txt):
         return ""
 
 
-def cmp(x, y):
+def cmp(x: str, y: str) -> int:
     """
     Replacement for built-in funciton cmp that was removed in Python 3
 
@@ -118,7 +124,7 @@ def cmp(x, y):
     return (x > y) - (x < y)
 
 
-def cat_to_opts(cat, pp=None, script=None, priority=None):
+def cat_to_opts(cat: str, pp: Optional[Any] = None, script: Optional[str] = None, priority: Union[int, str] = None) -> Tuple[str, str, str, Union[int, str]]:
     """ Derive options from category, if options not already defined.
         Specified options have priority over category-options.
         If no valid category is given, special category '*' will supply default values
@@ -215,7 +221,7 @@ def cat_convert(cat):
     return None
 
 
-def windows_variant():
+def windows_variant() -> Tuple[bool, bool]:
     """ Determine Windows variant
         Return vista_plus, x64
     """
@@ -282,7 +288,7 @@ def set_serv_parms(service, args):
     return True
 
 
-def get_from_url(url):
+def get_from_url(url: str) -> NoReturn:
     """ Retrieve URL and return content """
     try:
         with urllib.request.urlopen(url) as response:
@@ -291,7 +297,7 @@ def get_from_url(url):
         return None
 
 
-def convert_version(text):
+def convert_version(text: Union[bytes, str]) -> Tuple[int, bool]:
     """ Convert version string to numerical value and a testversion indicator """
     version = 0
     test = True
@@ -310,7 +316,7 @@ def convert_version(text):
     return version, test
 
 
-def check_latest_version():
+def check_latest_version() -> None:
     """ Do an online check for the latest version
 
         Perform an online version check
@@ -395,7 +401,7 @@ def check_latest_version():
         sabnzbd.NEW_VERSION = (latest_testlabel, url_beta)
 
 
-def from_units(val):
+def from_units(val: str) -> float:
     """ Convert K/M/G/T/P notation to float """
     val = str(val).strip().upper()
     if val == "-1":
@@ -419,7 +425,7 @@ def from_units(val):
         return 0.0
 
 
-def to_units(val, postfix=""):
+def to_units(val: float, postfix: str = "") -> str:
     """ Convert number to K/M/G/T/P notation
         Show single decimal for M and higher
     """
@@ -448,7 +454,7 @@ def to_units(val, postfix=""):
     return fmt % (sign, val, unit, postfix)
 
 
-def caller_name(skip=2):
+def caller_name(skip: int = 2) -> str:
     """Get a name of a caller in the format module.method
        Originally used: https://gist.github.com/techtonik/2151727
        Adapted for speed by using sys calls directly
@@ -615,7 +621,7 @@ except:
 _HAVE_STATM = _PAGE_SIZE and memory_usage()
 
 
-def loadavg():
+def loadavg() -> str:
     """ Return 1, 5 and 15 minute load average of host or "" if not supported """
     p = ""
     if not sabnzbd.WIN32 and not sabnzbd.DARWIN:
@@ -630,10 +636,10 @@ def loadavg():
     return p
 
 
-def format_time_string(seconds):
+def format_time_string(seconds: float) -> str:
     """ Return a formatted and translated time string """
 
-    def unit(single, n):
+    def unit(single: str, n: int) -> str:
         # Seconds and minutes are special due to historical reasons
         if single == "minute" or (single == "second" and n == 1):
             single = single[:3]
@@ -666,7 +672,7 @@ def format_time_string(seconds):
     return " ".join(completestr)
 
 
-def int_conv(value):
+def int_conv(value: Union[int, str]) -> int:
     """ Safe conversion to int (can handle None) """
     try:
         value = int(value)
@@ -761,14 +767,14 @@ def find_on_path(targets):
     return None
 
 
-def probablyipv4(ip):
+def probablyipv4(ip: str) -> bool:
     if ip.count(".") == 3 and re.sub("[0123456789.]", "", ip) == "":
         return True
     else:
         return False
 
 
-def probablyipv6(ip):
+def probablyipv6(ip: str) -> bool:
     # Returns True if the given input is probably an IPv6 address
     # Square Brackets like '[2001::1]' are OK
     if ip.count(":") >= 2 and re.sub("[0123456789abcdefABCDEF:\[\]]", "", ip) == "":

--- a/type_info.json
+++ b/type_info.json
@@ -1,0 +1,30253 @@
+[
+    {
+        "path": "SABnzbd.py",
+        "line": 102,
+        "func_name": "GUIHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "SABnzbd.py",
+        "line": 107,
+        "func_name": "GUIHandler.__init__",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "SABnzbd.py",
+        "line": 136,
+        "func_name": "GUIHandler.count",
+        "type_comments": [
+            "() -> int"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "SABnzbd.py",
+        "line": 139,
+        "func_name": "GUIHandler.content",
+        "type_comments": [
+            "() -> List"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "SABnzbd.py",
+        "line": 248,
+        "func_name": "identify_web_template",
+        "type_comments": [
+            "(None, str, str) -> str",
+            "(sabnzbd.config.OptionStr, str, None) -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "SABnzbd.py",
+        "line": 279,
+        "func_name": "check_template_scheme",
+        "type_comments": [
+            "(str, str) -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "SABnzbd.py",
+        "line": 289,
+        "func_name": "fix_webname",
+        "type_comments": [
+            "(None) -> None",
+            "(str) -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "SABnzbd.py",
+        "line": 306,
+        "func_name": "get_user_profile_paths",
+        "type_comments": [
+            "(bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "SABnzbd.py",
+        "line": 372,
+        "func_name": "print_modules",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "SABnzbd.py",
+        "line": 442,
+        "func_name": "all_localhosts",
+        "type_comments": [
+            "() -> List[str]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "SABnzbd.py",
+        "line": 480,
+        "func_name": "get_webhost",
+        "type_comments": [
+            "(None, None, None) -> Tuple[str, int, str, int]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "SABnzbd.py",
+        "line": 697,
+        "func_name": "commandline_handler",
+        "type_comments": [
+            "() -> Tuple[str, List, List[str], List]"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "SABnzbd.py",
+        "line": 1523,
+        "func_name": "SABnzbd",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "SABnzbd.py",
+        "line": 1592,
+        "func_name": "HandleCommandLine",
+        "type_comments": [
+            "(bool) -> bool"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_compression.py",
+        "line": 9,
+        "func_name": "BaseStream",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_compression.py",
+        "line": 12,
+        "func_name": "BaseStream._check_not_closed",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_compression.py",
+        "line": 33,
+        "func_name": "DecompressReader",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 249,
+        "func_name": "DocDescriptor",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 258,
+        "func_name": "OpenWrapper",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 281,
+        "func_name": "IOBase",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 440,
+        "func_name": "IOBase._checkClosed",
+        "type_comments": [
+            "(str) -> None",
+            "(None) -> None"
+        ],
+        "samples": 23
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 479,
+        "func_name": "IOBase.readline",
+        "type_comments": [
+            "(int) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(int) -> bytes"
+        ],
+        "samples": 54
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 491,
+        "func_name": "nreadahead",
+        "type_comments": [
+            "() -> pyannotate_runtime.collect_types.NoReturnType",
+            "() -> int"
+        ],
+        "samples": 54
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 557,
+        "func_name": "RawIOBase",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 623,
+        "func_name": "BufferedIOBase",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 729,
+        "func_name": "_BufferedIOMixin",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 738,
+        "func_name": "_BufferedIOMixin.__init__",
+        "type_comments": [
+            "(socket.SocketIO) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 769,
+        "func_name": "_BufferedIOMixin.flush",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 774,
+        "func_name": "_BufferedIOMixin.close",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 795,
+        "func_name": "raw",
+        "type_comments": [
+            "() -> socket.SocketIO"
+        ],
+        "samples": 39
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 799,
+        "func_name": "closed",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 23
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 834,
+        "func_name": "BytesIO",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 972,
+        "func_name": "BufferedReader",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 983,
+        "func_name": "BufferedReader.__init__",
+        "type_comments": [
+            "(socket.SocketIO, int) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 999,
+        "func_name": "BufferedReader._reset_read_buf",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 1003,
+        "func_name": "BufferedReader.read",
+        "type_comments": [
+            "(int) -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 109
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 1016,
+        "func_name": "BufferedReader._read_unlocked",
+        "type_comments": [
+            "(int) -> bytes"
+        ],
+        "samples": 109
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 1068,
+        "func_name": "BufferedReader.peek",
+        "type_comments": [
+            "(int) -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 54
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 1078,
+        "func_name": "BufferedReader._peek_unlocked",
+        "type_comments": [
+            "(int) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(int) -> bytes"
+        ],
+        "samples": 54
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 1166,
+        "func_name": "BufferedWriter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 1175,
+        "func_name": "BufferedWriter.__init__",
+        "type_comments": [
+            "(socket.SocketIO, int) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 1271,
+        "func_name": "BufferedRWPair",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 1344,
+        "func_name": "BufferedRandom",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 1418,
+        "func_name": "FileIO",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 1757,
+        "func_name": "TextIOBase",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 1825,
+        "func_name": "IncrementalNewlineDecoder",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 1910,
+        "func_name": "TextIOWrapper",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\_pyio.py",
+        "line": 2577,
+        "func_name": "StringIO",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 105,
+        "func_name": "_AttributeHolder",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 152,
+        "func_name": "HelpFormatter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 202,
+        "func_name": "_Section",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 650,
+        "func_name": "RawDescriptionHelpFormatter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 661,
+        "func_name": "RawTextHelpFormatter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 672,
+        "func_name": "ArgumentDefaultsHelpFormatter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 689,
+        "func_name": "MetavarTypeHelpFormatter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 722,
+        "func_name": "ArgumentError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 742,
+        "func_name": "ArgumentTypeError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 751,
+        "func_name": "Action",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 842,
+        "func_name": "_StoreAction",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 877,
+        "func_name": "_StoreConstAction",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 900,
+        "func_name": "_StoreTrueAction",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 917,
+        "func_name": "_StoreFalseAction",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 934,
+        "func_name": "_AppendAction",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 972,
+        "func_name": "_AppendConstAction",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 999,
+        "func_name": "_CountAction",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 1022,
+        "func_name": "_HelpAction",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 1041,
+        "func_name": "_VersionAction",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 1067,
+        "func_name": "_SubParsersAction",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 1069,
+        "func_name": "_ChoicesPseudoAction",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 1165,
+        "func_name": "FileType",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 1219,
+        "func_name": "Namespace",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 1239,
+        "func_name": "_ActionsContainer",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 1546,
+        "func_name": "_ArgumentGroup",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 1580,
+        "func_name": "_MutuallyExclusiveGroup",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\argparse.py",
+        "line": 1600,
+        "func_name": "ArgumentParser",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\bz2.py",
+        "line": 28,
+        "func_name": "BZ2File",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\calendar.py",
+        "line": 24,
+        "func_name": "IllegalMonthError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\calendar.py",
+        "line": 31,
+        "func_name": "IllegalWeekdayError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\calendar.py",
+        "line": 50,
+        "func_name": "_localized_month",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\calendar.py",
+        "line": 55,
+        "func_name": "_localized_month.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\calendar.py",
+        "line": 69,
+        "func_name": "_localized_day",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\calendar.py",
+        "line": 74,
+        "func_name": "_localized_day.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\calendar.py",
+        "line": 148,
+        "func_name": "Calendar",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\calendar.py",
+        "line": 154,
+        "func_name": "Calendar.__init__",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\calendar.py",
+        "line": 160,
+        "func_name": "Calendar.setfirstweekday",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\calendar.py",
+        "line": 293,
+        "func_name": "TextCalendar",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\calendar.py",
+        "line": 410,
+        "func_name": "HTMLCalendar",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\calendar.py",
+        "line": 546,
+        "func_name": "different_locale",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\calendar.py",
+        "line": 558,
+        "func_name": "LocaleTextCalendar",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\calendar.py",
+        "line": 589,
+        "func_name": "LocaleHTMLCalendar",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\cgi.py",
+        "line": 225,
+        "func_name": "_parseparam",
+        "type_comments": [
+            "(str) -> Iterator",
+            "(str) -> Iterator[str]"
+        ],
+        "samples": 53
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\cgi.py",
+        "line": 237,
+        "func_name": "parse_header",
+        "type_comments": [
+            "(str) -> Tuple[str, Dict]",
+            "(str) -> Tuple[str, Dict[str, str]]"
+        ],
+        "samples": 26
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\cgi.py",
+        "line": 261,
+        "func_name": "MiniFieldStorage",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\configparser.py",
+        "line": 167,
+        "func_name": "Error",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\configparser.py",
+        "line": 180,
+        "func_name": "NoSectionError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\configparser.py",
+        "line": 189,
+        "func_name": "DuplicateSectionError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\configparser.py",
+        "line": 215,
+        "func_name": "DuplicateOptionError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\configparser.py",
+        "line": 242,
+        "func_name": "NoOptionError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\configparser.py",
+        "line": 253,
+        "func_name": "InterpolationError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\configparser.py",
+        "line": 263,
+        "func_name": "InterpolationMissingOptionError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\configparser.py",
+        "line": 275,
+        "func_name": "InterpolationSyntaxError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\configparser.py",
+        "line": 283,
+        "func_name": "InterpolationDepthError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\configparser.py",
+        "line": 296,
+        "func_name": "ParsingError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\configparser.py",
+        "line": 339,
+        "func_name": "MissingSectionHeaderError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\configparser.py",
+        "line": 359,
+        "func_name": "Interpolation",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\configparser.py",
+        "line": 375,
+        "func_name": "BasicInterpolation",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\configparser.py",
+        "line": 447,
+        "func_name": "ExtendedInterpolation",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\configparser.py",
+        "line": 521,
+        "func_name": "LegacyInterpolation",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\configparser.py",
+        "line": 559,
+        "func_name": "RawConfigParser",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\configparser.py",
+        "line": 1189,
+        "func_name": "ConfigParser",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\configparser.py",
+        "line": 1221,
+        "func_name": "SafeConfigParser",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\configparser.py",
+        "line": 1234,
+        "func_name": "SectionProxy",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\configparser.py",
+        "line": 1304,
+        "func_name": "ConverterMapping",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\contextlib.py",
+        "line": 81,
+        "func_name": "_GeneratorContextManagerBase.__init__",
+        "type_comments": [
+            "(function, Tuple[str, int], Dict) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\contextlib.py",
+        "line": 107,
+        "func_name": "_GeneratorContextManager.__enter__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\contextlib.py",
+        "line": 116,
+        "func_name": "_GeneratorContextManager.__exit__",
+        "type_comments": [
+            "(None, None, None) -> bool"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\contextlib.py",
+        "line": 210,
+        "func_name": "contextmanager",
+        "type_comments": [
+            "(function) -> function"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\contextlib.py",
+        "line": 237,
+        "func_name": "helper",
+        "type_comments": [
+            "(*Union[int, str]) -> contextlib._GeneratorContextManager"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\contextlib.py",
+        "line": 293,
+        "func_name": "closing.__init__",
+        "type_comments": [
+            "(socket.socket) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\contextlib.py",
+        "line": 295,
+        "func_name": "closing.__enter__",
+        "type_comments": [
+            "() -> socket.socket"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\contextlib.py",
+        "line": 297,
+        "func_name": "closing.__exit__",
+        "type_comments": [
+            "(*None) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 73,
+        "func_name": "CFUNCTYPE",
+        "type_comments": [
+            "(_ctypes.PyCSimpleType, *_ctypes.PyCSimpleType) -> _ctypes.PyCFuncPtrType",
+            "(_ctypes.PyCSimpleType) -> _ctypes.PyCFuncPtrType"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 99,
+        "func_name": "CFunctionType",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 139,
+        "func_name": "_check_size",
+        "type_comments": [
+            "(_ctypes.PyCSimpleType, None) -> None",
+            "(_ctypes.PyCSimpleType, str) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 151,
+        "func_name": "py_object",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 160,
+        "func_name": "c_short",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 164,
+        "func_name": "c_ushort",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 168,
+        "func_name": "c_long",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 172,
+        "func_name": "c_ulong",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 189,
+        "func_name": "c_float",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 193,
+        "func_name": "c_double",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 197,
+        "func_name": "c_longdouble",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 207,
+        "func_name": "c_longlong",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 211,
+        "func_name": "c_ulonglong",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 225,
+        "func_name": "c_byte",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 230,
+        "func_name": "c_char",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 235,
+        "func_name": "c_char_p",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 246,
+        "func_name": "c_bool",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 251,
+        "func_name": "c_wchar_p",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 256,
+        "func_name": "c_wchar",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 259,
+        "func_name": "_reset_cache",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 311,
+        "func_name": "CDLL",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 332,
+        "func_name": "CDLL.__init__",
+        "type_comments": [
+            "(str, int, None, bool, bool) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(str, int, None, bool, bool) -> None",
+            "(str, None, int, bool, bool) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 350,
+        "func_name": "_FuncPtr",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 366,
+        "func_name": "CDLL.__getattr__",
+        "type_comments": [
+            "(str) -> ctypes._FuncPtr"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 373,
+        "func_name": "CDLL.__getitem__",
+        "type_comments": [
+            "(str) -> ctypes._FuncPtr"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 379,
+        "func_name": "PyDLL",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 388,
+        "func_name": "WinDLL",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 397,
+        "func_name": "HRESULT",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 410,
+        "func_name": "OleDLL",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 419,
+        "func_name": "LibraryLoader",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 420,
+        "func_name": "LibraryLoader.__init__",
+        "type_comments": [
+            "(type) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 423,
+        "func_name": "LibraryLoader.__getattr__",
+        "type_comments": [
+            "(str) -> ctypes.WinDLL",
+            "(str) -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 433,
+        "func_name": "LibraryLoader.LoadLibrary",
+        "type_comments": [
+            "(str) -> ctypes.WinDLL"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 481,
+        "func_name": "PYFUNCTYPE",
+        "type_comments": [
+            "(_ctypes.PyCSimpleType, *_ctypes.PyCSimpleType) -> _ctypes.PyCFuncPtrType"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\__init__.py",
+        "line": 482,
+        "func_name": "CFunctionType",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\_endian.py",
+        "line": 23,
+        "func_name": "_swapped_meta",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\_endian.py",
+        "line": 46,
+        "func_name": "BigEndianStructure",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\wintypes.py",
+        "line": 20,
+        "func_name": "VARIANT_BOOL",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\wintypes.py",
+        "line": 97,
+        "func_name": "RECT",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\wintypes.py",
+        "line": 104,
+        "func_name": "_SMALL_RECT",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\wintypes.py",
+        "line": 111,
+        "func_name": "_COORD",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\wintypes.py",
+        "line": 115,
+        "func_name": "POINT",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\wintypes.py",
+        "line": 120,
+        "func_name": "SIZE",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\wintypes.py",
+        "line": 128,
+        "func_name": "FILETIME",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\wintypes.py",
+        "line": 133,
+        "func_name": "MSG",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\wintypes.py",
+        "line": 143,
+        "func_name": "WIN32_FIND_DATAA",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ctypes\\wintypes.py",
+        "line": 155,
+        "func_name": "WIN32_FIND_DATAW",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\datetime.py",
+        "line": 41,
+        "func_name": "_days_before_year",
+        "type_comments": [
+            "(int) -> int"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\datetime.py",
+        "line": 46,
+        "func_name": "_days_in_month",
+        "type_comments": [
+            "(int, int) -> int"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\datetime.py",
+        "line": 379,
+        "func_name": "_check_int_field",
+        "type_comments": [
+            "(int) -> int"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\datetime.py",
+        "line": 396,
+        "func_name": "_check_date_fields",
+        "type_comments": [
+            "(int, int, int) -> Tuple[int, int, int]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\datetime.py",
+        "line": 409,
+        "func_name": "_check_time_fields",
+        "type_comments": [
+            "(int, int, int, int, int) -> Tuple[int, int, int, int, int]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\datetime.py",
+        "line": 426,
+        "func_name": "_check_tzinfo_arg",
+        "type_comments": [
+            "(datetime.timezone) -> None",
+            "(None) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\datetime.py",
+        "line": 454,
+        "func_name": "timedelta",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\datetime.py",
+        "line": 473,
+        "func_name": "__new__",
+        "type_comments": [
+            "(int, int, int, int, int, int, int) -> datetime.timedelta"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\datetime.py",
+        "line": 646,
+        "func_name": "timedelta.__neg__",
+        "type_comments": [
+            "() -> datetime.timedelta"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\datetime.py",
+        "line": 774,
+        "func_name": "date",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\datetime.py",
+        "line": 804,
+        "func_name": "__new__",
+        "type_comments": [
+            "(int, int, int) -> datetime.date"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\datetime.py",
+        "line": 1092,
+        "func_name": "tzinfo",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\datetime.py",
+        "line": 1162,
+        "func_name": "time",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\datetime.py",
+        "line": 1187,
+        "func_name": "__new__",
+        "type_comments": [
+            "(int, int, int, int, None, int) -> datetime.time"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\datetime.py",
+        "line": 1509,
+        "func_name": "datetime",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\datetime.py",
+        "line": 1517,
+        "func_name": "__new__",
+        "type_comments": [
+            "(int, int, int, int, int, int, int, datetime.timezone, int) -> datetime.datetime",
+            "(int, int, int, int, int, int, int, None, int) -> datetime.datetime"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\datetime.py",
+        "line": 2136,
+        "func_name": "timezone",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\datetime.py",
+        "line": 2156,
+        "func_name": "_create",
+        "type_comments": [
+            "(datetime.timedelta, None) -> datetime.timezone"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\difflib.py",
+        "line": 43,
+        "func_name": "SequenceMatcher",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\difflib.py",
+        "line": 751,
+        "func_name": "Differ",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\difflib.py",
+        "line": 1707,
+        "func_name": "HtmlDiff",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\_encoded_words.py",
+        "line": 73,
+        "func_name": "_QByteMap",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\_parseaddr.py",
+        "line": 203,
+        "func_name": "AddrlistClass",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\_parseaddr.py",
+        "line": 495,
+        "func_name": "AddressList",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\_policybase.py",
+        "line": 18,
+        "func_name": "_PolicyBase",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\_policybase.py",
+        "line": 41,
+        "func_name": "_PolicyBase.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\_policybase.py",
+        "line": 94,
+        "func_name": "_append_doc",
+        "type_comments": [
+            "(str, str) -> str"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\_policybase.py",
+        "line": 99,
+        "func_name": "_extend_docstrings",
+        "type_comments": [
+            "() -> abc.ABCMeta"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\_policybase.py",
+        "line": 112,
+        "func_name": "Policy",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\_policybase.py",
+        "line": 271,
+        "func_name": "Compat32",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\_policybase.py",
+        "line": 281,
+        "func_name": "Compat32._sanitize_header",
+        "type_comments": [
+            "(str, str) -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\_policybase.py",
+        "line": 293,
+        "func_name": "Compat32.header_source_parse",
+        "type_comments": [
+            "(List[str]) -> Tuple[str, str]"
+        ],
+        "samples": 12
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\_policybase.py",
+        "line": 311,
+        "func_name": "Compat32.header_fetch_parse",
+        "type_comments": [
+            "(str, str) -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\charset.py",
+        "line": 167,
+        "func_name": "Charset",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\charset.py",
+        "line": 211,
+        "func_name": "Charset.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\errors.py",
+        "line": 8,
+        "func_name": "MessageError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\errors.py",
+        "line": 12,
+        "func_name": "MessageParseError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\errors.py",
+        "line": 16,
+        "func_name": "HeaderParseError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\errors.py",
+        "line": 20,
+        "func_name": "BoundaryError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\errors.py",
+        "line": 24,
+        "func_name": "MultipartConversionError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\errors.py",
+        "line": 28,
+        "func_name": "CharsetError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\errors.py",
+        "line": 33,
+        "func_name": "MessageDefect",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\errors.py",
+        "line": 41,
+        "func_name": "NoBoundaryInMultipartDefect",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\errors.py",
+        "line": 44,
+        "func_name": "StartBoundaryNotFoundDefect",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\errors.py",
+        "line": 47,
+        "func_name": "CloseBoundaryNotFoundDefect",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\errors.py",
+        "line": 50,
+        "func_name": "FirstHeaderLineIsContinuationDefect",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\errors.py",
+        "line": 53,
+        "func_name": "MisplacedEnvelopeHeaderDefect",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\errors.py",
+        "line": 56,
+        "func_name": "MissingHeaderBodySeparatorDefect",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\errors.py",
+        "line": 61,
+        "func_name": "MultipartInvariantViolationDefect",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\errors.py",
+        "line": 64,
+        "func_name": "InvalidMultipartContentTransferEncodingDefect",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\errors.py",
+        "line": 67,
+        "func_name": "UndecodableBytesDefect",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\errors.py",
+        "line": 70,
+        "func_name": "InvalidBase64PaddingDefect",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\errors.py",
+        "line": 73,
+        "func_name": "InvalidBase64CharactersDefect",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\errors.py",
+        "line": 76,
+        "func_name": "InvalidBase64LengthDefect",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\errors.py",
+        "line": 81,
+        "func_name": "HeaderDefect",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\errors.py",
+        "line": 87,
+        "func_name": "InvalidHeaderDefect",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\errors.py",
+        "line": 90,
+        "func_name": "HeaderMissingRequiredValue",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\errors.py",
+        "line": 93,
+        "func_name": "NonPrintableDefect",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\errors.py",
+        "line": 104,
+        "func_name": "ObsoleteHeaderDefect",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\errors.py",
+        "line": 107,
+        "func_name": "NonASCIILocalPartDefect",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\feedparser.py",
+        "line": 45,
+        "func_name": "BufferedSubFile",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\feedparser.py",
+        "line": 53,
+        "func_name": "BufferedSubFile.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\feedparser.py",
+        "line": 70,
+        "func_name": "BufferedSubFile.close",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\feedparser.py",
+        "line": 78,
+        "func_name": "BufferedSubFile.readline",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 45
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\feedparser.py",
+        "line": 101,
+        "func_name": "BufferedSubFile.push",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\feedparser.py",
+        "line": 122,
+        "func_name": "BufferedSubFile.pushlines",
+        "type_comments": [
+            "(List) -> None",
+            "(List[str]) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\feedparser.py",
+        "line": 125,
+        "func_name": "BufferedSubFile.__iter__",
+        "type_comments": [
+            "() -> email.feedparser.BufferedSubFile"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\feedparser.py",
+        "line": 128,
+        "func_name": "BufferedSubFile.__next__",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 45
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\feedparser.py",
+        "line": 136,
+        "func_name": "FeedParser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\feedparser.py",
+        "line": 139,
+        "func_name": "FeedParser.__init__",
+        "type_comments": [
+            "(None, email._policybase.Compat32) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\feedparser.py",
+        "line": 173,
+        "func_name": "FeedParser.feed",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\feedparser.py",
+        "line": 178,
+        "func_name": "FeedParser._call_parse",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\feedparser.py",
+        "line": 184,
+        "func_name": "FeedParser.close",
+        "type_comments": [
+            "() -> email.message.Message"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\feedparser.py",
+        "line": 197,
+        "func_name": "FeedParser._new_message",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\feedparser.py",
+        "line": 210,
+        "func_name": "FeedParser._pop_message",
+        "type_comments": [
+            "() -> email.message.Message"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\feedparser.py",
+        "line": 218,
+        "func_name": "FeedParser._parsegen",
+        "type_comments": [
+            "() -> Iterator",
+            "() -> Iterator[object]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\feedparser.py",
+        "line": 471,
+        "func_name": "FeedParser._parse_headers",
+        "type_comments": [
+            "(List[str]) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\feedparser.py",
+        "line": 532,
+        "func_name": "BytesFeedParser",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\generator.py",
+        "line": 26,
+        "func_name": "Generator",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\generator.py",
+        "line": 392,
+        "func_name": "BytesGenerator",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\generator.py",
+        "line": 445,
+        "func_name": "DecodedGenerator",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\header.py",
+        "line": 179,
+        "func_name": "Header",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\header.py",
+        "line": 413,
+        "func_name": "_ValueFormatter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\header.py",
+        "line": 541,
+        "func_name": "_Accumulator",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\message.py",
+        "line": 29,
+        "func_name": "_splitparam",
+        "type_comments": [
+            "(str) -> Tuple[str, str]"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\message.py",
+        "line": 105,
+        "func_name": "Message",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\message.py",
+        "line": 462,
+        "func_name": "Message.get",
+        "type_comments": [
+            "(str, object) -> object",
+            "(str, object) -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\message.py",
+        "line": 479,
+        "func_name": "Message.set_raw",
+        "type_comments": [
+            "(str, str) -> None"
+        ],
+        "samples": 13
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\message.py",
+        "line": 497,
+        "func_name": "Message.get_all",
+        "type_comments": [
+            "(str, None) -> None",
+            "(str, None) -> List[str]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\message.py",
+        "line": 564,
+        "func_name": "Message.get_content_type",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\message.py",
+        "line": 588,
+        "func_name": "Message.get_content_maintype",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\message.py",
+        "line": 606,
+        "func_name": "Message.get_default_type",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\message.py",
+        "line": 945,
+        "func_name": "MIMEPart",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\message.py",
+        "line": 1159,
+        "func_name": "EmailMessage",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\parser.py",
+        "line": 17,
+        "func_name": "Parser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\parser.py",
+        "line": 18,
+        "func_name": "Parser.__init__",
+        "type_comments": [
+            "(None, email._policybase.Compat32) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\parser.py",
+        "line": 42,
+        "func_name": "Parser.parse",
+        "type_comments": [
+            "(_io.StringIO, bool) -> email.message.Message"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\parser.py",
+        "line": 60,
+        "func_name": "Parser.parsestr",
+        "type_comments": [
+            "(str, bool) -> email.message.Message"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\parser.py",
+        "line": 72,
+        "func_name": "HeaderParser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\parser.py",
+        "line": 80,
+        "func_name": "BytesParser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\parser.py",
+        "line": 127,
+        "func_name": "BytesHeaderParser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\utils.py",
+        "line": 51,
+        "func_name": "_has_surrogates",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\utils.py",
+        "line": 117,
+        "func_name": "_format_timetuple_and_zone",
+        "type_comments": [
+            "(time.struct_time, str) -> str"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\email\\utils.py",
+        "line": 155,
+        "func_name": "format_datetime",
+        "type_comments": [
+            "(datetime.datetime, bool) -> str"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\getopt.py",
+        "line": 43,
+        "func_name": "GetoptError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\getopt.py",
+        "line": 56,
+        "func_name": "getopt",
+        "type_comments": [
+            "(List, str, List[str]) -> Tuple[List, List]"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\gettext.py",
+        "line": 253,
+        "func_name": "NullTranslations",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\gettext.py",
+        "line": 328,
+        "func_name": "GNUTranslations",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\gettext.py",
+        "line": 336,
+        "func_name": "GNUTranslations._get_versions",
+        "type_comments": [
+            "(int) -> Tuple[int, int]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\gettext.py",
+        "line": 340,
+        "func_name": "GNUTranslations._parse",
+        "type_comments": [
+            "(_io.BufferedReader) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\gettext.py",
+        "line": 451,
+        "func_name": "GNUTranslations.gettext",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 11
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\gettext.py",
+        "line": 474,
+        "func_name": "find",
+        "type_comments": [
+            "(str, str, List[str], bool) -> List[str]",
+            "(str, str, List[str], bool) -> List"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\gettext.py",
+        "line": 514,
+        "func_name": "translation",
+        "type_comments": [
+            "(str, str, List[str], None, bool, None) -> gettext.GNUTranslations",
+            "(str, str, List[str], None, bool, None) -> gettext.NullTranslations"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\gzip.py",
+        "line": 64,
+        "func_name": "write32u",
+        "type_comments": [
+            "(_io.BufferedWriter, int) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\gzip.py",
+        "line": 69,
+        "func_name": "_PaddedFile",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\gzip.py",
+        "line": 110,
+        "func_name": "GzipFile",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\gzip.py",
+        "line": 123,
+        "func_name": "GzipFile.__init__",
+        "type_comments": [
+            "(str, None, int, _io.BufferedWriter, None) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\gzip.py",
+        "line": 213,
+        "func_name": "GzipFile._init_write",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\gzip.py",
+        "line": 221,
+        "func_name": "GzipFile._write_gzip_header",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\gzip.py",
+        "line": 247,
+        "func_name": "GzipFile.write",
+        "type_comments": [
+            "(bytes) -> int"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\gzip.py",
+        "line": 298,
+        "func_name": "closed",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\gzip.py",
+        "line": 302,
+        "func_name": "GzipFile.close",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\gzip.py",
+        "line": 321,
+        "func_name": "GzipFile.flush",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\gzip.py",
+        "line": 377,
+        "func_name": "_GzipReader",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\__init__.py",
+        "line": 5,
+        "func_name": "HTTPStatus",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\__init__.py",
+        "line": 20,
+        "func_name": "__new__",
+        "type_comments": [
+            "(int, str, str) -> http.HTTPStatus"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 163,
+        "func_name": "HTTPMessage",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 193,
+        "func_name": "parse_headers",
+        "type_comments": [
+            "(_io.BufferedReader, type) -> http.client.HTTPMessage"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 217,
+        "func_name": "HTTPResponse",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 226,
+        "func_name": "HTTPResponse.__init__",
+        "type_comments": [
+            "(ssl.SSLSocket, int, str, None) -> None",
+            "(socket.socket, int, str, None) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 256,
+        "func_name": "HTTPResponse._read_status",
+        "type_comments": [
+            "() -> Tuple[str, int, str]"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 289,
+        "func_name": "HTTPResponse.begin",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 369,
+        "func_name": "HTTPResponse._check_close",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 398,
+        "func_name": "HTTPResponse._close_conn",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 403,
+        "func_name": "HTTPResponse.close",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 415,
+        "func_name": "HTTPResponse.flush",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 436,
+        "func_name": "HTTPResponse.read",
+        "type_comments": [
+            "(None) -> bytes"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 502,
+        "func_name": "HTTPResponse._read_next_chunk_size",
+        "type_comments": [
+            "() -> int"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 518,
+        "func_name": "HTTPResponse._read_and_discard_trailer",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 532,
+        "func_name": "HTTPResponse._get_chunk_left",
+        "type_comments": [
+            "() -> None",
+            "() -> int"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 556,
+        "func_name": "HTTPResponse._readall_chunked",
+        "type_comments": [
+            "() -> bytes"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 594,
+        "func_name": "HTTPResponse._safe_read",
+        "type_comments": [
+            "(int) -> bytes"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 737,
+        "func_name": "HTTPResponse.info",
+        "type_comments": [
+            "() -> http.client.HTTPMessage"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 779,
+        "func_name": "HTTPConnection",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 795,
+        "func_name": "_get_content_length",
+        "type_comments": [
+            "(None, str) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 827,
+        "func_name": "HTTPConnection.__init__",
+        "type_comments": [
+            "(str, None, object, None, int) -> None",
+            "(str, None, int, None, int) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 871,
+        "func_name": "HTTPConnection._get_hostport",
+        "type_comments": [
+            "(str, None) -> Tuple[str, int]"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 891,
+        "func_name": "HTTPConnection.set_debuglevel",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 925,
+        "func_name": "HTTPConnection.connect",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 934,
+        "func_name": "HTTPConnection.close",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 948,
+        "func_name": "HTTPConnection.send",
+        "type_comments": [
+            "(bytes) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 986,
+        "func_name": "HTTPConnection._output",
+        "type_comments": [
+            "(bytes) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 1007,
+        "func_name": "HTTPConnection._send_output",
+        "type_comments": [
+            "(None, bool) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 1061,
+        "func_name": "HTTPConnection.putrequest",
+        "type_comments": [
+            "(str, str, int, bool) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 1185,
+        "func_name": "HTTPConnection.putheader",
+        "type_comments": [
+            "(str, *str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 1213,
+        "func_name": "HTTPConnection.endheaders",
+        "type_comments": [
+            "(None, bool) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 1226,
+        "func_name": "HTTPConnection.request",
+        "type_comments": [
+            "(str, str, None, Dict[str, str], bool) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 1231,
+        "func_name": "HTTPConnection._send_request",
+        "type_comments": [
+            "(str, str, None, Dict[str, str], bool) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 1277,
+        "func_name": "HTTPConnection.getresponse",
+        "type_comments": [
+            "() -> http.client.HTTPResponse"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 1345,
+        "func_name": "HTTPSConnection",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 1352,
+        "func_name": "HTTPSConnection.__init__",
+        "type_comments": [
+            "(str, None, None, None, object, None, None, None, int) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 1381,
+        "func_name": "HTTPSConnection.connect",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 1396,
+        "func_name": "HTTPException",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 1401,
+        "func_name": "NotConnected",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 1404,
+        "func_name": "InvalidURL",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 1407,
+        "func_name": "UnknownProtocol",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 1412,
+        "func_name": "UnknownTransferEncoding",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 1415,
+        "func_name": "UnimplementedFileMode",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 1418,
+        "func_name": "IncompleteRead",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 1433,
+        "func_name": "ImproperConnectionState",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 1436,
+        "func_name": "CannotSendRequest",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 1439,
+        "func_name": "CannotSendHeader",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 1442,
+        "func_name": "ResponseNotReady",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 1445,
+        "func_name": "BadStatusLine",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 1452,
+        "func_name": "LineTooLong",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\client.py",
+        "line": 1457,
+        "func_name": "RemoteDisconnected",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\cookies.py",
+        "line": 144,
+        "func_name": "CookieError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\cookies.py",
+        "line": 189,
+        "func_name": "_unquote",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 13
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\cookies.py",
+        "line": 253,
+        "func_name": "Morsel",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\cookies.py",
+        "line": 288,
+        "func_name": "Morsel.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 13
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\cookies.py",
+        "line": 348,
+        "func_name": "Morsel.set",
+        "type_comments": [
+            "(str, str, str) -> None"
+        ],
+        "samples": 13
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\cookies.py",
+        "line": 457,
+        "func_name": "BaseCookie",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\cookies.py",
+        "line": 478,
+        "func_name": "BaseCookie.__init__",
+        "type_comments": [
+            "(None) -> None"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\cookies.py",
+        "line": 482,
+        "func_name": "__set",
+        "type_comments": [
+            "(str, str, str) -> None"
+        ],
+        "samples": 13
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\cookies.py",
+        "line": 497,
+        "func_name": "BaseCookie.output",
+        "type_comments": [
+            "(None, str, str) -> str"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\cookies.py",
+        "line": 522,
+        "func_name": "BaseCookie.load",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\cookies.py",
+        "line": 536,
+        "func_name": "__parse_string",
+        "type_comments": [
+            "(str, re.Pattern) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\cookies.py",
+        "line": 597,
+        "func_name": "SimpleCookie",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\cookies.py",
+        "line": 604,
+        "func_name": "SimpleCookie.value_decode",
+        "type_comments": [
+            "(str) -> Tuple[str, str]"
+        ],
+        "samples": 13
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\server.py",
+        "line": 131,
+        "func_name": "HTTPServer",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\server.py",
+        "line": 143,
+        "func_name": "ThreadingHTTPServer",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\server.py",
+        "line": 147,
+        "func_name": "BaseHTTPRequestHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\server.py",
+        "line": 627,
+        "func_name": "SimpleHTTPRequestHandler",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\http\\server.py",
+        "line": 954,
+        "func_name": "CGIHTTPRequestHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 63,
+        "func_name": "ismodule",
+        "type_comments": [
+            "(type) -> bool",
+            "(frame) -> bool",
+            "(module) -> bool"
+        ],
+        "samples": 41
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 72,
+        "func_name": "isclass",
+        "type_comments": [
+            "(frame) -> bool"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 80,
+        "func_name": "ismethod",
+        "type_comments": [
+            "(frame) -> bool"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 158,
+        "func_name": "isfunction",
+        "type_comments": [
+            "(function) -> bool",
+            "(frame) -> bool"
+        ],
+        "samples": 10
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 228,
+        "func_name": "istraceback",
+        "type_comments": [
+            "(frame) -> bool"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 238,
+        "func_name": "isframe",
+        "type_comments": [
+            "(frame) -> bool"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 252,
+        "func_name": "iscode",
+        "type_comments": [
+            "(code) -> bool"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 478,
+        "func_name": "getmro",
+        "type_comments": [
+            "() -> Tuple[type, type]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 484,
+        "func_name": "unwrap",
+        "type_comments": [
+            "(function, function) -> function"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 504,
+        "func_name": "_is_wrapper",
+        "type_comments": [
+            "(function) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 642,
+        "func_name": "getfile",
+        "type_comments": [
+            "(module) -> str",
+            "(frame) -> str"
+        ],
+        "samples": 18
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 680,
+        "func_name": "getsourcefile",
+        "type_comments": [
+            "(module) -> str",
+            "(frame) -> str"
+        ],
+        "samples": 17
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 702,
+        "func_name": "getabsfile",
+        "type_comments": [
+            "(module, None) -> str",
+            "(frame, None) -> str"
+        ],
+        "samples": 17
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 714,
+        "func_name": "getmodule",
+        "type_comments": [
+            "(frame, None) -> module"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 2117,
+        "func_name": "_signature_from_function",
+        "type_comments": [
+            "(function) -> inspect.Signature"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 2198,
+        "func_name": "_signature_from_callable",
+        "type_comments": [
+            "(function, bool, bool, type) -> inspect.Signature"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 2467,
+        "func_name": "Parameter.__init__",
+        "type_comments": [
+            "(str, inspect._ParameterKind, type, type) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 2517,
+        "func_name": "name",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 2529,
+        "func_name": "kind",
+        "type_comments": [
+            "() -> inspect._ParameterKind"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 2579,
+        "func_name": "Parameter.__eq__",
+        "type_comments": [
+            "(inspect.Parameter) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 2750,
+        "func_name": "Signature.__init__",
+        "type_comments": [
+            "(List[inspect.Parameter], type, bool) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 2829,
+        "func_name": "from_callable",
+        "type_comments": [
+            "(function, bool) -> inspect.Signature"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 2835,
+        "func_name": "parameters",
+        "type_comments": [
+            "() -> mappingproxy"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 2839,
+        "func_name": "return_annotation",
+        "type_comments": [
+            "() -> type"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 2858,
+        "func_name": "Signature._hash_basis",
+        "type_comments": [
+            "() -> Tuple[Tuple[inspect.Parameter, inspect.Parameter], Dict, type]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 2872,
+        "func_name": "Signature.__eq__",
+        "type_comments": [
+            "(inspect.Signature) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\inspect.py",
+        "line": 3081,
+        "func_name": "signature",
+        "type_comments": [
+            "(function, bool) -> inspect.Signature"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\json\\__init__.py",
+        "line": 183,
+        "func_name": "dumps",
+        "type_comments": [
+            "(Dict[str, bool], bool, bool, bool, bool, None, None, None, None, bool) -> str",
+            "(Dict[str, Dict[str, Union[bool, int, str]]], bool, bool, bool, bool, None, None, None, None, bool) -> str",
+            "(Dict[str, Dict[str, Union[bool, str]]], bool, bool, bool, bool, None, None, None, None, bool) -> str",
+            "(Dict[str, Dict[str, Dict[str, Union[List[str], int, str]]]], bool, bool, bool, bool, None, None, None, None, bool) -> str",
+            "(Dict[str, Dict[str, Union[List[Dict[str, Union[int, str]]], str]]], bool, bool, bool, bool, None, None, None, None, bool) -> str"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\json\\decoder.py",
+        "line": 284,
+        "func_name": "JSONDecoder.__init__",
+        "type_comments": [
+            "(None, None, None, None, bool, None) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\json\\encoder.py",
+        "line": 104,
+        "func_name": "JSONEncoder.__init__",
+        "type_comments": [
+            "(bool, bool, bool, bool, bool, None, None, None) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\json\\encoder.py",
+        "line": 182,
+        "func_name": "JSONEncoder.encode",
+        "type_comments": [
+            "(Dict[str, bool]) -> str",
+            "(Dict[str, Dict[str, Union[bool, int, str]]]) -> str",
+            "(Dict[str, Dict[str, Union[bool, str]]]) -> str",
+            "(Dict[str, Dict[str, Dict[str, Union[List[str], int, str]]]]) -> str",
+            "(Dict[str, Dict[str, Union[List[Dict[str, Union[int, str]]], str]]]) -> str"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\json\\encoder.py",
+        "line": 204,
+        "func_name": "JSONEncoder.iterencode",
+        "type_comments": [
+            "(Dict[str, Dict[str, Union[List[Dict[str, Union[int, str]]], str]]], bool) -> List[str]",
+            "(Dict[str, Dict[str, Union[bool, str]]], bool) -> List[str]",
+            "(Dict[str, bool], bool) -> List[str]",
+            "(Dict[str, Dict[str, Union[bool, int, str]]], bool) -> List[str]",
+            "(Dict[str, Dict[str, Dict[str, Union[List[str], int, str]]]], bool) -> List[str]"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 117,
+        "func_name": "getLevelName",
+        "type_comments": [
+            "(int) -> str"
+        ],
+        "samples": 24
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 187,
+        "func_name": "_checkLevel",
+        "type_comments": [
+            "(int) -> int"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 212,
+        "func_name": "_acquireLock",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 221,
+        "func_name": "_releaseLock",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 232,
+        "func_name": "_register_at_fork_acquire_release",
+        "type_comments": [
+            "(__main__.GUIHandler) -> None",
+            "(logging.StreamHandler) -> None",
+            "(logging._StderrHandler) -> None",
+            "(logging.handlers.RotatingFileHandler) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 281,
+        "func_name": "LogRecord",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 293,
+        "func_name": "LogRecord.__init__",
+        "type_comments": [
+            "(str, int, str, int, str, Tuple[str, str, str], None, str, None) -> None",
+            "(str, int, str, int, str, Tuple[], None, str, None) -> None",
+            "(str, int, str, int, str, Tuple[str, str], None, str, None) -> None",
+            "(str, int, str, int, str, Tuple[int, str], None, str, None) -> None",
+            "(str, int, str, int, str, Tuple[float], None, str, None) -> None",
+            "(str, int, str, int, str, Tuple[int], None, str, None) -> None",
+            "(str, int, str, int, str, Tuple[List], None, str, None) -> None",
+            "(str, int, str, int, str, Tuple[str], None, str, None) -> None"
+        ],
+        "samples": 24
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 371,
+        "func_name": "LogRecord.getMessage",
+        "type_comments": [
+            "() -> pyannotate_runtime.collect_types.NoReturnType",
+            "() -> str"
+        ],
+        "samples": 49
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 420,
+        "func_name": "PercentStyle",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 426,
+        "func_name": "PercentStyle.__init__",
+        "type_comments": [
+            "(str) -> None",
+            "(None) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 429,
+        "func_name": "PercentStyle.usesTime",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 48
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 432,
+        "func_name": "PercentStyle.format",
+        "type_comments": [
+            "(logging.LogRecord) -> str"
+        ],
+        "samples": 48
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 435,
+        "func_name": "StrFormatStyle",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 444,
+        "func_name": "StringTemplateStyle",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 468,
+        "func_name": "Formatter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 513,
+        "func_name": "Formatter.__init__",
+        "type_comments": [
+            "(str, None, str) -> None",
+            "(None, None, str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 539,
+        "func_name": "Formatter.formatTime",
+        "type_comments": [
+            "(logging.LogRecord, None) -> str"
+        ],
+        "samples": 48
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 584,
+        "func_name": "Formatter.usesTime",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 48
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 590,
+        "func_name": "Formatter.formatMessage",
+        "type_comments": [
+            "(logging.LogRecord) -> str"
+        ],
+        "samples": 48
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 606,
+        "func_name": "Formatter.format",
+        "type_comments": [
+            "(logging.LogRecord) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(logging.LogRecord) -> str"
+        ],
+        "samples": 49
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 643,
+        "func_name": "BufferingFormatter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 685,
+        "func_name": "Filter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 722,
+        "func_name": "Filterer",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 727,
+        "func_name": "Filterer.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 747,
+        "func_name": "Filterer.filter",
+        "type_comments": [
+            "(logging.LogRecord) -> bool"
+        ],
+        "samples": 53
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 777,
+        "func_name": "_removeHandlerRef",
+        "type_comments": [
+            "(weakref) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 794,
+        "func_name": "_addHandlerRef",
+        "type_comments": [
+            "(logging.StreamHandler) -> None",
+            "(cherrypy._cplogging.NullHandler) -> None",
+            "(logging._StderrHandler) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 804,
+        "func_name": "Handler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 813,
+        "func_name": "Handler.__init__",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 842,
+        "func_name": "Handler.createLock",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 849,
+        "func_name": "Handler.acquire",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 63
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 856,
+        "func_name": "Handler.release",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 63
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 863,
+        "func_name": "Handler.setLevel",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 869,
+        "func_name": "Handler.format",
+        "type_comments": [
+            "(logging.LogRecord) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(logging.LogRecord) -> str"
+        ],
+        "samples": 49
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 892,
+        "func_name": "Handler.handle",
+        "type_comments": [
+            "(logging.LogRecord) -> bool"
+        ],
+        "samples": 34
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 910,
+        "func_name": "Handler.setFormatter",
+        "type_comments": [
+            "(logging.Formatter) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 942,
+        "func_name": "Handler.handleError",
+        "type_comments": [
+            "(logging.LogRecord) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 991,
+        "func_name": "StreamHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1000,
+        "func_name": "StreamHandler.__init__",
+        "type_comments": [
+            "(None) -> None",
+            "(_io.TextIOWrapper) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1011,
+        "func_name": "StreamHandler.flush",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 34
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1022,
+        "func_name": "StreamHandler.emit",
+        "type_comments": [
+            "(logging.LogRecord) -> None"
+        ],
+        "samples": 34
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1070,
+        "func_name": "FileHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1074,
+        "func_name": "FileHandler.__init__",
+        "type_comments": [
+            "(str, str, None, bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1116,
+        "func_name": "FileHandler._open",
+        "type_comments": [
+            "() -> _io.TextIOWrapper"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1123,
+        "func_name": "FileHandler.emit",
+        "type_comments": [
+            "(logging.LogRecord) -> None"
+        ],
+        "samples": 19
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1139,
+        "func_name": "_StderrHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1145,
+        "func_name": "_StderrHandler.__init__",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1163,
+        "func_name": "PlaceHolder",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1169,
+        "func_name": "PlaceHolder.__init__",
+        "type_comments": [
+            "(logging.Logger) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1175,
+        "func_name": "PlaceHolder.append",
+        "type_comments": [
+            "(logging.Logger) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1205,
+        "func_name": "Manager",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1210,
+        "func_name": "Manager.__init__",
+        "type_comments": [
+            "(logging.RootLogger) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1221,
+        "func_name": "Manager.getLogger",
+        "type_comments": [
+            "(str) -> logging.Logger"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1272,
+        "func_name": "Manager._fixupParents",
+        "type_comments": [
+            "(logging.Logger) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1309,
+        "func_name": "Manager._clear_cache",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1326,
+        "func_name": "Logger",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1341,
+        "func_name": "Logger.__init__",
+        "type_comments": [
+            "(str, int) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1354,
+        "func_name": "Logger.setLevel",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1361,
+        "func_name": "Logger.debug",
+        "type_comments": [
+            "(str, *str) -> None",
+            "(str) -> None",
+            "(str, *int) -> None"
+        ],
+        "samples": 13
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1373,
+        "func_name": "Logger.info",
+        "type_comments": [
+            "(str, *str) -> None",
+            "(str) -> None",
+            "(str, *Union[int, str]) -> None"
+        ],
+        "samples": 11
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1434,
+        "func_name": "Logger.log",
+        "type_comments": [
+            "(int, str) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1451,
+        "func_name": "Logger.findCaller",
+        "type_comments": [
+            "(bool) -> Tuple[str, int, str, None]"
+        ],
+        "samples": 24
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1481,
+        "func_name": "Logger.makeRecord",
+        "type_comments": [
+            "(str, int, str, int, str, Tuple[str, str, str], None, str, None, None) -> logging.LogRecord",
+            "(str, int, str, int, str, Tuple[], None, str, None, None) -> logging.LogRecord",
+            "(str, int, str, int, str, Tuple[str, str], None, str, None, None) -> logging.LogRecord",
+            "(str, int, str, int, str, Tuple[int, str], None, str, None, None) -> logging.LogRecord",
+            "(str, int, str, int, str, Tuple[str], None, str, None, None) -> logging.LogRecord",
+            "(str, int, str, int, str, Tuple[float], None, str, None, None) -> logging.LogRecord",
+            "(str, int, str, int, str, Tuple[int], None, str, None, None) -> logging.LogRecord",
+            "(str, int, str, int, str, Tuple[List], None, str, None, None) -> logging.LogRecord"
+        ],
+        "samples": 24
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1496,
+        "func_name": "Logger._log",
+        "type_comments": [
+            "(int, str, Tuple[str, str, str], None, None, bool) -> None",
+            "(int, str, Tuple[], None, None, bool) -> None",
+            "(int, str, Tuple[str, str], None, None, bool) -> None",
+            "(int, str, Tuple[int, str], None, None, bool) -> None",
+            "(int, str, Tuple[float], None, None, bool) -> None",
+            "(int, str, Tuple[int], None, None, bool) -> None",
+            "(int, str, Tuple[List], None, None, bool) -> None",
+            "(int, str, Tuple[str], None, None, bool) -> None"
+        ],
+        "samples": 24
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1521,
+        "func_name": "Logger.handle",
+        "type_comments": [
+            "(logging.LogRecord) -> None"
+        ],
+        "samples": 24
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1531,
+        "func_name": "Logger.addHandler",
+        "type_comments": [
+            "(__main__.GUIHandler) -> None",
+            "(logging.StreamHandler) -> None",
+            "(cherrypy._cplogging.NullHandler) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1575,
+        "func_name": "Logger.callHandlers",
+        "type_comments": [
+            "(logging.LogRecord) -> None"
+        ],
+        "samples": 24
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1605,
+        "func_name": "Logger.getEffectiveLevel",
+        "type_comments": [
+            "() -> int"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1619,
+        "func_name": "Logger.isEnabledFor",
+        "type_comments": [
+            "(int) -> bool"
+        ],
+        "samples": 24
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1667,
+        "func_name": "RootLogger",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1673,
+        "func_name": "RootLogger.__init__",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1684,
+        "func_name": "LoggerAdapter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1930,
+        "func_name": "getLogger",
+        "type_comments": [
+            "(str) -> logging.Logger",
+            "(str) -> logging.RootLogger"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1986,
+        "func_name": "info",
+        "type_comments": [
+            "(str, *str) -> None",
+            "(str) -> None",
+            "(str, *Union[int, str]) -> None"
+        ],
+        "samples": 11
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 1996,
+        "func_name": "debug",
+        "type_comments": [
+            "(str, *str) -> None",
+            "(str) -> None",
+            "(str, *int) -> None"
+        ],
+        "samples": 13
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\__init__.py",
+        "line": 2059,
+        "func_name": "NullHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\handlers.py",
+        "line": 44,
+        "func_name": "BaseRotatingHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\handlers.py",
+        "line": 50,
+        "func_name": "BaseRotatingHandler.__init__",
+        "type_comments": [
+            "(str, str, None, bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\handlers.py",
+        "line": 60,
+        "func_name": "BaseRotatingHandler.emit",
+        "type_comments": [
+            "(logging.LogRecord) -> None"
+        ],
+        "samples": 19
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\handlers.py",
+        "line": 114,
+        "func_name": "RotatingFileHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\handlers.py",
+        "line": 119,
+        "func_name": "RotatingFileHandler.__init__",
+        "type_comments": [
+            "(str, str, int, int, None, bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\handlers.py",
+        "line": 174,
+        "func_name": "RotatingFileHandler.shouldRollover",
+        "type_comments": [
+            "(logging.LogRecord) -> int"
+        ],
+        "samples": 18
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\handlers.py",
+        "line": 190,
+        "func_name": "TimedRotatingFileHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\handlers.py",
+        "line": 413,
+        "func_name": "WatchedFileHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\handlers.py",
+        "line": 482,
+        "func_name": "SocketHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\handlers.py",
+        "line": 649,
+        "func_name": "DatagramHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\handlers.py",
+        "line": 691,
+        "func_name": "SysLogHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\handlers.py",
+        "line": 945,
+        "func_name": "SMTPHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\handlers.py",
+        "line": 1025,
+        "func_name": "NTEventLogHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\handlers.py",
+        "line": 1123,
+        "func_name": "HTTPHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\handlers.py",
+        "line": 1202,
+        "func_name": "BufferingHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\handlers.py",
+        "line": 1259,
+        "func_name": "MemoryHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\handlers.py",
+        "line": 1332,
+        "func_name": "QueueHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\logging\\handlers.py",
+        "line": 1399,
+        "func_name": "QueueListener",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\lzma.py",
+        "line": 38,
+        "func_name": "LZMAFile",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\mimetypes.py",
+        "line": 58,
+        "func_name": "MimeTypes",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\mimetypes.py",
+        "line": 66,
+        "func_name": "MimeTypes.__init__",
+        "type_comments": [
+            "(Tuple[], bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\mimetypes.py",
+        "line": 80,
+        "func_name": "MimeTypes.add_type",
+        "type_comments": [
+            "(str, str, bool) -> None"
+        ],
+        "samples": 15
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\mimetypes.py",
+        "line": 230,
+        "func_name": "MimeTypes.read_windows_registry",
+        "type_comments": [
+            "(bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\mimetypes.py",
+        "line": 243,
+        "func_name": "enum_types",
+        "type_comments": [
+            "(PyHKEY) -> Iterator[str]"
+        ],
+        "samples": 119
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\mimetypes.py",
+        "line": 344,
+        "func_name": "init",
+        "type_comments": [
+            "(None) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\mimetypes.py",
+        "line": 375,
+        "func_name": "_default_mime_types",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\context.py",
+        "line": 14,
+        "func_name": "ProcessError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\context.py",
+        "line": 17,
+        "func_name": "BufferTooShort",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\context.py",
+        "line": 20,
+        "func_name": "TimeoutError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\context.py",
+        "line": 23,
+        "func_name": "AuthenticationError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\context.py",
+        "line": 30,
+        "func_name": "BaseContext",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\context.py",
+        "line": 202,
+        "func_name": "reducer",
+        "type_comments": [
+            "() -> module"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\context.py",
+        "line": 219,
+        "func_name": "Process",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\context.py",
+        "line": 225,
+        "func_name": "DefaultContext",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\context.py",
+        "line": 228,
+        "func_name": "DefaultContext.__init__",
+        "type_comments": [
+            "(multiprocessing.context.SpawnContext) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\context.py",
+        "line": 232,
+        "func_name": "DefaultContext.get_context",
+        "type_comments": [
+            "(None) -> multiprocessing.context.SpawnContext"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\context.py",
+        "line": 317,
+        "func_name": "SpawnProcess",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\context.py",
+        "line": 324,
+        "func_name": "SpawnContext",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\dummy\\__init__.py",
+        "line": 34,
+        "func_name": "DummyProcess",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\dummy\\__init__.py",
+        "line": 36,
+        "func_name": "DummyProcess.__init__",
+        "type_comments": [
+            "(None, function, None, Tuple[_queue.SimpleQueue, _queue.SimpleQueue, None, Tuple[], None, bool], Dict) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\dummy\\__init__.py",
+        "line": 43,
+        "func_name": "DummyProcess.start",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\dummy\\__init__.py",
+        "line": 53,
+        "func_name": "exitcode",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 55
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\dummy\\__init__.py",
+        "line": 82,
+        "func_name": "Namespace",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\dummy\\__init__.py",
+        "line": 100,
+        "func_name": "Value",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\dummy\\connection.py",
+        "line": 18,
+        "func_name": "Listener",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\dummy\\connection.py",
+        "line": 51,
+        "func_name": "Connection",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 53,
+        "func_name": "RemoteTraceback",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 59,
+        "func_name": "ExceptionWithTraceback",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 76,
+        "func_name": "MaybeEncodingError",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 93,
+        "func_name": "worker",
+        "type_comments": [
+            "(_queue.SimpleQueue, _queue.SimpleQueue, None, Tuple[], None, bool) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 146,
+        "func_name": "Pool",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 155,
+        "func_name": "Pool.__init__",
+        "type_comments": [
+            "(int, None, Tuple[], None, None) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 212,
+        "func_name": "Pool._join_exited_workers",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 56
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 227,
+        "func_name": "Pool._repopulate_pool",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 244,
+        "func_name": "Pool._maintain_pool",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 56
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 356,
+        "func_name": "Pool.apply_async",
+        "type_comments": [
+            "(function, Tuple[str], Dict, None, None) -> multiprocessing.pool.ApplyResult"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 405,
+        "func_name": "_handle_workers",
+        "type_comments": [
+            "(multiprocessing.pool.ThreadPool) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 418,
+        "func_name": "_handle_tasks",
+        "type_comments": [
+            "(_queue.SimpleQueue, builtin_function_or_method, _queue.SimpleQueue, List[multiprocessing.dummy.DummyProcess], Dict) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 464,
+        "func_name": "_handle_results",
+        "type_comments": [
+            "(_queue.SimpleQueue, builtin_function_or_method, Dict) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 629,
+        "func_name": "ApplyResult",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 631,
+        "func_name": "ApplyResult.__init__",
+        "type_comments": [
+            "(Dict, None, None) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 639,
+        "func_name": "ApplyResult.ready",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 647,
+        "func_name": "ApplyResult.wait",
+        "type_comments": [
+            "(float) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 650,
+        "func_name": "ApplyResult.get",
+        "type_comments": [
+            "(float) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(float) -> List[Tuple[socket.AddressFamily, int, int, str, Tuple[str, int]]]"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 659,
+        "func_name": "ApplyResult._set",
+        "type_comments": [
+            "(int, Tuple[bool, socket.gaierror]) -> None",
+            "(int, Tuple[bool, List[Tuple[socket.AddressFamily, int, int, str, Tuple[str, int]]]]) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 674,
+        "func_name": "MapResult",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 715,
+        "func_name": "IMapIterator",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 779,
+        "func_name": "IMapUnorderedIterator",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 793,
+        "func_name": "ThreadPool",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 796,
+        "func_name": "Process",
+        "type_comments": [
+            "() -> multiprocessing.dummy.DummyProcess"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 801,
+        "func_name": "ThreadPool.__init__",
+        "type_comments": [
+            "(int, None, Tuple[]) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\pool.py",
+        "line": 804,
+        "func_name": "ThreadPool._setup_queues",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\process.py",
+        "line": 36,
+        "func_name": "current_process",
+        "type_comments": [
+            "() -> multiprocessing.process._MainProcess"
+        ],
+        "samples": 24
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\process.py",
+        "line": 63,
+        "func_name": "BaseProcess",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\process.py",
+        "line": 180,
+        "func_name": "name",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 24
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\process.py",
+        "line": 325,
+        "func_name": "AuthenticationString",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\process.py",
+        "line": 339,
+        "func_name": "_MainProcess",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\process.py",
+        "line": 341,
+        "func_name": "_MainProcess.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\reduction.py",
+        "line": 33,
+        "func_name": "ForkingPickler",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\reduction.py",
+        "line": 43,
+        "func_name": "register",
+        "type_comments": [
+            "(type, function) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\reduction.py",
+        "line": 100,
+        "func_name": "DupHandle",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\reduction.py",
+        "line": 207,
+        "func_name": "_C",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\reduction.py",
+        "line": 247,
+        "func_name": "AbstractReducer",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\util.py",
+        "line": 48,
+        "func_name": "debug",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\util.py",
+        "line": 147,
+        "func_name": "Finalize",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\util.py",
+        "line": 151,
+        "func_name": "Finalize.__init__",
+        "type_comments": [
+            "(multiprocessing.pool.ThreadPool, method, Tuple[_queue.SimpleQueue, _queue.SimpleQueue, _queue.SimpleQueue, List[multiprocessing.dummy.DummyProcess], threading.Thread, threading.Thread, threading.Thread, Dict], None, int) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\util.py",
+        "line": 333,
+        "func_name": "ForkAwareThreadLock",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\multiprocessing\\util.py",
+        "line": 350,
+        "func_name": "ForkAwareLocal",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\nntplib.py",
+        "line": 96,
+        "func_name": "NNTPError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\nntplib.py",
+        "line": 105,
+        "func_name": "NNTPReplyError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\nntplib.py",
+        "line": 109,
+        "func_name": "NNTPTemporaryError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\nntplib.py",
+        "line": 113,
+        "func_name": "NNTPPermanentError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\nntplib.py",
+        "line": 117,
+        "func_name": "NNTPProtocolError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\nntplib.py",
+        "line": 121,
+        "func_name": "NNTPDataError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\nntplib.py",
+        "line": 296,
+        "func_name": "_NNTPBase",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\nntplib.py",
+        "line": 1019,
+        "func_name": "NNTP",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\nntplib.py",
+        "line": 1065,
+        "func_name": "NNTP_SSL",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\numbers.py",
+        "line": 12,
+        "func_name": "Number",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\numbers.py",
+        "line": 32,
+        "func_name": "Complex",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\numbers.py",
+        "line": 147,
+        "func_name": "Real",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\numbers.py",
+        "line": 267,
+        "func_name": "Rational",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\numbers.py",
+        "line": 294,
+        "func_name": "Integral",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\pickle.py",
+        "line": 68,
+        "func_name": "PicklingError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\pickle.py",
+        "line": 75,
+        "func_name": "UnpicklingError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\pickle.py",
+        "line": 88,
+        "func_name": "_Stop",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\pickle.py",
+        "line": 184,
+        "func_name": "_Framer",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\pickle.py",
+        "line": 247,
+        "func_name": "_Unframer",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\pickle.py",
+        "line": 372,
+        "func_name": "_Pickler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\pickle.py",
+        "line": 1021,
+        "func_name": "_Unpickler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\pkgutil.py",
+        "line": 194,
+        "func_name": "ImpImporter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\pkgutil.py",
+        "line": 268,
+        "func_name": "ImpLoader",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\pkgutil.py",
+        "line": 405,
+        "func_name": "get_importer",
+        "type_comments": [
+            "(str) -> _frozen_importlib_external.FileFinder",
+            "(str) -> None"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\pkgutil.py",
+        "line": 503,
+        "func_name": "extend_path",
+        "type_comments": [
+            "(List[str], str) -> List[str]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\platform.py",
+        "line": 533,
+        "func_name": "win32_ver",
+        "type_comments": [
+            "(str, str, str, str) -> Tuple[str, str, str, str]"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\platform.py",
+        "line": 722,
+        "func_name": "_platform",
+        "type_comments": [
+            "(*str) -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\platform.py",
+        "line": 754,
+        "func_name": "_node",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\platform.py",
+        "line": 923,
+        "func_name": "uname",
+        "type_comments": [
+            "() -> platform.uname_result"
+        ],
+        "samples": 32
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\platform.py",
+        "line": 1061,
+        "func_name": "system",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 11
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\platform.py",
+        "line": 1080,
+        "func_name": "release",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 11
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\platform.py",
+        "line": 1089,
+        "func_name": "version",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 11
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\platform.py",
+        "line": 1098,
+        "func_name": "machine",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 11
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\platform.py",
+        "line": 1149,
+        "func_name": "_sys_version",
+        "type_comments": [
+            "(None) -> Tuple[str, str, str, str, str, str, str]"
+        ],
+        "samples": 25
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\platform.py",
+        "line": 1253,
+        "func_name": "python_implementation",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 11
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\platform.py",
+        "line": 1266,
+        "func_name": "python_version",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 18
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\platform.py",
+        "line": 1334,
+        "func_name": "platform",
+        "type_comments": [
+            "(int, int) -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\plistlib.py",
+        "line": 139,
+        "func_name": "Data",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\plistlib.py",
+        "line": 247,
+        "func_name": "_PlistParser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\plistlib.py",
+        "line": 351,
+        "func_name": "_DumbXMLWriter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\plistlib.py",
+        "line": 389,
+        "func_name": "_PlistWriter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\plistlib.py",
+        "line": 522,
+        "func_name": "InvalidFileException",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\plistlib.py",
+        "line": 530,
+        "func_name": "_BinaryPlistParser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\plistlib.py",
+        "line": 699,
+        "func_name": "_BinaryPlistWriter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\pprint.py",
+        "line": 72,
+        "func_name": "_safe_key",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\pprint.py",
+        "line": 98,
+        "func_name": "PrettyPrinter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\pydoc.py",
+        "line": 293,
+        "func_name": "ErrorDuringImport",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\pydoc.py",
+        "line": 369,
+        "func_name": "Doc",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\pydoc.py",
+        "line": 431,
+        "func_name": "HTMLRepr",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\pydoc.py",
+        "line": 433,
+        "func_name": "HTMLRepr.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\pydoc.py",
+        "line": 473,
+        "func_name": "HTMLDoc",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\pydoc.py",
+        "line": 1040,
+        "func_name": "TextRepr",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\pydoc.py",
+        "line": 1042,
+        "func_name": "TextRepr.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\pydoc.py",
+        "line": 1072,
+        "func_name": "TextDoc",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\pydoc.py",
+        "line": 1438,
+        "func_name": "_PlainTextDoc",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\pydoc.py",
+        "line": 1696,
+        "func_name": "Helper",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\pydoc.py",
+        "line": 1871,
+        "func_name": "Helper.__init__",
+        "type_comments": [
+            "(None, None) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\pydoc.py",
+        "line": 2101,
+        "func_name": "ModuleScanner",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\queue.py",
+        "line": 33,
+        "func_name": "Queue.__init__",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\queue.py",
+        "line": 91,
+        "func_name": "Queue.qsize",
+        "type_comments": [
+            "() -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 98
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\queue.py",
+        "line": 96,
+        "func_name": "Queue.empty",
+        "type_comments": [
+            "() -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\queue.py",
+        "line": 121,
+        "func_name": "Queue.put",
+        "type_comments": [
+            "(Tuple[sabnzbd.nzbstuff.NzbObject, sabnzbd.nzbstuff.NzbFile], bool, None) -> None",
+            "(Tuple[sabnzbd.nzbstuff.Article, List, List[bytes]], bool, None) -> None",
+            "(cheroot.server.HTTPConnection, bool, int) -> None"
+        ],
+        "samples": 52
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\queue.py",
+        "line": 153,
+        "func_name": "Queue.get",
+        "type_comments": [
+            "(bool, None) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(bool, None) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 53
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\queue.py",
+        "line": 205,
+        "func_name": "Queue._init",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\queue.py",
+        "line": 208,
+        "func_name": "Queue._qsize",
+        "type_comments": [
+            "() -> int"
+        ],
+        "samples": 182
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\queue.py",
+        "line": 212,
+        "func_name": "Queue._put",
+        "type_comments": [
+            "(Tuple[sabnzbd.nzbstuff.NzbObject, sabnzbd.nzbstuff.NzbFile]) -> None",
+            "(Tuple[sabnzbd.nzbstuff.Article, List, List[bytes]]) -> None",
+            "(cheroot.server.HTTPConnection) -> None"
+        ],
+        "samples": 52
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\queue.py",
+        "line": 216,
+        "func_name": "Queue._get",
+        "type_comments": [
+            "() -> Tuple[sabnzbd.nzbstuff.NzbObject, sabnzbd.nzbstuff.NzbFile]",
+            "() -> Tuple[sabnzbd.nzbstuff.Article, List, List[bytes]]",
+            "() -> cheroot.server.HTTPConnection"
+        ],
+        "samples": 52
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\sched.py",
+        "line": 34,
+        "func_name": "Event",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\sched.py",
+        "line": 37,
+        "func_name": "__lt__",
+        "type_comments": [
+            "(sched.Event, sched.Event) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\sched.py",
+        "line": 55,
+        "func_name": "scheduler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\sched.py",
+        "line": 57,
+        "func_name": "scheduler.__init__",
+        "type_comments": [
+            "(builtin_function_or_method, method) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\sched.py",
+        "line": 65,
+        "func_name": "scheduler.enterabs",
+        "type_comments": [
+            "(float, int, sabnzbd.utils.kronos.SingleTask, Tuple[weakref], object) -> sched.Event",
+            "(float, int, sabnzbd.utils.kronos.WeekdayTask, Tuple[weakref], object) -> sched.Event",
+            "(float, int, sabnzbd.utils.kronos.IntervalTask, Tuple[weakref], object) -> sched.Event"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\sched.py",
+        "line": 79,
+        "func_name": "scheduler.enter",
+        "type_comments": [
+            "(int, int, sabnzbd.utils.kronos.IntervalTask, Tuple[weakref], object) -> sched.Event",
+            "(int, int, sabnzbd.utils.kronos.SingleTask, Tuple[weakref], object) -> sched.Event"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\selectors.py",
+        "line": 60,
+        "func_name": "_SelectorMapping",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\selectors.py",
+        "line": 80,
+        "func_name": "BaseSelector",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\selectors.py",
+        "line": 206,
+        "func_name": "_BaseSelectorImpl",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\selectors.py",
+        "line": 290,
+        "func_name": "SelectSelector",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\selectors.py",
+        "line": 341,
+        "func_name": "_PollLikeSelector",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\shlex.py",
+        "line": 19,
+        "func_name": "shlex",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\signal.py",
+        "line": 25,
+        "func_name": "_int_to_enum",
+        "type_comments": [
+            "(builtin_function_or_method, enum.EnumMeta) -> builtin_function_or_method",
+            "(int, enum.EnumMeta) -> signal.Handlers"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\signal.py",
+        "line": 45,
+        "func_name": "signal",
+        "type_comments": [
+            "(signal.Signals, function) -> builtin_function_or_method",
+            "(signal.Signals, function) -> signal.Handlers"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\smtplib.py",
+        "line": 71,
+        "func_name": "SMTPException",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\smtplib.py",
+        "line": 74,
+        "func_name": "SMTPNotSupportedError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\smtplib.py",
+        "line": 81,
+        "func_name": "SMTPServerDisconnected",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\smtplib.py",
+        "line": 89,
+        "func_name": "SMTPResponseException",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\smtplib.py",
+        "line": 103,
+        "func_name": "SMTPSenderRefused",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\smtplib.py",
+        "line": 116,
+        "func_name": "SMTPRecipientsRefused",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\smtplib.py",
+        "line": 129,
+        "func_name": "SMTPDataError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\smtplib.py",
+        "line": 132,
+        "func_name": "SMTPConnectError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\smtplib.py",
+        "line": 135,
+        "func_name": "SMTPHeloError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\smtplib.py",
+        "line": 138,
+        "func_name": "SMTPAuthenticationError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\smtplib.py",
+        "line": 189,
+        "func_name": "SMTP",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\smtplib.py",
+        "line": 994,
+        "func_name": "SMTP_SSL",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\smtplib.py",
+        "line": 1049,
+        "func_name": "LMTP",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socket.py",
+        "line": 97,
+        "func_name": "_intenum_converter",
+        "type_comments": [
+            "(int, enum.EnumMeta) -> socket.AddressFamily",
+            "(int, enum.EnumMeta) -> socket.SocketKind",
+            "(int, enum.EnumMeta) -> int"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socket.py",
+        "line": 130,
+        "func_name": "_GiveupOnSendfile",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socket.py",
+        "line": 133,
+        "func_name": "socket",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socket.py",
+        "line": 139,
+        "func_name": "socket.__init__",
+        "type_comments": [
+            "(socket.AddressFamily, int, int, None) -> None",
+            "(socket.AddressFamily, socket.SocketKind, int, None) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socket.py",
+        "line": 162,
+        "func_name": "socket.__repr__",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socket.py",
+        "line": 205,
+        "func_name": "socket.accept",
+        "type_comments": [
+            "() -> Tuple[socket.socket, Tuple[str, int]]",
+            "() -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socket.py",
+        "line": 221,
+        "func_name": "socket.makefile",
+        "type_comments": [
+            "(str, None, None, None, None) -> _io.BufferedReader"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socket.py",
+        "line": 406,
+        "func_name": "socket._decref_socketios",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socket.py",
+        "line": 412,
+        "func_name": "socket._real_close",
+        "type_comments": [
+            "(type) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socket.py",
+        "line": 416,
+        "func_name": "socket.close",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socket.py",
+        "line": 422,
+        "func_name": "socket.detach",
+        "type_comments": [
+            "() -> int"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socket.py",
+        "line": 432,
+        "func_name": "family",
+        "type_comments": [
+            "() -> socket.AddressFamily"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socket.py",
+        "line": 438,
+        "func_name": "type",
+        "type_comments": [
+            "() -> socket.SocketKind"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socket.py",
+        "line": 546,
+        "func_name": "SocketIO",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socket.py",
+        "line": 563,
+        "func_name": "SocketIO.__init__",
+        "type_comments": [
+            "(ssl.SSLSocket, str) -> None",
+            "(socket.socket, str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socket.py",
+        "line": 575,
+        "func_name": "SocketIO.readinto",
+        "type_comments": [
+            "(bytearray) -> pyannotate_runtime.collect_types.UnknownType",
+            "(bytearray) -> int",
+            "(memoryview) -> int"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socket.py",
+        "line": 598,
+        "func_name": "SocketIO.write",
+        "type_comments": [
+            "(bytes) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(bytes) -> pyannotate_runtime.collect_types.UnknownType",
+            "(bytes) -> int"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socket.py",
+        "line": 614,
+        "func_name": "SocketIO.readable",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 11
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socket.py",
+        "line": 621,
+        "func_name": "SocketIO.writable",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socket.py",
+        "line": 652,
+        "func_name": "SocketIO.close",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socket.py",
+        "line": 691,
+        "func_name": "create_connection",
+        "type_comments": [
+            "(Tuple[str, int], int, None) -> socket.socket",
+            "(Tuple[str, int], object, None) -> socket.socket"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socket.py",
+        "line": 731,
+        "func_name": "getaddrinfo",
+        "type_comments": [
+            "(str, int, socket.AddressFamily, int, int, int) -> List[Tuple[socket.AddressFamily, int, int, str, Tuple[str, int]]]",
+            "(str, None, int, int, int, int) -> List[Tuple[socket.AddressFamily, int, int, str, Tuple[str, int, int, int]]]",
+            "(str, int, int, socket.SocketKind, int, int) -> List[Tuple[socket.AddressFamily, socket.SocketKind, int, str, Tuple[str, int]]]",
+            "(str, int, socket.AddressFamily, socket.SocketKind, int, int) -> List[Tuple[socket.AddressFamily, socket.SocketKind, int, str, Tuple[str, int]]]",
+            "(str, None, int, int, int, int) -> List[Union[Tuple[socket.AddressFamily, int, int, str, Tuple[str, int, int, int]], Tuple[socket.AddressFamily, int, int, str, Tuple[str, int]]]]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socketserver.py",
+        "line": 153,
+        "func_name": "BaseServer",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socketserver.py",
+        "line": 390,
+        "func_name": "TCPServer",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socketserver.py",
+        "line": 516,
+        "func_name": "UDPServer",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socketserver.py",
+        "line": 631,
+        "func_name": "ThreadingMixIn",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socketserver.py",
+        "line": 681,
+        "func_name": "ThreadingUDPServer",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socketserver.py",
+        "line": 682,
+        "func_name": "ThreadingTCPServer",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socketserver.py",
+        "line": 696,
+        "func_name": "BaseRequestHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socketserver.py",
+        "line": 742,
+        "func_name": "StreamRequestHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socketserver.py",
+        "line": 787,
+        "func_name": "_SocketWriter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\socketserver.py",
+        "line": 806,
+        "func_name": "DatagramRequestHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\sqlite3\\dbapi2.py",
+        "line": 56,
+        "func_name": "register_adapters_and_converters",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 158,
+        "func_name": "TLSVersion",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 351,
+        "func_name": "_ASN1Object",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 356,
+        "func_name": "__new__",
+        "type_comments": [
+            "(str) -> ssl._ASN1Object",
+            "(str) -> Purpose"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 372,
+        "func_name": "Purpose",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 379,
+        "func_name": "SSLContext",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 387,
+        "func_name": "__new__",
+        "type_comments": [
+            "(ssl._SSLMethod) -> ssl.SSLContext"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 391,
+        "func_name": "SSLContext._encode_hostname",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 399,
+        "func_name": "SSLContext.wrap_socket",
+        "type_comments": [
+            "(socket.socket, bool, bool, bool, str, None) -> ssl.SSLSocket"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 460,
+        "func_name": "SSLContext._load_windows_store_certs",
+        "type_comments": [
+            "(str, Purpose) -> bytearray"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 474,
+        "func_name": "SSLContext.load_default_certs",
+        "type_comments": [
+            "(Purpose) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 538,
+        "func_name": "verify_mode",
+        "type_comments": [
+            "() -> ssl.VerifyMode"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 546,
+        "func_name": "verify_mode",
+        "type_comments": [
+            "(ssl.VerifyMode) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 551,
+        "func_name": "create_default_context",
+        "type_comments": [
+            "(Purpose, None, None, None) -> ssl.SSLContext"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 631,
+        "func_name": "SSLObject",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 784,
+        "func_name": "SSLSocket",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 796,
+        "func_name": "_create",
+        "type_comments": [
+            "(socket.socket, bool, bool, bool, str, ssl.SSLContext, None) -> ssl.SSLSocket"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 859,
+        "func_name": "context",
+        "type_comments": [
+            "() -> ssl.SSLContext"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 890,
+        "func_name": "SSLSocket._checkClosed",
+        "type_comments": [
+            "(None) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 894,
+        "func_name": "SSLSocket._check_connected",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 902,
+        "func_name": "SSLSocket.read",
+        "type_comments": [
+            "(int, memoryview) -> int"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 977,
+        "func_name": "SSLSocket.send",
+        "type_comments": [
+            "(memoryview, int) -> int"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 1004,
+        "func_name": "SSLSocket.sendall",
+        "type_comments": [
+            "(bytes, int) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 1041,
+        "func_name": "SSLSocket.recv_into",
+        "type_comments": [
+            "(memoryview, None, int) -> int"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 1106,
+        "func_name": "SSLSocket._real_close",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 1110,
+        "func_name": "SSLSocket.do_handshake",
+        "type_comments": [
+            "(bool) -> None",
+            "(bool) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 1121,
+        "func_name": "SSLSocket._real_connect",
+        "type_comments": [
+            "(Tuple[str, int], bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\ssl.py",
+        "line": 1147,
+        "func_name": "SSLSocket.connect",
+        "type_comments": [
+            "(Tuple[str, int]) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\string.py",
+        "line": 55,
+        "func_name": "_TemplateMetaclass",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\string.py",
+        "line": 65,
+        "func_name": "__init__",
+        "type_comments": [
+            "(str, Tuple[], Dict[str, str]) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\string.py",
+        "line": 78,
+        "func_name": "Template",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\string.py",
+        "line": 175,
+        "func_name": "Formatter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\subprocess.py",
+        "line": 57,
+        "func_name": "SubprocessError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\subprocess.py",
+        "line": 60,
+        "func_name": "CalledProcessError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\subprocess.py",
+        "line": 97,
+        "func_name": "TimeoutExpired",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\subprocess.py",
+        "line": 129,
+        "func_name": "STARTUPINFO",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\subprocess.py",
+        "line": 130,
+        "func_name": "STARTUPINFO.__init__",
+        "type_comments": [
+            "(int, None, None, None, int, Dict[str, List]) -> None",
+            "(int, None, None, None, int, None) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\subprocess.py",
+        "line": 139,
+        "func_name": "STARTUPINFO._copy",
+        "type_comments": [
+            "() -> subprocess.STARTUPINFO"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\subprocess.py",
+        "line": 199,
+        "func_name": "Handle",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\subprocess.py",
+        "line": 202,
+        "func_name": "Handle.Close",
+        "type_comments": [
+            "(builtin_function_or_method) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\subprocess.py",
+        "line": 207,
+        "func_name": "Handle.Detach",
+        "type_comments": [
+            "() -> int"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\subprocess.py",
+        "line": 226,
+        "func_name": "_cleanup",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\subprocess.py",
+        "line": 398,
+        "func_name": "CompletedProcess",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\subprocess.py",
+        "line": 608,
+        "func_name": "Popen",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\subprocess.py",
+        "line": 656,
+        "func_name": "Popen.__init__",
+        "type_comments": [
+            "(str, int, None, int, int, int, None, bool, bool, None, None, None, subprocess.STARTUPINFO, int, bool, bool, Tuple[], None, None, None) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\subprocess.py",
+        "line": 850,
+        "func_name": "Popen.__del__",
+        "type_comments": [
+            "(int, builtin_function_or_method) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\subprocess.py",
+        "line": 1013,
+        "func_name": "Popen._get_handles",
+        "type_comments": [
+            "(int, int, int) -> Tuple[subprocess.Handle, subprocess.Handle, subprocess.Handle, subprocess.Handle, int, subprocess.Handle]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\subprocess.py",
+        "line": 1085,
+        "func_name": "Popen._make_inheritable",
+        "type_comments": [
+            "(subprocess.Handle) -> subprocess.Handle"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\subprocess.py",
+        "line": 1094,
+        "func_name": "Popen._filter_handle_list",
+        "type_comments": [
+            "(List[int]) -> List[int]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\subprocess.py",
+        "line": 1107,
+        "func_name": "Popen._execute_child",
+        "type_comments": [
+            "(str, None, None, bool, Tuple[], None, None, subprocess.STARTUPINFO, int, bool, subprocess.Handle, int, int, subprocess.Handle, int, subprocess.Handle, bool, bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\subprocess.py",
+        "line": 1204,
+        "func_name": "Popen._internal_poll",
+        "type_comments": [
+            "(int, builtin_function_or_method, int, builtin_function_or_method) -> int"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\sysconfig.py",
+        "line": 121,
+        "func_name": "_is_python_source_dir",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\sysconfig.py",
+        "line": 131,
+        "func_name": "is_python_build",
+        "type_comments": [
+            "(bool) -> bool"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\sysconfig.py",
+        "line": 174,
+        "func_name": "_get_default_scheme",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\sysconfig.py",
+        "line": 598,
+        "func_name": "get_platform",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\textwrap.py",
+        "line": 17,
+        "func_name": "TextWrapper",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 75,
+        "func_name": "RLock",
+        "type_comments": [
+            "() -> _thread.RLock"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 216,
+        "func_name": "Condition.__init__",
+        "type_comments": [
+            "(_thread.lock) -> None",
+            "(_thread.RLock) -> None"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 240,
+        "func_name": "Condition.__enter__",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 103
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 243,
+        "func_name": "Condition.__exit__",
+        "type_comments": [
+            "(*None) -> None",
+            "(*Union[_queue.Empty, traceback, type]) -> None"
+        ],
+        "samples": 103
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 249,
+        "func_name": "Condition._release_save",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 41
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 252,
+        "func_name": "Condition._acquire_restore",
+        "type_comments": [
+            "(None) -> None"
+        ],
+        "samples": 41
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 255,
+        "func_name": "Condition._is_owned",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 136
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 264,
+        "func_name": "Condition.wait",
+        "type_comments": [
+            "(None) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(None) -> pyannotate_runtime.collect_types.UnknownType",
+            "(float) -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 42
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 335,
+        "func_name": "Condition.notify",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 101
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 358,
+        "func_name": "Condition.notify_all",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 499,
+        "func_name": "Event.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 507,
+        "func_name": "Event.is_set",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 58
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 513,
+        "func_name": "Event.set",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 534,
+        "func_name": "Event.wait",
+        "type_comments": [
+            "(None) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(float) -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 728,
+        "func_name": "_newname",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 758,
+        "func_name": "Thread.__init__",
+        "type_comments": [
+            "(None, function, None, Tuple[multiprocessing.pool.ThreadPool], None, None) -> None",
+            "(None, function, None, Tuple[_queue.SimpleQueue, _queue.SimpleQueue, None, Tuple[], None, bool], Dict, None) -> None",
+            "(None, function, None, Tuple[_queue.SimpleQueue, builtin_function_or_method, Dict], None, None) -> None",
+            "(None, None, None, Tuple[], None, None) -> None",
+            "(None, function, None, Tuple[socket.socket, str, int, int, Dict[int, sabnzbd.newswrapper.NewsWrapper], sabnzbd.newswrapper.NNTP], None, None) -> None",
+            "(None, function, None, Tuple[_queue.SimpleQueue, builtin_function_or_method, _queue.SimpleQueue, List[multiprocessing.dummy.DummyProcess], Dict], None, None) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 829,
+        "func_name": "Thread.start",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 854,
+        "func_name": "Thread.run",
+        "type_comments": [
+            "() -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 968,
+        "func_name": "Thread._stop",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 1000,
+        "func_name": "Thread.join",
+        "type_comments": [
+            "(None) -> None",
+            "(None) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 1038,
+        "func_name": "Thread._wait_for_tstate_lock",
+        "type_comments": [
+            "(bool, int) -> None"
+        ],
+        "samples": 57
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 1052,
+        "func_name": "name",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 24
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 1063,
+        "func_name": "name",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 1080,
+        "func_name": "Thread.is_alive",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 57
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 1096,
+        "func_name": "daemon",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 1112,
+        "func_name": "daemon",
+        "type_comments": [
+            "(bool) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 1123,
+        "func_name": "Thread.setDaemon",
+        "type_comments": [
+            "(bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 1126,
+        "func_name": "Thread.getName",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 1129,
+        "func_name": "Thread.setName",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\threading.py",
+        "line": 1206,
+        "func_name": "current_thread",
+        "type_comments": [
+            "() -> cheroot.workers.threadpool.WorkerThread",
+            "() -> sabnzbd.postproc.PostProcessor",
+            "() -> sabnzbd.sabtray.SABTrayThread",
+            "() -> sabnzbd.assembler.Assembler",
+            "() -> sabnzbd.directunpacker.DirectUnpacker",
+            "() -> sabnzbd.downloader.Downloader",
+            "() -> threading._MainThread"
+        ],
+        "samples": 26
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\traceback.py",
+        "line": 200,
+        "func_name": "extract_stack",
+        "type_comments": [
+            "(None, int) -> traceback.StackSummary"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\traceback.py",
+        "line": 243,
+        "func_name": "FrameSummary.__init__",
+        "type_comments": [
+            "(str, int, str, bool, None, None) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\traceback.py",
+        "line": 272,
+        "func_name": "FrameSummary.__getitem__",
+        "type_comments": [
+            "(slice) -> Tuple[str, int]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\traceback.py",
+        "line": 282,
+        "func_name": "line",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\traceback.py",
+        "line": 289,
+        "func_name": "walk_stack",
+        "type_comments": [
+            "(frame) -> Iterator",
+            "(frame) -> Iterator[Tuple[frame, int]]"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\traceback.py",
+        "line": 318,
+        "func_name": "extract",
+        "type_comments": [
+            "(type, generator, int, bool, bool) -> traceback.StackSummary"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\error.py",
+        "line": 19,
+        "func_name": "URLError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\error.py",
+        "line": 35,
+        "func_name": "HTTPError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\error.py",
+        "line": 73,
+        "func_name": "ContentTooShortError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 98,
+        "func_name": "_noop",
+        "type_comments": [
+            "(urllib.parse.ParseResult) -> urllib.parse.ParseResult",
+            "(urllib.parse.SplitResult) -> urllib.parse.SplitResult"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 101,
+        "func_name": "_encode_result",
+        "type_comments": [
+            "(urllib.parse.SplitResult, str, str) -> urllib.parse.SplitResultBytes"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 105,
+        "func_name": "_decode_args",
+        "type_comments": [
+            "(Tuple[bytes, str], str, str) -> Tuple[str, str]"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 109,
+        "func_name": "_coerce_args",
+        "type_comments": [
+            "(*Union[bytes, str]) -> Tuple[str, str, function]",
+            "(*str) -> Tuple[str, str, function]"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 126,
+        "func_name": "_ResultMixinStr",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 130,
+        "func_name": "_ResultMixinStr.encode",
+        "type_comments": [
+            "(str, str) -> urllib.parse.SplitResultBytes"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 134,
+        "func_name": "_ResultMixinBytes",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 142,
+        "func_name": "_NetlocResultMixinBase",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 175,
+        "func_name": "_NetlocResultMixinStr",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 205,
+        "func_name": "_NetlocResultMixinBytes",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 310,
+        "func_name": "DefragResult",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 318,
+        "func_name": "SplitResult",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 323,
+        "func_name": "ParseResult",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 329,
+        "func_name": "DefragResultBytes",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 337,
+        "func_name": "SplitResultBytes",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 342,
+        "func_name": "ParseResultBytes",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 348,
+        "func_name": "_fix_result_transcoding",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 361,
+        "func_name": "urlparse",
+        "type_comments": [
+            "(str, str, bool) -> urllib.parse.ParseResult"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 386,
+        "func_name": "_splitnetloc",
+        "type_comments": [
+            "(str, int) -> Tuple[str, str]"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 394,
+        "func_name": "urlsplit",
+        "type_comments": [
+            "(str, str, bool) -> urllib.parse.SplitResult",
+            "(bytes, str, bool) -> urllib.parse.SplitResultBytes"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 567,
+        "func_name": "unquote_to_bytes",
+        "type_comments": [
+            "(bytes) -> bytes"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 599,
+        "func_name": "unquote",
+        "type_comments": [
+            "(str, str, str) -> str"
+        ],
+        "samples": 74
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 724,
+        "func_name": "unquote_plus",
+        "type_comments": [
+            "(str, str, str) -> str"
+        ],
+        "samples": 74
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 740,
+        "func_name": "Quoter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 941,
+        "func_name": "unwrap",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 950,
+        "func_name": "splittype",
+        "type_comments": [
+            "(str) -> Tuple[str, str]"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 963,
+        "func_name": "splithost",
+        "type_comments": [
+            "(str) -> Tuple[str, str]"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\parse.py",
+        "line": 1025,
+        "func_name": "splittag",
+        "type_comments": [
+            "(str) -> Tuple[str, None]"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 307,
+        "func_name": "request_host",
+        "type_comments": [
+            "(urllib.request.Request) -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 323,
+        "func_name": "Request",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 325,
+        "func_name": "Request.__init__",
+        "type_comments": [
+            "(str, None, Dict, None, bool, None) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 343,
+        "func_name": "full_url",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 349,
+        "func_name": "full_url",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 366,
+        "func_name": "data",
+        "type_comments": [
+            "(None) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 380,
+        "func_name": "Request._parse",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 388,
+        "func_name": "Request.get_method",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 393,
+        "func_name": "Request.get_full_url",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 404,
+        "func_name": "Request.has_proxy",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 407,
+        "func_name": "Request.add_header",
+        "type_comments": [
+            "(str, str) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 411,
+        "func_name": "Request.add_unredirected_header",
+        "type_comments": [
+            "(str, str) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 415,
+        "func_name": "Request.has_header",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 433,
+        "func_name": "OpenerDirector",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 434,
+        "func_name": "OpenerDirector.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 445,
+        "func_name": "OpenerDirector.add_handler",
+        "type_comments": [
+            "(urllib.request.UnknownHandler) -> None",
+            "(urllib.request.ProxyHandler) -> None",
+            "(urllib.request.HTTPDefaultErrorHandler) -> None",
+            "(urllib.request.HTTPRedirectHandler) -> None",
+            "(urllib.request.HTTPHandler) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 496,
+        "func_name": "OpenerDirector._call_chain",
+        "type_comments": [
+            "(Dict[str, Union[List[urllib.request.DataHandler], List[urllib.request.FTPHandler], List[urllib.request.FileHandler], List[urllib.request.HTTPHandler], List[urllib.request.UnknownHandler]]], str, str, *urllib.request.Request) -> None",
+            "(Dict[str, Union[List[urllib.request.DataHandler], List[urllib.request.FTPHandler], List[urllib.request.FileHandler], List[urllib.request.HTTPHandler], List[urllib.request.UnknownHandler]]], str, str, *urllib.request.Request) -> http.client.HTTPResponse"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 507,
+        "func_name": "OpenerDirector.open",
+        "type_comments": [
+            "(str, None, object) -> http.client.HTTPResponse",
+            "(urllib.request.Request, None, int) -> http.client.HTTPResponse"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 535,
+        "func_name": "OpenerDirector._open",
+        "type_comments": [
+            "(urllib.request.Request, None) -> http.client.HTTPResponse"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 575,
+        "func_name": "build_opener",
+        "type_comments": [
+            "() -> urllib.request.OpenerDirector"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 611,
+        "func_name": "BaseHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 614,
+        "func_name": "BaseHandler.add_parent",
+        "type_comments": [
+            "(urllib.request.OpenerDirector) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 621,
+        "func_name": "BaseHandler.__lt__",
+        "type_comments": [
+            "(urllib.request.HTTPDefaultErrorHandler) -> bool",
+            "(urllib.request.UnknownHandler) -> bool",
+            "(urllib.request.HTTPHandler) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 630,
+        "func_name": "HTTPErrorProcessor",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 634,
+        "func_name": "HTTPErrorProcessor.http_response",
+        "type_comments": [
+            "(urllib.request.Request, http.client.HTTPResponse) -> http.client.HTTPResponse"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 647,
+        "func_name": "HTTPDefaultErrorHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 651,
+        "func_name": "HTTPRedirectHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 793,
+        "func_name": "ProxyHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 797,
+        "func_name": "ProxyHandler.__init__",
+        "type_comments": [
+            "(None) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 835,
+        "func_name": "HTTPPasswordMgr",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 899,
+        "func_name": "HTTPPasswordMgrWithDefaultRealm",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 909,
+        "func_name": "HTTPPasswordMgrWithPriorAuth",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 940,
+        "func_name": "AbstractBasicAuthHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 1020,
+        "func_name": "HTTPBasicAuthHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 1031,
+        "func_name": "ProxyBasicAuthHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 1050,
+        "func_name": "AbstractDigestAuthHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 1194,
+        "func_name": "HTTPDigestAuthHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 1212,
+        "func_name": "ProxyDigestAuthHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 1224,
+        "func_name": "AbstractHTTPHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 1226,
+        "func_name": "AbstractHTTPHandler.__init__",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 1237,
+        "func_name": "AbstractHTTPHandler.do_request_",
+        "type_comments": [
+            "(urllib.request.Request) -> urllib.request.Request"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 1275,
+        "func_name": "AbstractHTTPHandler.do_open",
+        "type_comments": [
+            "(type, urllib.request.Request) -> http.client.HTTPResponse"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 1342,
+        "func_name": "HTTPHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 1344,
+        "func_name": "HTTPHandler.http_open",
+        "type_comments": [
+            "(urllib.request.Request) -> http.client.HTTPResponse"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 1351,
+        "func_name": "HTTPSHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 1353,
+        "func_name": "HTTPSHandler.__init__",
+        "type_comments": [
+            "(int, None, None) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 1358,
+        "func_name": "HTTPSHandler.https_open",
+        "type_comments": [
+            "(urllib.request.Request) -> http.client.HTTPResponse"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 1366,
+        "func_name": "HTTPCookieProcessor",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 1384,
+        "func_name": "UnknownHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 1442,
+        "func_name": "FileHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 1499,
+        "func_name": "FTPHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 1557,
+        "func_name": "CacheFTPHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 1610,
+        "func_name": "DataHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 1663,
+        "func_name": "URLopener",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 2108,
+        "func_name": "FancyURLopener",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 2361,
+        "func_name": "ftpwrapper",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 2456,
+        "func_name": "getproxies_environment",
+        "type_comments": [
+            "() -> Dict"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 2617,
+        "func_name": "getproxies_registry",
+        "type_comments": [
+            "() -> Dict"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\request.py",
+        "line": 2662,
+        "func_name": "getproxies",
+        "type_comments": [
+            "() -> Dict"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\response.py",
+        "line": 14,
+        "func_name": "addbase",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\response.py",
+        "line": 37,
+        "func_name": "addclosehook",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\response.py",
+        "line": 57,
+        "func_name": "addinfo",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\urllib\\response.py",
+        "line": 68,
+        "func_name": "addinfourl",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\uu.py",
+        "line": 39,
+        "func_name": "Error",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\uuid.py",
+        "line": 63,
+        "func_name": "SafeUUID",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\uuid.py",
+        "line": 69,
+        "func_name": "UUID",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\uuid.py",
+        "line": 121,
+        "func_name": "UUID.__init__",
+        "type_comments": [
+            "(None, bytes, None, None, None, int, uuid.SafeUUID) -> None",
+            "(str, None, None, None, None, None, uuid.SafeUUID) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\uuid.py",
+        "line": 264,
+        "func_name": "UUID.__str__",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\uuid.py",
+        "line": 318,
+        "func_name": "hex",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\uuid.py",
+        "line": 757,
+        "func_name": "uuid4",
+        "type_comments": [
+            "() -> uuid.UUID"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\webbrowser.py",
+        "line": 14,
+        "func_name": "Error",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\webbrowser.py",
+        "line": 123,
+        "func_name": "BaseBrowser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\webbrowser.py",
+        "line": 142,
+        "func_name": "GenericBrowser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\webbrowser.py",
+        "line": 169,
+        "func_name": "BackgroundBrowser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\webbrowser.py",
+        "line": 187,
+        "func_name": "UnixBrowser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\webbrowser.py",
+        "line": 265,
+        "func_name": "Mozilla",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\webbrowser.py",
+        "line": 275,
+        "func_name": "Netscape",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\webbrowser.py",
+        "line": 286,
+        "func_name": "Galeon",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\webbrowser.py",
+        "line": 296,
+        "func_name": "Chrome",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\webbrowser.py",
+        "line": 308,
+        "func_name": "Opera",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\webbrowser.py",
+        "line": 318,
+        "func_name": "Elinks",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\webbrowser.py",
+        "line": 332,
+        "func_name": "Konqueror",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\webbrowser.py",
+        "line": 384,
+        "func_name": "Grail",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\webbrowser.py",
+        "line": 578,
+        "func_name": "WindowsDefault",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\etree\\ElementPath.py",
+        "line": 255,
+        "func_name": "_SelectorContext",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\etree\\ElementTree.py",
+        "line": 124,
+        "func_name": "Element",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\etree\\ElementTree.py",
+        "line": 495,
+        "func_name": "QName",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\etree\\ElementTree.py",
+        "line": 543,
+        "func_name": "ElementTree",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\etree\\ElementTree.py",
+        "line": 1139,
+        "func_name": "_ListDataStream",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\etree\\ElementTree.py",
+        "line": 1249,
+        "func_name": "XMLPullParser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\etree\\ElementTree.py",
+        "line": 1302,
+        "func_name": "XML",
+        "type_comments": [
+            "(str, None) -> xml.etree.ElementTree.Element"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\etree\\ElementTree.py",
+        "line": 1361,
+        "func_name": "TreeBuilder",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\etree\\ElementTree.py",
+        "line": 1437,
+        "func_name": "XMLParser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\__init__.py",
+        "line": 70,
+        "func_name": "make_parser",
+        "type_comments": [
+            "(List[str]) -> xml.sax.expatreader.ExpatParser"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\__init__.py",
+        "line": 103,
+        "func_name": "_create_parser",
+        "type_comments": [
+            "(str) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(str) -> xml.sax.expatreader.ExpatParser"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\_exceptions.py",
+        "line": 9,
+        "func_name": "SAXException",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\_exceptions.py",
+        "line": 46,
+        "func_name": "SAXParseException",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\_exceptions.py",
+        "line": 105,
+        "func_name": "SAXNotRecognizedException",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\_exceptions.py",
+        "line": 115,
+        "func_name": "SAXNotSupportedException",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\_exceptions.py",
+        "line": 125,
+        "func_name": "SAXReaderNotAvailable",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\expatreader.py",
+        "line": 46,
+        "func_name": "_ClosedParser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\expatreader.py",
+        "line": 51,
+        "func_name": "ExpatLocator",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\expatreader.py",
+        "line": 87,
+        "func_name": "ExpatParser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\expatreader.py",
+        "line": 90,
+        "func_name": "ExpatParser.__init__",
+        "type_comments": [
+            "(int, int) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\expatreader.py",
+        "line": 436,
+        "func_name": "create_parser",
+        "type_comments": [
+            "() -> xml.sax.expatreader.ExpatParser"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\handler.py",
+        "line": 22,
+        "func_name": "ErrorHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\handler.py",
+        "line": 47,
+        "func_name": "ContentHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\handler.py",
+        "line": 54,
+        "func_name": "ContentHandler.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\handler.py",
+        "line": 208,
+        "func_name": "DTDHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\handler.py",
+        "line": 223,
+        "func_name": "EntityResolver",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\saxutils.py",
+        "line": 113,
+        "func_name": "XMLGenerator",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\saxutils.py",
+        "line": 228,
+        "func_name": "XMLFilterBase",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\xmlreader.py",
+        "line": 11,
+        "func_name": "XMLReader",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\xmlreader.py",
+        "line": 24,
+        "func_name": "XMLReader.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\xmlreader.py",
+        "line": 91,
+        "func_name": "IncrementalParser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\xmlreader.py",
+        "line": 111,
+        "func_name": "IncrementalParser.__init__",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\xmlreader.py",
+        "line": 165,
+        "func_name": "Locator",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\xmlreader.py",
+        "line": 189,
+        "func_name": "InputSource",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\xmlreader.py",
+        "line": 205,
+        "func_name": "InputSource.__init__",
+        "type_comments": [
+            "(None) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\xmlreader.py",
+        "line": 278,
+        "func_name": "AttributesImpl",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xml\\sax\\xmlreader.py",
+        "line": 340,
+        "func_name": "AttributesNSImpl",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xmlrpc\\client.py",
+        "line": 187,
+        "func_name": "Error",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xmlrpc\\client.py",
+        "line": 202,
+        "func_name": "ProtocolError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xmlrpc\\client.py",
+        "line": 221,
+        "func_name": "ResponseError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xmlrpc\\client.py",
+        "line": 234,
+        "func_name": "Fault",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xmlrpc\\client.py",
+        "line": 291,
+        "func_name": "DateTime",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xmlrpc\\client.py",
+        "line": 381,
+        "func_name": "Binary",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xmlrpc\\client.py",
+        "line": 427,
+        "func_name": "ExpatParser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xmlrpc\\client.py",
+        "line": 460,
+        "func_name": "Marshaller",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xmlrpc\\client.py",
+        "line": 627,
+        "func_name": "Unmarshaller",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xmlrpc\\client.py",
+        "line": 821,
+        "func_name": "_MultiCallMethod",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xmlrpc\\client.py",
+        "line": 832,
+        "func_name": "MultiCallIterator",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xmlrpc\\client.py",
+        "line": 848,
+        "func_name": "MultiCall",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xmlrpc\\client.py",
+        "line": 1081,
+        "func_name": "GzipDecodedResponse",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xmlrpc\\client.py",
+        "line": 1103,
+        "func_name": "_Method",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xmlrpc\\client.py",
+        "line": 1120,
+        "func_name": "Transport",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xmlrpc\\client.py",
+        "line": 1347,
+        "func_name": "SafeTransport",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\xmlrpc\\client.py",
+        "line": 1388,
+        "func_name": "ServerProxy",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\zipfile.py",
+        "line": 38,
+        "func_name": "BadZipFile",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\zipfile.py",
+        "line": 42,
+        "func_name": "LargeZipFile",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\zipfile.py",
+        "line": 313,
+        "func_name": "ZipInfo",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\zipfile.py",
+        "line": 592,
+        "func_name": "LZMACompressor",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\zipfile.py",
+        "line": 615,
+        "func_name": "LZMADecompressor",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\zipfile.py",
+        "line": 715,
+        "func_name": "_SharedFile",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\zipfile.py",
+        "line": 753,
+        "func_name": "_Tellable",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\zipfile.py",
+        "line": 773,
+        "func_name": "ZipExtFile",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\zipfile.py",
+        "line": 1071,
+        "func_name": "_ZipWriteFile",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\zipfile.py",
+        "line": 1146,
+        "func_name": "ZipFile",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\AppData\\Local\\Programs\\Python\\Python37\\Lib\\zipfile.py",
+        "line": 1922,
+        "func_name": "PyZipFile",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\_bootlocale.py",
+        "line": 11,
+        "func_name": "getpreferredencoding",
+        "type_comments": [
+            "(bool) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\_collections_abc.py",
+        "line": 72,
+        "func_name": "_check_methods",
+        "type_comments": [
+            "(type, *str) -> bool"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\_collections_abc.py",
+        "line": 252,
+        "func_name": "__subclasshook__",
+        "type_comments": [
+            "(type) -> bool"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\_collections_abc.py",
+        "line": 302,
+        "func_name": "__subclasshook__",
+        "type_comments": [
+            "(type) -> NotImplementedType"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\_collections_abc.py",
+        "line": 392,
+        "func_name": "__subclasshook__",
+        "type_comments": [
+            "(type) -> NotImplementedType"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\_collections_abc.py",
+        "line": 657,
+        "func_name": "Mapping.get",
+        "type_comments": [
+            "(str, str) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\_collections_abc.py",
+        "line": 664,
+        "func_name": "Mapping.__contains__",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\_collections_abc.py",
+        "line": 676,
+        "func_name": "Mapping.items",
+        "type_comments": [
+            "() -> collections.abc.ItemsView"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\_collections_abc.py",
+        "line": 698,
+        "func_name": "MappingView.__init__",
+        "type_comments": [
+            "(os._Environ) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\_collections_abc.py",
+        "line": 742,
+        "func_name": "ItemsView.__iter__",
+        "type_comments": [
+            "() -> Iterator[Tuple[str, str]]"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\_collections_abc.py",
+        "line": 816,
+        "func_name": "MutableMapping.clear",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\_weakrefset.py",
+        "line": 36,
+        "func_name": "WeakSet.__init__",
+        "type_comments": [
+            "(None) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\_weakrefset.py",
+        "line": 38,
+        "func_name": "_remove",
+        "type_comments": [
+            "(weakref, weakref) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\_weakrefset.py",
+        "line": 81,
+        "func_name": "WeakSet.add",
+        "type_comments": [
+            "(sabnzbd.downloader.Downloader) -> None",
+            "(threading.Thread) -> None",
+            "(multiprocessing.dummy.DummyProcess) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\abc.py",
+        "line": 7,
+        "func_name": "abstractmethod",
+        "type_comments": [
+            "(function) -> function"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\abc.py",
+        "line": 125,
+        "func_name": "__new__",
+        "type_comments": [
+            "(type, str, Tuple[abc.ABCMeta], Dict[str, Union[function, str]]) -> abc.ABCMeta",
+            "(type, str, Tuple[abc.ABCMeta], Dict[str, Union[configparser.BasicInterpolation, function, str]]) -> abc.ABCMeta",
+            "(type, str, Tuple[], Dict[str, Union[function, str]]) -> abc.ABCMeta"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\abc.py",
+        "line": 130,
+        "func_name": "register",
+        "type_comments": [
+            "(type) -> type"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\abc.py",
+        "line": 137,
+        "func_name": "__instancecheck__",
+        "type_comments": [
+            "(List[Union[pkg_resources._vendor.pyparsing.CharsNotIn, pkg_resources._vendor.pyparsing.MatchFirst]]) -> bool",
+            "(List[Union[pkg_resources._vendor.pyparsing.Regex, pkg_resources._vendor.pyparsing.Word]]) -> bool",
+            "(List[Union[pkg_resources._vendor.pyparsing.And, pkg_resources._vendor.pyparsing.MatchFirst]]) -> bool",
+            "(List[Union[pkg_resources._vendor.pyparsing.MatchFirst, pkg_resources._vendor.pyparsing.Regex]]) -> bool",
+            "(List[Union[pkg_resources._vendor.pyparsing.MatchFirst, pkg_resources._vendor.pyparsing.Suppress]]) -> bool",
+            "(List[Union[pkg_resources._vendor.pyparsing.Literal, pkg_resources._vendor.pyparsing.Optional]]) -> bool",
+            "(List[Union[pkg_resources._vendor.pyparsing.Forward, pkg_resources._vendor.pyparsing.Suppress]]) -> bool",
+            "(Tuple[int, str, None, str, str]) -> bool"
+        ],
+        "samples": 12
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\abc.py",
+        "line": 141,
+        "func_name": "__subclasscheck__",
+        "type_comments": [
+            "(type) -> bool",
+            "(abc.ABCMeta) -> bool",
+            "(type) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\codecs.py",
+        "line": 94,
+        "func_name": "__new__",
+        "type_comments": [
+            "(builtin_function_or_method, builtin_function_or_method, type, type, type, type, str, None) -> codecs.CodecInfo",
+            "(method, method, type, type, type, type, str, None) -> codecs.CodecInfo"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\codecs.py",
+        "line": 186,
+        "func_name": "IncrementalEncoder.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\codecs.py",
+        "line": 214,
+        "func_name": "IncrementalEncoder.setstate",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 19
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\codecs.py",
+        "line": 260,
+        "func_name": "IncrementalDecoder.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\codecs.py",
+        "line": 309,
+        "func_name": "BufferedIncrementalDecoder.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\codecs.py",
+        "line": 319,
+        "func_name": "BufferedIncrementalDecoder.decode",
+        "type_comments": [
+            "(bytes, bool) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\collections\\__init__.py",
+        "line": 42,
+        "func_name": "__getattr__",
+        "type_comments": [
+            "(str) -> abc.ABCMeta"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\collections\\__init__.py",
+        "line": 316,
+        "func_name": "namedtuple",
+        "type_comments": [
+            "(str, List[str], bool, None, None) -> type",
+            "(str, str, bool, None, None) -> type"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\copy.py",
+        "line": 66,
+        "func_name": "copy",
+        "type_comments": [
+            "(pkg_resources._vendor.pyparsing.Group) -> pkg_resources._vendor.pyparsing.Group",
+            "(pkg_resources._vendor.pyparsing.Optional) -> pkg_resources._vendor.pyparsing.Optional",
+            "(pkg_resources._vendor.pyparsing.Regex) -> pkg_resources._vendor.pyparsing.Regex",
+            "(pkg_resources._vendor.pyparsing.MatchFirst) -> pkg_resources._vendor.pyparsing.MatchFirst",
+            "(pkg_resources._vendor.pyparsing.Literal) -> pkg_resources._vendor.pyparsing.Literal",
+            "(pkg_resources._vendor.pyparsing.And) -> pkg_resources._vendor.pyparsing.And"
+        ],
+        "samples": 13
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\copy.py",
+        "line": 190,
+        "func_name": "_deepcopy_atomic",
+        "type_comments": [
+            "(str, Dict[int, Union[Dict[str, bool], List, List[List]]]) -> str",
+            "(str, Dict[int, Dict]) -> str",
+            "(str, Dict[int, Dict[str, bool]]) -> str",
+            "(bool, Dict[int, Dict]) -> bool",
+            "(bool, Dict[int, Dict[str, bool]]) -> bool"
+        ],
+        "samples": 29
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\copy.py",
+        "line": 210,
+        "func_name": "_deepcopy_list",
+        "type_comments": [
+            "(List, Dict[int, Union[Dict[str, bool], List, List[List]]], function) -> List",
+            "(List, Dict[int, Union[Dict[str, bool], List[List]]], function) -> List",
+            "(List, Dict[int, Dict[str, bool]], function) -> List"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\copy.py",
+        "line": 219,
+        "func_name": "_deepcopy_tuple",
+        "type_comments": [
+            "(Tuple[str, str], Dict[int, Dict[str, bool]], function) -> Tuple[str, str]"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\copy.py",
+        "line": 236,
+        "func_name": "_deepcopy_dict",
+        "type_comments": [
+            "(Dict[str, bool], Dict, function) -> Dict[str, bool]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\copy.py",
+        "line": 252,
+        "func_name": "_keep_alive",
+        "type_comments": [
+            "(Dict[str, bool], Dict[int, Union[Dict[str, bool], List, List[List]]]) -> None",
+            "(List, Dict[int, Union[Dict[str, bool], List, List[List]]]) -> None",
+            "(List, Dict[int, Union[Dict[str, bool], List]]) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\copyreg.py",
+        "line": 87,
+        "func_name": "__newobj__",
+        "type_comments": [
+            "() -> pkg_resources._vendor.pyparsing.Group",
+            "() -> pkg_resources._vendor.pyparsing.Suppress",
+            "() -> pkg_resources._vendor.pyparsing.Optional",
+            "() -> pkg_resources._vendor.pyparsing.Regex",
+            "() -> pkg_resources._vendor.pyparsing.Literal",
+            "() -> pkg_resources._vendor.pyparsing.And"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\copyreg.py",
+        "line": 96,
+        "func_name": "_slotnames",
+        "type_comments": [
+            "() -> List"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\encodings\\__init__.py",
+        "line": 43,
+        "func_name": "normalize_encoding",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\encodings\\__init__.py",
+        "line": 71,
+        "func_name": "search_function",
+        "type_comments": [
+            "(str) -> codecs.CodecInfo"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\encodings\\cp1252.py",
+        "line": 18,
+        "func_name": "IncrementalEncoder.encode",
+        "type_comments": [
+            "(str, bool) -> bytes"
+        ],
+        "samples": 19
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\encodings\\cp1252.py",
+        "line": 22,
+        "func_name": "IncrementalDecoder.decode",
+        "type_comments": [
+            "(bytes, bool) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\encodings\\idna.py",
+        "line": 147,
+        "func_name": "Codec.encode",
+        "type_comments": [
+            "(str, str) -> Tuple[bytes, int]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\encodings\\idna.py",
+        "line": 218,
+        "func_name": "IncrementalEncoder",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\encodings\\idna.py",
+        "line": 253,
+        "func_name": "IncrementalDecoder",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\encodings\\idna.py",
+        "line": 292,
+        "func_name": "StreamWriter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\encodings\\idna.py",
+        "line": 295,
+        "func_name": "StreamReader",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\encodings\\idna.py",
+        "line": 300,
+        "func_name": "getregentry",
+        "type_comments": [
+            "() -> codecs.CodecInfo"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\encodings\\unicode_internal.py",
+        "line": 28,
+        "func_name": "StreamWriter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\encodings\\unicode_internal.py",
+        "line": 31,
+        "func_name": "StreamReader",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\encodings\\unicode_internal.py",
+        "line": 36,
+        "func_name": "getregentry",
+        "type_comments": [
+            "() -> codecs.CodecInfo"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 18,
+        "func_name": "_is_descriptor",
+        "type_comments": [
+            "(int) -> bool",
+            "(Tuple[int, str, str]) -> bool"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 26,
+        "func_name": "_is_dunder",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 34,
+        "func_name": "_is_sunder",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 41,
+        "func_name": "_make_class_unpicklable",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 63,
+        "func_name": "_EnumDict.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 69,
+        "func_name": "_EnumDict.__setitem__",
+        "type_comments": [
+            "(str, int) -> None",
+            "(str, function) -> None",
+            "(str, Tuple[int, str]) -> None",
+            "(str, Tuple[int, str, str]) -> None",
+            "(str, str) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 124,
+        "func_name": "__prepare__",
+        "type_comments": [
+            "(type, str, Tuple[enum.EnumMeta]) -> enum._EnumDict"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 134,
+        "func_name": "__new__",
+        "type_comments": [
+            "(type, str, Tuple[enum.EnumMeta], enum._EnumDict) -> enum.EnumMeta"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 283,
+        "func_name": "__call__",
+        "type_comments": [
+            "(int, None, None, None, None, int) -> socket.AddressFamily",
+            "(int, None, None, None, None, int) -> re.RegexFlag",
+            "(re.RegexFlag, None, None, None, None, int) -> re.RegexFlag",
+            "(str, List[Tuple[str, int]], str, None, None, int) -> enum.EnumMeta",
+            "(inspect._ParameterKind, None, None, None, None, int) -> inspect._ParameterKind"
+        ],
+        "samples": 27
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 334,
+        "func_name": "__getattr__",
+        "type_comments": [
+            "(str) -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 359,
+        "func_name": "__members__",
+        "type_comments": [
+            "() -> mappingproxy"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 375,
+        "func_name": "__setattr__",
+        "type_comments": [
+            "(str, collections.OrderedDict) -> None",
+            "(str, List) -> None",
+            "(str, Dict) -> None",
+            "(str, socket.AddressFamily) -> None",
+            "(str, socket.AddressInfo) -> None",
+            "(str, ssl.Options) -> None",
+            "(str, http.HTTPStatus) -> None",
+            "(str, type) -> None"
+        ],
+        "samples": 11
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 388,
+        "func_name": "_create_",
+        "type_comments": [
+            "(str, List[Tuple[str, int]], str, None, None, int) -> enum.EnumMeta"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 441,
+        "func_name": "_get_mixins_",
+        "type_comments": [
+            "(Tuple[enum.EnumMeta]) -> Tuple[type, enum.EnumMeta]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 452,
+        "func_name": "_find_data_type",
+        "type_comments": [
+            "(Tuple[enum.EnumMeta]) -> type"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 473,
+        "func_name": "_find_new_",
+        "type_comments": [
+            "(enum._EnumDict, type, enum.EnumMeta) -> Tuple[builtin_function_or_method, bool, bool]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 525,
+        "func_name": "__new__",
+        "type_comments": [
+            "(int) -> socket.AddressFamily",
+            "(int) -> re.RegexFlag",
+            "(re.RegexFlag) -> re.RegexFlag",
+            "(int) -> socket.SocketKind",
+            "(inspect._ParameterKind) -> inspect._ParameterKind"
+        ],
+        "samples": 27
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 563,
+        "func_name": "_generate_next_value_",
+        "type_comments": [
+            "(str, int, int, List[int]) -> int",
+            "(str, int, int, List) -> int"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 572,
+        "func_name": "_missing_",
+        "type_comments": [
+            "(int) -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 580,
+        "func_name": "IntEnum.__str__",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 607,
+        "func_name": "Enum.__hash__",
+        "type_comments": [
+            "() -> int"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 620,
+        "func_name": "name",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 625,
+        "func_name": "value",
+        "type_comments": [
+            "() -> int"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 630,
+        "func_name": "_convert",
+        "type_comments": [
+            "(str, str, function, None) -> enum.EnumMeta"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 790,
+        "func_name": "_missing_",
+        "type_comments": [
+            "(int) -> re.RegexFlag"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 797,
+        "func_name": "_create_pseudo_member_",
+        "type_comments": [
+            "(int) -> re.RegexFlag"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 827,
+        "func_name": "IntFlag.__or__",
+        "type_comments": [
+            "(re.RegexFlag) -> re.RegexFlag"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 833,
+        "func_name": "IntFlag.__and__",
+        "type_comments": [
+            "(int) -> re.RegexFlag"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 852,
+        "func_name": "_high_bit",
+        "type_comments": [
+            "(int) -> int"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 869,
+        "func_name": "_decompose",
+        "type_comments": [
+            "(enum.EnumMeta, int) -> Tuple[List[re.RegexFlag], int]"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\enum.py",
+        "line": 904,
+        "func_name": "_power_of_two",
+        "type_comments": [
+            "(int) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\fnmatch.py",
+        "line": 19,
+        "func_name": "fnmatch",
+        "type_comments": [
+            "(str, str) -> bool"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\fnmatch.py",
+        "line": 38,
+        "func_name": "_compile_pattern",
+        "type_comments": [
+            "(str) -> builtin_function_or_method"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\fnmatch.py",
+        "line": 64,
+        "func_name": "fnmatchcase",
+        "type_comments": [
+            "(str, str) -> bool"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\fnmatch.py",
+        "line": 74,
+        "func_name": "translate",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\functools.py",
+        "line": 37,
+        "func_name": "update_wrapper",
+        "type_comments": [
+            "(function, builtin_function_or_method, Tuple[str, str, str, str, str], Tuple[str]) -> function",
+            "(functools._lru_cache_wrapper, function, Tuple[str, str, str, str, str], Tuple[str]) -> functools._lru_cache_wrapper",
+            "(function, function, Tuple[str, str, str, str, str], Tuple[str]) -> function"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\functools.py",
+        "line": 67,
+        "func_name": "wraps",
+        "type_comments": [
+            "(function, Tuple[str, str, str, str, str], Tuple[str]) -> functools.partial",
+            "(builtin_function_or_method, Tuple[str, str, str, str, str], Tuple[str]) -> functools.partial"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\functools.py",
+        "line": 445,
+        "func_name": "lru_cache",
+        "type_comments": [
+            "(int, bool) -> function"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\functools.py",
+        "line": 476,
+        "func_name": "decorating_function",
+        "type_comments": [
+            "(method) -> functools._lru_cache_wrapper",
+            "(function) -> functools._lru_cache_wrapper"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\functools.py",
+        "line": 747,
+        "func_name": "singledispatch",
+        "type_comments": [
+            "(function) -> function"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\functools.py",
+        "line": 788,
+        "func_name": "register",
+        "type_comments": [
+            "(function) -> function"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\genericpath.py",
+        "line": 16,
+        "func_name": "exists",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 36
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\genericpath.py",
+        "line": 27,
+        "func_name": "isfile",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\genericpath.py",
+        "line": 53,
+        "func_name": "getmtime",
+        "type_comments": [
+            "(str) -> float"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\genericpath.py",
+        "line": 87,
+        "func_name": "samestat",
+        "type_comments": [
+            "(os.stat_result, os.stat_result) -> bool"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\genericpath.py",
+        "line": 94,
+        "func_name": "samefile",
+        "type_comments": [
+            "(str, str) -> bool"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\genericpath.py",
+        "line": 117,
+        "func_name": "_splitext",
+        "type_comments": [
+            "(str, str, str, str) -> Tuple[str, str]"
+        ],
+        "samples": 44
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\hashlib.py",
+        "line": 73,
+        "func_name": "__get_builtin_constructor",
+        "type_comments": [
+            "(str) -> type"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\hashlib.py",
+        "line": 116,
+        "func_name": "__get_openssl_constructor",
+        "type_comments": [
+            "(str) -> builtin_function_or_method"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\hmac.py",
+        "line": 26,
+        "func_name": "HMAC",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\imp.py",
+        "line": 48,
+        "func_name": "new_module",
+        "type_comments": [
+            "(str) -> module"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\imp.py",
+        "line": 105,
+        "func_name": "get_suffixes",
+        "type_comments": [
+            "() -> List[Tuple[str, str, int]]"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\imp.py",
+        "line": 114,
+        "func_name": "NullImporter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\imp.py",
+        "line": 133,
+        "func_name": "_HackedGetData",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\imp.py",
+        "line": 160,
+        "func_name": "_LoadSourceCompatibility",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\imp.py",
+        "line": 179,
+        "func_name": "_LoadCompiledCompatibility",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\imp.py",
+        "line": 330,
+        "func_name": "load_dynamic",
+        "type_comments": [
+            "(str, str, None) -> module"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\linecache.py",
+        "line": 15,
+        "func_name": "getline",
+        "type_comments": [
+            "(str, int, None) -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\linecache.py",
+        "line": 37,
+        "func_name": "getlines",
+        "type_comments": [
+            "(str, None) -> List[str]"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\linecache.py",
+        "line": 53,
+        "func_name": "checkcache",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\linecache.py",
+        "line": 82,
+        "func_name": "updatecache",
+        "type_comments": [
+            "(str, None) -> List[str]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\linecache.py",
+        "line": 147,
+        "func_name": "lazycache",
+        "type_comments": [
+            "(str, Dict[str, Union[_frozen_importlib.ModuleSpec, _frozen_importlib_external.SourceFileLoader, str]]) -> bool"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\locale.py",
+        "line": 384,
+        "func_name": "normalize",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\locale.py",
+        "line": 618,
+        "func_name": "getpreferredencoding",
+        "type_comments": [
+            "(bool) -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\ntpath.py",
+        "line": 34,
+        "func_name": "_get_bothseps",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 42
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\ntpath.py",
+        "line": 44,
+        "func_name": "normcase",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 70
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\ntpath.py",
+        "line": 67,
+        "func_name": "isabs",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\ntpath.py",
+        "line": 75,
+        "func_name": "join",
+        "type_comments": [
+            "(str, *str) -> str"
+        ],
+        "samples": 50
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\ntpath.py",
+        "line": 122,
+        "func_name": "splitdrive",
+        "type_comments": [
+            "(str) -> Tuple[str, str]"
+        ],
+        "samples": 156
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\ntpath.py",
+        "line": 178,
+        "func_name": "split",
+        "type_comments": [
+            "(str) -> Tuple[str, str]"
+        ],
+        "samples": 42
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\ntpath.py",
+        "line": 201,
+        "func_name": "splitext",
+        "type_comments": [
+            "(str) -> Tuple[str, str]"
+        ],
+        "samples": 44
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\ntpath.py",
+        "line": 212,
+        "func_name": "basename",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 34
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\ntpath.py",
+        "line": 219,
+        "func_name": "dirname",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\ntpath.py",
+        "line": 226,
+        "func_name": "islink",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\ntpath.py",
+        "line": 287,
+        "func_name": "expanduser",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\ntpath.py",
+        "line": 337,
+        "func_name": "expandvars",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\ntpath.py",
+        "line": 450,
+        "func_name": "normpath",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 58
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\ntpath.py",
+        "line": 523,
+        "func_name": "abspath",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 43
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\os.py",
+        "line": 40,
+        "func_name": "_get_exports_list",
+        "type_comments": [
+            "(module) -> List[str]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\os.py",
+        "line": 196,
+        "func_name": "makedirs",
+        "type_comments": [
+            "(str, int, bool) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\os.py",
+        "line": 278,
+        "func_name": "walk",
+        "type_comments": [
+            "(str, bool, None, bool) -> Iterator",
+            "(str, bool, None, bool) -> Iterator[Tuple[str, List, List[str]]]",
+            "(str, bool, None, bool) -> Iterator[Tuple[str, List[str], List[str]]]",
+            "(str, bool, None, bool) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\os.py",
+        "line": 673,
+        "func_name": "_Environ.__getitem__",
+        "type_comments": [
+            "(str) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(str) -> str"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\os.py",
+        "line": 696,
+        "func_name": "_Environ.__iter__",
+        "type_comments": [
+            "() -> Iterator[str]"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\os.py",
+        "line": 737,
+        "func_name": "check_str",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\os.py",
+        "line": 743,
+        "func_name": "encodekey",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\os.py",
+        "line": 769,
+        "func_name": "getenv",
+        "type_comments": [
+            "(str, None) -> str",
+            "(str, None) -> None",
+            "(str, str) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\random.py",
+        "line": 72,
+        "func_name": "Random",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\random.py",
+        "line": 88,
+        "func_name": "Random.__init__",
+        "type_comments": [
+            "(None) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\random.py",
+        "line": 97,
+        "func_name": "Random.seed",
+        "type_comments": [
+            "(None, int) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\random.py",
+        "line": 174,
+        "func_name": "Random.randrange",
+        "type_comments": [
+            "(int, int, int, type) -> int"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\random.py",
+        "line": 218,
+        "func_name": "Random.randint",
+        "type_comments": [
+            "(int, int) -> int"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\random.py",
+        "line": 224,
+        "func_name": "Random._randbelow",
+        "type_comments": [
+            "(int, type, int, type, type, type) -> int"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\random.py",
+        "line": 256,
+        "func_name": "Random.choice",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\random.py",
+        "line": 669,
+        "func_name": "SystemRandom",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\re.py",
+        "line": 170,
+        "func_name": "match",
+        "type_comments": [
+            "(str, str, int) -> re.Match",
+            "(str, str, int) -> None"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\re.py",
+        "line": 180,
+        "func_name": "search",
+        "type_comments": [
+            "(re.Pattern, str, int) -> None",
+            "(str, str, re.RegexFlag) -> None"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\re.py",
+        "line": 185,
+        "func_name": "sub",
+        "type_comments": [
+            "(str, str, str, int, int) -> str"
+        ],
+        "samples": 10
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\re.py",
+        "line": 215,
+        "func_name": "findall",
+        "type_comments": [
+            "(re.Pattern, str, int) -> List[str]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\re.py",
+        "line": 232,
+        "func_name": "compile",
+        "type_comments": [
+            "(bytes, re.RegexFlag) -> re.Pattern",
+            "(str, re.RegexFlag) -> re.Pattern",
+            "(str, int) -> re.Pattern"
+        ],
+        "samples": 17
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\re.py",
+        "line": 252,
+        "func_name": "escape",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\re.py",
+        "line": 271,
+        "func_name": "_compile",
+        "type_comments": [
+            "(re.Pattern, int) -> re.Pattern",
+            "(str, re.RegexFlag) -> re.Pattern",
+            "(str, int) -> re.Pattern"
+        ],
+        "samples": 28
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\re.py",
+        "line": 297,
+        "func_name": "_compile_repl",
+        "type_comments": [
+            "(str, re.Pattern) -> Tuple[List[Tuple[int, int]], List]",
+            "(str, re.Pattern) -> Tuple[List[Tuple[int, int]], List[Optional[str]]]"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\re.py",
+        "line": 307,
+        "func_name": "_subx",
+        "type_comments": [
+            "(re.Pattern, str) -> function"
+        ],
+        "samples": 20
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\re.py",
+        "line": 313,
+        "func_name": "filter",
+        "type_comments": [
+            "(re.Match, Tuple[List[Tuple[int, int]], List[Optional[str]]]) -> str",
+            "(re.Match, Tuple[List[Tuple[int, int]], List]) -> str"
+        ],
+        "samples": 45
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\reprlib.py",
+        "line": 38,
+        "func_name": "Repr.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\shutil.py",
+        "line": 55,
+        "func_name": "Error",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\shutil.py",
+        "line": 58,
+        "func_name": "SameFileError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\shutil.py",
+        "line": 61,
+        "func_name": "SpecialFileError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\shutil.py",
+        "line": 65,
+        "func_name": "ExecError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\shutil.py",
+        "line": 68,
+        "func_name": "ReadError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\shutil.py",
+        "line": 71,
+        "func_name": "RegistryError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\shutil.py",
+        "line": 76,
+        "func_name": "copyfileobj",
+        "type_comments": [
+            "(_io.BufferedReader, _io.BufferedWriter, int) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\shutil.py",
+        "line": 84,
+        "func_name": "_samefile",
+        "type_comments": [
+            "(str, str) -> bool"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\shutil.py",
+        "line": 96,
+        "func_name": "copyfile",
+        "type_comments": [
+            "(str, str, bool) -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\shutil.py",
+        "line": 125,
+        "func_name": "copymode",
+        "type_comments": [
+            "(str, str, bool) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\CacheRegion.py",
+        "line": 31,
+        "func_name": "CacheItem",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\CacheRegion.py",
+        "line": 75,
+        "func_name": "_CacheDataStoreWrapper",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\CacheRegion.py",
+        "line": 90,
+        "func_name": "CacheRegion",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\CacheStore.py",
+        "line": 20,
+        "func_name": "Error",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\CacheStore.py",
+        "line": 24,
+        "func_name": "AbstractCacheStore",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\CacheStore.py",
+        "line": 42,
+        "func_name": "MemoryCacheStore",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\CacheStore.py",
+        "line": 74,
+        "func_name": "MemcachedCacheStore",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 138,
+        "func_name": "GenUtils",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 161,
+        "func_name": "GenUtils.genCacheInfo",
+        "type_comments": [
+            "(Dict[str, Optional[str]]) -> Dict"
+        ],
+        "samples": 13
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 209,
+        "func_name": "GenUtils.genPlainVar",
+        "type_comments": [
+            "(List[Tuple[str, bool, str]]) -> str"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 221,
+        "func_name": "GenUtils.genNameMapperVar",
+        "type_comments": [
+            "(List[Tuple[str, bool, str]]) -> str"
+        ],
+        "samples": 16
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 326,
+        "func_name": "MethodCompiler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 327,
+        "func_name": "MethodCompiler.__init__",
+        "type_comments": [
+            "(str, Cheetah.Compiler.AutoClassCompiler, None, List) -> None",
+            "(str, Cheetah.Compiler.AutoClassCompiler, str, List) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 338,
+        "func_name": "MethodCompiler.setting",
+        "type_comments": [
+            "(str) -> bool",
+            "(str) -> str",
+            "(str) -> int"
+        ],
+        "samples": 47
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 341,
+        "func_name": "MethodCompiler._setupState",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 360,
+        "func_name": "MethodCompiler.cleanupState",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 365,
+        "func_name": "MethodCompiler.methodName",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 373,
+        "func_name": "MethodCompiler.indentation",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 44
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 376,
+        "func_name": "MethodCompiler.indent",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 379,
+        "func_name": "MethodCompiler.dedent",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 387,
+        "func_name": "MethodCompiler.methodDef",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 396,
+        "func_name": "MethodCompiler.wrapCode",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 407,
+        "func_name": "MethodCompiler.methodSignature",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 410,
+        "func_name": "MethodCompiler.setMethodSignature",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 413,
+        "func_name": "MethodCompiler.methodBody",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 416,
+        "func_name": "MethodCompiler.docString",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 431,
+        "func_name": "MethodCompiler.addChunk",
+        "type_comments": [
+            "(str) -> None",
+            "(str) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 44
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 436,
+        "func_name": "MethodCompiler.appendToPrevChunk",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 24
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 439,
+        "func_name": "MethodCompiler.addWriteChunk",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 16
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 442,
+        "func_name": "MethodCompiler.addFilteredChunk",
+        "type_comments": [
+            "(str, None, None, None) -> None",
+            "(str, None, str, Tuple[int, int]) -> None"
+        ],
+        "samples": 15
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 469,
+        "func_name": "MethodCompiler._appendToPrevStrConst",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 16
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 475,
+        "func_name": "MethodCompiler.commitStrConst",
+        "type_comments": [
+            "() -> None",
+            "() -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 45
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 514,
+        "func_name": "MethodCompiler.isErrorCatcherOn",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 524,
+        "func_name": "MethodCompiler.addStrConst",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 16
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 534,
+        "func_name": "MethodCompiler.addPlaceholder",
+        "type_comments": [
+            "(str, None, str, Dict[str, Optional[str]], Tuple[int, int], bool) -> None"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 570,
+        "func_name": "MethodCompiler.addSet",
+        "type_comments": [
+            "(str, Cheetah.Parser.Components, int) -> None",
+            "(str, Cheetah.Parser.Components, int) -> None",
+            "(str, Cheetah.Parser.Components, int) -> None",
+            "(str, Cheetah.Parser.Components, int) -> None",
+            "(str, Cheetah.Parser.Components, int) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 600,
+        "func_name": "MethodCompiler.addInclude",
+        "type_comments": [
+            "(str, str, bool) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 619,
+        "func_name": "MethodCompiler.addIndentingDirective",
+        "type_comments": [
+            "(str, None) -> None",
+            "(str, Tuple[int, int]) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 628,
+        "func_name": "MethodCompiler.addReIndentingDirective",
+        "type_comments": [
+            "(str, bool, Tuple[int, int]) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 641,
+        "func_name": "MethodCompiler.addIf",
+        "type_comments": [
+            "(str, Tuple[int, int]) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 651,
+        "func_name": "MethodCompiler.addTernaryExpr",
+        "type_comments": [
+            "(str, str, str, Tuple[int, int]) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 662,
+        "func_name": "MethodCompiler.addElse",
+        "type_comments": [
+            "(str, bool, Tuple[int, int]) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1059,
+        "func_name": "AutoMethodCompiler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1061,
+        "func_name": "AutoMethodCompiler._setupState",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1068,
+        "func_name": "AutoMethodCompiler._useKWsDictArgForPassingTrans",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1076,
+        "func_name": "AutoMethodCompiler.isClassMethod",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1081,
+        "func_name": "AutoMethodCompiler.isStaticMethod",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1086,
+        "func_name": "AutoMethodCompiler.cleanupState",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1122,
+        "func_name": "AutoMethodCompiler._addAutoSetupCode",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1169,
+        "func_name": "AutoMethodCompiler._addAutoCleanupCode",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1179,
+        "func_name": "AutoMethodCompiler.addStop",
+        "type_comments": [
+            "(None) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1183,
+        "func_name": "AutoMethodCompiler.addMethArg",
+        "type_comments": [
+            "(str, str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1186,
+        "func_name": "AutoMethodCompiler.methodSignature",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1223,
+        "func_name": "ClassCompiler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1227,
+        "func_name": "ClassCompiler.__init__",
+        "type_comments": [
+            "(str, str, Cheetah.Compiler.ModuleCompiler, str, Cheetah.Compiler.ModuleCompiler) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1247,
+        "func_name": "ClassCompiler.setting",
+        "type_comments": [
+            "(str) -> bool",
+            "(str) -> None",
+            "(str) -> str",
+            "(str) -> int"
+        ],
+        "samples": 50
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1250,
+        "func_name": "ClassCompiler.__getattr__",
+        "type_comments": [
+            "(str) -> method"
+        ],
+        "samples": 51
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1269,
+        "func_name": "ClassCompiler._setupState",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1301,
+        "func_name": "ClassCompiler.cleanupState",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1314,
+        "func_name": "ClassCompiler._setupInitMethod",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1351,
+        "func_name": "ClassCompiler.className",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1382,
+        "func_name": "ClassCompiler._spawnMethodCompiler",
+        "type_comments": [
+            "(str, type, None) -> Cheetah.Compiler.MethodCompiler",
+            "(str, None, str) -> Cheetah.Compiler.AutoMethodCompiler"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1395,
+        "func_name": "ClassCompiler._setActiveMethodCompiler",
+        "type_comments": [
+            "(Cheetah.Compiler.AutoMethodCompiler) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1401,
+        "func_name": "ClassCompiler._popActiveMethodCompiler",
+        "type_comments": [
+            "() -> Cheetah.Compiler.AutoMethodCompiler"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1404,
+        "func_name": "ClassCompiler._swallowMethodCompiler",
+        "type_comments": [
+            "(Cheetah.Compiler.MethodCompiler, int) -> Cheetah.Compiler.MethodCompiler",
+            "(Cheetah.Compiler.AutoMethodCompiler, None) -> Cheetah.Compiler.AutoMethodCompiler"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1419,
+        "func_name": "ClassCompiler._finishedMethods",
+        "type_comments": [
+            "() -> List[Union[Cheetah.Compiler.AutoMethodCompiler, Cheetah.Compiler.MethodCompiler]]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1436,
+        "func_name": "ClassCompiler.addAttribute",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1532,
+        "func_name": "ClassCompiler.classDef",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1541,
+        "func_name": "ClassCompiler.wrapClassDef",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1547,
+        "func_name": "addMethods",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1555,
+        "func_name": "addAttributes",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1573,
+        "func_name": "ClassCompiler.classSignature",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1576,
+        "func_name": "ClassCompiler.classDocstring",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1586,
+        "func_name": "ClassCompiler.methodDefs",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1591,
+        "func_name": "ClassCompiler.attributes",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1601,
+        "func_name": "AutoClassCompiler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1608,
+        "func_name": "ModuleCompiler",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1613,
+        "func_name": "ModuleCompiler.__init__",
+        "type_comments": [
+            "(None, str, str, str, None, None, None, Dict) -> None",
+            "(None, str, str, str, None, None, None, Dict[str, Union[bool, str]]) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1720,
+        "func_name": "ModuleCompiler.__getattr__",
+        "type_comments": [
+            "(str) -> method"
+        ],
+        "samples": 28
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1738,
+        "func_name": "ModuleCompiler._initializeSettings",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1741,
+        "func_name": "ModuleCompiler._setupCompilerState",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1797,
+        "func_name": "ModuleCompiler.compile",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1807,
+        "func_name": "ModuleCompiler._spawnClassCompiler",
+        "type_comments": [
+            "(str, None) -> Cheetah.Compiler.AutoClassCompiler"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1818,
+        "func_name": "ModuleCompiler._addActiveClassCompiler",
+        "type_comments": [
+            "(Cheetah.Compiler.AutoClassCompiler) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1824,
+        "func_name": "ModuleCompiler._popActiveClassCompiler",
+        "type_comments": [
+            "() -> Cheetah.Compiler.AutoClassCompiler"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1827,
+        "func_name": "ModuleCompiler._swallowClassCompiler",
+        "type_comments": [
+            "(Cheetah.Compiler.AutoClassCompiler) -> Cheetah.Compiler.AutoClassCompiler"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1833,
+        "func_name": "ModuleCompiler._finishedClasses",
+        "type_comments": [
+            "() -> List[Cheetah.Compiler.AutoClassCompiler]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1839,
+        "func_name": "ModuleCompiler.addImportedVarNames",
+        "type_comments": [
+            "(List[str], str) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1947,
+        "func_name": "ModuleCompiler.getModuleEncoding",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1960,
+        "func_name": "ModuleCompiler.addModuleGlobal",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1966,
+        "func_name": "ModuleCompiler.addSpecialVar",
+        "type_comments": [
+            "(str, str, bool) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 1972,
+        "func_name": "ModuleCompiler.addImportStatement",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 2026,
+        "func_name": "ModuleCompiler.getModuleCode",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 2053,
+        "func_name": "ModuleCompiler.wrapModuleDef",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 2116,
+        "func_name": "ModuleCompiler.timestamp",
+        "type_comments": [
+            "(float) -> str",
+            "(None) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 2121,
+        "func_name": "ModuleCompiler.moduleHeader",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 2134,
+        "func_name": "ModuleCompiler.moduleDocstring",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 2141,
+        "func_name": "ModuleCompiler.specialVars",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 2149,
+        "func_name": "ModuleCompiler.importStatements",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 2152,
+        "func_name": "ModuleCompiler.moduleConstants",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 2155,
+        "func_name": "ModuleCompiler.classDefs",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Compiler.py",
+        "line": 2159,
+        "func_name": "ModuleCompiler.moduleFooter",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\DummyTransaction.py",
+        "line": 15,
+        "func_name": "DummyResponseFailure",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\DummyTransaction.py",
+        "line": 19,
+        "func_name": "DummyResponse",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\DummyTransaction.py",
+        "line": 25,
+        "func_name": "DummyResponse.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\DummyTransaction.py",
+        "line": 49,
+        "func_name": "DummyResponse.write",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 55
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\DummyTransaction.py",
+        "line": 56,
+        "func_name": "DummyResponse.getvalue",
+        "type_comments": [
+            "(None) -> str"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\DummyTransaction.py",
+        "line": 72,
+        "func_name": "DummyTransaction",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\DummyTransaction.py",
+        "line": 81,
+        "func_name": "DummyTransaction.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\DummyTransaction.py",
+        "line": 84,
+        "func_name": "DummyTransaction.response",
+        "type_comments": [
+            "(None) -> Cheetah.DummyTransaction.DummyResponse"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\DummyTransaction.py",
+        "line": 90,
+        "func_name": "TransformerResponse",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\DummyTransaction.py",
+        "line": 105,
+        "func_name": "TransformerTransaction",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\ErrorCatchers.py",
+        "line": 6,
+        "func_name": "Error",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\ErrorCatchers.py",
+        "line": 10,
+        "func_name": "ErrorCatcher",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\ErrorCatchers.py",
+        "line": 27,
+        "func_name": "BigEcho",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\ErrorCatchers.py",
+        "line": 32,
+        "func_name": "KeyError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\ErrorCatchers.py",
+        "line": 38,
+        "func_name": "ListErrors",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Filters.py",
+        "line": 14,
+        "func_name": "Filter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Filters.py",
+        "line": 17,
+        "func_name": "Filter.__init__",
+        "type_comments": [
+            "(_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_menu_tmpl.Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_menu_tmpl) -> None",
+            "(_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_static_javascripts_glitter_js.Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_static_javascripts_glitter_js) -> None",
+            "(Cheetah.Template.Template) -> None",
+            "(_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates_staticcfg_images_logo_small_svg.Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates_staticcfg_images_logo_small_svg) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Filters.py",
+        "line": 26,
+        "func_name": "Filter.filter",
+        "type_comments": [
+            "(str, None, type) -> str"
+        ],
+        "samples": 27
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Filters.py",
+        "line": 50,
+        "func_name": "Markdown",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Filters.py",
+        "line": 78,
+        "func_name": "CodeHighlighter",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Filters.py",
+        "line": 125,
+        "func_name": "MaxLen",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Filters.py",
+        "line": 135,
+        "func_name": "WebSafe",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Filters.py",
+        "line": 157,
+        "func_name": "Strip",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Filters.py",
+        "line": 191,
+        "func_name": "StripSqueeze",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Macros\\I18n.py",
+        "line": 5,
+        "func_name": "I18n",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\NameMapper.py",
+        "line": 332,
+        "func_name": "Mixin",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 31,
+        "func_name": "cachedRegex",
+        "type_comments": [
+            "(str) -> re.Pattern"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 37,
+        "func_name": "escapeRegexChars",
+        "type_comments": [
+            "(str, re.Pattern) -> str"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 141,
+        "func_name": "makeTripleQuoteRe",
+        "type_comments": [
+            "(str, str) -> re.Pattern"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 267,
+        "func_name": "ParseError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 334,
+        "func_name": "ForbiddenSyntax",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 338,
+        "func_name": "ForbiddenExpression",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 342,
+        "func_name": "ForbiddenDirective",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 346,
+        "func_name": "CheetahVariable",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 355,
+        "func_name": "Placeholder",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 359,
+        "func_name": "ArgList",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 394,
+        "func_name": "_LowLevelParser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 402,
+        "func_name": "_LowLevelParser.setSettingsManager",
+        "type_comments": [
+            "(Cheetah.Compiler.ModuleCompiler) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 405,
+        "func_name": "_LowLevelParser.setting",
+        "type_comments": [
+            "(str, Cheetah.Unspecified._Unspecified) -> List",
+            "(str, Cheetah.Unspecified._Unspecified) -> str"
+        ],
+        "samples": 71
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 411,
+        "func_name": "_LowLevelParser.setSetting",
+        "type_comments": [
+            "(str, bool) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 423,
+        "func_name": "_LowLevelParser.configureParser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 449,
+        "func_name": "_LowLevelParser._makeCheetahVarREs",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 517,
+        "func_name": "_LowLevelParser._makeCommentREs",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 533,
+        "func_name": "_LowLevelParser._makeDirectiveREs",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 547,
+        "func_name": "_LowLevelParser._makePspREs",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 556,
+        "func_name": "_LowLevelParser._unescapeCheetahVars",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 16
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 563,
+        "func_name": "_LowLevelParser._unescapeDirectives",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 16
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 570,
+        "func_name": "_LowLevelParser.isLineClearToStartToken",
+        "type_comments": [
+            "(None) -> bool"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 573,
+        "func_name": "_LowLevelParser.matchTopLevelToken",
+        "type_comments": [
+            "() -> re.Match",
+            "() -> None",
+            "() -> str"
+        ],
+        "samples": 500
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 593,
+        "func_name": "_LowLevelParser.matchPyToken",
+        "type_comments": [
+            "() -> re.Match"
+        ],
+        "samples": 19
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 603,
+        "func_name": "_LowLevelParser.getPyToken",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 19
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 611,
+        "func_name": "_LowLevelParser.matchEOLSlurpToken",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 69
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 621,
+        "func_name": "_LowLevelParser.matchCommentStartToken",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 93
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 631,
+        "func_name": "_LowLevelParser.matchMultiLineCommentStartToken",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 91
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 686,
+        "func_name": "_LowLevelParser.getDottedName",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 16
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 708,
+        "func_name": "_LowLevelParser.matchIdentifier",
+        "type_comments": [
+            "() -> re.Match"
+        ],
+        "samples": 25
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 711,
+        "func_name": "_LowLevelParser.getIdentifier",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 16
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 729,
+        "func_name": "_LowLevelParser.matchAssignmentOperator",
+        "type_comments": [
+            "() -> re.Match"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 735,
+        "func_name": "_LowLevelParser.getAssignmentOperator",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 741,
+        "func_name": "_LowLevelParser.matchDirective",
+        "type_comments": [
+            "() -> bool",
+            "() -> str"
+        ],
+        "samples": 75
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 752,
+        "func_name": "_LowLevelParser.matchDirectiveName",
+        "type_comments": [
+            "(str) -> None",
+            "(str) -> str"
+        ],
+        "samples": 11
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 780,
+        "func_name": "_LowLevelParser.matchDirectiveStartToken",
+        "type_comments": [
+            "() -> re.Match",
+            "() -> None"
+        ],
+        "samples": 82
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 783,
+        "func_name": "_LowLevelParser.getDirectiveStartToken",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 12
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 789,
+        "func_name": "_LowLevelParser.matchDirectiveEndToken",
+        "type_comments": [
+            "() -> re.Match",
+            "() -> None"
+        ],
+        "samples": 18
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 792,
+        "func_name": "_LowLevelParser.getDirectiveEndToken",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 798,
+        "func_name": "_LowLevelParser.matchColonForSingleLineShortFormDirective",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 810,
+        "func_name": "_LowLevelParser.matchPSPStartToken",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 69
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 828,
+        "func_name": "_LowLevelParser.matchCheetahVarStart",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 19
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 832,
+        "func_name": "_LowLevelParser.matchCheetahVarStartToken",
+        "type_comments": [
+            "() -> re.Match"
+        ],
+        "samples": 16
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 836,
+        "func_name": "_LowLevelParser.matchCheetahVarInExpressionStartToken",
+        "type_comments": [
+            "() -> re.Match",
+            "() -> None"
+        ],
+        "samples": 20
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 841,
+        "func_name": "_LowLevelParser.matchVariablePlaceholderStart",
+        "type_comments": [
+            "() -> re.Match",
+            "() -> None"
+        ],
+        "samples": 91
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 845,
+        "func_name": "_LowLevelParser.matchExpressionPlaceholderStart",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 73
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 849,
+        "func_name": "_LowLevelParser.getCheetahVarStartToken",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 16
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 856,
+        "func_name": "_LowLevelParser.getCacheToken",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 16
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 864,
+        "func_name": "_LowLevelParser.getSilentPlaceholderToken",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 16
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 895,
+        "func_name": "_LowLevelParser.getCheetahVar",
+        "type_comments": [
+            "(bool, bool) -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 905,
+        "func_name": "_LowLevelParser.getCheetahVarBody",
+        "type_comments": [
+            "(bool) -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 910,
+        "func_name": "_LowLevelParser.getCheetahVarNameChunks",
+        "type_comments": [
+            "() -> List[Tuple[str, bool, str]]"
+        ],
+        "samples": 16
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 969,
+        "func_name": "_LowLevelParser.getCallArgString",
+        "type_comments": [
+            "(List, Cheetah.Unspecified._Unspecified) -> str"
+        ],
+        "samples": 13
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 1141,
+        "func_name": "_LowLevelParser.getExpressionParts",
+        "type_comments": [
+            "(bool, None, List[str], Cheetah.Unspecified._Unspecified) -> List[str]",
+            "(bool, None, None, Cheetah.Unspecified._Unspecified) -> List[str]",
+            "(bool, None, Tuple[str, str, str, str, str, str, str, str, str, str], bool) -> List[str]"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 1251,
+        "func_name": "_LowLevelParser.getExpression",
+        "type_comments": [
+            "(bool, None, None, Cheetah.Unspecified._Unspecified) -> str",
+            "(bool, None, Tuple[str, str, str, str, str, str, str, str, str, str], bool) -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 1266,
+        "func_name": "_LowLevelParser.transformToken",
+        "type_comments": [
+            "(str, int) -> str"
+        ],
+        "samples": 19
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 1322,
+        "func_name": "_LowLevelParser.getPlaceholder",
+        "type_comments": [
+            "(bool, bool, bool) -> Tuple[str, str, Tuple[int, int], Dict[str, Optional[str]], None, bool]"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 1393,
+        "func_name": "_HighLevelParser",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 1398,
+        "func_name": "_HighLevelParser.__init__",
+        "type_comments": [
+            "(str, str, None, Cheetah.Compiler.ModuleCompiler) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 1406,
+        "func_name": "_HighLevelParser.setupState",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 1411,
+        "func_name": "_HighLevelParser.cleanup",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 1420,
+        "func_name": "_HighLevelParser.configureParser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 1424,
+        "func_name": "_HighLevelParser._initDirectives",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 1425,
+        "func_name": "normalizeParserVal",
+        "type_comments": [
+            "(str) -> method",
+            "(None) -> None"
+        ],
+        "samples": 20
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 1484,
+        "func_name": "_HighLevelParser._applyExpressionFilters",
+        "type_comments": [
+            "(str, str, str, int) -> str",
+            "(str, str, None, int) -> str"
+        ],
+        "samples": 15
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 1524,
+        "func_name": "_HighLevelParser._filterDisabledDirectives",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 1536,
+        "func_name": "_HighLevelParser.parse",
+        "type_comments": [
+            "(None, bool) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 1566,
+        "func_name": "_HighLevelParser.eatPlainText",
+        "type_comments": [
+            "() -> re.Match",
+            "() -> None",
+            "() -> str"
+        ],
+        "samples": 16
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 1626,
+        "func_name": "_HighLevelParser.eatPlaceholder",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 1669,
+        "func_name": "_HighLevelParser.eatDirective",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 1704,
+        "func_name": "_HighLevelParser._eatRestOfDirectiveTag",
+        "type_comments": [
+            "(bool, int) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 1766,
+        "func_name": "_HighLevelParser.eatSimpleExprDirective",
+        "type_comments": [
+            "(str, bool) -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 1784,
+        "func_name": "_HighLevelParser.eatSimpleIndentingDirective",
+        "type_comments": [
+            "(str, method, bool) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 1822,
+        "func_name": "_HighLevelParser.eatEndDirective",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 2245,
+        "func_name": "_HighLevelParser.eatSet",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 2276,
+        "func_name": "Components",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 2315,
+        "func_name": "_HighLevelParser.eatInclude",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 2701,
+        "func_name": "_HighLevelParser.eatIf",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 2765,
+        "func_name": "_HighLevelParser.pushToOpenDirectivesStack",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 2769,
+        "func_name": "_HighLevelParser.popFromOpenDirectivesStack",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Parser.py",
+        "line": 2779,
+        "func_name": "_HighLevelParser.assertEmptyOpenDirectivesStack",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Servlet.py",
+        "line": 9,
+        "func_name": "Servlet",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Servlet.py",
+        "line": 36,
+        "func_name": "Servlet.serverSidePath",
+        "type_comments": [
+            "(str, function, function) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SettingsManager.py",
+        "line": 25,
+        "func_name": "mergeNestedDictionaries",
+        "type_comments": [
+            "(Dict[str, bool], Dict[str, Union[bool, str]], bool, bool) -> Dict[str, bool]",
+            "(Dict, Dict[str, bool], bool, bool) -> Dict[str, bool]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SettingsManager.py",
+        "line": 73,
+        "func_name": "Error",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SettingsManager.py",
+        "line": 77,
+        "func_name": "NoDefault",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SettingsManager.py",
+        "line": 81,
+        "func_name": "ConfigParserCaseSensitive",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SettingsManager.py",
+        "line": 89,
+        "func_name": "_SettingsCollector",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SettingsManager.py",
+        "line": 205,
+        "func_name": "SettingsManager",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SettingsManager.py",
+        "line": 212,
+        "func_name": "SettingsManager.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SettingsManager.py",
+        "line": 232,
+        "func_name": "SettingsManager.setting",
+        "type_comments": [
+            "(str, type) -> str",
+            "(str, type) -> int",
+            "(str, type) -> bool",
+            "(str, type) -> List[str]",
+            "(str, type) -> List"
+        ],
+        "samples": 173
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SettingsManager.py",
+        "line": 246,
+        "func_name": "SettingsManager.setSetting",
+        "type_comments": [
+            "(str, bool) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SettingsManager.py",
+        "line": 250,
+        "func_name": "SettingsManager.settings",
+        "type_comments": [
+            "() -> Dict[str, bool]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SettingsManager.py",
+        "line": 262,
+        "func_name": "SettingsManager.updateSettings",
+        "type_comments": [
+            "(Dict[str, Union[bool, str]], bool) -> None",
+            "(Dict[str, bool], bool) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SourceReader.py",
+        "line": 11,
+        "func_name": "Error",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SourceReader.py",
+        "line": 15,
+        "func_name": "SourceReader",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SourceReader.py",
+        "line": 16,
+        "func_name": "SourceReader.__init__",
+        "type_comments": [
+            "(str, str, None, None) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SourceReader.py",
+        "line": 41,
+        "func_name": "SourceReader.src",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 500
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SourceReader.py",
+        "line": 47,
+        "func_name": "SourceReader.__len__",
+        "type_comments": [
+            "() -> int"
+        ],
+        "samples": 79
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SourceReader.py",
+        "line": 50,
+        "func_name": "SourceReader.__getitem__",
+        "type_comments": [
+            "(slice) -> str"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SourceReader.py",
+        "line": 67,
+        "func_name": "SourceReader.lineNum",
+        "type_comments": [
+            "(int) -> int"
+        ],
+        "samples": 15
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SourceReader.py",
+        "line": 75,
+        "func_name": "SourceReader.getRowCol",
+        "type_comments": [
+            "(None) -> Tuple[int, int]",
+            "(int) -> Tuple[int, int]"
+        ],
+        "samples": 15
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SourceReader.py",
+        "line": 94,
+        "func_name": "SourceReader.pos",
+        "type_comments": [
+            "() -> int"
+        ],
+        "samples": 500
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SourceReader.py",
+        "line": 97,
+        "func_name": "SourceReader.setPos",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 39
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SourceReader.py",
+        "line": 101,
+        "func_name": "SourceReader.validPos",
+        "type_comments": [
+            "(int) -> bool"
+        ],
+        "samples": 43
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SourceReader.py",
+        "line": 104,
+        "func_name": "SourceReader.checkPos",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 500
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SourceReader.py",
+        "line": 112,
+        "func_name": "SourceReader.breakPoint",
+        "type_comments": [
+            "() -> int"
+        ],
+        "samples": 11
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SourceReader.py",
+        "line": 144,
+        "func_name": "SourceReader.atEnd",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 500
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SourceReader.py",
+        "line": 150,
+        "func_name": "SourceReader.peek",
+        "type_comments": [
+            "(int) -> str"
+        ],
+        "samples": 500
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SourceReader.py",
+        "line": 155,
+        "func_name": "SourceReader.getc",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 43
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SourceReader.py",
+        "line": 169,
+        "func_name": "SourceReader.advance",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 500
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SourceReader.py",
+        "line": 183,
+        "func_name": "SourceReader.readTo",
+        "type_comments": [
+            "(int, int) -> str",
+            "(int, None) -> str"
+        ],
+        "samples": 63
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SourceReader.py",
+        "line": 198,
+        "func_name": "SourceReader.find",
+        "type_comments": [
+            "(str, int) -> int",
+            "(str, None) -> int"
+        ],
+        "samples": 10
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SourceReader.py",
+        "line": 203,
+        "func_name": "SourceReader.startswith",
+        "type_comments": [
+            "(str, None) -> bool"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SourceReader.py",
+        "line": 214,
+        "func_name": "SourceReader.findBOL",
+        "type_comments": [
+            "(int) -> int"
+        ],
+        "samples": 45
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SourceReader.py",
+        "line": 220,
+        "func_name": "SourceReader.findEOL",
+        "type_comments": [
+            "(None, bool) -> int"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SourceReader.py",
+        "line": 230,
+        "func_name": "SourceReader.isLineClearToPos",
+        "type_comments": [
+            "(None) -> bool"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SourceReader.py",
+        "line": 244,
+        "func_name": "SourceReader.matchWhiteSpace",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 20
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\SourceReader.py",
+        "line": 247,
+        "func_name": "SourceReader.getWhiteSpace",
+        "type_comments": [
+            "(None, str) -> str"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Template.py",
+        "line": 64,
+        "func_name": "createMethod",
+        "type_comments": [
+            "(function, type) -> function"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Template.py",
+        "line": 78,
+        "func_name": "Error",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Template.py",
+        "line": 82,
+        "func_name": "PreprocessError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Template.py",
+        "line": 97,
+        "func_name": "hashDict",
+        "type_comments": [
+            "(Dict[str, Union[bool, str]]) -> int"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Template.py",
+        "line": 112,
+        "func_name": "_genUniqueModuleName",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Template.py",
+        "line": 137,
+        "func_name": "CompileCacheItem",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Template.py",
+        "line": 141,
+        "func_name": "TemplatePreprocessor",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Template.py",
+        "line": 186,
+        "func_name": "Template",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Template.py",
+        "line": 345,
+        "func_name": "_getCompilerClass",
+        "type_comments": [
+            "(type, None, str) -> type"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Template.py",
+        "line": 349,
+        "func_name": "_getCompilerSettings",
+        "type_comments": [
+            "(type, None, str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Template.py",
+        "line": 353,
+        "func_name": "compile",
+        "type_comments": [
+            "(type, None, str, bool, Dict[str, Union[bool, str]], Cheetah.Unspecified._Unspecified, None, Cheetah.Unspecified._Unspecified, None, Cheetah.Unspecified._Unspecified, Cheetah.Unspecified._Unspecified, Cheetah.Unspecified._Unspecified, Cheetah.Unspecified._Unspecified, Cheetah.Unspecified._Unspecified, Cheetah.Unspecified._Unspecified, Cheetah.Unspecified._Unspecified, None, bool) -> type",
+            "(type, None, str, bool, Cheetah.Unspecified._Unspecified, Cheetah.Unspecified._Unspecified, None, Cheetah.Unspecified._Unspecified, Cheetah.Unspecified._Unspecified, Cheetah.Unspecified._Unspecified, Cheetah.Unspecified._Unspecified, Cheetah.Unspecified._Unspecified, Cheetah.Unspecified._Unspecified, Cheetah.Unspecified._Unspecified, Cheetah.Unspecified._Unspecified, Cheetah.Unspecified._Unspecified, None, Cheetah.Unspecified._Unspecified) -> type"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Template.py",
+        "line": 1008,
+        "func_name": "_addCheetahPlumbingCodeToClass",
+        "type_comments": [
+            "(type, type) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Template.py",
+        "line": 1096,
+        "func_name": "Template.__init__",
+        "type_comments": [
+            "(None, None, None, None, str, module, None, Cheetah.Unspecified._Unspecified, Dict, List[Union[Dict, Dict[str, Union[function, str]], _Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_menu_tmpl.Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_menu_tmpl, _Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_main_tmpl.Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_main_tmpl]]) -> None",
+            "(None, None, None, None, str, module, None, Cheetah.Unspecified._Unspecified, Dict, List[Union[Dict, Dict[str, Union[function, str]], _Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_main_tmpl.Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_main_tmpl]]) -> None",
+            "(None, None, None, None, str, module, None, Cheetah.Unspecified._Unspecified, None, None) -> None",
+            "(None, None, List[Dict[str, Union[function, str]]], str, str, module, None, Dict[str, Union[bool, str]], None, None) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Template.py",
+        "line": 1356,
+        "func_name": "Template.searchList",
+        "type_comments": [
+            "() -> List[Union[Dict, Dict[str, Union[function, str]], _Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_menu_tmpl.Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_menu_tmpl, _Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_main_tmpl.Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_main_tmpl]]",
+            "() -> List[Union[Dict, Dict[str, Union[function, str]], _Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_main_tmpl.Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_main_tmpl]]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Template.py",
+        "line": 1498,
+        "func_name": "Template.getFileContents",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Template.py",
+        "line": 1523,
+        "func_name": "Template._initCheetahInstance",
+        "type_comments": [
+            "(None, None, str, module, None, Dict, Cheetah.Unspecified._Unspecified, List[Union[Dict, Dict[str, Union[function, str]], _Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_main_tmpl.Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_main_tmpl]]) -> None",
+            "(None, None, str, module, None, None, Cheetah.Unspecified._Unspecified, None) -> None",
+            "(List[Dict[str, Union[function, str]]], None, str, module, None, None, Dict[str, Union[bool, str]], None) -> None",
+            "(None, None, str, module, None, Dict, Cheetah.Unspecified._Unspecified, List[Union[Dict, Dict[str, Union[function, str]], _Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_menu_tmpl.Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_menu_tmpl, _Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_main_tmpl.Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_main_tmpl]]) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Template.py",
+        "line": 1615,
+        "func_name": "Template._compile",
+        "type_comments": [
+            "(None, str, Dict[str, Union[bool, str]], None, None) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Template.py",
+        "line": 1660,
+        "func_name": "Template._handleCheetahInclude",
+        "type_comments": [
+            "(str, Cheetah.DummyTransaction.DummyTransaction, str, bool) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Template.py",
+        "line": 1712,
+        "func_name": "Template._getTemplateAPIClassForIncludeDirectiveCompilation",
+        "type_comments": [
+            "(None, str) -> type"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Unspecified.py",
+        "line": 4,
+        "func_name": "_Unspecified",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Utils\\Indenter.py",
+        "line": 20,
+        "func_name": "IndentProcessor",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Utils\\Indenter.py",
+        "line": 89,
+        "func_name": "Indenter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Utils\\WebInputMixin.py",
+        "line": 8,
+        "func_name": "NonNumericInputError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\Cheetah\\Utils\\WebInputMixin.py",
+        "line": 15,
+        "func_name": "_Converter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\big5prober.py",
+        "line": 34,
+        "func_name": "Big5Prober",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\chardistribution.py",
+        "line": 40,
+        "func_name": "CharDistributionAnalysis",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\chardistribution.py",
+        "line": 113,
+        "func_name": "EUCTWDistributionAnalysis",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\chardistribution.py",
+        "line": 132,
+        "func_name": "EUCKRDistributionAnalysis",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\chardistribution.py",
+        "line": 151,
+        "func_name": "GB2312DistributionAnalysis",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\chardistribution.py",
+        "line": 170,
+        "func_name": "Big5DistributionAnalysis",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\chardistribution.py",
+        "line": 192,
+        "func_name": "SJISDistributionAnalysis",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\chardistribution.py",
+        "line": 217,
+        "func_name": "EUCJPDistributionAnalysis",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\charsetgroupprober.py",
+        "line": 32,
+        "func_name": "CharSetGroupProber",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\charsetprober.py",
+        "line": 35,
+        "func_name": "CharSetProber",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\codingstatemachine.py",
+        "line": 33,
+        "func_name": "CodingStateMachine",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\cp949prober.py",
+        "line": 34,
+        "func_name": "CP949Prober",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\enums.py",
+        "line": 8,
+        "func_name": "InputState",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\enums.py",
+        "line": 17,
+        "func_name": "LanguageFilter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\enums.py",
+        "line": 32,
+        "func_name": "ProbingState",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\enums.py",
+        "line": 41,
+        "func_name": "MachineState",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\enums.py",
+        "line": 50,
+        "func_name": "SequenceLikelihood",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\enums.py",
+        "line": 65,
+        "func_name": "CharacterCategory",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\escprober.py",
+        "line": 35,
+        "func_name": "EscCharSetProber",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\eucjpprober.py",
+        "line": 36,
+        "func_name": "EUCJPProber",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\euckrprober.py",
+        "line": 34,
+        "func_name": "EUCKRProber",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\euctwprober.py",
+        "line": 33,
+        "func_name": "EUCTWProber",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\gb2312prober.py",
+        "line": 33,
+        "func_name": "GB2312Prober",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\hebrewprober.py",
+        "line": 128,
+        "func_name": "HebrewProber",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\jpcntx.py",
+        "line": 116,
+        "func_name": "JapaneseContextAnalysis",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\jpcntx.py",
+        "line": 183,
+        "func_name": "SJISContextAnalysis",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\jpcntx.py",
+        "line": 212,
+        "func_name": "EUCJPContextAnalysis",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\latin1prober.py",
+        "line": 96,
+        "func_name": "Latin1Prober",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\mbcharsetprober.py",
+        "line": 34,
+        "func_name": "MultiByteCharSetProber",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\mbcsgroupprober.py",
+        "line": 41,
+        "func_name": "MBCSGroupProber",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\sbcharsetprober.py",
+        "line": 33,
+        "func_name": "SingleByteCharSetProber",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\sjisprober.py",
+        "line": 36,
+        "func_name": "SJISProber",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\universaldetector.py",
+        "line": 51,
+        "func_name": "UniversalDetector",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\chardet\\utf8prober.py",
+        "line": 35,
+        "func_name": "UTF8Prober",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\_compat.py",
+        "line": 29,
+        "func_name": "ntob",
+        "type_comments": [
+            "(str, str) -> bytes"
+        ],
+        "samples": 67
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\_compat.py",
+        "line": 41,
+        "func_name": "bton",
+        "type_comments": [
+            "(bytes, str) -> str"
+        ],
+        "samples": 111
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\_compat.py",
+        "line": 77,
+        "func_name": "assert_native",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 68
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\errors.py",
+        "line": 10,
+        "func_name": "MaxSizeExceeded",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\errors.py",
+        "line": 17,
+        "func_name": "NoSSLError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\errors.py",
+        "line": 21,
+        "func_name": "FatalSSLAlert",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\errors.py",
+        "line": 25,
+        "func_name": "plat_specific_errors",
+        "type_comments": [
+            "(*str) -> List[int]"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\makefile.py",
+        "line": 28,
+        "func_name": "BufferedWriter.write",
+        "type_comments": [
+            "(bytes) -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 13
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\makefile.py",
+        "line": 39,
+        "func_name": "BufferedWriter._flush_unlocked",
+        "type_comments": [
+            "() -> pyannotate_runtime.collect_types.NoReturnType",
+            "() -> None",
+            "() -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\makefile.py",
+        "line": 51,
+        "func_name": "MakeFile_PY2",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\makefile.py",
+        "line": 112,
+        "func_name": "FauxSocket",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\makefile.py",
+        "line": 399,
+        "func_name": "StreamReader",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\makefile.py",
+        "line": 402,
+        "func_name": "StreamReader.__init__",
+        "type_comments": [
+            "(socket.socket, str, int) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\makefile.py",
+        "line": 406,
+        "func_name": "StreamWriter",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\makefile.py",
+        "line": 409,
+        "func_name": "StreamWriter.__init__",
+        "type_comments": [
+            "(socket.socket, str, int) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\makefile.py",
+        "line": 413,
+        "func_name": "MakeFile",
+        "type_comments": [
+            "(socket.socket, str, int) -> cheroot.makefile.StreamWriter",
+            "(socket.socket, str, int) -> cheroot.makefile.StreamReader"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 173,
+        "func_name": "HeaderReader",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 231,
+        "func_name": "HeaderReader._allow_header",
+        "type_comments": [
+            "(bytes) -> bool"
+        ],
+        "samples": 45
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 234,
+        "func_name": "HeaderReader._transform_key",
+        "type_comments": [
+            "(bytes) -> bytes"
+        ],
+        "samples": 45
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 239,
+        "func_name": "DropUnderscoreHeaderReader",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 247,
+        "func_name": "SizeCheckWrapper",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 250,
+        "func_name": "SizeCheckWrapper.__init__",
+        "type_comments": [
+            "(cheroot.makefile.StreamReader, int) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 261,
+        "func_name": "SizeCheckWrapper._check_length",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 54
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 280,
+        "func_name": "SizeCheckWrapper.readline",
+        "type_comments": [
+            "(None) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(None) -> bytes"
+        ],
+        "samples": 54
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 348,
+        "func_name": "KnownLengthRFile",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 351,
+        "func_name": "KnownLengthRFile.__init__",
+        "type_comments": [
+            "(cheroot.makefile.StreamReader, int) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 362,
+        "func_name": "KnownLengthRFile.read",
+        "type_comments": [
+            "(int) -> bytes"
+        ],
+        "samples": 60
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 443,
+        "func_name": "ChunkedRFile",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 636,
+        "func_name": "HTTPRequest",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 674,
+        "func_name": "HTTPRequest.__init__",
+        "type_comments": [
+            "(cherrypy._cpwsgi_server.CPWSGIServer, cheroot.server.HTTPConnection, bool, bool) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 707,
+        "func_name": "HTTPRequest.parse_request",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 737,
+        "func_name": "HTTPRequest.read_request_line",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 954,
+        "func_name": "HTTPRequest.read_request_headers",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1040,
+        "func_name": "HTTPRequest.respond",
+        "type_comments": [
+            "() -> pyannotate_runtime.collect_types.NoReturnType",
+            "() -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1062,
+        "func_name": "HTTPRequest.simple_response",
+        "type_comments": [
+            "(str, str) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1099,
+        "func_name": "HTTPRequest.ensure_headers_sent",
+        "type_comments": [
+            "() -> None",
+            "() -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 18
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1105,
+        "func_name": "HTTPRequest.write",
+        "type_comments": [
+            "(bytes) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(bytes) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1114,
+        "func_name": "HTTPRequest.send_headers",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1191,
+        "func_name": "HTTPConnection",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1203,
+        "func_name": "HTTPConnection.__init__",
+        "type_comments": [
+            "(cherrypy._cpwsgi_server.CPWSGIServer, socket.socket, function) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1230,
+        "func_name": "HTTPConnection.communicate",
+        "type_comments": [
+            "() -> None",
+            "() -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1300,
+        "func_name": "HTTPConnection._conditional_error",
+        "type_comments": [
+            "(cherrypy._cpwsgi_server.CPWSGIHTTPRequest, str) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1316,
+        "func_name": "HTTPConnection.close",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1432,
+        "func_name": "HTTPConnection._close_kernel_socket",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1468,
+        "func_name": "prevent_socket_inheritance",
+        "type_comments": [
+            "(socket.socket) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1480,
+        "func_name": "HTTPServer",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1555,
+        "func_name": "HTTPServer.__init__",
+        "type_comments": [
+            "(Tuple[str, int], type, int, int, str, bool, bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1585,
+        "func_name": "HTTPServer.clear_stats",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1625,
+        "func_name": "HTTPServer.__str__",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1630,
+        "func_name": "bind_addr",
+        "type_comments": [
+            "() -> Tuple[str, int]"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1648,
+        "func_name": "bind_addr",
+        "type_comments": [
+            "(Tuple[str, int]) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1682,
+        "func_name": "HTTPServer.prepare",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1749,
+        "func_name": "HTTPServer.serve",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1767,
+        "func_name": "HTTPServer.start",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1795,
+        "func_name": "HTTPServer.bind",
+        "type_comments": [
+            "(socket.AddressFamily, socket.SocketKind, int) -> socket.socket"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1870,
+        "func_name": "prepare_socket",
+        "type_comments": [
+            "(Tuple[str, int], socket.AddressFamily, socket.SocketKind, int, bool, None) -> socket.socket"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1916,
+        "func_name": "bind_socket",
+        "type_comments": [
+            "(socket.socket, Tuple[str, int]) -> socket.socket"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1922,
+        "func_name": "resolve_real_bind_addr",
+        "type_comments": [
+            "(socket.socket) -> Tuple[str, int]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 1940,
+        "func_name": "HTTPServer.tick",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 2032,
+        "func_name": "interrupt",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 2044,
+        "func_name": "HTTPServer.stop",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 2090,
+        "func_name": "Gateway",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\server.py",
+        "line": 2093,
+        "func_name": "Gateway.__init__",
+        "type_comments": [
+            "(cherrypy._cpwsgi_server.CPWSGIHTTPRequest) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\ssl\\__init__.py",
+        "line": 11,
+        "func_name": "Adapter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\ssl\\builtin.py",
+        "line": 54,
+        "func_name": "BuiltinSSLAdapter",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\workers\\threadpool.py",
+        "line": 17,
+        "func_name": "TrueyZero",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\workers\\threadpool.py",
+        "line": 32,
+        "func_name": "WorkerThread",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\workers\\threadpool.py",
+        "line": 52,
+        "func_name": "WorkerThread.__init__",
+        "type_comments": [
+            "(cherrypy._cpwsgi_server.CPWSGIServer) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\workers\\threadpool.py",
+        "line": 95,
+        "func_name": "WorkerThread.run",
+        "type_comments": [
+            "() -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\workers\\threadpool.py",
+        "line": 126,
+        "func_name": "ThreadPool",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\workers\\threadpool.py",
+        "line": 133,
+        "func_name": "ThreadPool.__init__",
+        "type_comments": [
+            "(cherrypy._cpwsgi_server.CPWSGIServer, int, int, int, int) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\workers\\threadpool.py",
+        "line": 156,
+        "func_name": "ThreadPool.start",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\workers\\threadpool.py",
+        "line": 172,
+        "func_name": "ThreadPool.put",
+        "type_comments": [
+            "(cheroot.server.HTTPConnection) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\workers\\threadpool.py",
+        "line": 225,
+        "func_name": "ThreadPool.stop",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\wsgi.py",
+        "line": 41,
+        "func_name": "Server",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\wsgi.py",
+        "line": 47,
+        "func_name": "Server.__init__",
+        "type_comments": [
+            "(Tuple[str, int], cherrypy._cptree.Tree, int, str, int, int, int, int, int, int, bool, bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\wsgi.py",
+        "line": 98,
+        "func_name": "Gateway",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\wsgi.py",
+        "line": 101,
+        "func_name": "Gateway.__init__",
+        "type_comments": [
+            "(cherrypy._cpwsgi_server.CPWSGIHTTPRequest) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\wsgi.py",
+        "line": 112,
+        "func_name": "gateway_map",
+        "type_comments": [
+            "() -> Dict[Tuple[int, int], type]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\wsgi.py",
+        "line": 130,
+        "func_name": "Gateway.respond",
+        "type_comments": [
+            "() -> pyannotate_runtime.collect_types.NoReturnType",
+            "() -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\wsgi.py",
+        "line": 154,
+        "func_name": "Gateway.start_response",
+        "type_comments": [
+            "(str, List[Tuple[str, str]], None) -> method"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\wsgi.py",
+        "line": 188,
+        "func_name": "_encode_status",
+        "type_comments": [
+            "(str) -> bytes"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\wsgi.py",
+        "line": 203,
+        "func_name": "Gateway.write",
+        "type_comments": [
+            "(bytes) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(bytes) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\wsgi.py",
+        "line": 237,
+        "func_name": "Gateway_10",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\wsgi.py",
+        "line": 242,
+        "func_name": "Gateway_10.get_environ",
+        "type_comments": [
+            "() -> Dict[str, str]"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\wsgi.py",
+        "line": 314,
+        "func_name": "Gateway_u0",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cheroot\\wsgi.py",
+        "line": 363,
+        "func_name": "PathInfoDispatcher",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\__init__.py",
+        "line": 130,
+        "func_name": "_HandleSignalsPlugin",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\__init__.py",
+        "line": 136,
+        "func_name": "_HandleSignalsPlugin.__init__",
+        "type_comments": [
+            "(cherrypy.process.win32.Win32Bus) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\__init__.py",
+        "line": 181,
+        "func_name": "_Serving",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\__init__.py",
+        "line": 203,
+        "func_name": "_Serving.load",
+        "type_comments": [
+            "(cherrypy._cprequest.Request, cherrypy._cprequest.Response) -> None"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\__init__.py",
+        "line": 207,
+        "func_name": "_Serving.clear",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\__init__.py",
+        "line": 215,
+        "func_name": "_ThreadLocalProxy",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\__init__.py",
+        "line": 219,
+        "func_name": "_ThreadLocalProxy.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\__init__.py",
+        "line": 222,
+        "func_name": "_ThreadLocalProxy.__getattr__",
+        "type_comments": [
+            "(str) -> cherrypy.lib.httputil.Host",
+            "(str) -> method",
+            "(str) -> cherrypy._cptree.Application",
+            "(str) -> cherrypy.lib.httputil.HeaderMap",
+            "(str) -> None"
+        ],
+        "samples": 22
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\__init__.py",
+        "line": 226,
+        "func_name": "_ThreadLocalProxy.__setattr__",
+        "type_comments": [
+            "(str, cherrypy._cptree.Application) -> None",
+            "(str, str) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\__init__.py",
+        "line": 306,
+        "func_name": "_GlobalLogManager",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\__init__.py",
+        "line": 330,
+        "func_name": "_GlobalLogManager.access",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\__init__.py",
+        "line": 350,
+        "func_name": "_buslog",
+        "type_comments": [
+            "(str, int) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpchecker.py",
+        "line": 9,
+        "func_name": "Checker",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpchecker.py",
+        "line": 26,
+        "func_name": "Checker.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpchecker.py",
+        "line": 51,
+        "func_name": "Checker.check_app_config_entries_dont_start_with_script_name",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpchecker.py",
+        "line": 69,
+        "func_name": "Checker.check_site_config_entries_in_app_config",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpchecker.py",
+        "line": 108,
+        "func_name": "Checker.check_app_config_brackets",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpchecker.py",
+        "line": 123,
+        "func_name": "Checker.check_static_paths",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpchecker.py",
+        "line": 193,
+        "func_name": "Checker._compat",
+        "type_comments": [
+            "(Dict[str, Dict[str, Union[Dict[str, str], List[Tuple[str, str]], bool, str]]]) -> None",
+            "(cherrypy._cpconfig.Config) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpchecker.py",
+        "line": 214,
+        "func_name": "Checker.check_compatibility",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpchecker.py",
+        "line": 225,
+        "func_name": "Checker._known_ns",
+        "type_comments": [
+            "(cherrypy._cptree.Application) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpchecker.py",
+        "line": 262,
+        "func_name": "Checker.check_config_namespaces",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpchecker.py",
+        "line": 272,
+        "func_name": "Checker._populate_known_types",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpchecker.py",
+        "line": 276,
+        "func_name": "traverse",
+        "type_comments": [
+            "(cherrypy.process.win32.Win32Bus, str) -> None",
+            "(cherrypy._cpserver.Server, str) -> None",
+            "(cherrypy._ThreadLocalProxy, str) -> None",
+            "(cherrypy._GlobalLogManager, str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpchecker.py",
+        "line": 291,
+        "func_name": "Checker._known_types",
+        "type_comments": [
+            "(Dict[str, Dict[str, Union[Dict[str, str], List[Tuple[str, str]], bool, str]]]) -> None",
+            "(cherrypy._cpconfig.Config) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpchecker.py",
+        "line": 306,
+        "func_name": "Checker.check_config_types",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpchecker.py",
+        "line": 315,
+        "func_name": "Checker.check_localhost",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpcompat.py",
+        "line": 33,
+        "func_name": "ntou",
+        "type_comments": [
+            "(str, str) -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpcompat.py",
+        "line": 50,
+        "func_name": "assert_native",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpconfig.py",
+        "line": 126,
+        "func_name": "_if_filename_register_autoreload",
+        "type_comments": [
+            "(Dict[str, bool]) -> None",
+            "(Dict[str, Dict[str, Union[Dict[str, str], List[Tuple[str, str]], bool, str]]]) -> None",
+            "(Dict[str, Union[bool, int, str]]) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpconfig.py",
+        "line": 132,
+        "func_name": "merge",
+        "type_comments": [
+            "(Dict, Dict[str, Dict[str, Union[Dict[str, str], List[Tuple[str, str]], bool, str]]]) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpconfig.py",
+        "line": 151,
+        "func_name": "Config",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpconfig.py",
+        "line": 154,
+        "func_name": "Config.update",
+        "type_comments": [
+            "(Dict[str, bool]) -> None",
+            "(Dict[str, Union[bool, int, str]]) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpconfig.py",
+        "line": 159,
+        "func_name": "Config._apply",
+        "type_comments": [
+            "(Dict[str, bool]) -> None",
+            "(Dict[str, Union[bool, int, str]]) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpconfig.py",
+        "line": 178,
+        "func_name": "_Vars",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpconfig.py",
+        "line": 230,
+        "func_name": "_server_namespace_handler",
+        "type_comments": [
+            "(str, int) -> None",
+            "(str, str) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpconfig.py",
+        "line": 260,
+        "func_name": "_engine_namespace_handler",
+        "type_comments": [
+            "(str, bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpdispatch.py",
+        "line": 23,
+        "func_name": "PageHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpdispatch.py",
+        "line": 32,
+        "func_name": "args",
+        "type_comments": [
+            "() -> Tuple[]"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpdispatch.py",
+        "line": 37,
+        "func_name": "args",
+        "type_comments": [
+            "(Tuple[]) -> Tuple[]",
+            "(Tuple[str]) -> Tuple[str]"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpdispatch.py",
+        "line": 52,
+        "func_name": "PageHandler.__call__",
+        "type_comments": [
+            "() -> bytes",
+            "() -> str"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpdispatch.py",
+        "line": 217,
+        "func_name": "LateParamPageHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpdispatch.py",
+        "line": 227,
+        "func_name": "kwargs",
+        "type_comments": [
+            "() -> Dict[str, str]",
+            "() -> Dict"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpdispatch.py",
+        "line": 235,
+        "func_name": "kwargs",
+        "type_comments": [
+            "(Dict) -> None"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpdispatch.py",
+        "line": 253,
+        "func_name": "validate_translator",
+        "type_comments": [
+            "(Dict[int, int]) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpdispatch.py",
+        "line": 258,
+        "func_name": "Dispatcher",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpdispatch.py",
+        "line": 279,
+        "func_name": "Dispatcher.__init__",
+        "type_comments": [
+            "(None, Dict[int, int]) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpdispatch.py",
+        "line": 298,
+        "func_name": "Dispatcher.find_handler",
+        "type_comments": [
+            "(str) -> Tuple[function, List[str]]",
+            "(str) -> Tuple[method, List]",
+            "(str) -> Tuple[None, List]",
+            "(str) -> Tuple[method, List[str]]"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpdispatch.py",
+        "line": 396,
+        "func_name": "set_conf",
+        "type_comments": [
+            "() -> Dict[str, Union[bool, str]]"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpdispatch.py",
+        "line": 454,
+        "func_name": "MethodDispatcher",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpdispatch.py",
+        "line": 498,
+        "func_name": "RoutesDispatcher",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cperror.py",
+        "line": 137,
+        "func_name": "CherryPyException",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cperror.py",
+        "line": 143,
+        "func_name": "InternalRedirect",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cperror.py",
+        "line": 174,
+        "func_name": "HTTPRedirect",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cperror.py",
+        "line": 339,
+        "func_name": "HTTPError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cperror.py",
+        "line": 368,
+        "func_name": "HTTPError.__init__",
+        "type_comments": [
+            "(int, str) -> None",
+            "(int, None) -> None"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cperror.py",
+        "line": 426,
+        "func_name": "NotFound",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cperror.py",
+        "line": 434,
+        "func_name": "NotFound.__init__",
+        "type_comments": [
+            "(None) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cplogging.py",
+        "line": 125,
+        "func_name": "NullHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cplogging.py",
+        "line": 135,
+        "func_name": "NullHandler.createLock",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cplogging.py",
+        "line": 139,
+        "func_name": "LogManager",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cplogging.py",
+        "line": 169,
+        "func_name": "LogManager.__init__",
+        "type_comments": [
+            "(int, str) -> None",
+            "(None, str) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cplogging.py",
+        "line": 199,
+        "func_name": "LogManager.error",
+        "type_comments": [
+            "(str, str, int, bool) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cplogging.py",
+        "line": 223,
+        "func_name": "LogManager.access",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cplogging.py",
+        "line": 288,
+        "func_name": "LogManager.time",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cplogging.py",
+        "line": 297,
+        "func_name": "LogManager._get_builtin_handler",
+        "type_comments": [
+            "(logging.Logger, str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cplogging.py",
+        "line": 303,
+        "func_name": "LogManager._set_screen_handler",
+        "type_comments": [
+            "(logging.Logger, bool, _io.TextIOWrapper) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cplogging.py",
+        "line": 316,
+        "func_name": "screen",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cplogging.py",
+        "line": 327,
+        "func_name": "screen",
+        "type_comments": [
+            "(bool) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cplogging.py",
+        "line": 340,
+        "func_name": "LogManager._set_file_handler",
+        "type_comments": [
+            "(logging.Logger, str) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cplogging.py",
+        "line": 355,
+        "func_name": "error_file",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cplogging.py",
+        "line": 367,
+        "func_name": "error_file",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cplogging.py",
+        "line": 371,
+        "func_name": "access_file",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cplogging.py",
+        "line": 383,
+        "func_name": "access_file",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cplogging.py",
+        "line": 400,
+        "func_name": "wsgi",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cplogging.py",
+        "line": 416,
+        "func_name": "WSGIErrorHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cplogging.py",
+        "line": 453,
+        "func_name": "LazyRfc3339UtcTime",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cplogging.py",
+        "line": 454,
+        "func_name": "LazyRfc3339UtcTime.__str__",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpreqbody.py",
+        "line": 279,
+        "func_name": "Entity",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpreqbody.py",
+        "line": 409,
+        "func_name": "Entity.__init__",
+        "type_comments": [
+            "(cheroot.server.KnownLengthRFile, cherrypy.lib.httputil.HeaderMap, None, None) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpreqbody.py",
+        "line": 480,
+        "func_name": "Entity.readline",
+        "type_comments": [
+            "(None) -> bytes"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpreqbody.py",
+        "line": 508,
+        "func_name": "Entity.make_file",
+        "type_comments": [
+            "() -> tempfile._TemporaryFileWrapper"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpreqbody.py",
+        "line": 544,
+        "func_name": "Entity.process",
+        "type_comments": [
+            "() -> None",
+            "() -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpreqbody.py",
+        "line": 571,
+        "func_name": "Part",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpreqbody.py",
+        "line": 612,
+        "func_name": "Part.__init__",
+        "type_comments": [
+            "(cherrypy._cpreqbody.SizedReader, cherrypy.lib.httputil.HeaderMap, bytes) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpreqbody.py",
+        "line": 618,
+        "func_name": "from_fp",
+        "type_comments": [
+            "(cherrypy._cpreqbody.SizedReader, bytes) -> cherrypy._cpreqbody.Part"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpreqbody.py",
+        "line": 623,
+        "func_name": "read_headers",
+        "type_comments": [
+            "(cherrypy._cpreqbody.SizedReader) -> cherrypy.lib.httputil.HeaderMap"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpreqbody.py",
+        "line": 653,
+        "func_name": "Part.read_lines_to_boundary",
+        "type_comments": [
+            "(tempfile._TemporaryFileWrapper) -> tempfile._TemporaryFileWrapper"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpreqbody.py",
+        "line": 711,
+        "func_name": "Part.default_proc",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpreqbody.py",
+        "line": 725,
+        "func_name": "Part.read_into_file",
+        "type_comments": [
+            "(None) -> tempfile._TemporaryFileWrapper"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpreqbody.py",
+        "line": 741,
+        "func_name": "SizedReader",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpreqbody.py",
+        "line": 743,
+        "func_name": "SizedReader.__init__",
+        "type_comments": [
+            "(cheroot.server.KnownLengthRFile, int, None, int, bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpreqbody.py",
+        "line": 755,
+        "func_name": "SizedReader.read",
+        "type_comments": [
+            "(int, None) -> bytes"
+        ],
+        "samples": 62
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpreqbody.py",
+        "line": 846,
+        "func_name": "SizedReader.readline",
+        "type_comments": [
+            "(None) -> bytes",
+            "(int) -> bytes"
+        ],
+        "samples": 62
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpreqbody.py",
+        "line": 887,
+        "func_name": "SizedReader.finish",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpreqbody.py",
+        "line": 920,
+        "func_name": "RequestBody",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpreqbody.py",
+        "line": 945,
+        "func_name": "RequestBody.__init__",
+        "type_comments": [
+            "(cheroot.server.KnownLengthRFile, cherrypy.lib.httputil.HeaderMap, None, Dict) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpreqbody.py",
+        "line": 967,
+        "func_name": "RequestBody.process",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 16,
+        "func_name": "Hook",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 41,
+        "func_name": "Hook.__init__",
+        "type_comments": [
+            "(type, None, int) -> None",
+            "(function, None, int) -> None"
+        ],
+        "samples": 25
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 54,
+        "func_name": "Hook.__lt__",
+        "type_comments": [
+            "(cherrypy._cprequest.Hook) -> bool"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 61,
+        "func_name": "Hook.__call__",
+        "type_comments": [
+            "() -> None",
+            "() -> cherrypy.lib.encoding.ResponseEncoder"
+        ],
+        "samples": 17
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 78,
+        "func_name": "__new__",
+        "type_comments": [
+            "(List[str]) -> cherrypy._cprequest.HookMap",
+            "(None) -> cherrypy._cprequest.HookMap"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 84,
+        "func_name": "HookMap.__init__",
+        "type_comments": [
+            "(*List[str]) -> None",
+            "() -> None"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 91,
+        "func_name": "HookMap.run",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 31
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 116,
+        "func_name": "HookMap.__copy__",
+        "type_comments": [
+            "() -> cherrypy._cprequest.HookMap"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 149,
+        "func_name": "request_namespace",
+        "type_comments": [
+            "(str, bool) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 169,
+        "func_name": "error_page_namespace",
+        "type_comments": [
+            "(str, function) -> None"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 182,
+        "func_name": "Request",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 481,
+        "func_name": "Request.__init__",
+        "type_comments": [
+            "(cherrypy.lib.httputil.Host, cherrypy.lib.httputil.Host, str, str) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 506,
+        "func_name": "Request.close",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 514,
+        "func_name": "Request.run",
+        "type_comments": [
+            "(str, str, str, str, generator, cheroot.server.KnownLengthRFile) -> cherrypy._cprequest.Response"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 623,
+        "func_name": "Request.respond",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 645,
+        "func_name": "Request._do_respond",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 694,
+        "func_name": "Request.process_query_string",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 707,
+        "func_name": "Request.process_headers",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 740,
+        "func_name": "Request.get_resource",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 765,
+        "func_name": "ResponseBody",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 772,
+        "func_name": "ResponseBody.__get__",
+        "type_comments": [
+            "(cherrypy._cprequest.Response, type) -> List[bytes]",
+            "(cherrypy._cprequest.Response, type) -> List",
+            "(cherrypy._cprequest.Response, type) -> generator"
+        ],
+        "samples": 23
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 779,
+        "func_name": "ResponseBody.__set__",
+        "type_comments": [
+            "(cherrypy._cprequest.Response, bytes) -> None",
+            "(cherrypy._cprequest.Response, generator) -> None",
+            "(cherrypy._cprequest.Response, List[bytes]) -> None"
+        ],
+        "samples": 18
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 791,
+        "func_name": "Response",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 828,
+        "func_name": "Response.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 844,
+        "func_name": "Response.collapse_body",
+        "type_comments": [
+            "() -> bytes"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 858,
+        "func_name": "Response.finalize",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 905,
+        "func_name": "LazyUUID4",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 906,
+        "func_name": "LazyUUID4.__str__",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cprequest.py",
+        "line": 910,
+        "func_name": "uuid4",
+        "type_comments": [
+            "() -> uuid.UUID"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpserver.py",
+        "line": 12,
+        "func_name": "Server",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpserver.py",
+        "line": 28,
+        "func_name": "socket_host",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpserver.py",
+        "line": 157,
+        "func_name": "Server.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpserver.py",
+        "line": 164,
+        "func_name": "Server.httpserver_from_self",
+        "type_comments": [
+            "(None) -> Tuple[cherrypy._cpwsgi_server.CPWSGIServer, Tuple[str, int]]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpserver.py",
+        "line": 176,
+        "func_name": "Server.start",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpserver.py",
+        "line": 183,
+        "func_name": "bind_addr",
+        "type_comments": [
+            "() -> Tuple[str, int]"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptools.py",
+        "line": 34,
+        "func_name": "_getargs",
+        "type_comments": [
+            "(function) -> Tuple[str, str]",
+            "(function) -> Tuple[]",
+            "(function) -> Tuple[str, str, str, str, str]"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptools.py",
+        "line": 50,
+        "func_name": "Tool",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptools.py",
+        "line": 59,
+        "func_name": "Tool.__init__",
+        "type_comments": [
+            "(str, function, None, int) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptools.py",
+        "line": 75,
+        "func_name": "Tool._setargs",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptools.py",
+        "line": 94,
+        "func_name": "Tool._merged_args",
+        "type_comments": [
+            "(None) -> Dict[str, Tuple[str, str, str, str, str, str, str, str]]",
+            "(None) -> Dict"
+        ],
+        "samples": 26
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptools.py",
+        "line": 135,
+        "func_name": "Tool._setup",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 26
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptools.py",
+        "line": 149,
+        "func_name": "HandlerTool",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptools.py",
+        "line": 161,
+        "func_name": "HandlerTool.__init__",
+        "type_comments": [
+            "(function, None) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptools.py",
+        "line": 164,
+        "func_name": "HandlerTool.handler",
+        "type_comments": [
+            "(*str) -> function"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptools.py",
+        "line": 199,
+        "func_name": "HandlerWrapperTool",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptools.py",
+        "line": 234,
+        "func_name": "ErrorTool",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptools.py",
+        "line": 238,
+        "func_name": "ErrorTool.__init__",
+        "type_comments": [
+            "(function, None) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptools.py",
+        "line": 256,
+        "func_name": "SessionTool",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptools.py",
+        "line": 275,
+        "func_name": "SessionTool.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptools.py",
+        "line": 327,
+        "func_name": "XMLRPCController",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptools.py",
+        "line": 390,
+        "func_name": "SessionAuthTool",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptools.py",
+        "line": 394,
+        "func_name": "CachingTool",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptools.py",
+        "line": 418,
+        "func_name": "Toolbox",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptools.py",
+        "line": 426,
+        "func_name": "Toolbox.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptools.py",
+        "line": 429,
+        "func_name": "Toolbox.__setattr__",
+        "type_comments": [
+            "(str, cherrypy._cptools.Tool) -> None",
+            "(str, cherrypy._cptools.SessionAuthTool) -> None",
+            "(str, str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptools.py",
+        "line": 437,
+        "func_name": "Toolbox.__enter__",
+        "type_comments": [
+            "() -> function"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptools.py",
+        "line": 441,
+        "func_name": "populate",
+        "type_comments": [
+            "(str, Tuple[str, str, str, str, str, str, str, str]) -> None",
+            "(str, bool) -> None"
+        ],
+        "samples": 36
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptools.py",
+        "line": 447,
+        "func_name": "Toolbox.__exit__",
+        "type_comments": [
+            "(None, None, None) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptree.py",
+        "line": 10,
+        "func_name": "Application",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptree.py",
+        "line": 45,
+        "func_name": "Application.__init__",
+        "type_comments": [
+            "(sabnzbd.interface.MainPage, str, None) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptree.py",
+        "line": 81,
+        "func_name": "script_name",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptree.py",
+        "line": 112,
+        "func_name": "Application.merge",
+        "type_comments": [
+            "(Dict[str, Dict[str, Union[Dict[str, str], List[Tuple[str, str]], bool, str]]]) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptree.py",
+        "line": 119,
+        "func_name": "Application.find_config",
+        "type_comments": [
+            "(str, str, cherrypy._cpdispatch.Dispatcher) -> cherrypy._cpdispatch.Dispatcher"
+        ],
+        "samples": 13
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptree.py",
+        "line": 138,
+        "func_name": "Application.get_serving",
+        "type_comments": [
+            "(cherrypy.lib.httputil.Host, cherrypy.lib.httputil.Host, str, str) -> Tuple[cherrypy._cprequest.Request, cherrypy._cprequest.Response]"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptree.py",
+        "line": 166,
+        "func_name": "Application.__call__",
+        "type_comments": [
+            "(Dict[str, str], method) -> cherrypy._cpwsgi._TrappedResponse",
+            "(Dict[str, str], method) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptree.py",
+        "line": 186,
+        "func_name": "Tree.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptree.py",
+        "line": 190,
+        "func_name": "Tree.mount",
+        "type_comments": [
+            "(sabnzbd.interface.MainPage, str, Dict[str, Dict[str, Union[Dict[str, str], List[Tuple[str, str]], bool, str]]]) -> cherrypy._cptree.Application"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptree.py",
+        "line": 260,
+        "func_name": "Tree.script_name",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cptree.py",
+        "line": 283,
+        "func_name": "Tree.__call__",
+        "type_comments": [
+            "(Dict[str, str], method) -> cherrypy._cpwsgi._TrappedResponse",
+            "(Dict[str, str], method) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi.py",
+        "line": 36,
+        "func_name": "VirtualHost",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi.py",
+        "line": 91,
+        "func_name": "InternalRedirector",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi.py",
+        "line": 95,
+        "func_name": "InternalRedirector.__init__",
+        "type_comments": [
+            "(method, bool) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi.py",
+        "line": 99,
+        "func_name": "InternalRedirector.__call__",
+        "type_comments": [
+            "(Dict[str, str], method) -> cherrypy._cpwsgi.AppResponse"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi.py",
+        "line": 139,
+        "func_name": "ExceptionTrapper",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi.py",
+        "line": 143,
+        "func_name": "ExceptionTrapper.__init__",
+        "type_comments": [
+            "(cherrypy._cpwsgi.InternalRedirector, Tuple[type, type]) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi.py",
+        "line": 147,
+        "func_name": "ExceptionTrapper.__call__",
+        "type_comments": [
+            "(Dict[str, str], method) -> cherrypy._cpwsgi._TrappedResponse"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi.py",
+        "line": 156,
+        "func_name": "_TrappedResponse",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi.py",
+        "line": 160,
+        "func_name": "_TrappedResponse.__init__",
+        "type_comments": [
+            "(cherrypy._cpwsgi.InternalRedirector, Dict[str, str], method, Tuple[type, type]) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi.py",
+        "line": 171,
+        "func_name": "_TrappedResponse.__iter__",
+        "type_comments": [
+            "() -> cherrypy._cpwsgi._TrappedResponse"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi.py",
+        "line": 175,
+        "func_name": "_TrappedResponse.__next__",
+        "type_comments": [
+            "() -> pyannotate_runtime.collect_types.NoReturnType",
+            "() -> bytes"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi.py",
+        "line": 178,
+        "func_name": "_TrappedResponse.close",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi.py",
+        "line": 182,
+        "func_name": "_TrappedResponse.trap",
+        "type_comments": [
+            "(cherrypy._cpwsgi.InternalRedirector, *Union[Dict[str, str], method]) -> cherrypy._cpwsgi.AppResponse",
+            "(cherrypy._cpwsgi.InternalRedirector, *Union[Dict[str, str], method]) -> pyannotate_runtime.collect_types.UnknownType",
+            "(builtin_function_or_method, *cherrypy._cpwsgi.AppResponse) -> bytes",
+            "(builtin_function_or_method, *cherrypy._cpwsgi.AppResponse) -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 17
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi.py",
+        "line": 228,
+        "func_name": "AppResponse",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi.py",
+        "line": 232,
+        "func_name": "AppResponse.__init__",
+        "type_comments": [
+            "(Dict[str, str], method, cherrypy._cptree.Application) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi.py",
+        "line": 273,
+        "func_name": "AppResponse.__iter__",
+        "type_comments": [
+            "() -> cherrypy._cpwsgi.AppResponse"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi.py",
+        "line": 276,
+        "func_name": "AppResponse.__next__",
+        "type_comments": [
+            "() -> pyannotate_runtime.collect_types.NoReturnType",
+            "() -> bytes"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi.py",
+        "line": 279,
+        "func_name": "AppResponse.close",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi.py",
+        "line": 295,
+        "func_name": "AppResponse.run",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi.py",
+        "line": 345,
+        "func_name": "AppResponse.recode_path_qs",
+        "type_comments": [
+            "(str, str) -> Tuple[str, str]"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi.py",
+        "line": 370,
+        "func_name": "AppResponse.translate_headers",
+        "type_comments": [
+            "(Dict[str, str]) -> Iterator",
+            "(Dict[str, str]) -> Iterator[Tuple[str, str]]"
+        ],
+        "samples": 54
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi.py",
+        "line": 382,
+        "func_name": "CPWSGIApp",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi.py",
+        "line": 410,
+        "func_name": "CPWSGIApp.__init__",
+        "type_comments": [
+            "(cherrypy._cptree.Application, None) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi.py",
+        "line": 417,
+        "func_name": "CPWSGIApp.tail",
+        "type_comments": [
+            "(Dict[str, str], method) -> cherrypy._cpwsgi.AppResponse"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi.py",
+        "line": 425,
+        "func_name": "CPWSGIApp.__call__",
+        "type_comments": [
+            "(Dict[str, str], method) -> cherrypy._cpwsgi._TrappedResponse"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi_server.py",
+        "line": 14,
+        "func_name": "CPWSGIHTTPRequest",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi_server.py",
+        "line": 21,
+        "func_name": "CPWSGIHTTPRequest.__init__",
+        "type_comments": [
+            "(cherrypy._cpwsgi_server.CPWSGIServer, cheroot.server.HTTPConnection) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi_server.py",
+        "line": 35,
+        "func_name": "CPWSGIServer",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_cpwsgi_server.py",
+        "line": 47,
+        "func_name": "CPWSGIServer.__init__",
+        "type_comments": [
+            "(cherrypy._cpserver.Server) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_helper.py",
+        "line": 10,
+        "func_name": "expose",
+        "type_comments": [
+            "(function, None) -> function"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_helper.py",
+        "line": 312,
+        "func_name": "_ClassPropertyDescriptor",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_helper.py",
+        "line": 319,
+        "func_name": "_ClassPropertyDescriptor.__init__",
+        "type_comments": [
+            "(classmethod, None) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\_helper.py",
+        "line": 334,
+        "func_name": "classproperty",
+        "type_comments": [
+            "(function) -> cherrypy._helper._ClassPropertyDescriptor"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\__init__.py",
+        "line": 47,
+        "func_name": "file_generator",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\__init__.py",
+        "line": 90,
+        "func_name": "set_vary_header",
+        "type_comments": [
+            "(cherrypy._cprequest.Response, str) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\auth_digest.py",
+        "line": 155,
+        "func_name": "HttpDigestAuthorization",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\caching.py",
+        "line": 44,
+        "func_name": "Cache",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\caching.py",
+        "line": 66,
+        "func_name": "AntiStampedeCache",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\cptools.py",
+        "line": 233,
+        "func_name": "response_headers",
+        "type_comments": [
+            "(List[Tuple[str, str]], bool) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\cptools.py",
+        "line": 283,
+        "func_name": "SessionAuth",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\cptools.py",
+        "line": 469,
+        "func_name": "trailing_slash",
+        "type_comments": [
+            "(bool, bool, None, bool) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\cptools.py",
+        "line": 588,
+        "func_name": "MonitoredHeaderMap",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\encoding.py",
+        "line": 39,
+        "func_name": "UTF8StreamEncoder",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\encoding.py",
+        "line": 65,
+        "func_name": "ResponseEncoder",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\encoding.py",
+        "line": 75,
+        "func_name": "ResponseEncoder.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\encoding.py",
+        "line": 106,
+        "func_name": "ResponseEncoder.encode_string",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\encoding.py",
+        "line": 122,
+        "func_name": "ResponseEncoder.find_acceptable_charset",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\encoding.py",
+        "line": 217,
+        "func_name": "ResponseEncoder.__call__",
+        "type_comments": [
+            "() -> List[bytes]"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\encoding.py",
+        "line": 259,
+        "func_name": "prepare_iter",
+        "type_comments": [
+            "(bytes) -> List[bytes]",
+            "(List[bytes]) -> List[bytes]",
+            "(str) -> List[str]",
+            "(generator) -> generator"
+        ],
+        "samples": 23
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\encoding.py",
+        "line": 284,
+        "func_name": "compress",
+        "type_comments": [
+            "(List[bytes], int) -> Iterator",
+            "(List[bytes], int) -> Iterator[bytes]"
+        ],
+        "samples": 54
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\encoding.py",
+        "line": 326,
+        "func_name": "gzip",
+        "type_comments": [
+            "(int, Tuple[str, str, str, str, str, str, str, str], bool) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 38,
+        "func_name": "urljoin",
+        "type_comments": [
+            "(*str) -> str"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 127,
+        "func_name": "HeaderElement",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 131,
+        "func_name": "HeaderElement.__init__",
+        "type_comments": [
+            "(str, Dict) -> None"
+        ],
+        "samples": 27
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 143,
+        "func_name": "HeaderElement.__str__",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 22
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 153,
+        "func_name": "parse",
+        "type_comments": [
+            "(str) -> Tuple[str, Dict]"
+        ],
+        "samples": 27
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 159,
+        "func_name": "from_str",
+        "type_comments": [
+            "(str) -> cherrypy.lib.httputil.HeaderElement"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 169,
+        "func_name": "AcceptElement",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 180,
+        "func_name": "from_str",
+        "type_comments": [
+            "(str) -> cherrypy.lib.httputil.AcceptElement"
+        ],
+        "samples": 18
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 197,
+        "func_name": "qvalue",
+        "type_comments": [
+            "() -> float"
+        ],
+        "samples": 27
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 222,
+        "func_name": "AcceptElement.__lt__",
+        "type_comments": [
+            "(cherrypy.lib.httputil.AcceptElement) -> bool"
+        ],
+        "samples": 13
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 232,
+        "func_name": "header_elements",
+        "type_comments": [
+            "(str, str) -> List[cherrypy.lib.httputil.AcceptElement]",
+            "(str, str) -> List[cherrypy.lib.httputil.HeaderElement]",
+            "(str, None) -> List"
+        ],
+        "samples": 23
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 265,
+        "func_name": "decode_TEXT_maybe",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 49
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 272,
+        "func_name": "valid_status",
+        "type_comments": [
+            "(None) -> Tuple[int, str, str]",
+            "(int) -> Tuple[int, str, str]"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 323,
+        "func_name": "_parse_qs",
+        "type_comments": [
+            "(str, bool, int, str) -> Dict[str, str]",
+            "(str, bool, int, str) -> Dict"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 371,
+        "func_name": "parse_query_string",
+        "type_comments": [
+            "(str, bool, str) -> Dict[str, str]",
+            "(str, bool, str) -> Dict"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 391,
+        "func_name": "KeyTransformingDict",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 400,
+        "func_name": "KeyTransformingDict.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 408,
+        "func_name": "KeyTransformingDict.__setitem__",
+        "type_comments": [
+            "(str, str) -> None"
+        ],
+        "samples": 67
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 416,
+        "func_name": "KeyTransformingDict.__contains__",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 424,
+        "func_name": "KeyTransformingDict.get",
+        "type_comments": [
+            "(str, *None) -> None",
+            "(str, *str) -> str",
+            "(str) -> None",
+            "(str) -> str"
+        ],
+        "samples": 36
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 449,
+        "func_name": "CaseInsensitiveDict",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 456,
+        "func_name": "transform_key",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 104
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 475,
+        "func_name": "HeaderMap",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 495,
+        "func_name": "HeaderMap.elements",
+        "type_comments": [
+            "(str) -> List[cherrypy.lib.httputil.AcceptElement]",
+            "(str) -> List[cherrypy.lib.httputil.HeaderElement]",
+            "(str) -> List"
+        ],
+        "samples": 23
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 505,
+        "func_name": "HeaderMap.output",
+        "type_comments": [
+            "() -> List[Tuple[bytes, bytes]]"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 509,
+        "func_name": "encode_header_items",
+        "type_comments": [
+            "(dict_items) -> Iterator",
+            "(dict_items) -> Iterator[Tuple[bytes, bytes]]"
+        ],
+        "samples": 41
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 521,
+        "func_name": "encode_header_item",
+        "type_comments": [
+            "(str) -> bytes"
+        ],
+        "samples": 68
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 531,
+        "func_name": "encode",
+        "type_comments": [
+            "(str) -> bytes"
+        ],
+        "samples": 73
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 554,
+        "func_name": "Host",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\httputil.py",
+        "line": 568,
+        "func_name": "Host.__init__",
+        "type_comments": [
+            "(str, int, str) -> None",
+            "(str, int, None) -> None"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\locking.py",
+        "line": 9,
+        "func_name": "Timer",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\locking.py",
+        "line": 28,
+        "func_name": "LockTimeout",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\locking.py",
+        "line": 32,
+        "func_name": "LockChecker",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\reprconf.py",
+        "line": 29,
+        "func_name": "NamespaceSet",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\reprconf.py",
+        "line": 44,
+        "func_name": "NamespaceSet.__call__",
+        "type_comments": [
+            "(Dict[str, bool]) -> None",
+            "(Dict) -> None",
+            "(Dict[str, Union[bool, int, str]]) -> None",
+            "(Dict[str, Union[bool, str]]) -> None"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\reprconf.py",
+        "line": 98,
+        "func_name": "NamespaceSet.__copy__",
+        "type_comments": [
+            "() -> cherrypy.lib.reprconf.NamespaceSet"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\reprconf.py",
+        "line": 105,
+        "func_name": "Config",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\reprconf.py",
+        "line": 116,
+        "func_name": "Config.__init__",
+        "type_comments": [
+            "(None) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\reprconf.py",
+        "line": 123,
+        "func_name": "Config.reset",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\reprconf.py",
+        "line": 128,
+        "func_name": "Config.update",
+        "type_comments": [
+            "(Dict[str, bool]) -> None",
+            "(Dict[str, Union[bool, int, str]]) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\reprconf.py",
+        "line": 132,
+        "func_name": "Config._apply",
+        "type_comments": [
+            "(Dict[str, bool]) -> None",
+            "(Dict[str, Union[bool, int, str]]) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\reprconf.py",
+        "line": 149,
+        "func_name": "Parser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\reprconf.py",
+        "line": 199,
+        "func_name": "load",
+        "type_comments": [
+            "(Dict[str, bool]) -> Dict[str, bool]",
+            "(Dict[str, Dict[str, Union[Dict[str, str], List[Tuple[str, str]], bool, str]]]) -> Dict[str, Dict[str, Union[Dict[str, str], List[Tuple[str, str]], bool, str]]]",
+            "(Dict[str, Union[bool, int, str]]) -> Dict[str, Union[bool, int, str]]"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\reprconf.py",
+        "line": 214,
+        "func_name": "_Builder",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\sessions.py",
+        "line": 123,
+        "func_name": "Session",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\sessions.py",
+        "line": 397,
+        "func_name": "RamSession",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\sessions.py",
+        "line": 457,
+        "func_name": "FileSession",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\sessions.py",
+        "line": 612,
+        "func_name": "MemcachedSession",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\lib\\static.py",
+        "line": 18,
+        "func_name": "_setup_mimetypes",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\plugins.py",
+        "line": 33,
+        "func_name": "SimplePlugin",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\plugins.py",
+        "line": 41,
+        "func_name": "SimplePlugin.__init__",
+        "type_comments": [
+            "(cherrypy.process.win32.Win32Bus) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\plugins.py",
+        "line": 44,
+        "func_name": "SimplePlugin.subscribe",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\plugins.py",
+        "line": 61,
+        "func_name": "SignalHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\plugins.py",
+        "line": 97,
+        "func_name": "SignalHandler.__init__",
+        "type_comments": [
+            "(cherrypy.process.win32.Win32Bus) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\plugins.py",
+        "line": 220,
+        "func_name": "DropPrivileges",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\plugins.py",
+        "line": 334,
+        "func_name": "Daemonizer",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\plugins.py",
+        "line": 425,
+        "func_name": "PIDFile",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\plugins.py",
+        "line": 454,
+        "func_name": "PerpetualTimer",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\plugins.py",
+        "line": 484,
+        "func_name": "BackgroundTask",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\plugins.py",
+        "line": 526,
+        "func_name": "Monitor",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\plugins.py",
+        "line": 541,
+        "func_name": "Monitor.__init__",
+        "type_comments": [
+            "(cherrypy.process.win32.Win32Bus, method, int, None) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\plugins.py",
+        "line": 583,
+        "func_name": "Autoreloader",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\plugins.py",
+        "line": 614,
+        "func_name": "Autoreloader.__init__",
+        "type_comments": [
+            "(cherrypy.process.win32.Win32Bus, int, str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\plugins.py",
+        "line": 700,
+        "func_name": "ThreadManager",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\plugins.py",
+        "line": 720,
+        "func_name": "ThreadManager.__init__",
+        "type_comments": [
+            "(cherrypy.process.win32.Win32Bus) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\plugins.py",
+        "line": 728,
+        "func_name": "ThreadManager.acquire_thread",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\plugins.py",
+        "line": 749,
+        "func_name": "ThreadManager.stop",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\servers.py",
+        "line": 129,
+        "func_name": "Timeouts",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\servers.py",
+        "line": 134,
+        "func_name": "ServerAdapter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\servers.py",
+        "line": 156,
+        "func_name": "ServerAdapter.subscribe",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\servers.py",
+        "line": 164,
+        "func_name": "ServerAdapter.start",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\servers.py",
+        "line": 189,
+        "func_name": "description",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\servers.py",
+        "line": 202,
+        "func_name": "ServerAdapter._get_base",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\servers.py",
+        "line": 217,
+        "func_name": "ServerAdapter._start_http_thread",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\servers.py",
+        "line": 242,
+        "func_name": "ServerAdapter.wait",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\servers.py",
+        "line": 274,
+        "func_name": "ServerAdapter.stop",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\servers.py",
+        "line": 294,
+        "func_name": "FlupCGIServer",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\servers.py",
+        "line": 318,
+        "func_name": "FlupFCGIServer",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\servers.py",
+        "line": 364,
+        "func_name": "FlupSCGIServer",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\servers.py",
+        "line": 402,
+        "func_name": "_safe_wait",
+        "type_comments": [
+            "(str, int) -> Iterator",
+            "(str, int) -> Iterator"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\win32.py",
+        "line": 13,
+        "func_name": "ConsoleCtrlHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\win32.py",
+        "line": 71,
+        "func_name": "Win32Bus",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\win32.py",
+        "line": 78,
+        "func_name": "Win32Bus.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\win32.py",
+        "line": 93,
+        "func_name": "state",
+        "type_comments": [
+            "() -> cherrypy.process.wspbus.State"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\win32.py",
+        "line": 97,
+        "func_name": "state",
+        "type_comments": [
+            "(cherrypy.process.wspbus.State) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\win32.py",
+        "line": 103,
+        "func_name": "Win32Bus.wait",
+        "type_comments": [
+            "(cherrypy.process.wspbus.State, float, None) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\win32.py",
+        "line": 122,
+        "func_name": "_ControlCodes",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\win32.py",
+        "line": 154,
+        "func_name": "PyWebService",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\wspbus.py",
+        "line": 96,
+        "func_name": "ChannelFailures",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\wspbus.py",
+        "line": 101,
+        "func_name": "ChannelFailures.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 18
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\wspbus.py",
+        "line": 121,
+        "func_name": "ChannelFailures.__bool__",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 18
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\wspbus.py",
+        "line": 129,
+        "func_name": "_StateEnum",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\wspbus.py",
+        "line": 131,
+        "func_name": "State",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\wspbus.py",
+        "line": 137,
+        "func_name": "_StateEnum.__setattr__",
+        "type_comments": [
+            "(str, cherrypy.process.wspbus.State) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\wspbus.py",
+        "line": 162,
+        "func_name": "Bus",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\wspbus.py",
+        "line": 177,
+        "func_name": "Bus.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\wspbus.py",
+        "line": 188,
+        "func_name": "Bus.subscribe",
+        "type_comments": [
+            "(str, method, None) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\wspbus.py",
+        "line": 208,
+        "func_name": "Bus.unsubscribe",
+        "type_comments": [
+            "(str, method) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\wspbus.py",
+        "line": 215,
+        "func_name": "Bus.publish",
+        "type_comments": [
+            "(str, *int) -> List",
+            "(str, *Union[int, str]) -> List",
+            "(str) -> List",
+            "(str) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 18
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\wspbus.py",
+        "line": 285,
+        "func_name": "Bus.exit",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\wspbus.py",
+        "line": 553,
+        "func_name": "Bus.stop",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cherrypy\\process\\wspbus.py",
+        "line": 580,
+        "func_name": "Bus.log",
+        "type_comments": [
+            "(str, int, bool) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 141,
+        "func_name": "Builder",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 208,
+        "func_name": "ConfigObjError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 219,
+        "func_name": "NestingError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 225,
+        "func_name": "ParseError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 233,
+        "func_name": "ReloadError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 242,
+        "func_name": "DuplicateError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 248,
+        "func_name": "ConfigspecError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 254,
+        "func_name": "InterpolationError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 258,
+        "func_name": "InterpolationLoopError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 267,
+        "func_name": "RepeatSectionError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 303,
+        "func_name": "InterpolationEngine.interpolate",
+        "type_comments": [
+            "(str, str) -> str"
+        ],
+        "samples": 15
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 308,
+        "func_name": "recursive_interpolate",
+        "type_comments": [
+            "(str, str, configobj.Section, Dict) -> str"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 410,
+        "func_name": "ConfigParserInterpolation",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 422,
+        "func_name": "TemplateInterpolation",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 458,
+        "func_name": "Section",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 486,
+        "func_name": "Section.__init__",
+        "type_comments": [
+            "(configobj.Section, int, configobj.ConfigObj, Dict[str, Union[int, str]], str) -> None",
+            "(configobj.ConfigObj, int, configobj.ConfigObj, None, str) -> None",
+            "(configobj.ConfigObj, int, configobj.ConfigObj, None, None) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 512,
+        "func_name": "Section._initialise",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 529,
+        "func_name": "Section._interpolate",
+        "type_comments": [
+            "(str, str) -> str"
+        ],
+        "samples": 16
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 552,
+        "func_name": "Section.__getitem__",
+        "type_comments": [
+            "(str) -> str",
+            "(str) -> int",
+            "(str) -> float",
+            "(str) -> configobj.Section",
+            "(str) -> List[str]",
+            "(str) -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 47
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 559,
+        "func_name": "_check",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 569,
+        "func_name": "Section.__setitem__",
+        "type_comments": [
+            "(str, configobj.Section, bool) -> None",
+            "(str, str, bool) -> None",
+            "(str, Dict[str, Union[int, str]], bool) -> pyannotate_runtime.collect_types.UnknownType",
+            "(str, int, bool) -> None",
+            "(str, List[str], bool) -> None"
+        ],
+        "samples": 26
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 639,
+        "func_name": "Section.get",
+        "type_comments": [
+            "(str, None) -> None",
+            "(str, None) -> List[str]"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 729,
+        "func_name": "Section.iterkeys",
+        "type_comments": [
+            "() -> list_iterator"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 1071,
+        "func_name": "ConfigObj",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 1174,
+        "func_name": "ConfigObj.__init__",
+        "type_comments": [
+            "(str, None, None, str, bool, bool, bool, bool, bool, bool, None, str, bool, bool, bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 1232,
+        "func_name": "ConfigObj._load",
+        "type_comments": [
+            "(str, None) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 1328,
+        "func_name": "ConfigObj._initialise",
+        "type_comments": [
+            "(Dict[str, Optional[Union[bool, str]]]) -> None",
+            "(None) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 1371,
+        "func_name": "ConfigObj._handle_bom",
+        "type_comments": [
+            "(List[bytes]) -> List[str]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 1488,
+        "func_name": "ConfigObj._a_to_u",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 18
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 1496,
+        "func_name": "ConfigObj._decode",
+        "type_comments": [
+            "(List[bytes], str) -> List[str]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 1521,
+        "func_name": "ConfigObj._decode_element",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 37
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 1543,
+        "func_name": "ConfigObj._parse",
+        "type_comments": [
+            "(List[str]) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 1710,
+        "func_name": "ConfigObj._match_depth",
+        "type_comments": [
+            "(configobj.Section, int) -> configobj.Section"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 1748,
+        "func_name": "ConfigObj._unquote",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 27
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 1758,
+        "func_name": "ConfigObj._quote",
+        "type_comments": [
+            "(int, bool) -> str",
+            "(str, bool) -> str"
+        ],
+        "samples": 27
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 1829,
+        "func_name": "ConfigObj._get_single_quote",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 1849,
+        "func_name": "ConfigObj._handle_value",
+        "type_comments": [
+            "(str) -> Tuple[str, None]"
+        ],
+        "samples": 15
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 1982,
+        "func_name": "ConfigObj._write_line",
+        "type_comments": [
+            "(str, str, int, str) -> str",
+            "(str, str, str, str) -> str"
+        ],
+        "samples": 15
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 1996,
+        "func_name": "ConfigObj._write_marker",
+        "type_comments": [
+            "(str, int, str, str) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 2005,
+        "func_name": "ConfigObj._handle_comment",
+        "type_comments": [
+            "(str) -> str",
+            "(None) -> str"
+        ],
+        "samples": 16
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 2017,
+        "func_name": "ConfigObj.write",
+        "type_comments": [
+            "(None, configobj.Section) -> List[str]",
+            "(None, None) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\configobj.py",
+        "line": 2375,
+        "func_name": "SimpleVal",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\exceptions.py",
+        "line": 10,
+        "func_name": "_Reasons",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\exceptions.py",
+        "line": 24,
+        "func_name": "UnsupportedAlgorithm",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\exceptions.py",
+        "line": 30,
+        "func_name": "AlreadyFinalized",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\exceptions.py",
+        "line": 34,
+        "func_name": "AlreadyUpdated",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\exceptions.py",
+        "line": 38,
+        "func_name": "NotYetFinalized",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\exceptions.py",
+        "line": 42,
+        "func_name": "InvalidTag",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\exceptions.py",
+        "line": 46,
+        "func_name": "InvalidSignature",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\exceptions.py",
+        "line": 50,
+        "func_name": "InternalError",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\exceptions.py",
+        "line": 56,
+        "func_name": "InvalidKey",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\backends\\interfaces.py",
+        "line": 12,
+        "func_name": "CipherBackend",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\backends\\interfaces.py",
+        "line": 33,
+        "func_name": "HashBackend",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\backends\\interfaces.py",
+        "line": 48,
+        "func_name": "HMACBackend",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\backends\\interfaces.py",
+        "line": 64,
+        "func_name": "CMACBackend",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\backends\\interfaces.py",
+        "line": 79,
+        "func_name": "PBKDF2HMACBackend",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\backends\\interfaces.py",
+        "line": 96,
+        "func_name": "RSABackend",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\backends\\interfaces.py",
+        "line": 131,
+        "func_name": "DSABackend",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\backends\\interfaces.py",
+        "line": 183,
+        "func_name": "EllipticCurveBackend",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\backends\\interfaces.py",
+        "line": 231,
+        "func_name": "PEMSerializationBackend",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\backends\\interfaces.py",
+        "line": 253,
+        "func_name": "DERSerializationBackend",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\backends\\interfaces.py",
+        "line": 275,
+        "func_name": "X509Backend",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\backends\\interfaces.py",
+        "line": 334,
+        "func_name": "DHBackend",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\backends\\interfaces.py",
+        "line": 389,
+        "func_name": "ScryptBackend",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\algorithms.py",
+        "line": 26,
+        "func_name": "AES",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\algorithms.py",
+        "line": 42,
+        "func_name": "Camellia",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\algorithms.py",
+        "line": 57,
+        "func_name": "TripleDES",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\algorithms.py",
+        "line": 76,
+        "func_name": "Blowfish",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\algorithms.py",
+        "line": 91,
+        "func_name": "CAST5",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\algorithms.py",
+        "line": 106,
+        "func_name": "ARC4",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\algorithms.py",
+        "line": 119,
+        "func_name": "IDEA",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\algorithms.py",
+        "line": 133,
+        "func_name": "SEED",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\algorithms.py",
+        "line": 148,
+        "func_name": "ChaCha20",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\base.py",
+        "line": 20,
+        "func_name": "CipherAlgorithm",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\base.py",
+        "line": 35,
+        "func_name": "BlockCipherAlgorithm",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\base.py",
+        "line": 44,
+        "func_name": "CipherContext",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\base.py",
+        "line": 67,
+        "func_name": "AEADCipherContext",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\base.py",
+        "line": 76,
+        "func_name": "AEADDecryptionContext",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\base.py",
+        "line": 86,
+        "func_name": "AEADEncryptionContext",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\base.py",
+        "line": 96,
+        "func_name": "Cipher",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\base.py",
+        "line": 141,
+        "func_name": "_CipherContext",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\base.py",
+        "line": 164,
+        "func_name": "_AEADCipherContext",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\base.py",
+        "line": 228,
+        "func_name": "_AEADEncryptionContext",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\modes.py",
+        "line": 14,
+        "func_name": "Mode",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\modes.py",
+        "line": 30,
+        "func_name": "ModeWithInitializationVector",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\modes.py",
+        "line": 39,
+        "func_name": "ModeWithTweak",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\modes.py",
+        "line": 48,
+        "func_name": "ModeWithNonce",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\modes.py",
+        "line": 57,
+        "func_name": "ModeWithAuthenticationTag",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\modes.py",
+        "line": 85,
+        "func_name": "CBC",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\modes.py",
+        "line": 98,
+        "func_name": "XTS",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\modes.py",
+        "line": 121,
+        "func_name": "ECB",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\modes.py",
+        "line": 128,
+        "func_name": "OFB",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\modes.py",
+        "line": 141,
+        "func_name": "CFB",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\modes.py",
+        "line": 154,
+        "func_name": "CFB8",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\modes.py",
+        "line": 167,
+        "func_name": "CTR",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\ciphers\\modes.py",
+        "line": 186,
+        "func_name": "GCM",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\hashes.py",
+        "line": 18,
+        "func_name": "HashAlgorithm",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\hashes.py",
+        "line": 33,
+        "func_name": "HashContext",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\hashes.py",
+        "line": 67,
+        "func_name": "Hash",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\hashes.py",
+        "line": 110,
+        "func_name": "SHA1",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\hashes.py",
+        "line": 117,
+        "func_name": "SHA512_224",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\hashes.py",
+        "line": 124,
+        "func_name": "SHA512_256",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\hashes.py",
+        "line": 131,
+        "func_name": "SHA224",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\hashes.py",
+        "line": 138,
+        "func_name": "SHA256",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\hashes.py",
+        "line": 145,
+        "func_name": "SHA384",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\hashes.py",
+        "line": 152,
+        "func_name": "SHA512",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\hashes.py",
+        "line": 159,
+        "func_name": "SHA3_224",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\hashes.py",
+        "line": 165,
+        "func_name": "SHA3_256",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\hashes.py",
+        "line": 171,
+        "func_name": "SHA3_384",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\hashes.py",
+        "line": 177,
+        "func_name": "SHA3_512",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\hashes.py",
+        "line": 183,
+        "func_name": "SHAKE128",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\hashes.py",
+        "line": 200,
+        "func_name": "SHAKE256",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\hashes.py",
+        "line": 217,
+        "func_name": "MD5",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\hashes.py",
+        "line": 224,
+        "func_name": "BLAKE2b",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\hashes.py",
+        "line": 241,
+        "func_name": "BLAKE2s",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\kdf\\__init__.py",
+        "line": 12,
+        "func_name": "KeyDerivationFunction",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\hazmat\\primitives\\kdf\\pbkdf2.py",
+        "line": 16,
+        "func_name": "PBKDF2HMAC",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\utils.py",
+        "line": 16,
+        "func_name": "CryptographyDeprecationWarning",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\utils.py",
+        "line": 40,
+        "func_name": "read_only_property",
+        "type_comments": [
+            "(str) -> property"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\utils.py",
+        "line": 44,
+        "func_name": "register_interface",
+        "type_comments": [
+            "(abc.ABCMeta) -> function"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\utils.py",
+        "line": 45,
+        "func_name": "register_decorator",
+        "type_comments": [
+            "(type) -> type"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\utils.py",
+        "line": 86,
+        "func_name": "InterfaceNotImplemented",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\utils.py",
+        "line": 96,
+        "func_name": "verify_interface",
+        "type_comments": [
+            "(abc.ABCMeta, type) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\utils.py",
+        "line": 122,
+        "func_name": "_DeprecatedValue",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\cryptography\\utils.py",
+        "line": 129,
+        "func_name": "_ModuleWithDeprecations",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\feedparser.py",
+        "line": 202,
+        "func_name": "sgmllib",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\feedparser.py",
+        "line": 203,
+        "func_name": "SGMLParser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\feedparser.py",
+        "line": 267,
+        "func_name": "ThingsNobodyCaresAboutButMe",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\feedparser.py",
+        "line": 268,
+        "func_name": "CharacterEncodingOverride",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\feedparser.py",
+        "line": 269,
+        "func_name": "CharacterEncodingUnknown",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\feedparser.py",
+        "line": 270,
+        "func_name": "NonXMLContentType",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\feedparser.py",
+        "line": 271,
+        "func_name": "UndeclaredNamespace",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\feedparser.py",
+        "line": 291,
+        "func_name": "FeedParserDict",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\feedparser.py",
+        "line": 448,
+        "func_name": "_FeedParserMixin",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\feedparser.py",
+        "line": 1968,
+        "func_name": "_StrictFeedParser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\feedparser.py",
+        "line": 2065,
+        "func_name": "_BaseHTMLProcessor",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\feedparser.py",
+        "line": 2251,
+        "func_name": "_LooseFeedParser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\feedparser.py",
+        "line": 2284,
+        "func_name": "_RelativeURIResolver",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\feedparser.py",
+        "line": 2354,
+        "func_name": "_HTMLSanitizer",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\feedparser.py",
+        "line": 2756,
+        "func_name": "_FeedURLHandler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\feedparser.py",
+        "line": 2961,
+        "func_name": "registerDateHandler",
+        "type_comments": [
+            "(function) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\gntp\\core.py",
+        "line": 39,
+        "func_name": "_GNTPBuffer",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\gntp\\core.py",
+        "line": 55,
+        "func_name": "_GNTPBase",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\gntp\\core.py",
+        "line": 284,
+        "func_name": "GNTPRegister",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\gntp\\core.py",
+        "line": 388,
+        "func_name": "GNTPNotice",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\gntp\\core.py",
+        "line": 440,
+        "func_name": "GNTPSubscribe",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\gntp\\core.py",
+        "line": 459,
+        "func_name": "GNTPOK",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\gntp\\core.py",
+        "line": 475,
+        "func_name": "GNTPError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\gntp\\errors.py",
+        "line": 4,
+        "func_name": "BaseError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\gntp\\errors.py",
+        "line": 8,
+        "func_name": "ParseError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\gntp\\errors.py",
+        "line": 13,
+        "func_name": "AuthError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\gntp\\errors.py",
+        "line": 18,
+        "func_name": "UnsupportedError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\gntp\\errors.py",
+        "line": 23,
+        "func_name": "NetworkError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\gntp\\notifier.py",
+        "line": 33,
+        "func_name": "GrowlNotifier",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\gntp\\shim.py",
+        "line": 17,
+        "func_name": "b",
+        "type_comments": [
+            "(str) -> bytes"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\jaraco\\functools.py",
+        "line": 272,
+        "func_name": "Throttler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\jaraco\\functools.py",
+        "line": 425,
+        "func_name": "save_method_args",
+        "type_comments": [
+            "(function) -> function"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\more_itertools\\more.py",
+        "line": 172,
+        "func_name": "peekable",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\more_itertools\\more.py",
+        "line": 726,
+        "func_name": "bucket",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\more_itertools\\more.py",
+        "line": 1910,
+        "func_name": "SequenceView",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\more_itertools\\more.py",
+        "line": 1954,
+        "func_name": "seekable",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\more_itertools\\more.py",
+        "line": 2040,
+        "func_name": "run_length",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 118,
+        "func_name": "PEP440Warning",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 135,
+        "func_name": "_declare_state",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 175,
+        "func_name": "get_supported_platform",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 249,
+        "func_name": "ResolutionError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 256,
+        "func_name": "VersionConflict",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 288,
+        "func_name": "ContextualVersionConflict",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 301,
+        "func_name": "DistributionNotFound",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 328,
+        "func_name": "UnknownExtra",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 342,
+        "func_name": "register_loader_type",
+        "type_comments": [
+            "(type, type) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 352,
+        "func_name": "get_provider",
+        "type_comments": [
+            "(pkg_resources.Requirement) -> pkg_resources.DistInfoDistribution"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 385,
+        "func_name": "get_build_platform",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 474,
+        "func_name": "get_distribution",
+        "type_comments": [
+            "(str) -> pkg_resources.DistInfoDistribution"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 500,
+        "func_name": "IMetadataProvider",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 523,
+        "func_name": "IResourceProvider",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 551,
+        "func_name": "WorkingSet",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 554,
+        "func_name": "WorkingSet.__init__",
+        "type_comments": [
+            "(None) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 567,
+        "func_name": "_build_master",
+        "type_comments": [
+            "() -> pkg_resources.WorkingSet"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 609,
+        "func_name": "WorkingSet.add_entry",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 628,
+        "func_name": "WorkingSet.find",
+        "type_comments": [
+            "(pkg_resources.Requirement) -> pkg_resources.DistInfoDistribution"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 666,
+        "func_name": "WorkingSet.__iter__",
+        "type_comments": [
+            "() -> Iterator[pkg_resources.DistInfoDistribution]"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 683,
+        "func_name": "WorkingSet.add",
+        "type_comments": [
+            "(pkg_resources.DistInfoDistribution, str, bool, bool) -> None"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 713,
+        "func_name": "WorkingSet.resolve",
+        "type_comments": [
+            "(generator, None, None, bool, None) -> List[pkg_resources.DistInfoDistribution]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 889,
+        "func_name": "WorkingSet.require",
+        "type_comments": [
+            "(*str) -> List[pkg_resources.DistInfoDistribution]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 905,
+        "func_name": "WorkingSet.subscribe",
+        "type_comments": [
+            "(function, bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 919,
+        "func_name": "WorkingSet._added_new",
+        "type_comments": [
+            "(pkg_resources.DistInfoDistribution) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 937,
+        "func_name": "_ReqExtras",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 942,
+        "func_name": "_ReqExtras.markers_pass",
+        "type_comments": [
+            "(pkg_resources.Requirement, None) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 957,
+        "func_name": "Environment",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1107,
+        "func_name": "ExtractionError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1123,
+        "func_name": "ResourceManager",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1127,
+        "func_name": "ResourceManager.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1315,
+        "func_name": "safe_name",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1323,
+        "func_name": "safe_version",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1335,
+        "func_name": "safe_extra",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1381,
+        "func_name": "NullProvider",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1404,
+        "func_name": "NullProvider.has_metadata",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1407,
+        "func_name": "NullProvider.get_metadata",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1413,
+        "func_name": "NullProvider.get_metadata_lines",
+        "type_comments": [
+            "(str) -> generator"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1468,
+        "func_name": "NullProvider._fn",
+        "type_comments": [
+            "(str, str) -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1484,
+        "func_name": "EggProvider",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1506,
+        "func_name": "DefaultProvider",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1509,
+        "func_name": "DefaultProvider._has",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1521,
+        "func_name": "DefaultProvider._get",
+        "type_comments": [
+            "(str) -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1525,
+        "func_name": "_register",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1536,
+        "func_name": "EmptyProvider",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1549,
+        "func_name": "EmptyProvider.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1556,
+        "func_name": "ZipManifests",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1583,
+        "func_name": "MemoizedZipManifests",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1603,
+        "func_name": "ZipProvider",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1778,
+        "func_name": "FileMetadata",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1790,
+        "func_name": "FileMetadata.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1793,
+        "func_name": "FileMetadata.has_metadata",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1796,
+        "func_name": "FileMetadata.get_metadata",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1805,
+        "func_name": "FileMetadata._warn_on_replacement",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1813,
+        "func_name": "FileMetadata.get_metadata_lines",
+        "type_comments": [
+            "(str) -> generator"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1817,
+        "func_name": "PathMetadata",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1837,
+        "func_name": "PathMetadata.__init__",
+        "type_comments": [
+            "(str, str) -> None"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1842,
+        "func_name": "EggMetadata",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1860,
+        "func_name": "register_finder",
+        "type_comments": [
+            "(type, function) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1870,
+        "func_name": "find_distributions",
+        "type_comments": [
+            "(str, bool) -> Tuple[]",
+            "(str, bool) -> generator"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1907,
+        "func_name": "find_nothing",
+        "type_comments": [
+            "(None, str, bool) -> Tuple[]"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1914,
+        "func_name": "_by_version_descending",
+        "type_comments": [
+            "(generator) -> List"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1929,
+        "func_name": "_by_version",
+        "type_comments": [
+            "(str) -> List[Union[pkg_resources.extern.packaging.version.LegacyVersion, pkg_resources.extern.packaging.version.Version]]"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1940,
+        "func_name": "find_on_path",
+        "type_comments": [
+            "(_frozen_importlib_external.FileFinder, str, bool) -> Iterator[pkg_resources.DistInfoDistribution]",
+            "(_frozen_importlib_external.FileFinder, str, bool) -> Iterator"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1972,
+        "func_name": "dist_factory",
+        "type_comments": [
+            "(str, str, bool) -> function",
+            "(str, str, bool) -> pkg_resources.NoDists"
+        ],
+        "samples": 34
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1989,
+        "func_name": "NoDists",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 1997,
+        "func_name": "NoDists.__bool__",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 29
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2006,
+        "func_name": "safe_listdir",
+        "type_comments": [
+            "(str) -> List[str]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2027,
+        "func_name": "distributions_from_metadata",
+        "type_comments": [
+            "(str) -> Iterator",
+            "(str) -> Iterator[pkg_resources.DistInfoDistribution]"
+        ],
+        "samples": 10
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2076,
+        "func_name": "register_namespace_handler",
+        "type_comments": [
+            "(type, function) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2094,
+        "func_name": "_handle_ns",
+        "type_comments": [
+            "(str, str) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2159,
+        "func_name": "declare_namespace",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2193,
+        "func_name": "fixup_namespace_packages",
+        "type_comments": [
+            "(str, None) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2232,
+        "func_name": "normalize_path",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2237,
+        "func_name": "_cygwin_patch",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2248,
+        "func_name": "_normalize_cached",
+        "type_comments": [
+            "(str, Dict[str, str]) -> str",
+            "(str, Dict) -> str"
+        ],
+        "samples": 29
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2256,
+        "func_name": "_is_egg_path",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2263,
+        "func_name": "_is_unpacked_egg",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2281,
+        "func_name": "yield_lines",
+        "type_comments": [
+            "(str) -> Iterator",
+            "(str) -> Iterator[str]"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2310,
+        "func_name": "EntryPoint",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2451,
+        "func_name": "_version_from_file",
+        "type_comments": [
+            "(generator) -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2456,
+        "func_name": "is_version_line",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2464,
+        "func_name": "Distribution",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2468,
+        "func_name": "Distribution.__init__",
+        "type_comments": [
+            "(str, pkg_resources.PathMetadata, str, str, None, None, int) -> None"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2481,
+        "func_name": "from_location",
+        "type_comments": [
+            "(str, str, pkg_resources.PathMetadata) -> pkg_resources.DistInfoDistribution"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2498,
+        "func_name": "Distribution._reload_version",
+        "type_comments": [
+            "() -> pkg_resources.DistInfoDistribution"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2540,
+        "func_name": "key",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2581,
+        "func_name": "version",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2633,
+        "func_name": "Distribution.requires",
+        "type_comments": [
+            "(Tuple[]) -> List",
+            "(Tuple[]) -> List[pkg_resources.Requirement]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2647,
+        "func_name": "Distribution._get_metadata",
+        "type_comments": [
+            "(str) -> Iterator",
+            "(str) -> Iterator",
+            "(str) -> Iterator[str]"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2652,
+        "func_name": "Distribution.activate",
+        "type_comments": [
+            "(None, bool) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2688,
+        "func_name": "Distribution.__getattr__",
+        "type_comments": [
+            "(str) -> method",
+            "(str) -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2746,
+        "func_name": "Distribution.insert_on",
+        "type_comments": [
+            "(List[str], None, bool) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2857,
+        "func_name": "EggInfoDistribution",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2858,
+        "func_name": "EggInfoDistribution._reload_version",
+        "type_comments": [
+            "() -> pkg_resources.EggInfoDistribution"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2876,
+        "func_name": "DistInfoDistribution",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2884,
+        "func_name": "_parsed_pkg_info",
+        "type_comments": [
+            "() -> email.message.Message"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2894,
+        "func_name": "_dep_map",
+        "type_comments": [
+            "() -> Dict",
+            "() -> Dict",
+            "() -> Dict[Optional[str], List[pkg_resources.Requirement]]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2902,
+        "func_name": "DistInfoDistribution._compute_dependencies",
+        "type_comments": [
+            "() -> Dict",
+            "() -> Dict",
+            "() -> Dict[Optional[str], List[pkg_resources.Requirement]]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2911,
+        "func_name": "reqs_for_extra",
+        "type_comments": [
+            "(str) -> Iterator",
+            "(str) -> Iterator[pkg_resources.Requirement]",
+            "(None) -> Iterator[pkg_resources.Requirement]"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2946,
+        "func_name": "RequirementParseError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2951,
+        "func_name": "parse_requirements",
+        "type_comments": [
+            "(Tuple[str]) -> Iterator[pkg_resources.Requirement]",
+            "(Tuple[str]) -> Iterator",
+            "(str) -> Iterator",
+            "(str) -> Iterator[pkg_resources.Requirement]"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2973,
+        "func_name": "Requirement",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2974,
+        "func_name": "Requirement.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 2994,
+        "func_name": "Requirement.__eq__",
+        "type_comments": [
+            "(pkg_resources.Requirement) -> bool"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 3003,
+        "func_name": "Requirement.__contains__",
+        "type_comments": [
+            "(pkg_resources.DistInfoDistribution) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 3015,
+        "func_name": "Requirement.__hash__",
+        "type_comments": [
+            "() -> int"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 3021,
+        "func_name": "parse",
+        "type_comments": [
+            "(str) -> pkg_resources.Requirement"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 3027,
+        "func_name": "_always_object",
+        "type_comments": [
+            "(Tuple[type, type]) -> Tuple[type, type]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 3037,
+        "func_name": "_find_adapter",
+        "type_comments": [
+            "(Dict[type, function], _frozen_importlib_external.FileFinder) -> function",
+            "(Dict[type, function], None) -> function"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 3109,
+        "func_name": "_call_aside",
+        "type_comments": [
+            "(function) -> function"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 3114,
+        "func_name": "_initialize",
+        "type_comments": [
+            "(Dict[str, Union[_frozen_importlib.ModuleSpec, _frozen_importlib_external.SourceFileLoader, str]]) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 3126,
+        "func_name": "_initialize_master_working_set",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\__init__.py",
+        "line": 3165,
+        "func_name": "PkgResourcesDeprecationWarning",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\appdirs.py",
+        "line": 407,
+        "func_name": "AppDirs",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\_compat.py",
+        "line": 20,
+        "func_name": "with_metaclass",
+        "type_comments": [
+            "(type, *type) -> pkg_resources.extern.packaging._compat.metaclass"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\_compat.py",
+        "line": 27,
+        "func_name": "metaclass",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\_compat.py",
+        "line": 28,
+        "func_name": "__new__",
+        "type_comments": [
+            "(str, Tuple[pkg_resources.extern.packaging._compat.metaclass], Dict[str, Union[function, str]]) -> abc.ABCMeta"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\_structures.py",
+        "line": 7,
+        "func_name": "Infinity",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\_structures.py",
+        "line": 33,
+        "func_name": "Infinity.__neg__",
+        "type_comments": [
+            "() -> pkg_resources.extern.packaging._structures.NegativeInfinity"
+        ],
+        "samples": 17
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\_structures.py",
+        "line": 39,
+        "func_name": "NegativeInfinity",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\markers.py",
+        "line": 25,
+        "func_name": "InvalidMarker",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\markers.py",
+        "line": 31,
+        "func_name": "UndefinedComparison",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\markers.py",
+        "line": 37,
+        "func_name": "UndefinedEnvironmentName",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\markers.py",
+        "line": 44,
+        "func_name": "Node",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\markers.py",
+        "line": 46,
+        "func_name": "Node.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\markers.py",
+        "line": 49,
+        "func_name": "Node.__str__",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 23
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\markers.py",
+        "line": 59,
+        "func_name": "Variable",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\markers.py",
+        "line": 61,
+        "func_name": "Variable.serialize",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\markers.py",
+        "line": 65,
+        "func_name": "Value",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\markers.py",
+        "line": 67,
+        "func_name": "Value.serialize",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\markers.py",
+        "line": 71,
+        "func_name": "Op",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\markers.py",
+        "line": 73,
+        "func_name": "Op.serialize",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 20
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\markers.py",
+        "line": 141,
+        "func_name": "_coerce_parse_result",
+        "type_comments": [
+            "(pkg_resources._vendor.pyparsing.ParseResults) -> pyannotate_runtime.collect_types.UnknownType",
+            "(Tuple[pkg_resources.extern.packaging.markers.Variable, pkg_resources.extern.packaging.markers.Op, pkg_resources.extern.packaging.markers.Value]) -> Tuple[pkg_resources.extern.packaging.markers.Variable, pkg_resources.extern.packaging.markers.Op, pkg_resources.extern.packaging.markers.Value]"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\markers.py",
+        "line": 148,
+        "func_name": "_format_marker",
+        "type_comments": [
+            "(Tuple[pkg_resources.extern.packaging.markers.Variable, pkg_resources.extern.packaging.markers.Op, pkg_resources.extern.packaging.markers.Value], bool) -> str",
+            "(List[Tuple[pkg_resources.extern.packaging.markers.Variable, pkg_resources.extern.packaging.markers.Op, pkg_resources.extern.packaging.markers.Value]], bool) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\markers.py",
+        "line": 183,
+        "func_name": "_eval_op",
+        "type_comments": [
+            "(str, pkg_resources.extern.packaging.markers.Op, str) -> bool",
+            "(None, pkg_resources.extern.packaging.markers.Op, str) -> bool"
+        ],
+        "samples": 12
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\markers.py",
+        "line": 203,
+        "func_name": "_get_env",
+        "type_comments": [
+            "(Dict[str, str], str) -> None",
+            "(Dict[str, str], str) -> str"
+        ],
+        "samples": 12
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\markers.py",
+        "line": 214,
+        "func_name": "_evaluate_markers",
+        "type_comments": [
+            "(List[Tuple[pkg_resources.extern.packaging.markers.Variable, pkg_resources.extern.packaging.markers.Op, pkg_resources.extern.packaging.markers.Value]], Dict[str, str]) -> bool"
+        ],
+        "samples": 12
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\markers.py",
+        "line": 241,
+        "func_name": "format_full_version",
+        "type_comments": [
+            "(sys.version_info) -> str"
+        ],
+        "samples": 11
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\markers.py",
+        "line": 249,
+        "func_name": "default_environment",
+        "type_comments": [
+            "() -> Dict[str, str]"
+        ],
+        "samples": 11
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\markers.py",
+        "line": 272,
+        "func_name": "Marker",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\markers.py",
+        "line": 274,
+        "func_name": "Marker.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\markers.py",
+        "line": 282,
+        "func_name": "Marker.__str__",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\markers.py",
+        "line": 288,
+        "func_name": "Marker.evaluate",
+        "type_comments": [
+            "(Dict[str, None]) -> bool",
+            "(Dict[str, str]) -> bool"
+        ],
+        "samples": 11
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\requirements.py",
+        "line": 88,
+        "func_name": "Requirement.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\specifiers.py",
+        "line": 21,
+        "func_name": "BaseSpecifier",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\specifiers.py",
+        "line": 78,
+        "func_name": "_IndividualSpecifier",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\specifiers.py",
+        "line": 82,
+        "func_name": "_IndividualSpecifier.__init__",
+        "type_comments": [
+            "(str, None) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(str, None) -> None"
+        ],
+        "samples": 12
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\specifiers.py",
+        "line": 111,
+        "func_name": "_IndividualSpecifier.__hash__",
+        "type_comments": [
+            "() -> int"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\specifiers.py",
+        "line": 136,
+        "func_name": "_IndividualSpecifier._get_operator",
+        "type_comments": [
+            "(str) -> method"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\specifiers.py",
+        "line": 139,
+        "func_name": "_IndividualSpecifier._coerce_version",
+        "type_comments": [
+            "(pkg_resources.extern.packaging.version.Version) -> pkg_resources.extern.packaging.version.Version"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\specifiers.py",
+        "line": 144,
+        "func_name": "operator",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\specifiers.py",
+        "line": 148,
+        "func_name": "version",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\specifiers.py",
+        "line": 163,
+        "func_name": "_IndividualSpecifier.contains",
+        "type_comments": [
+            "(pkg_resources.extern.packaging.version.Version, bool) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\specifiers.py",
+        "line": 214,
+        "func_name": "LegacySpecifier",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\specifiers.py",
+        "line": 266,
+        "func_name": "_require_version_compare",
+        "type_comments": [
+            "(function) -> function"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\specifiers.py",
+        "line": 267,
+        "func_name": "wrapped",
+        "type_comments": [
+            "(pkg_resources.extern.packaging.version.Version, str) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\specifiers.py",
+        "line": 275,
+        "func_name": "Specifier",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\specifiers.py",
+        "line": 413,
+        "func_name": "_compare_equal",
+        "type_comments": [
+            "(pkg_resources.extern.packaging.version.Version, str) -> bool"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\specifiers.py",
+        "line": 456,
+        "func_name": "_compare_greater_than_equal",
+        "type_comments": [
+            "(pkg_resources.extern.packaging.version.Version, str) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\specifiers.py",
+        "line": 460,
+        "func_name": "_compare_less_than",
+        "type_comments": [
+            "(pkg_resources.extern.packaging.version.Version, str) -> bool"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\specifiers.py",
+        "line": 519,
+        "func_name": "prereleases",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\specifiers.py",
+        "line": 589,
+        "func_name": "SpecifierSet",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\specifiers.py",
+        "line": 591,
+        "func_name": "SpecifierSet.__init__",
+        "type_comments": [
+            "(str, None) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\specifiers.py",
+        "line": 624,
+        "func_name": "SpecifierSet.__hash__",
+        "type_comments": [
+            "() -> int"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\specifiers.py",
+        "line": 650,
+        "func_name": "SpecifierSet.__eq__",
+        "type_comments": [
+            "(pkg_resources.extern.packaging.specifiers.SpecifierSet) -> bool"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\specifiers.py",
+        "line": 673,
+        "func_name": "SpecifierSet.__iter__",
+        "type_comments": [
+            "() -> set_iterator"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\specifiers.py",
+        "line": 700,
+        "func_name": "SpecifierSet.contains",
+        "type_comments": [
+            "(str, bool) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\version.py",
+        "line": 42,
+        "func_name": "_BaseVersion",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\version.py",
+        "line": 47,
+        "func_name": "_BaseVersion.__lt__",
+        "type_comments": [
+            "(pkg_resources.extern.packaging.version.LegacyVersion) -> bool"
+        ],
+        "samples": 12
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\version.py",
+        "line": 53,
+        "func_name": "_BaseVersion.__eq__",
+        "type_comments": [
+            "(pkg_resources.extern.packaging.version.LegacyVersion) -> bool"
+        ],
+        "samples": 12
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\version.py",
+        "line": 56,
+        "func_name": "_BaseVersion.__ge__",
+        "type_comments": [
+            "(pkg_resources.extern.packaging.version.Version) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\version.py",
+        "line": 65,
+        "func_name": "_BaseVersion._compare",
+        "type_comments": [
+            "(pkg_resources.extern.packaging.version.LegacyVersion, function) -> bool"
+        ],
+        "samples": 19
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\version.py",
+        "line": 72,
+        "func_name": "LegacyVersion",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\version.py",
+        "line": 74,
+        "func_name": "LegacyVersion.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 10
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\version.py",
+        "line": 114,
+        "func_name": "_parse_version_parts",
+        "type_comments": [
+            "(str) -> Iterator",
+            "(str) -> Iterator[str]"
+        ],
+        "samples": 26
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\version.py",
+        "line": 131,
+        "func_name": "_legacy_cmpkey",
+        "type_comments": [
+            "(str) -> Tuple[int, Tuple[str, str, str, str]]",
+            "(str) -> Tuple[int, Tuple[str, str]]"
+        ],
+        "samples": 10
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\version.py",
+        "line": 191,
+        "func_name": "Version",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\version.py",
+        "line": 198,
+        "func_name": "Version.__init__",
+        "type_comments": [
+            "(str) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(str) -> None"
+        ],
+        "samples": 16
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\version.py",
+        "line": 236,
+        "func_name": "Version.__str__",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\version.py",
+        "line": 266,
+        "func_name": "public",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\version.py",
+        "line": 283,
+        "func_name": "local",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\version.py",
+        "line": 289,
+        "func_name": "is_prerelease",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\version.py",
+        "line": 298,
+        "func_name": "_parse_letter_version",
+        "type_comments": [
+            "(None, None) -> None"
+        ],
+        "samples": 24
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\version.py",
+        "line": 332,
+        "func_name": "_parse_local_version",
+        "type_comments": [
+            "(None) -> None"
+        ],
+        "samples": 11
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\packaging\\version.py",
+        "line": 343,
+        "func_name": "_cmpkey",
+        "type_comments": [
+            "(int, Tuple[int, int, int], None, None, None, None) -> Tuple[int, Tuple[int], pkg_resources.extern.packaging._structures.Infinity, pkg_resources.extern.packaging._structures.NegativeInfinity, pkg_resources.extern.packaging._structures.Infinity, pkg_resources.extern.packaging._structures.NegativeInfinity]",
+            "(int, Tuple[int, int], None, None, None, None) -> Tuple[int, Tuple[int, int], pkg_resources.extern.packaging._structures.Infinity, pkg_resources.extern.packaging._structures.NegativeInfinity, pkg_resources.extern.packaging._structures.Infinity, pkg_resources.extern.packaging._structures.NegativeInfinity]",
+            "(int, Tuple[int, int, int], None, None, None, None) -> Tuple[int, Tuple[int, int, int], pkg_resources.extern.packaging._structures.Infinity, pkg_resources.extern.packaging._structures.NegativeInfinity, pkg_resources.extern.packaging._structures.Infinity, pkg_resources.extern.packaging._structures.NegativeInfinity]",
+            "(int, Tuple[int, int, int], None, None, None, None) -> Tuple[int, Tuple[int, int], pkg_resources.extern.packaging._structures.Infinity, pkg_resources.extern.packaging._structures.NegativeInfinity, pkg_resources.extern.packaging._structures.Infinity, pkg_resources.extern.packaging._structures.NegativeInfinity]"
+        ],
+        "samples": 11
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 195,
+        "func_name": "_Constants",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 205,
+        "func_name": "ParseBaseException",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 209,
+        "func_name": "ParseBaseException.__init__",
+        "type_comments": [
+            "(str, int, str, pkg_resources._vendor.pyparsing.Regex) -> None",
+            "(str, int, str, pkg_resources._vendor.pyparsing.Word) -> None",
+            "(str, int, str, pkg_resources._vendor.pyparsing.Literal) -> None"
+        ],
+        "samples": 137
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 261,
+        "func_name": "ParseException",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 282,
+        "func_name": "ParseFatalException",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 287,
+        "func_name": "ParseSyntaxException",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 306,
+        "func_name": "RecursiveGrammarException",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 314,
+        "func_name": "_ParseResultsWithOffset",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 315,
+        "func_name": "_ParseResultsWithOffset.__init__",
+        "type_comments": [
+            "(int, int) -> None",
+            "(str, int) -> None",
+            "(pkg_resources._vendor.pyparsing.ParseResults, int) -> None",
+            "(pkg_resources.extern.packaging.markers.Marker, int) -> None"
+        ],
+        "samples": 38
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 317,
+        "func_name": "_ParseResultsWithOffset.__getitem__",
+        "type_comments": [
+            "(int) -> pkg_resources.extern.packaging.markers.Marker",
+            "(int) -> pkg_resources._vendor.pyparsing.ParseResults",
+            "(int) -> str",
+            "(int) -> int"
+        ],
+        "samples": 78
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 324,
+        "func_name": "ParseResults",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 363,
+        "func_name": "__new__",
+        "type_comments": [
+            "(str, None, bool, bool) -> pkg_resources._vendor.pyparsing.ParseResults",
+            "(pkg_resources._vendor.pyparsing.ParseResults, None, bool, bool) -> pkg_resources._vendor.pyparsing.ParseResults",
+            "(List, None, bool, bool) -> pkg_resources._vendor.pyparsing.ParseResults",
+            "(List[str], None, bool, bool) -> pkg_resources._vendor.pyparsing.ParseResults",
+            "(List, str, bool, bool) -> pkg_resources._vendor.pyparsing.ParseResults",
+            "(pkg_resources._vendor.pyparsing.ParseResults, str, bool, bool) -> pkg_resources._vendor.pyparsing.ParseResults",
+            "(List[pkg_resources._vendor.pyparsing.ParseResults], None, bool, bool) -> pkg_resources._vendor.pyparsing.ParseResults",
+            "(pkg_resources.extern.packaging.markers.Op, None, bool, bool) -> pkg_resources._vendor.pyparsing.ParseResults"
+        ],
+        "samples": 141
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 372,
+        "func_name": "ParseResults.__init__",
+        "type_comments": [
+            "(List, str, bool, bool, builtin_function_or_method) -> None",
+            "(str, None, bool, bool, builtin_function_or_method) -> None",
+            "(List, None, bool, bool, builtin_function_or_method) -> None",
+            "(List[str], None, bool, bool, builtin_function_or_method) -> None",
+            "(pkg_resources._vendor.pyparsing.ParseResults, str, bool, bool, builtin_function_or_method) -> None",
+            "(List[pkg_resources._vendor.pyparsing.ParseResults], None, bool, bool, builtin_function_or_method) -> None",
+            "(pkg_resources.extern.packaging.markers.Op, None, bool, bool, builtin_function_or_method) -> None",
+            "(pkg_resources._vendor.pyparsing.ParseResults, None, bool, bool, builtin_function_or_method) -> None"
+        ],
+        "samples": 141
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 411,
+        "func_name": "ParseResults.__getitem__",
+        "type_comments": [
+            "(int) -> pkg_resources._vendor.pyparsing.ParseResults",
+            "(str) -> pkg_resources._vendor.pyparsing.ParseResults",
+            "(int) -> str",
+            "(str) -> int",
+            "(str) -> str",
+            "(str) -> pkg_resources.extern.packaging.markers.Marker",
+            "(str) -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 42
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 420,
+        "func_name": "ParseResults.__setitem__",
+        "type_comments": [
+            "(str, int, builtin_function_or_method) -> None",
+            "(str, str, builtin_function_or_method) -> None",
+            "(str, pkg_resources._vendor.pyparsing._ParseResultsWithOffset, builtin_function_or_method) -> None",
+            "(str, pkg_resources.extern.packaging.markers.Marker, builtin_function_or_method) -> None"
+        ],
+        "samples": 37
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 433,
+        "func_name": "ParseResults.__delitem__",
+        "type_comments": [
+            "(slice) -> None"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 457,
+        "func_name": "ParseResults.__len__",
+        "type_comments": [
+            "() -> int"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 458,
+        "func_name": "ParseResults.__bool__",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 40
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 460,
+        "func_name": "ParseResults.__iter__",
+        "type_comments": [
+            "() -> list_iterator"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 506,
+        "func_name": "ParseResults.haskeys",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 18
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 644,
+        "func_name": "ParseResults.__getattr__",
+        "type_comments": [
+            "(str) -> pkg_resources.extern.packaging.markers.Marker",
+            "(str) -> pkg_resources._vendor.pyparsing.ParseResults",
+            "(str) -> str"
+        ],
+        "samples": 20
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 663,
+        "func_name": "ParseResults.__iadd__",
+        "type_comments": [
+            "(pkg_resources._vendor.pyparsing.ParseResults) -> pkg_resources._vendor.pyparsing.ParseResults"
+        ],
+        "samples": 31
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 693,
+        "func_name": "ParseResults._asStringList",
+        "type_comments": [
+            "(str) -> List[str]"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 755,
+        "func_name": "ParseResults.copy",
+        "type_comments": [
+            "() -> pkg_resources._vendor.pyparsing.ParseResults"
+        ],
+        "samples": 10
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1039,
+        "func_name": "_trim_arity",
+        "type_comments": [
+            "(function, int) -> function"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1047,
+        "func_name": "extract_stack",
+        "type_comments": [
+            "(int) -> List[Tuple[str, int]]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1069,
+        "func_name": "wrapper",
+        "type_comments": [
+            "(*Union[int, pkg_resources._vendor.pyparsing.ParseResults, str]) -> pkg_resources.extern.packaging.markers.Op",
+            "(*Union[int, pkg_resources._vendor.pyparsing.ParseResults, str]) -> Tuple[pkg_resources.extern.packaging.markers.Variable, pkg_resources.extern.packaging.markers.Op, pkg_resources.extern.packaging.markers.Value]",
+            "(*Union[int, pkg_resources._vendor.pyparsing.ParseResults, str]) -> pyannotate_runtime.collect_types.UnknownType",
+            "(*Union[int, pkg_resources._vendor.pyparsing.ParseResults, str]) -> pkg_resources.extern.packaging.markers.Variable",
+            "(*Union[int, pkg_resources._vendor.pyparsing.ParseResults, str]) -> str",
+            "(*Union[int, pkg_resources._vendor.pyparsing.ParseResults, str]) -> int",
+            "(*Union[int, pkg_resources._vendor.pyparsing.ParseResults, str]) -> pkg_resources.extern.packaging.markers.Value"
+        ],
+        "samples": 29
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1103,
+        "func_name": "ParserElement",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1144,
+        "func_name": "ParserElement.__init__",
+        "type_comments": [
+            "(bool) -> None"
+        ],
+        "samples": 11
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1167,
+        "func_name": "ParserElement.copy",
+        "type_comments": [
+            "() -> pkg_resources._vendor.pyparsing.Group",
+            "() -> pkg_resources._vendor.pyparsing.Suppress",
+            "() -> pkg_resources._vendor.pyparsing.Optional",
+            "() -> pkg_resources._vendor.pyparsing.Regex",
+            "() -> pkg_resources._vendor.pyparsing.Literal",
+            "() -> pkg_resources._vendor.pyparsing.And"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1190,
+        "func_name": "ParserElement.setName",
+        "type_comments": [
+            "(str) -> pkg_resources._vendor.pyparsing.LineStart",
+            "(str) -> pkg_resources._vendor.pyparsing.LineEnd",
+            "(str) -> pkg_resources._vendor.pyparsing.StringStart",
+            "(str) -> pkg_resources._vendor.pyparsing.Empty",
+            "(str) -> pkg_resources._vendor.pyparsing.StringEnd"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1204,
+        "func_name": "ParserElement.setResultsName",
+        "type_comments": [
+            "(str, bool) -> pkg_resources._vendor.pyparsing.Optional",
+            "(str, bool) -> pkg_resources._vendor.pyparsing.And",
+            "(str, bool) -> pkg_resources._vendor.pyparsing.Group",
+            "(str, bool) -> pkg_resources._vendor.pyparsing.Word"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1250,
+        "func_name": "ParserElement.setParseAction",
+        "type_comments": [
+            "(*function) -> pkg_resources._vendor.pyparsing.Word",
+            "(*function) -> pkg_resources._vendor.pyparsing.Regex",
+            "(*function) -> pkg_resources._vendor.pyparsing.Combine"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1288,
+        "func_name": "ParserElement.addParseAction",
+        "type_comments": [
+            "(*builtin_function_or_method) -> pkg_resources._vendor.pyparsing.MatchFirst",
+            "(*function) -> pkg_resources._vendor.pyparsing.And"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1298,
+        "func_name": "ParserElement.addCondition",
+        "type_comments": [
+            "(*function) -> pkg_resources._vendor.pyparsing.And"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1351,
+        "func_name": "ParserElement.preParse",
+        "type_comments": [
+            "(str, int) -> int"
+        ],
+        "samples": 177
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1363,
+        "func_name": "ParserElement.parseImpl",
+        "type_comments": [
+            "(str, int, bool) -> Tuple[int, List]"
+        ],
+        "samples": 11
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1366,
+        "func_name": "ParserElement.postParse",
+        "type_comments": [
+            "(str, int, pkg_resources._vendor.pyparsing.ParseResults) -> pkg_resources._vendor.pyparsing.ParseResults",
+            "(str, int, List) -> List",
+            "(str, int, str) -> str"
+        ],
+        "samples": 98
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1370,
+        "func_name": "ParserElement._parseNoCache",
+        "type_comments": [
+            "(str, int, bool, bool) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(str, int, bool, bool) -> pyannotate_runtime.collect_types.UnknownType",
+            "(str, int, bool, bool) -> Tuple[int, pkg_resources._vendor.pyparsing.ParseResults]"
+        ],
+        "samples": 268
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1441,
+        "func_name": "ParserElement.tryParse",
+        "type_comments": [
+            "(str, int) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(str, int) -> int"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1455,
+        "func_name": "_UnboundedCache",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1478,
+        "func_name": "_FifoCache",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1567,
+        "func_name": "resetCache",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1608,
+        "func_name": "ParserElement.parseString",
+        "type_comments": [
+            "(str, bool) -> pkg_resources._vendor.pyparsing.ParseResults",
+            "(str, bool) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1821,
+        "func_name": "ParserElement.__add__",
+        "type_comments": [
+            "(pkg_resources._vendor.pyparsing.Suppress) -> pkg_resources._vendor.pyparsing.And",
+            "(str) -> pkg_resources._vendor.pyparsing.And",
+            "(pkg_resources._vendor.pyparsing.Optional) -> pkg_resources._vendor.pyparsing.And",
+            "(pkg_resources._vendor.pyparsing.MatchFirst) -> pkg_resources._vendor.pyparsing.And",
+            "(pkg_resources._vendor.pyparsing.Group) -> pkg_resources._vendor.pyparsing.And"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1841,
+        "func_name": "ParserElement.__radd__",
+        "type_comments": [
+            "(str) -> pkg_resources._vendor.pyparsing.And"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1877,
+        "func_name": "ParserElement.__mul__",
+        "type_comments": [
+            "(Tuple[int, int]) -> pkg_resources._vendor.pyparsing.Optional",
+            "(int) -> pkg_resources._vendor.pyparsing.And"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1926,
+        "func_name": "makeOptionalList",
+        "type_comments": [
+            "(int) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1948,
+        "func_name": "ParserElement.__or__",
+        "type_comments": [
+            "(pkg_resources._vendor.pyparsing.Regex) -> pkg_resources._vendor.pyparsing.MatchFirst",
+            "(pkg_resources._vendor.pyparsing.CharsNotIn) -> pkg_resources._vendor.pyparsing.MatchFirst",
+            "(pkg_resources._vendor.pyparsing.MatchFirst) -> pkg_resources._vendor.pyparsing.MatchFirst",
+            "(pkg_resources._vendor.pyparsing.And) -> pkg_resources._vendor.pyparsing.MatchFirst"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 1972,
+        "func_name": "ParserElement.__xor__",
+        "type_comments": [
+            "(pkg_resources._vendor.pyparsing.Regex) -> pkg_resources._vendor.pyparsing.Or"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2020,
+        "func_name": "ParserElement.__invert__",
+        "type_comments": [
+            "() -> pkg_resources._vendor.pyparsing.NotAny"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2026,
+        "func_name": "ParserElement.__call__",
+        "type_comments": [
+            "(str) -> pkg_resources._vendor.pyparsing.Combine",
+            "(str) -> pkg_resources._vendor.pyparsing.Regex",
+            "(None) -> pkg_resources._vendor.pyparsing.Regex",
+            "(str) -> pkg_resources._vendor.pyparsing.Word"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2045,
+        "func_name": "ParserElement.suppress",
+        "type_comments": [
+            "() -> pkg_resources._vendor.pyparsing.Suppress"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2052,
+        "func_name": "ParserElement.leaveWhitespace",
+        "type_comments": [
+            "() -> pkg_resources._vendor.pyparsing.Literal",
+            "() -> pkg_resources._vendor.pyparsing.Regex"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2061,
+        "func_name": "ParserElement.setWhitespaceChars",
+        "type_comments": [
+            "(str) -> pkg_resources._vendor.pyparsing.Group",
+            "(str) -> pkg_resources._vendor.pyparsing.Suppress",
+            "(str) -> pkg_resources._vendor.pyparsing.LineEnd",
+            "(str) -> pkg_resources._vendor.pyparsing.OneOrMore",
+            "(str) -> pkg_resources._vendor.pyparsing.And",
+            "(str) -> pkg_resources._vendor.pyparsing.ZeroOrMore"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2153,
+        "func_name": "ParserElement.__str__",
+        "type_comments": [
+            "() -> pyannotate_runtime.collect_types.NoReturnType",
+            "() -> str"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2159,
+        "func_name": "ParserElement.streamline",
+        "type_comments": [
+            "() -> pkg_resources._vendor.pyparsing.Optional",
+            "() -> pkg_resources._vendor.pyparsing.OneOrMore",
+            "() -> pkg_resources._vendor.pyparsing.Literal",
+            "() -> pkg_resources._vendor.pyparsing.And",
+            "() -> pkg_resources._vendor.pyparsing.ZeroOrMore"
+        ],
+        "samples": 11
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2364,
+        "func_name": "Token",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2368,
+        "func_name": "Token.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2372,
+        "func_name": "Empty",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2376,
+        "func_name": "Empty.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2383,
+        "func_name": "NoMatch",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2398,
+        "func_name": "Literal",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2412,
+        "func_name": "Literal.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2431,
+        "func_name": "Literal.parseImpl",
+        "type_comments": [
+            "(str, int, bool) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(str, int, bool) -> Tuple[int, str]"
+        ],
+        "samples": 136
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2439,
+        "func_name": "Keyword",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2504,
+        "func_name": "CaselessLiteral",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2527,
+        "func_name": "CaselessKeyword",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2545,
+        "func_name": "CloseMatch",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2606,
+        "func_name": "Word",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2653,
+        "func_name": "Word.__init__",
+        "type_comments": [
+            "(str, None, int, int, int, bool, str) -> None",
+            "(str, None, int, int, int, bool, None) -> None",
+            "(str, str, int, int, int, bool, None) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2707,
+        "func_name": "Word.parseImpl",
+        "type_comments": [
+            "(str, int, bool) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(str, int, bool) -> Tuple[int, str]"
+        ],
+        "samples": 16
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2742,
+        "func_name": "Word.__str__",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2751,
+        "func_name": "charsAsStr",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2765,
+        "func_name": "Regex",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2779,
+        "func_name": "Regex.__init__",
+        "type_comments": [
+            "(str, int) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2813,
+        "func_name": "Regex.parseImpl",
+        "type_comments": [
+            "(str, int, bool) -> Tuple[int, pkg_resources._vendor.pyparsing.ParseResults]"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2826,
+        "func_name": "Regex.__str__",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2838,
+        "func_name": "QuotedString",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2863,
+        "func_name": "QuotedString.__init__",
+        "type_comments": [
+            "(str, None, None, bool, bool, None, bool) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2928,
+        "func_name": "QuotedString.parseImpl",
+        "type_comments": [
+            "(str, int, bool) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(str, int, bool) -> Tuple[int, str]"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2963,
+        "func_name": "QuotedString.__str__",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2975,
+        "func_name": "CharsNotIn",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 2991,
+        "func_name": "CharsNotIn.__init__",
+        "type_comments": [
+            "(str, int, int, int) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3015,
+        "func_name": "CharsNotIn.parseImpl",
+        "type_comments": [
+            "(str, int, bool) -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3032,
+        "func_name": "CharsNotIn.__str__",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3046,
+        "func_name": "White",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3061,
+        "func_name": "White.__init__",
+        "type_comments": [
+            "(str, int, int, int) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3097,
+        "func_name": "_PositionToken",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3098,
+        "func_name": "_PositionToken.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3104,
+        "func_name": "GoToColumn",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3130,
+        "func_name": "LineStart",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3151,
+        "func_name": "LineStart.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3160,
+        "func_name": "LineEnd",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3164,
+        "func_name": "LineEnd.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3180,
+        "func_name": "StringStart",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3184,
+        "func_name": "StringStart.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3188,
+        "func_name": "StringStart.parseImpl",
+        "type_comments": [
+            "(str, int, bool) -> Tuple[int, List]"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3195,
+        "func_name": "StringEnd",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3199,
+        "func_name": "StringEnd.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3203,
+        "func_name": "StringEnd.parseImpl",
+        "type_comments": [
+            "(str, int, bool) -> Tuple[int, List]"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3213,
+        "func_name": "WordStart",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3233,
+        "func_name": "WordEnd",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3256,
+        "func_name": "ParseExpression",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3260,
+        "func_name": "ParseExpression.__init__",
+        "type_comments": [
+            "(List[Union[pkg_resources._vendor.pyparsing.MatchFirst, pkg_resources._vendor.pyparsing.Regex]], bool) -> None",
+            "(List[Union[pkg_resources._vendor.pyparsing.Regex, pkg_resources._vendor.pyparsing.Word]], bool) -> None",
+            "(List[Union[pkg_resources._vendor.pyparsing.MatchFirst, pkg_resources._vendor.pyparsing.Suppress]], bool) -> None",
+            "(List[Union[pkg_resources._vendor.pyparsing.And, pkg_resources._vendor.pyparsing.MatchFirst]], bool) -> None",
+            "(List[Union[pkg_resources._vendor.pyparsing.Literal, pkg_resources._vendor.pyparsing.Optional]], bool) -> None",
+            "(List[Union[pkg_resources._vendor.pyparsing.Forward, pkg_resources._vendor.pyparsing.Suppress]], bool) -> None",
+            "(List[Union[pkg_resources._vendor.pyparsing.CharsNotIn, pkg_resources._vendor.pyparsing.MatchFirst]], bool) -> None"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3288,
+        "func_name": "ParseExpression.leaveWhitespace",
+        "type_comments": [
+            "() -> pkg_resources._vendor.pyparsing.And",
+            "() -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3319,
+        "func_name": "ParseExpression.streamline",
+        "type_comments": [
+            "() -> pkg_resources._vendor.pyparsing.And",
+            "() -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3353,
+        "func_name": "ParseExpression.setResultsName",
+        "type_comments": [
+            "(str, bool) -> pkg_resources._vendor.pyparsing.And"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3363,
+        "func_name": "ParseExpression.copy",
+        "type_comments": [
+            "() -> pkg_resources._vendor.pyparsing.And",
+            "() -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3368,
+        "func_name": "And",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3384,
+        "func_name": "_ErrorStop",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3390,
+        "func_name": "And.__init__",
+        "type_comments": [
+            "(List[Union[pkg_resources._vendor.pyparsing.And, pkg_resources._vendor.pyparsing.MatchFirst]], bool) -> None",
+            "(List[Union[pkg_resources._vendor.pyparsing.MatchFirst, pkg_resources._vendor.pyparsing.Suppress]], bool) -> None",
+            "(List[Union[pkg_resources._vendor.pyparsing.And, pkg_resources._vendor.pyparsing.Group]], bool) -> None",
+            "(List[Union[pkg_resources._vendor.pyparsing.And, pkg_resources._vendor.pyparsing.Literal]], bool) -> None",
+            "(List[Union[pkg_resources._vendor.pyparsing.And, pkg_resources._vendor.pyparsing.Word]], bool) -> None",
+            "(List[Union[pkg_resources._vendor.pyparsing.Literal, pkg_resources._vendor.pyparsing.Optional]], bool) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3397,
+        "func_name": "And.parseImpl",
+        "type_comments": [
+            "(str, int, bool) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(str, int, bool) -> pyannotate_runtime.collect_types.UnknownType",
+            "(str, int, bool) -> Tuple[int, pkg_resources._vendor.pyparsing.ParseResults]"
+        ],
+        "samples": 36
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3434,
+        "func_name": "And.__str__",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3444,
+        "func_name": "Or",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3458,
+        "func_name": "Or.__init__",
+        "type_comments": [
+            "(List[pkg_resources._vendor.pyparsing.Regex], bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3465,
+        "func_name": "Or.parseImpl",
+        "type_comments": [
+            "(str, int, bool) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(str, int, bool) -> Tuple[int, pkg_resources._vendor.pyparsing.ParseResults]"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3508,
+        "func_name": "Or.__str__",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3523,
+        "func_name": "MatchFirst",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3540,
+        "func_name": "MatchFirst.__init__",
+        "type_comments": [
+            "(List[Union[pkg_resources._vendor.pyparsing.MatchFirst, pkg_resources._vendor.pyparsing.Regex]], bool) -> None",
+            "(List[Union[pkg_resources._vendor.pyparsing.Regex, pkg_resources._vendor.pyparsing.Word]], bool) -> None",
+            "(List[Union[pkg_resources._vendor.pyparsing.Group, pkg_resources._vendor.pyparsing.MatchFirst]], bool) -> None",
+            "(List[pkg_resources._vendor.pyparsing.And], bool) -> None",
+            "(List[Union[pkg_resources._vendor.pyparsing.CharsNotIn, pkg_resources._vendor.pyparsing.MatchFirst]], bool) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3547,
+        "func_name": "MatchFirst.parseImpl",
+        "type_comments": [
+            "(str, int, bool) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(str, int, bool) -> pyannotate_runtime.collect_types.UnknownType",
+            "(str, int, bool) -> Tuple[int, pkg_resources._vendor.pyparsing.ParseResults]"
+        ],
+        "samples": 36
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3576,
+        "func_name": "MatchFirst.__str__",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3591,
+        "func_name": "Each",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3715,
+        "func_name": "ParseElementEnhance",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3719,
+        "func_name": "ParseElementEnhance.__init__",
+        "type_comments": [
+            "(pkg_resources._vendor.pyparsing.And, bool) -> None",
+            "(str, bool) -> None",
+            "(pkg_resources._vendor.pyparsing.OneOrMore, bool) -> None",
+            "(pkg_resources._vendor.pyparsing.Literal, bool) -> None",
+            "(pkg_resources._vendor.pyparsing.MatchFirst, bool) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3737,
+        "func_name": "ParseElementEnhance.parseImpl",
+        "type_comments": [
+            "(str, int, bool) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(str, int, bool) -> pyannotate_runtime.collect_types.UnknownType",
+            "(str, int, bool) -> Tuple[int, pkg_resources._vendor.pyparsing.ParseResults]"
+        ],
+        "samples": 24
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3743,
+        "func_name": "ParseElementEnhance.leaveWhitespace",
+        "type_comments": [
+            "() -> pyannotate_runtime.collect_types.UnknownType",
+            "() -> pkg_resources._vendor.pyparsing.Combine"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3762,
+        "func_name": "ParseElementEnhance.streamline",
+        "type_comments": [
+            "() -> pkg_resources._vendor.pyparsing.Optional",
+            "() -> pkg_resources._vendor.pyparsing.Suppress",
+            "() -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3781,
+        "func_name": "ParseElementEnhance.__str__",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3792,
+        "func_name": "FollowedBy",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3818,
+        "func_name": "NotAny",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3829,
+        "func_name": "NotAny.__init__",
+        "type_comments": [
+            "(pkg_resources._vendor.pyparsing.LineEnd) -> None",
+            "(pkg_resources._vendor.pyparsing.Literal) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3841,
+        "func_name": "NotAny.__str__",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3850,
+        "func_name": "_MultipleMatch",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3851,
+        "func_name": "_MultipleMatch.__init__",
+        "type_comments": [
+            "(pkg_resources._vendor.pyparsing.And, None) -> None",
+            "(pkg_resources._vendor.pyparsing.Group, None) -> None",
+            "(pkg_resources._vendor.pyparsing.MatchFirst, None) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3859,
+        "func_name": "_MultipleMatch.parseImpl",
+        "type_comments": [
+            "(str, int, bool) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(str, int, bool) -> pyannotate_runtime.collect_types.UnknownType",
+            "(str, int, bool) -> Tuple[int, pkg_resources._vendor.pyparsing.ParseResults]"
+        ],
+        "samples": 13
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3888,
+        "func_name": "OneOrMore",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3914,
+        "func_name": "OneOrMore.__str__",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3923,
+        "func_name": "ZeroOrMore",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3935,
+        "func_name": "ZeroOrMore.__init__",
+        "type_comments": [
+            "(pkg_resources._vendor.pyparsing.Word, None) -> None",
+            "(pkg_resources._vendor.pyparsing.And, None) -> None",
+            "(pkg_resources._vendor.pyparsing.Group, None) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3939,
+        "func_name": "ZeroOrMore.parseImpl",
+        "type_comments": [
+            "(str, int, bool) -> Tuple[int, List]",
+            "(str, int, bool) -> pyannotate_runtime.collect_types.UnknownType",
+            "(str, int, bool) -> Tuple[int, pkg_resources._vendor.pyparsing.ParseResults]"
+        ],
+        "samples": 13
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3945,
+        "func_name": "ZeroOrMore.__str__",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3954,
+        "func_name": "_NullToken",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3962,
+        "func_name": "Optional",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 3997,
+        "func_name": "Optional.__init__",
+        "type_comments": [
+            "(str, List[bool]) -> None",
+            "(pkg_resources._vendor.pyparsing.And, pkg_resources._vendor.pyparsing._NullToken) -> None",
+            "(str, pkg_resources._vendor.pyparsing._NullToken) -> None",
+            "(pkg_resources._vendor.pyparsing.MatchFirst, str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4003,
+        "func_name": "Optional.parseImpl",
+        "type_comments": [
+            "(str, int, bool) -> Tuple[int, List]",
+            "(str, int, bool) -> Tuple[int, pkg_resources._vendor.pyparsing.ParseResults]"
+        ],
+        "samples": 10
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4017,
+        "func_name": "Optional.__str__",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4026,
+        "func_name": "SkipTo",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4141,
+        "func_name": "Forward",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4160,
+        "func_name": "Forward.__init__",
+        "type_comments": [
+            "(None) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4163,
+        "func_name": "Forward.__lshift__",
+        "type_comments": [
+            "(pkg_resources._vendor.pyparsing.And) -> pkg_resources._vendor.pyparsing.Forward"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4183,
+        "func_name": "Forward.streamline",
+        "type_comments": [
+            "() -> pkg_resources._vendor.pyparsing.Forward",
+            "() -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4197,
+        "func_name": "Forward.__str__",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4214,
+        "func_name": "Forward.copy",
+        "type_comments": [
+            "() -> pkg_resources._vendor.pyparsing.Forward"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4222,
+        "func_name": "_ForwardNoRecurse",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4226,
+        "func_name": "TokenConverter",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4230,
+        "func_name": "TokenConverter.__init__",
+        "type_comments": [
+            "(pkg_resources._vendor.pyparsing.OneOrMore, bool) -> None",
+            "(pkg_resources._vendor.pyparsing.And, bool) -> None",
+            "(str, bool) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4234,
+        "func_name": "Combine",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4251,
+        "func_name": "Combine.__init__",
+        "type_comments": [
+            "(pkg_resources._vendor.pyparsing.MatchFirst, str, bool) -> None",
+            "(pkg_resources._vendor.pyparsing.And, str, bool) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4268,
+        "func_name": "Combine.postParse",
+        "type_comments": [
+            "(str, int, pkg_resources._vendor.pyparsing.ParseResults) -> pkg_resources._vendor.pyparsing.ParseResults",
+            "(str, int, pkg_resources._vendor.pyparsing.ParseResults) -> List[pkg_resources._vendor.pyparsing.ParseResults]"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4278,
+        "func_name": "Group",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4292,
+        "func_name": "Group.__init__",
+        "type_comments": [
+            "(pkg_resources._vendor.pyparsing.OneOrMore) -> None",
+            "(pkg_resources._vendor.pyparsing.And) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4296,
+        "func_name": "Group.postParse",
+        "type_comments": [
+            "(str, int, pkg_resources._vendor.pyparsing.ParseResults) -> List[pkg_resources._vendor.pyparsing.ParseResults]"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4299,
+        "func_name": "Dict",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4335,
+        "func_name": "Dict.__init__",
+        "type_comments": [
+            "(pkg_resources._vendor.pyparsing.ZeroOrMore) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4364,
+        "func_name": "Suppress",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4383,
+        "func_name": "Suppress.postParse",
+        "type_comments": [
+            "(str, int, pkg_resources._vendor.pyparsing.ParseResults) -> List"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4390,
+        "func_name": "OnlyOnce",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4450,
+        "func_name": "delimitedList",
+        "type_comments": [
+            "(pkg_resources._vendor.pyparsing.Optional, str, bool) -> pkg_resources._vendor.pyparsing.And"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4565,
+        "func_name": "_escapeRegexRangeChars",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4681,
+        "func_name": "originalTextFor",
+        "type_comments": [
+            "(pkg_resources._vendor.pyparsing.Optional, bool) -> pkg_resources._vendor.pyparsing.And",
+            "(pkg_resources._vendor.pyparsing.Forward, bool) -> pkg_resources._vendor.pyparsing.And"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4763,
+        "func_name": "srange",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4825,
+        "func_name": "tokenMap",
+        "type_comments": [
+            "(type, *int) -> function",
+            "(function) -> function",
+            "(type) -> function"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4875,
+        "func_name": "_makeTags",
+        "type_comments": [
+            "(pkg_resources._vendor.pyparsing.Word, bool) -> Tuple[pkg_resources._vendor.pyparsing.And, pkg_resources._vendor.pyparsing.Combine]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 4904,
+        "func_name": "makeHTMLTags",
+        "type_comments": [
+            "(pkg_resources._vendor.pyparsing.Word) -> Tuple[pkg_resources._vendor.pyparsing.And, pkg_resources._vendor.pyparsing.Combine]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\pyparsing.py",
+        "line": 5399,
+        "func_name": "pyparsing_common",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 75,
+        "func_name": "_add_doc",
+        "type_comments": [
+            "(function, str) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 80,
+        "func_name": "_import_module",
+        "type_comments": [
+            "(str) -> module",
+            "(str) -> pkg_resources._vendor.six.Module_six_moves_urllib"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 86,
+        "func_name": "_LazyDescr",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 88,
+        "func_name": "_LazyDescr.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 13
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 91,
+        "func_name": "_LazyDescr.__get__",
+        "type_comments": [
+            "(pkg_resources._vendor.six._MovedItems, type) -> module",
+            "(pkg_resources._vendor.six._MovedItems, type) -> module",
+            "(pkg_resources._vendor.six._MovedItems, type) -> type",
+            "(pkg_resources._vendor.six._MovedItems, type) -> pkg_resources._vendor.six.Module_six_moves_urllib"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 103,
+        "func_name": "MovedModule",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 105,
+        "func_name": "MovedModule.__init__",
+        "type_comments": [
+            "(str, str, str) -> None",
+            "(str, str, None) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 114,
+        "func_name": "MovedModule._resolve",
+        "type_comments": [
+            "() -> module",
+            "() -> pkg_resources._vendor.six.Module_six_moves_urllib"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 124,
+        "func_name": "_LazyModule",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 126,
+        "func_name": "_LazyModule.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 139,
+        "func_name": "MovedAttribute",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 141,
+        "func_name": "MovedAttribute.__init__",
+        "type_comments": [
+            "(str, str, str, None, None) -> None",
+            "(str, str, str, str, str) -> None",
+            "(str, str, str, str, None) -> None"
+        ],
+        "samples": 12
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 159,
+        "func_name": "MovedAttribute._resolve",
+        "type_comments": [
+            "() -> type"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 164,
+        "func_name": "_SixMetaPathImporter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 173,
+        "func_name": "_SixMetaPathImporter.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 177,
+        "func_name": "_SixMetaPathImporter._add_module",
+        "type_comments": [
+            "(pkg_resources._vendor.six.Module_six_moves_urllib, *str) -> None",
+            "(pkg_resources._vendor.six.MovedModule, *str) -> None",
+            "(pkg_resources._vendor.six.MovedModule, *str) -> None",
+            "(pkg_resources._vendor.six.Module_six_moves_urllib, *str) -> None"
+        ],
+        "samples": 12
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 181,
+        "func_name": "_SixMetaPathImporter._get_module",
+        "type_comments": [
+            "(str) -> pkg_resources._vendor.six.Module_six_moves_urllib_request",
+            "(str) -> pkg_resources._vendor.six.Module_six_moves_urllib_parse",
+            "(str) -> pkg_resources._vendor.six.Module_six_moves_urllib_error",
+            "(str) -> pkg_resources._vendor.six.Module_six_moves_urllib_response",
+            "(str) -> pkg_resources._vendor.six.Module_six_moves_urllib_robotparser",
+            "(str) -> pkg_resources._vendor.six.Module_six_moves_urllib_request",
+            "(str) -> pkg_resources._vendor.six.Module_six_moves_urllib_parse",
+            "(str) -> pkg_resources._vendor.six.Module_six_moves_urllib_error"
+        ],
+        "samples": 10
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 184,
+        "func_name": "_SixMetaPathImporter.find_module",
+        "type_comments": [
+            "(str, List) -> pkg_resources._vendor.six._SixMetaPathImporter",
+            "(str, None) -> None",
+            "(str, List[str]) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 189,
+        "func_name": "__get_module",
+        "type_comments": [
+            "(str) -> pkg_resources._vendor.six._MovedItems",
+            "(str) -> pkg_resources._vendor.six.Module_six_moves_urllib"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 195,
+        "func_name": "_SixMetaPathImporter.load_module",
+        "type_comments": [
+            "(str) -> pkg_resources._vendor.six._MovedItems",
+            "(str) -> pkg_resources._vendor.six.Module_six_moves_urllib"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 209,
+        "func_name": "_SixMetaPathImporter.is_package",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 229,
+        "func_name": "_MovedItems",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 320,
+        "func_name": "Module_six_moves_urllib_parse",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 360,
+        "func_name": "Module_six_moves_urllib_error",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 380,
+        "func_name": "Module_six_moves_urllib_request",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 430,
+        "func_name": "Module_six_moves_urllib_response",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 451,
+        "func_name": "Module_six_moves_urllib_robotparser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\_vendor\\six.py",
+        "line": 469,
+        "func_name": "Module_six_moves_urllib",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\extern\\__init__.py",
+        "line": 4,
+        "func_name": "VendorImporter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\extern\\__init__.py",
+        "line": 10,
+        "func_name": "VendorImporter.__init__",
+        "type_comments": [
+            "(str, Tuple[str, str, str, str], None) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\extern\\__init__.py",
+        "line": 23,
+        "func_name": "VendorImporter.find_module",
+        "type_comments": [
+            "(str, List[str]) -> pkg_resources.extern.VendorImporter",
+            "(str, List) -> pkg_resources.extern.VendorImporter",
+            "(str, List) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\extern\\__init__.py",
+        "line": 35,
+        "func_name": "VendorImporter.load_module",
+        "type_comments": [
+            "(str) -> pkg_resources._vendor.six._MovedItems",
+            "(str) -> module"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\pkg_resources\\extern\\__init__.py",
+        "line": 64,
+        "func_name": "VendorImporter.install",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\portend.py",
+        "line": 21,
+        "func_name": "client_host",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\portend.py",
+        "line": 34,
+        "func_name": "Checker",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\portend.py",
+        "line": 35,
+        "func_name": "Checker.__init__",
+        "type_comments": [
+            "(float) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\portend.py",
+        "line": 38,
+        "func_name": "Checker.assert_free",
+        "type_comments": [
+            "(str, int) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(str, int) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\portend.py",
+        "line": 69,
+        "func_name": "Checker._connect",
+        "type_comments": [
+            "(socket.AddressFamily, socket.SocketKind, int, str, Tuple[str, int]) -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\portend.py",
+        "line": 86,
+        "func_name": "Timeout",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\portend.py",
+        "line": 90,
+        "func_name": "PortNotFree",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\portend.py",
+        "line": 94,
+        "func_name": "free",
+        "type_comments": [
+            "(str, int, int) -> None",
+            "(str, int, float) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\portend.py",
+        "line": 125,
+        "func_name": "occupied",
+        "type_comments": [
+            "(str, int, int) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\portend.py",
+        "line": 174,
+        "func_name": "HostPort",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\six.py",
+        "line": 80,
+        "func_name": "_import_module",
+        "type_comments": [
+            "(str) -> module"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\six.py",
+        "line": 91,
+        "func_name": "_LazyDescr.__get__",
+        "type_comments": [
+            "(six._MovedItems, type) -> type"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\six.py",
+        "line": 114,
+        "func_name": "MovedModule._resolve",
+        "type_comments": [
+            "() -> six.Module_six_moves_urllib"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\six.py",
+        "line": 159,
+        "func_name": "MovedAttribute._resolve",
+        "type_comments": [
+            "() -> type"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\six.py",
+        "line": 184,
+        "func_name": "_SixMetaPathImporter.find_module",
+        "type_comments": [
+            "(str, None) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\six.py",
+        "line": 189,
+        "func_name": "__get_module",
+        "type_comments": [
+            "(str) -> six.Module_six_moves_urllib"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\six.py",
+        "line": 195,
+        "func_name": "_SixMetaPathImporter.load_module",
+        "type_comments": [
+            "(str) -> six.Module_six_moves_urllib"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\six.py",
+        "line": 209,
+        "func_name": "_SixMetaPathImporter.is_package",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\six.py",
+        "line": 835,
+        "func_name": "add_metaclass",
+        "type_comments": [
+            "(type) -> function"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\six.py",
+        "line": 837,
+        "func_name": "wrapper",
+        "type_comments": [
+            "() -> abc.ABCMeta"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\tempora\\__init__.py",
+        "line": 18,
+        "func_name": "Parser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\tempora\\__init__.py",
+        "line": 141,
+        "func_name": "DatetimeConstructor",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\tempora\\timing.py",
+        "line": 18,
+        "func_name": "Stopwatch",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\tempora\\timing.py",
+        "line": 50,
+        "func_name": "Stopwatch.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\tempora\\timing.py",
+        "line": 54,
+        "func_name": "Stopwatch.reset",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\tempora\\timing.py",
+        "line": 68,
+        "func_name": "Stopwatch.split",
+        "type_comments": [
+            "() -> datetime.timedelta"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\tempora\\timing.py",
+        "line": 81,
+        "func_name": "IntervalGovernor",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\tempora\\timing.py",
+        "line": 107,
+        "func_name": "Timer",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\tempora\\timing.py",
+        "line": 118,
+        "func_name": "Timer.__init__",
+        "type_comments": [
+            "(int) -> None",
+            "(float) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\tempora\\timing.py",
+        "line": 122,
+        "func_name": "Timer._accept",
+        "type_comments": [
+            "(float) -> float",
+            "(int) -> int"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\tempora\\timing.py",
+        "line": 133,
+        "func_name": "Timer.expired",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\tempora\\timing.py",
+        "line": 137,
+        "func_name": "BackoffDelay",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\win32\\lib\\pywintypes.py",
+        "line": 3,
+        "func_name": "__import_pywin32_system_module__",
+        "type_comments": [
+            "(str, Dict[str, Optional[Union[_frozen_importlib.ModuleSpec, _frozen_importlib_external.SourceFileLoader, str]]]) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\win32\\lib\\win32gui_struct.py",
+        "line": 64,
+        "func_name": "_make_text_buffer",
+        "type_comments": [
+            "(str) -> array.array"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\win32\\lib\\win32gui_struct.py",
+        "line": 92,
+        "func_name": "_make_bytes",
+        "type_comments": [
+            "(str) -> bytes"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\win32\\lib\\win32gui_struct.py",
+        "line": 121,
+        "func_name": "PackMENUITEMINFO",
+        "type_comments": [
+            "(None, None, None, int, None, None, None, str, None, None) -> Tuple[array.array, List[array.array]]",
+            "(None, None, int, None, None, None, None, str, None, None) -> Tuple[array.array, List[array.array]]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\win32\\lib\\win32gui_struct.py",
+        "line": 691,
+        "func_name": "DEV_BROADCAST_INFO",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\win32\\lib\\win32serviceutil.py",
+        "line": 751,
+        "func_name": "ServiceFramework",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\win32com\\__init__.py",
+        "line": 26,
+        "func_name": "SetupEnvironment",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\win32com\\__init__.py",
+        "line": 76,
+        "func_name": "__PackageSupportBuildPath__",
+        "type_comments": [
+            "(List[str]) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\zc\\lockfile\\__init__.py",
+        "line": 20,
+        "func_name": "LockError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\zc\\lockfile\\__init__.py",
+        "line": 64,
+        "func_name": "LazyHostName",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\site-packages\\zc\\lockfile\\__init__.py",
+        "line": 71,
+        "func_name": "LockFile",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_compile.py",
+        "line": 65,
+        "func_name": "_combine_flags",
+        "type_comments": [
+            "(int, int, int, int) -> int"
+        ],
+        "samples": 30
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_compile.py",
+        "line": 71,
+        "func_name": "_compile",
+        "type_comments": [
+            "(List[Union[int, sre_constants._NamedIntConstant]], List[Union[Tuple[sre_constants._NamedIntConstant, None], Tuple[sre_constants._NamedIntConstant, int]]], int) -> None",
+            "(List[Union[int, sre_constants._NamedIntConstant]], List[Union[Tuple[sre_constants._NamedIntConstant, List[Tuple[sre_constants._NamedIntConstant, Tuple[int, int]]]], Tuple[sre_constants._NamedIntConstant, Tuple[int, sre_constants._NamedIntConstant, sre_parse.SubPattern]]]], int) -> pyannotate_runtime.collect_types.UnknownType",
+            "(List[Union[int, sre_constants._NamedIntConstant]], sre_parse.SubPattern, int) -> pyannotate_runtime.collect_types.UnknownType",
+            "(List[Union[int, sre_constants._NamedIntConstant]], List[Union[Tuple[sre_constants._NamedIntConstant, Tuple[None, List[sre_parse.SubPattern]]], Tuple[sre_constants._NamedIntConstant, int]]], int) -> pyannotate_runtime.collect_types.UnknownType",
+            "(List[Union[int, sre_constants._NamedIntConstant]], List[Union[Tuple[sre_constants._NamedIntConstant, Tuple[int, int, int, sre_parse.SubPattern]], Tuple[sre_constants._NamedIntConstant, Tuple[int, int, sre_parse.SubPattern]], Tuple[sre_constants._NamedIntConstant, int]]], int) -> pyannotate_runtime.collect_types.UnknownType",
+            "(List[Union[int, sre_constants._NamedIntConstant]], List[Union[Tuple[sre_constants._NamedIntConstant, Tuple[None, List[sre_parse.SubPattern]]], Tuple[sre_constants._NamedIntConstant, int], Tuple[sre_constants._NamedIntConstant, sre_constants._NamedIntConstant]]], int) -> pyannotate_runtime.collect_types.UnknownType",
+            "(List[Union[int, sre_constants._NamedIntConstant]], List[Union[Tuple[sre_constants._NamedIntConstant, List[Tuple[sre_constants._NamedIntConstant, sre_constants._NamedIntConstant]]], Tuple[sre_constants._NamedIntConstant, Tuple[int, int, int, sre_parse.SubPattern]]]], int) -> pyannotate_runtime.collect_types.UnknownType",
+            "(List[Union[int, sre_constants._NamedIntConstant]], sre_parse.SubPattern, int) -> None"
+        ],
+        "samples": 82
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_compile.py",
+        "line": 249,
+        "func_name": "_compile_charset",
+        "type_comments": [
+            "(List[Tuple[sre_constants._NamedIntConstant, List[int]]], int, List[Union[int, sre_constants._NamedIntConstant]]) -> None",
+            "(List[Union[Tuple[sre_constants._NamedIntConstant, Tuple[int, int]], Tuple[sre_constants._NamedIntConstant, int]]], int, List[Union[int, sre_constants._NamedIntConstant]]) -> None",
+            "(List[Union[Tuple[sre_constants._NamedIntConstant, int], Tuple[sre_constants._NamedIntConstant, sre_constants._NamedIntConstant]]], int, List[Union[int, sre_constants._NamedIntConstant]]) -> None",
+            "(List[Tuple[sre_constants._NamedIntConstant, int]], int, List[Union[int, sre_constants._NamedIntConstant]]) -> None",
+            "(List[Tuple[sre_constants._NamedIntConstant, sre_constants._NamedIntConstant]], int, List[Union[int, sre_constants._NamedIntConstant]]) -> None",
+            "(List[Union[Tuple[sre_constants._NamedIntConstant, List[int]], Tuple[sre_constants._NamedIntConstant, None], Tuple[sre_constants._NamedIntConstant, sre_constants._NamedIntConstant]]], int, List[Union[int, sre_constants._NamedIntConstant]]) -> None",
+            "(List[Tuple[sre_constants._NamedIntConstant, Tuple[int, int]]], int, List[Union[int, sre_constants._NamedIntConstant]]) -> None"
+        ],
+        "samples": 38
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_compile.py",
+        "line": 276,
+        "func_name": "_optimize_charset",
+        "type_comments": [
+            "(List[Tuple[sre_constants._NamedIntConstant, Tuple[int, int]]], None, None, None) -> Tuple[List[Tuple[sre_constants._NamedIntConstant, Tuple[int, int]]], bool]",
+            "(List[Union[Tuple[sre_constants._NamedIntConstant, Tuple[int, int]], Tuple[sre_constants._NamedIntConstant, int]]], builtin_function_or_method, builtin_function_or_method, None) -> Tuple[List[Union[Tuple[sre_constants._NamedIntConstant, Tuple[int, int]], Tuple[sre_constants._NamedIntConstant, int]]], bool]",
+            "(List[Union[Tuple[sre_constants._NamedIntConstant, Tuple[int, int]], Tuple[sre_constants._NamedIntConstant, int]]], None, None, None) -> Tuple[List[Tuple[sre_constants._NamedIntConstant, List[int]]], bool]",
+            "(List[Union[Tuple[sre_constants._NamedIntConstant, Tuple[int, int]], Tuple[sre_constants._NamedIntConstant, int]]], builtin_function_or_method, builtin_function_or_method, None) -> Tuple[List[Tuple[sre_constants._NamedIntConstant, List[int]]], bool]",
+            "(List[Union[Tuple[sre_constants._NamedIntConstant, int], Tuple[sre_constants._NamedIntConstant, sre_constants._NamedIntConstant]]], None, None, None) -> Tuple[List[Union[Tuple[sre_constants._NamedIntConstant, int], Tuple[sre_constants._NamedIntConstant, sre_constants._NamedIntConstant]]], bool]",
+            "(List[Tuple[sre_constants._NamedIntConstant, int]], None, None, None) -> Tuple[List[Tuple[sre_constants._NamedIntConstant, int]], bool]",
+            "(List[Tuple[sre_constants._NamedIntConstant, sre_constants._NamedIntConstant]], None, None, None) -> Tuple[List[Tuple[sre_constants._NamedIntConstant, sre_constants._NamedIntConstant]], bool]",
+            "(List[Tuple[sre_constants._NamedIntConstant, int]], None, None, None) -> Tuple[List[Union[Tuple[sre_constants._NamedIntConstant, Tuple[int, int]], Tuple[sre_constants._NamedIntConstant, int]]], bool]"
+        ],
+        "samples": 38
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_compile.py",
+        "line": 411,
+        "func_name": "_mk_bitmap",
+        "type_comments": [
+            "(bytearray, int, type) -> List[int]"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_compile.py",
+        "line": 416,
+        "func_name": "_bytes_to_codes",
+        "type_comments": [
+            "(bytearray) -> List[int]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_compile.py",
+        "line": 423,
+        "func_name": "_simple",
+        "type_comments": [
+            "(sre_parse.SubPattern) -> bool"
+        ],
+        "samples": 28
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_compile.py",
+        "line": 432,
+        "func_name": "_generate_overlap_table",
+        "type_comments": [
+            "(List[int]) -> List[int]"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_compile.py",
+        "line": 453,
+        "func_name": "_get_iscased",
+        "type_comments": [
+            "(int) -> builtin_function_or_method",
+            "(int) -> None"
+        ],
+        "samples": 23
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_compile.py",
+        "line": 461,
+        "func_name": "_get_literal_prefix",
+        "type_comments": [
+            "(sre_parse.SubPattern, int) -> Tuple[List, None, bool]",
+            "(sre_parse.SubPattern, int) -> Tuple[List[int], None, bool]",
+            "(sre_parse.SubPattern, int) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 15
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_compile.py",
+        "line": 492,
+        "func_name": "_get_charset_prefix",
+        "type_comments": [
+            "(sre_parse.SubPattern, int) -> List[Tuple[sre_constants._NamedIntConstant, sre_constants._NamedIntConstant]]",
+            "(sre_parse.SubPattern, int) -> None",
+            "(sre_parse.SubPattern, int) -> List[Tuple[sre_constants._NamedIntConstant, Tuple[int, int]]]"
+        ],
+        "samples": 12
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_compile.py",
+        "line": 536,
+        "func_name": "_compile_info",
+        "type_comments": [
+            "(List, sre_parse.SubPattern, int) -> None"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_compile.py",
+        "line": 595,
+        "func_name": "isstring",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 23
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_compile.py",
+        "line": 598,
+        "func_name": "_code",
+        "type_comments": [
+            "(sre_parse.SubPattern, int) -> List[Union[int, sre_constants._NamedIntConstant]]"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_compile.py",
+        "line": 759,
+        "func_name": "compile",
+        "type_comments": [
+            "(str, int) -> re.Pattern",
+            "(bytes, int) -> re.Pattern"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 76,
+        "func_name": "Pattern.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 81,
+        "func_name": "groups",
+        "type_comments": [
+            "() -> int"
+        ],
+        "samples": 69
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 84,
+        "func_name": "Pattern.opengroup",
+        "type_comments": [
+            "(None) -> int",
+            "(str) -> int"
+        ],
+        "samples": 27
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 96,
+        "func_name": "Pattern.closegroup",
+        "type_comments": [
+            "(int, sre_parse.SubPattern) -> None"
+        ],
+        "samples": 27
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 98,
+        "func_name": "Pattern.checkgroup",
+        "type_comments": [
+            "(int) -> bool"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 101,
+        "func_name": "Pattern.checklookbehindgroup",
+        "type_comments": [
+            "(int, sre_parse.Tokenizer) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 111,
+        "func_name": "SubPattern.__init__",
+        "type_comments": [
+            "(sre_parse.Pattern, List[Tuple[sre_constants._NamedIntConstant, List[Union[Tuple[sre_constants._NamedIntConstant, Tuple[int, int]], Tuple[sre_constants._NamedIntConstant, int]]]]]) -> None",
+            "(sre_parse.Pattern, None) -> None",
+            "(sre_parse.Pattern, List[Tuple[sre_constants._NamedIntConstant, int]]) -> None",
+            "(sre_parse.Pattern, List[Tuple[sre_constants._NamedIntConstant, Tuple[int, int, int, sre_parse.SubPattern]]]) -> None",
+            "(sre_parse.Pattern, List[Tuple[sre_constants._NamedIntConstant, None]]) -> None",
+            "(sre_parse.Pattern, List[Tuple[sre_constants._NamedIntConstant, List[Tuple[sre_constants._NamedIntConstant, int]]]]) -> None",
+            "(sre_parse.Pattern, List[Tuple[sre_constants._NamedIntConstant, List[Tuple[sre_constants._NamedIntConstant, Tuple[int, int]]]]]) -> None",
+            "(sre_parse.Pattern, List[Tuple[sre_constants._NamedIntConstant, List[Tuple[sre_constants._NamedIntConstant, sre_constants._NamedIntConstant]]]]) -> None"
+        ],
+        "samples": 88
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 160,
+        "func_name": "SubPattern.__len__",
+        "type_comments": [
+            "() -> int"
+        ],
+        "samples": 160
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 162,
+        "func_name": "SubPattern.__delitem__",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 164,
+        "func_name": "SubPattern.__getitem__",
+        "type_comments": [
+            "(int) -> Tuple[sre_constants._NamedIntConstant, List[Union[Tuple[sre_constants._NamedIntConstant, Tuple[int, int]], Tuple[sre_constants._NamedIntConstant, int]]]]",
+            "(int) -> Tuple[sre_constants._NamedIntConstant, int]",
+            "(int) -> Tuple[sre_constants._NamedIntConstant, List[Tuple[sre_constants._NamedIntConstant, int]]]",
+            "(int) -> Tuple[sre_constants._NamedIntConstant, List[Union[Tuple[sre_constants._NamedIntConstant, int], Tuple[sre_constants._NamedIntConstant, sre_constants._NamedIntConstant]]]]",
+            "(int) -> Tuple[sre_constants._NamedIntConstant, List[Tuple[sre_constants._NamedIntConstant, sre_constants._NamedIntConstant]]]",
+            "(slice) -> sre_parse.SubPattern",
+            "(int) -> Tuple[sre_constants._NamedIntConstant, Tuple[int, int, int, sre_parse.SubPattern]]",
+            "(int) -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 459
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 168,
+        "func_name": "SubPattern.__setitem__",
+        "type_comments": [
+            "(int, Tuple[sre_constants._NamedIntConstant, Tuple[int, int, sre_parse.SubPattern]]) -> None",
+            "(slice, sre_parse.SubPattern) -> None",
+            "(int, Tuple[sre_constants._NamedIntConstant, Tuple[int, sre_constants._NamedIntConstant, sre_parse.SubPattern]]) -> None"
+        ],
+        "samples": 30
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 172,
+        "func_name": "SubPattern.append",
+        "type_comments": [
+            "(Tuple[sre_constants._NamedIntConstant, Tuple[int, int, int, sre_parse.SubPattern]]) -> None",
+            "(Tuple[sre_constants._NamedIntConstant, int]) -> None",
+            "(Tuple[sre_constants._NamedIntConstant, Tuple[None, int, int, sre_parse.SubPattern]]) -> None",
+            "(Tuple[sre_constants._NamedIntConstant, Tuple[None, List[sre_parse.SubPattern]]]) -> None",
+            "(Tuple[sre_constants._NamedIntConstant, List[Tuple[sre_constants._NamedIntConstant, sre_constants._NamedIntConstant]]]) -> None",
+            "(Tuple[sre_constants._NamedIntConstant, List[Tuple[sre_constants._NamedIntConstant, int]]]) -> None",
+            "(Tuple[sre_constants._NamedIntConstant, List[Union[Tuple[sre_constants._NamedIntConstant, None], Tuple[sre_constants._NamedIntConstant, int], Tuple[sre_constants._NamedIntConstant, sre_constants._NamedIntConstant]]]]) -> None",
+            "(Tuple[sre_constants._NamedIntConstant, List[Union[Tuple[sre_constants._NamedIntConstant, Tuple[int, int]], Tuple[sre_constants._NamedIntConstant, int]]]]) -> None"
+        ],
+        "samples": 135
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 174,
+        "func_name": "SubPattern.getwidth",
+        "type_comments": [
+            "() -> Tuple[int, sre_constants._NamedIntConstant]",
+            "() -> Tuple[int, int]",
+            "() -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 103
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 224,
+        "func_name": "Tokenizer.__init__",
+        "type_comments": [
+            "(bytes) -> None",
+            "(str) -> None"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 233,
+        "func_name": "__next",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 500
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 249,
+        "func_name": "Tokenizer.match",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 204
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 254,
+        "func_name": "Tokenizer.get",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 491
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 258,
+        "func_name": "Tokenizer.getwhile",
+        "type_comments": [
+            "(int, frozenset) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 267,
+        "func_name": "Tokenizer.getuntil",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 286,
+        "func_name": "Tokenizer.tell",
+        "type_comments": [
+            "() -> int"
+        ],
+        "samples": 108
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 288,
+        "func_name": "Tokenizer.seek",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 295,
+        "func_name": "_class_escape",
+        "type_comments": [
+            "(sre_parse.Tokenizer, str) -> Tuple[sre_constants._NamedIntConstant, List[Tuple[sre_constants._NamedIntConstant, sre_constants._NamedIntConstant]]]",
+            "(sre_parse.Tokenizer, str) -> Tuple[sre_constants._NamedIntConstant, int]"
+        ],
+        "samples": 12
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 343,
+        "func_name": "_escape",
+        "type_comments": [
+            "(sre_parse.Tokenizer, str, sre_parse.Pattern) -> Tuple[sre_constants._NamedIntConstant, sre_constants._NamedIntConstant]",
+            "(sre_parse.Tokenizer, str, sre_parse.Pattern) -> Tuple[sre_constants._NamedIntConstant, List[Tuple[sre_constants._NamedIntConstant, sre_constants._NamedIntConstant]]]",
+            "(sre_parse.Tokenizer, str, sre_parse.Pattern) -> Tuple[sre_constants._NamedIntConstant, int]"
+        ],
+        "samples": 27
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 408,
+        "func_name": "_uniq",
+        "type_comments": [
+            "(List[Tuple[sre_constants._NamedIntConstant, int]]) -> List[Tuple[sre_constants._NamedIntConstant, int]]",
+            "(List[Tuple[sre_constants._NamedIntConstant, Tuple[int, int]]]) -> List[Tuple[sre_constants._NamedIntConstant, Tuple[int, int]]]",
+            "(List[Union[Tuple[sre_constants._NamedIntConstant, Tuple[int, int]], Tuple[sre_constants._NamedIntConstant, int]]]) -> List[Union[Tuple[sre_constants._NamedIntConstant, Tuple[int, int]], Tuple[sre_constants._NamedIntConstant, int]]]"
+        ],
+        "samples": 18
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 417,
+        "func_name": "_parse_sub",
+        "type_comments": [
+            "(sre_parse.Tokenizer, sre_parse.Pattern, int, int) -> sre_parse.SubPattern",
+            "(sre_parse.Tokenizer, sre_parse.Pattern, bool, int) -> sre_parse.SubPattern",
+            "(sre_parse.Tokenizer, sre_parse.Pattern, bool, int) -> pyannotate_runtime.collect_types.UnknownType",
+            "(sre_parse.Tokenizer, sre_parse.Pattern, int, int) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 42
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 475,
+        "func_name": "_parse",
+        "type_comments": [
+            "(sre_parse.Tokenizer, sre_parse.Pattern, int, int, bool) -> sre_parse.SubPattern",
+            "(sre_parse.Tokenizer, sre_parse.Pattern, bool, int, bool) -> sre_parse.SubPattern",
+            "(sre_parse.Tokenizer, sre_parse.Pattern, bool, int, bool) -> pyannotate_runtime.collect_types.UnknownType",
+            "(sre_parse.Tokenizer, sre_parse.Pattern, int, int, bool) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 57
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 843,
+        "func_name": "_parse_flags",
+        "type_comments": [
+            "(sre_parse.Tokenizer, sre_parse.Pattern, str) -> None",
+            "(sre_parse.Tokenizer, sre_parse.Pattern, str) -> Tuple[int, int]"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 903,
+        "func_name": "fix_flags",
+        "type_comments": [
+            "(bytes, int) -> int",
+            "(str, int) -> int"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 919,
+        "func_name": "parse",
+        "type_comments": [
+            "(bytes, int, None) -> sre_parse.SubPattern",
+            "(str, int, None) -> sre_parse.SubPattern"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 951,
+        "func_name": "parse_template",
+        "type_comments": [
+            "(str, re.Pattern) -> Tuple[List[Tuple[int, int]], List]",
+            "(str, re.Pattern) -> Tuple[List[Tuple[int, int]], List[Optional[str]]]"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 960,
+        "func_name": "addgroup",
+        "type_comments": [
+            "(int, int) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\sre_parse.py",
+        "line": 1036,
+        "func_name": "expand_template",
+        "type_comments": [
+            "(Tuple[List[Tuple[int, int]], List[Optional[str]]], re.Match) -> str",
+            "(Tuple[List[Tuple[int, int]], List], re.Match) -> str"
+        ],
+        "samples": 45
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\tempfile.py",
+        "line": 93,
+        "func_name": "_infer_return_type",
+        "type_comments": [
+            "(*Optional[str]) -> type",
+            "(*str) -> type",
+            "(*None) -> type"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\tempfile.py",
+        "line": 114,
+        "func_name": "_sanitize_params",
+        "type_comments": [
+            "(None, str, None) -> Tuple[str, str, str, type]",
+            "(str, str, str) -> Tuple[str, str, str, type]",
+            "(None, None, None) -> Tuple[str, str, str, type]"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\tempfile.py",
+        "line": 132,
+        "func_name": "_RandomNameSequence",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\tempfile.py",
+        "line": 142,
+        "func_name": "rng",
+        "type_comments": [
+            "() -> random.Random"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\tempfile.py",
+        "line": 153,
+        "func_name": "_RandomNameSequence.__next__",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\tempfile.py",
+        "line": 159,
+        "func_name": "_candidate_tempdir_list",
+        "type_comments": [
+            "() -> List[str]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\tempfile.py",
+        "line": 186,
+        "func_name": "_get_default_tempdir",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\tempfile.py",
+        "line": 233,
+        "func_name": "_get_candidate_names",
+        "type_comments": [
+            "() -> tempfile._RandomNameSequence"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\tempfile.py",
+        "line": 247,
+        "func_name": "_mkstemp_inner",
+        "type_comments": [
+            "(str, str, str, int, type) -> Tuple[int, str]"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\tempfile.py",
+        "line": 287,
+        "func_name": "gettempdir",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\tempfile.py",
+        "line": 303,
+        "func_name": "mkstemp",
+        "type_comments": [
+            "(str, None, None, bool) -> Tuple[int, str]",
+            "(str, str, str, bool) -> Tuple[int, str]"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\tempfile.py",
+        "line": 414,
+        "func_name": "_TemporaryFileCloser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\tempfile.py",
+        "line": 422,
+        "func_name": "_TemporaryFileCloser.__init__",
+        "type_comments": [
+            "(_io.BufferedRandom, str, bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\tempfile.py",
+        "line": 457,
+        "func_name": "_TemporaryFileWrapper",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\tempfile.py",
+        "line": 465,
+        "func_name": "_TemporaryFileWrapper.__init__",
+        "type_comments": [
+            "(_io.BufferedRandom, str, bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\tempfile.py",
+        "line": 471,
+        "func_name": "_TemporaryFileWrapper.__getattr__",
+        "type_comments": [
+            "(str) -> function"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\tempfile.py",
+        "line": 479,
+        "func_name": "func_wrapper",
+        "type_comments": [
+            "(*bytes) -> int"
+        ],
+        "samples": 62
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\tempfile.py",
+        "line": 520,
+        "func_name": "NamedTemporaryFile",
+        "type_comments": [
+            "(str, int, None, None, None, None, None, bool) -> tempfile._TemporaryFileWrapper"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\tempfile.py",
+        "line": 627,
+        "func_name": "SpooledTemporaryFile",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\tempfile.py",
+        "line": 775,
+        "func_name": "TemporaryDirectory",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\tokenize.py",
+        "line": 147,
+        "func_name": "_compile",
+        "type_comments": [
+            "(str) -> re.Pattern"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\tokenize.py",
+        "line": 350,
+        "func_name": "detect_encoding",
+        "type_comments": [
+            "(builtin_function_or_method) -> Tuple[str, List[bytes]]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\tokenize.py",
+        "line": 374,
+        "func_name": "read_or_stop",
+        "type_comments": [
+            "() -> bytes"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\tokenize.py",
+        "line": 380,
+        "func_name": "find_cookie",
+        "type_comments": [
+            "(bytes) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\tokenize.py",
+        "line": 443,
+        "func_name": "open",
+        "type_comments": [
+            "(str) -> _io.TextIOWrapper"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\types.py",
+        "line": 164,
+        "func_name": "DynamicClassAttribute.__get__",
+        "type_comments": [
+            "(re.RegexFlag, enum.EnumMeta) -> str",
+            "(re.RegexFlag, enum.EnumMeta) -> int"
+        ],
+        "samples": 15
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\warnings.py",
+        "line": 130,
+        "func_name": "filterwarnings",
+        "type_comments": [
+            "(str, str, type, str, int, bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\warnings.py",
+        "line": 165,
+        "func_name": "simplefilter",
+        "type_comments": [
+            "(str, type, int, bool) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\warnings.py",
+        "line": 181,
+        "func_name": "_add_filter",
+        "type_comments": [
+            "(bool, *Optional[Union[str, type]]) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\warnings.py",
+        "line": 453,
+        "func_name": "catch_warnings.__init__",
+        "type_comments": [
+            "(bool, None) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\warnings.py",
+        "line": 474,
+        "func_name": "catch_warnings.__enter__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\warnings.py",
+        "line": 493,
+        "func_name": "catch_warnings.__exit__",
+        "type_comments": [
+            "(*None) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\weakref.py",
+        "line": 36,
+        "func_name": "WeakMethod",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\weakref.py",
+        "line": 90,
+        "func_name": "WeakValueDictionary",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\weakref.py",
+        "line": 102,
+        "func_name": "__init__",
+        "type_comments": [
+            "(*weakref.WeakValueDictionary) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\weakref.py",
+        "line": 288,
+        "func_name": "update",
+        "type_comments": [
+            "(*weakref.WeakValueDictionary) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\weakref.py",
+        "line": 322,
+        "func_name": "KeyedRef",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\weakref.py",
+        "line": 343,
+        "func_name": "WeakKeyDictionary",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\weakref.py",
+        "line": 354,
+        "func_name": "WeakKeyDictionary.__init__",
+        "type_comments": [
+            "(None) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\weakref.py",
+        "line": 406,
+        "func_name": "WeakKeyDictionary.__setitem__",
+        "type_comments": [
+            "(multiprocessing.dummy.DummyProcess, None) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\weakref.py",
+        "line": 472,
+        "func_name": "WeakKeyDictionary.popitem",
+        "type_comments": [
+            "() -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\weakref.py",
+        "line": 498,
+        "func_name": "finalize",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "C:\\Users\\safv\\Documents\\GitHub\\tests\\py3\\lib\\weakref.py",
+        "line": 523,
+        "func_name": "_Info",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates__inc_footer_uc_tmpl.py",
+        "line": 51,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates__inc_footer_uc_tmpl",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates__inc_footer_uc_tmpl.py",
+        "line": 57,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates__inc_footer_uc_tmpl.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates__inc_footer_uc_tmpl.py",
+        "line": 68,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates__inc_footer_uc_tmpl.respond",
+        "type_comments": [
+            "(Cheetah.DummyTransaction.DummyTransaction) -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates__inc_header_uc_tmpl.py",
+        "line": 51,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates__inc_header_uc_tmpl",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates__inc_header_uc_tmpl.py",
+        "line": 57,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates__inc_header_uc_tmpl.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates__inc_header_uc_tmpl.py",
+        "line": 68,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates__inc_header_uc_tmpl.respond",
+        "type_comments": [
+            "(Cheetah.DummyTransaction.DummyTransaction) -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates_config_tmpl.py",
+        "line": 52,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates_config_tmpl",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates_config_tmpl.py",
+        "line": 58,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates_config_tmpl.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates_config_tmpl.py",
+        "line": 69,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates_config_tmpl.respond",
+        "type_comments": [
+            "(None) -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates_staticcfg_images_logo_full_svg.py",
+        "line": 51,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates_staticcfg_images_logo_full_svg",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates_staticcfg_images_logo_full_svg.py",
+        "line": 57,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates_staticcfg_images_logo_full_svg.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates_staticcfg_images_logo_full_svg.py",
+        "line": 68,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates_staticcfg_images_logo_full_svg.respond",
+        "type_comments": [
+            "(Cheetah.DummyTransaction.DummyTransaction) -> str"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates_staticcfg_images_logo_small_svg.py",
+        "line": 51,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates_staticcfg_images_logo_small_svg",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates_staticcfg_images_logo_small_svg.py",
+        "line": 57,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates_staticcfg_images_logo_small_svg.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates_staticcfg_images_logo_small_svg.py",
+        "line": 68,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Config_templates_staticcfg_images_logo_small_svg.respond",
+        "type_comments": [
+            "(Cheetah.DummyTransaction.DummyTransaction) -> str"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_history_tmpl.py",
+        "line": 51,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_history_tmpl",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_history_tmpl.py",
+        "line": 57,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_history_tmpl.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_history_tmpl.py",
+        "line": 68,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_history_tmpl.respond",
+        "type_comments": [
+            "(Cheetah.DummyTransaction.DummyTransaction) -> str"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_menu_tmpl.py",
+        "line": 51,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_menu_tmpl",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_menu_tmpl.py",
+        "line": 57,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_menu_tmpl.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_menu_tmpl.py",
+        "line": 68,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_menu_tmpl.respond",
+        "type_comments": [
+            "(Cheetah.DummyTransaction.DummyTransaction) -> str"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_messages_tmpl.py",
+        "line": 51,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_messages_tmpl",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_messages_tmpl.py",
+        "line": 57,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_messages_tmpl.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_messages_tmpl.py",
+        "line": 68,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_messages_tmpl.respond",
+        "type_comments": [
+            "(Cheetah.DummyTransaction.DummyTransaction) -> str"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_overlays_tmpl.py",
+        "line": 52,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_overlays_tmpl",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_overlays_tmpl.py",
+        "line": 58,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_overlays_tmpl.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_overlays_tmpl.py",
+        "line": 69,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_overlays_tmpl.respond",
+        "type_comments": [
+            "(Cheetah.DummyTransaction.DummyTransaction) -> str"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_queue_tmpl.py",
+        "line": 51,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_queue_tmpl",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_queue_tmpl.py",
+        "line": 57,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_queue_tmpl.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_queue_tmpl.py",
+        "line": 68,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_include_queue_tmpl.respond",
+        "type_comments": [
+            "(Cheetah.DummyTransaction.DummyTransaction) -> str"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_main_tmpl.py",
+        "line": 51,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_main_tmpl",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_main_tmpl.py",
+        "line": 57,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_main_tmpl.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_main_tmpl.py",
+        "line": 68,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_main_tmpl.respond",
+        "type_comments": [
+            "(None) -> str"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_static_javascripts_glitter_js.py",
+        "line": 51,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_static_javascripts_glitter_js",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_static_javascripts_glitter_js.py",
+        "line": 57,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_static_javascripts_glitter_js.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "_Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_static_javascripts_glitter_js.py",
+        "line": 68,
+        "func_name": "Users_safv_Documents_GitHub_sabnzbd3_interfaces_Glitter_templates_static_javascripts_glitter_js.respond",
+        "type_comments": [
+            "(Cheetah.DummyTransaction.DummyTransaction) -> str"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 211,
+        "func_name": "initialize",
+        "type_comments": [
+            "(bool, bool, bool, int) -> bool"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 344,
+        "func_name": "start",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 369,
+        "func_name": "halt",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 515,
+        "func_name": "set_https_verification",
+        "type_comments": [
+            "(int) -> bool"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 527,
+        "func_name": "guard_https_ver",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 555,
+        "func_name": "save_state",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 574,
+        "func_name": "unpause_all",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 593,
+        "func_name": "backup_nzb",
+        "type_comments": [
+            "(str, str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 600,
+        "func_name": "save_compressed",
+        "type_comments": [
+            "(str, str, str) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 624,
+        "func_name": "add_nzbfile",
+        "type_comments": [
+            "(cherrypy._cpreqbody.Part, None, None, str, str, None, bool, None) -> Tuple[int, List[str]]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 752,
+        "func_name": "shutdown_program",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 768,
+        "func_name": "change_queue_complete_action",
+        "type_comments": [
+            "(str, bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 825,
+        "func_name": "empty_queues",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 831,
+        "func_name": "keep_awake",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 853,
+        "func_name": "get_new_id",
+        "type_comments": [
+            "(str, str, None) -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 874,
+        "func_name": "save_data",
+        "type_comments": [
+            "(bytes, str, str, bool, bool) -> None",
+            "(Dict[int, Tuple[str, int]], str, str, bool, bool) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 902,
+        "func_name": "load_data",
+        "type_comments": [
+            "(str, str, bool, bool, bool) -> Tuple[str, Dict, Dict]",
+            "(str, str, bool, bool, bool) -> Tuple[int, List, List]",
+            "(str, str, bool, bool, bool) -> Tuple[float, Dict[str, int], Dict[str, int], Dict[str, int], Dict[str, int], float, float, float, float, float]",
+            "(str, str, bool, bool, bool) -> Dict",
+            "(str, str, bool, bool, bool) -> Tuple[int, List]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 931,
+        "func_name": "remove_data",
+        "type_comments": [
+            "(str, str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 941,
+        "func_name": "save_admin",
+        "type_comments": [
+            "(Tuple[int, List, List], str) -> None",
+            "(Tuple[float, Dict[str, int], Dict[str, int], Dict[str, int], Dict[str, int], float, float, float, float, float], str) -> None",
+            "(Tuple[int, List[str], List], str) -> None",
+            "(Tuple[int, List[sabnzbd.nzbstuff.NzbObject]], str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 947,
+        "func_name": "load_admin",
+        "type_comments": [
+            "(str, bool, bool) -> Tuple[str, Dict, Dict]",
+            "(str, bool, bool) -> Tuple[int, List, List]",
+            "(str, bool, bool) -> Tuple[float, Dict[str, int], Dict[str, int], Dict[str, int], Dict[str, int], float, float, float, float, float]",
+            "(str, bool, bool) -> Dict",
+            "(str, bool, bool) -> Tuple[int, List]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 953,
+        "func_name": "pp_to_opts",
+        "type_comments": [
+            "(str) -> Tuple[bool, bool, bool]"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 966,
+        "func_name": "opts_to_pp",
+        "type_comments": [
+            "(bool, bool, bool) -> int"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 991,
+        "func_name": "check_repair_request",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 1003,
+        "func_name": "check_all_tasks",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 1051,
+        "func_name": "pid_file",
+        "type_comments": [
+            "(None, None, int) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 1072,
+        "func_name": "check_incomplete_vs_complete",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 1091,
+        "func_name": "highest_server",
+        "type_comments": [
+            "(sabnzbd.downloader.Server) -> bool"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 1095,
+        "func_name": "test_ipv6",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 1124,
+        "func_name": "test_cert_checking",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\__init__.py",
+        "line": 1151,
+        "func_name": "history_updated",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 89,
+        "func_name": "api_handler",
+        "type_comments": [
+            "(Dict[str, str]) -> bytes",
+            "(Dict[str, str]) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 103,
+        "func_name": "_api_get_config",
+        "type_comments": [
+            "(str, str, Dict[str, str]) -> bytes"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 153,
+        "func_name": "_api_queue",
+        "type_comments": [
+            "(str, str, Dict[str, str]) -> bytes"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 255,
+        "func_name": "_api_queue_default",
+        "type_comments": [
+            "(str, str, Dict[str, str]) -> bytes"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 301,
+        "func_name": "_api_addfile",
+        "type_comments": [
+            "(cherrypy._cpreqbody.Part, str, Dict[str, str]) -> bytes"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 455,
+        "func_name": "_api_fullstatus",
+        "type_comments": [
+            "(str, str, Dict[str, str]) -> bytes"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 461,
+        "func_name": "_api_history",
+        "type_comments": [
+            "(str, str, Dict[str, str]) -> bytes"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 567,
+        "func_name": "_api_resume",
+        "type_comments": [
+            "(str, str, Dict[str, str]) -> bytes"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 795,
+        "func_name": "_api_config",
+        "type_comments": [
+            "(str, str, Dict[str, str]) -> bytes"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 800,
+        "func_name": "_api_config_speedlimit",
+        "type_comments": [
+            "(str, Dict[str, str]) -> bytes"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 966,
+        "func_name": "api_level",
+        "type_comments": [
+            "(str, str) -> int"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 977,
+        "func_name": "report",
+        "type_comments": [
+            "(str, None, str, bool, bool) -> bytes",
+            "(str, None, str, Dict[str, Union[List[Dict[str, Union[int, str]]], str]], bool) -> bytes",
+            "(str, None, str, Dict[str, Dict[str, Union[List[str], int, str]]], bool) -> bytes",
+            "(str, None, str, Dict[str, Union[bool, int, str]], bool) -> bytes",
+            "(str, None, str, Dict[str, Union[bool, str]], bool) -> bytes"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 1025,
+        "func_name": "xml_factory",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 1151,
+        "func_name": "build_status",
+        "type_comments": [
+            "(str, str) -> Dict[str, Union[bool, int, str]]"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 1257,
+        "func_name": "build_queue",
+        "type_comments": [
+            "(int, int, bool, str, str) -> Tuple[Dict[str, Union[bool, str]], List, float]",
+            "(int, int, bool, str, str) -> Tuple[Dict[str, Union[bool, int, str]], List[sabnzbd.constants.PNFO], float]",
+            "(int, int, bool, str, None) -> Tuple[Dict[str, Union[bool, int, str]], List[sabnzbd.constants.PNFO], float]",
+            "(int, int, bool, str, str) -> Tuple[Dict[str, Union[bool, int, str]], List, float]",
+            "(int, int, bool, str, str) -> Tuple[Dict[str, Union[bool, str]], List[sabnzbd.constants.PNFO], float]"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 1358,
+        "func_name": "fast_queue",
+        "type_comments": [
+            "() -> Tuple[bool, int, float, str]",
+            "() -> Tuple[int, int, float, str]"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 1487,
+        "func_name": "Ttemplate",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 25
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 1503,
+        "func_name": "clear_trans_cache",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 1510,
+        "func_name": "build_header",
+        "type_comments": [
+            "(str, None, bool) -> Dict[str, Union[bool, int, str]]",
+            "(str, str, bool) -> Dict[str, Union[bool, str]]",
+            "(str, str, bool) -> Dict[str, Union[bool, int, str]]",
+            "(str, None, bool) -> Dict[str, Union[function, str]]"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 1587,
+        "func_name": "build_queue_header",
+        "type_comments": [
+            "(str, int, int, str) -> Tuple[Dict[str, Union[bool, int, str]], List[sabnzbd.constants.PNFO], float, int, int]",
+            "(str, int, int, str) -> Tuple[Dict[str, Union[bool, str]], List, float, int, int]",
+            "(str, int, int, str) -> Tuple[Dict[str, Union[bool, int, str]], List, float, int, int]",
+            "(None, int, int, str) -> Tuple[Dict[str, Union[bool, int, str]], List[sabnzbd.constants.PNFO], float, int, int]",
+            "(str, int, int, str) -> Tuple[Dict[str, Union[bool, str]], List[sabnzbd.constants.PNFO], float, int, int]"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 1625,
+        "func_name": "build_history",
+        "type_comments": [
+            "(None, None, None, int, None, bool) -> Tuple[List[Dict[str, Union[int, str]]], int, int]",
+            "(int, int, str, str, None, str) -> Tuple[List[Dict[str, Union[int, str]]], int, int]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 1739,
+        "func_name": "get_active_history",
+        "type_comments": [
+            "(List, List[Dict[str, Union[int, str]]]) -> List[Dict[str, Union[int, str]]]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 1767,
+        "func_name": "format_bytes",
+        "type_comments": [
+            "(int) -> str"
+        ],
+        "samples": 23
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 1775,
+        "func_name": "calc_timeleft",
+        "type_comments": [
+            "(int, float) -> str"
+        ],
+        "samples": 11
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 1798,
+        "func_name": "list_scripts",
+        "type_comments": [
+            "(bool, bool) -> List[str]"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\api.py",
+        "line": 1817,
+        "func_name": "list_cats",
+        "type_comments": [
+            "(bool) -> List[str]"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\articlecache.py",
+        "line": 35,
+        "func_name": "ArticleCache",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\articlecache.py",
+        "line": 38,
+        "func_name": "ArticleCache.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\articlecache.py",
+        "line": 53,
+        "func_name": "cache_info",
+        "type_comments": [
+            "() -> sabnzbd.constants.ANFO"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "sabnzbd\\articlecache.py",
+        "line": 57,
+        "func_name": "new_limit",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\articlecache.py",
+        "line": 66,
+        "func_name": "reserve_space",
+        "type_comments": [
+            "(List) -> bool"
+        ],
+        "samples": 50
+    },
+    {
+        "path": "sabnzbd\\articlecache.py",
+        "line": 76,
+        "func_name": "free_reserve_space",
+        "type_comments": [
+            "(List) -> bool"
+        ],
+        "samples": 50
+    },
+    {
+        "path": "sabnzbd\\articlecache.py",
+        "line": 83,
+        "func_name": "save_article",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.Article, bytes) -> None"
+        ],
+        "samples": 50
+    },
+    {
+        "path": "sabnzbd\\articlecache.py",
+        "line": 125,
+        "func_name": "load_article",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.Article) -> bytes"
+        ],
+        "samples": 50
+    },
+    {
+        "path": "sabnzbd\\articlecache.py",
+        "line": 143,
+        "func_name": "flush_articles",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\articlecache.py",
+        "line": 151,
+        "func_name": "purge_articles",
+        "type_comments": [
+            "(List) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\articlecache.py",
+        "line": 161,
+        "func_name": "__flush_article",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.Article, bytes) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "sabnzbd\\assembler.py",
+        "line": 45,
+        "func_name": "Assembler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\assembler.py",
+        "line": 48,
+        "func_name": "Assembler.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\assembler.py",
+        "line": 59,
+        "func_name": "Assembler.run",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\assembler.py",
+        "line": 155,
+        "func_name": "Assembler.assemble",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbFile, str) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\assembler.py",
+        "line": 201,
+        "func_name": "is_cloaked",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbObject, str, List[str]) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\assembler.py",
+        "line": 222,
+        "func_name": "check_encrypted_and_unwanted_files",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbObject, str) -> Tuple[bool, None]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\assembler.py",
+        "line": 310,
+        "func_name": "nzo_filtered_by_rating",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbObject) -> Tuple[int, str]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\bpsmeter.py",
+        "line": 75,
+        "func_name": "next_month",
+        "type_comments": [
+            "(float) -> float"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\bpsmeter.py",
+        "line": 87,
+        "func_name": "BPSMeter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\bpsmeter.py",
+        "line": 90,
+        "func_name": "BPSMeter.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\bpsmeter.py",
+        "line": 121,
+        "func_name": "BPSMeter.save",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "sabnzbd\\bpsmeter.py",
+        "line": 148,
+        "func_name": "BPSMeter.read",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\bpsmeter.py",
+        "line": 173,
+        "func_name": "BPSMeter.update",
+        "type_comments": [
+            "(None, int, None) -> None",
+            "(str, int, None) -> None"
+        ],
+        "samples": 279
+    },
+    {
+        "path": "sabnzbd\\bpsmeter.py",
+        "line": 249,
+        "func_name": "BPSMeter.reset",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\bpsmeter.py",
+        "line": 256,
+        "func_name": "BPSMeter.add_empty_time",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "sabnzbd\\bpsmeter.py",
+        "line": 266,
+        "func_name": "BPSMeter.get_sums",
+        "type_comments": [
+            "() -> Tuple[int, int, int, int]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\bpsmeter.py",
+        "line": 295,
+        "func_name": "BPSMeter.get_bps",
+        "type_comments": [
+            "() -> float"
+        ],
+        "samples": 500
+    },
+    {
+        "path": "sabnzbd\\bpsmeter.py",
+        "line": 298,
+        "func_name": "BPSMeter.get_bps_list",
+        "type_comments": [
+            "() -> List[int]"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\bpsmeter.py",
+        "line": 304,
+        "func_name": "BPSMeter.get_stable_speed",
+        "type_comments": [
+            "(int) -> float",
+            "(int) -> bool",
+            "(int) -> None"
+        ],
+        "samples": 25
+    },
+    {
+        "path": "sabnzbd\\bpsmeter.py",
+        "line": 330,
+        "func_name": "BPSMeter.reset_quota",
+        "type_comments": [
+            "(bool) -> bool"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\bpsmeter.py",
+        "line": 407,
+        "func_name": "BPSMeter.get_quota",
+        "type_comments": [
+            "() -> Tuple[None, int, int]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\bpsmeter.py",
+        "line": 434,
+        "func_name": "BPSMeter.set_status",
+        "type_comments": [
+            "(bool, bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\cfg.py",
+        "line": 57,
+        "func_name": "validate_email",
+        "type_comments": [
+            "(List[str]) -> Tuple[None, List[str]]",
+            "(str) -> Tuple[None, str]"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\cfg.py",
+        "line": 70,
+        "func_name": "validate_server",
+        "type_comments": [
+            "(str) -> Tuple[None, str]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\cfg.py",
+        "line": 461,
+        "func_name": "set_root_folders",
+        "type_comments": [
+            "(str, str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\cfg.py",
+        "line": 473,
+        "func_name": "set_root_folders2",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 51,
+        "func_name": "Option",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 54,
+        "func_name": "Option.__init__",
+        "type_comments": [
+            "(str, str, List[str], bool, bool) -> None",
+            "(str, str, int, bool, bool) -> None",
+            "(str, str, str, bool, bool) -> None",
+            "(str, str, None, bool, bool) -> None"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 80,
+        "func_name": "Option.__call__",
+        "type_comments": [
+            "() -> str",
+            "() -> int",
+            "() -> pyannotate_runtime.collect_types.UnknownType",
+            "() -> List[str]",
+            "() -> List"
+        ],
+        "samples": 232
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 84,
+        "func_name": "Option.get",
+        "type_comments": [
+            "() -> List",
+            "() -> List[str]",
+            "() -> str",
+            "() -> int"
+        ],
+        "samples": 272
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 94,
+        "func_name": "Option.get_dict",
+        "type_comments": [
+            "(bool) -> Dict[str, int]",
+            "(bool) -> Dict[str, str]"
+        ],
+        "samples": 16
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 107,
+        "func_name": "__set",
+        "type_comments": [
+            "(List[List[str]]) -> None",
+            "(int) -> None",
+            "(str) -> None"
+        ],
+        "samples": 15
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 118,
+        "func_name": "Option.set",
+        "type_comments": [
+            "(List[List[str]]) -> None",
+            "(int) -> None",
+            "(str) -> None"
+        ],
+        "samples": 15
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 121,
+        "func_name": "Option.default",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 124,
+        "func_name": "Option.callback",
+        "type_comments": [
+            "(function) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 128,
+        "func_name": "Option.ident",
+        "type_comments": [
+            "() -> Tuple[List[str], str]"
+        ],
+        "samples": 17
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 133,
+        "func_name": "OptionNumber",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 136,
+        "func_name": "OptionNumber.__init__",
+        "type_comments": [
+            "(str, str, int, int, None, None, bool, bool) -> None",
+            "(str, str, int, None, None, None, bool, bool) -> None",
+            "(str, str, int, int, int, None, bool, bool) -> None"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 145,
+        "func_name": "OptionNumber.set",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 167,
+        "func_name": "OptionBool",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 170,
+        "func_name": "OptionBool.__init__",
+        "type_comments": [
+            "(str, str, int, bool, bool) -> None",
+            "(str, str, bool, bool, bool) -> None"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 173,
+        "func_name": "OptionBool.set",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 183,
+        "func_name": "OptionDir",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 186,
+        "func_name": "OptionDir.__init__",
+        "type_comments": [
+            "(str, str, str, bool, bool, function, bool, bool) -> None",
+            "(str, str, str, bool, bool, None, bool, bool) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 196,
+        "func_name": "OptionDir.get",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 33
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 204,
+        "func_name": "OptionDir.get_path",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 18
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 214,
+        "func_name": "OptionDir.get_clipped_path",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 226,
+        "func_name": "OptionDir.set_root",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 230,
+        "func_name": "OptionDir.set",
+        "type_comments": [
+            "(str, bool) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 252,
+        "func_name": "OptionDir.set_create",
+        "type_comments": [
+            "(bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 257,
+        "func_name": "OptionList",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 260,
+        "func_name": "OptionList.__init__",
+        "type_comments": [
+            "(str, str, str, None, bool, bool) -> None",
+            "(str, str, List[str], None, bool, bool) -> None",
+            "(str, str, None, None, bool, bool) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 266,
+        "func_name": "OptionList.set",
+        "type_comments": [
+            "(List[str]) -> None",
+            "(List) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 281,
+        "func_name": "OptionList.get_string",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 18
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 298,
+        "func_name": "OptionStr",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 301,
+        "func_name": "OptionStr.__init__",
+        "type_comments": [
+            "(str, str, str, None, bool, bool, bool) -> None"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 306,
+        "func_name": "OptionStr.get_float",
+        "type_comments": [
+            "() -> float"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 310,
+        "func_name": "OptionStr.get_int",
+        "type_comments": [
+            "() -> int"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 314,
+        "func_name": "OptionStr.set",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 327,
+        "func_name": "OptionPassword",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 330,
+        "func_name": "OptionPassword.__init__",
+        "type_comments": [
+            "(str, str, str, bool) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 334,
+        "func_name": "OptionPassword.get",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 338,
+        "func_name": "OptionPassword.get_stars",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 342,
+        "func_name": "OptionPassword.get_dict",
+        "type_comments": [
+            "(bool) -> Dict[str, str]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 349,
+        "func_name": "OptionPassword.set",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 356,
+        "func_name": "add_to_database",
+        "type_comments": [
+            "(str, str, sabnzbd.config.ConfigCat) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 379,
+        "func_name": "ConfigServer",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 382,
+        "func_name": "ConfigServer.__init__",
+        "type_comments": [
+            "(str, configobj.Section) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 408,
+        "func_name": "ConfigServer.set_dict",
+        "type_comments": [
+            "(configobj.Section) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 437,
+        "func_name": "ConfigServer.get_dict",
+        "type_comments": [
+            "(bool) -> Dict[str, Union[int, str]]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 474,
+        "func_name": "ConfigCat",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 477,
+        "func_name": "ConfigCat.__init__",
+        "type_comments": [
+            "(str, configobj.Section) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 491,
+        "func_name": "ConfigCat.set_dict",
+        "type_comments": [
+            "(configobj.Section) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 501,
+        "func_name": "ConfigCat.get_dict",
+        "type_comments": [
+            "(bool) -> Dict[str, Union[int, str]]"
+        ],
+        "samples": 18
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 518,
+        "func_name": "OptionFilters",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 521,
+        "func_name": "OptionFilters.__init__",
+        "type_comments": [
+            "(str, str, bool) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 555,
+        "func_name": "OptionFilters.get_dict",
+        "type_comments": [
+            "(bool) -> Dict[str, List[str]]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 564,
+        "func_name": "OptionFilters.set_dict",
+        "type_comments": [
+            "(configobj.Section) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 585,
+        "func_name": "ConfigRSS",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 588,
+        "func_name": "ConfigRSS.__init__",
+        "type_comments": [
+            "(str, configobj.Section) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 604,
+        "func_name": "ConfigRSS.set_dict",
+        "type_comments": [
+            "(configobj.Section) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 616,
+        "func_name": "ConfigRSS.get_dict",
+        "type_comments": [
+            "(bool) -> Dict[str, Union[List[str], str]]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 639,
+        "func_name": "get_dconfig",
+        "type_comments": [
+            "(str, str, bool) -> Tuple[bool, Dict[str, int]]",
+            "(str, str, bool) -> Tuple[bool, Dict[str, str]]",
+            "(str, None, bool) -> pyannotate_runtime.collect_types.UnknownType",
+            "(None, None, bool) -> pyannotate_runtime.collect_types.UnknownType",
+            "(str, str, bool) -> Tuple[bool, Dict[str, List[str]]]",
+            "(str, str, bool) -> Tuple[bool, Dict[str, Union[int, str]]]"
+        ],
+        "samples": 18
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 680,
+        "func_name": "get_config",
+        "type_comments": [
+            "(str, str) -> sabnzbd.config.OptionBool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 713,
+        "func_name": "read_config",
+        "type_comments": [
+            "(str) -> Tuple[bool, str]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 721,
+        "func_name": "_read_config",
+        "type_comments": [
+            "(str, bool) -> Tuple[bool, str]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 790,
+        "func_name": "save_config",
+        "type_comments": [
+            "(bool) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 872,
+        "func_name": "define_servers",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 892,
+        "func_name": "get_servers",
+        "type_comments": [
+            "() -> Dict[str, sabnzbd.config.ConfigServer]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 900,
+        "func_name": "define_categories",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 912,
+        "func_name": "get_categories",
+        "type_comments": [
+            "(int) -> Dict[str, sabnzbd.config.ConfigCat]"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 941,
+        "func_name": "get_ordered_categories",
+        "type_comments": [
+            "() -> List[Dict[str, Union[int, str]]]"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 960,
+        "func_name": "define_rss",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 972,
+        "func_name": "get_rss",
+        "type_comments": [
+            "() -> Dict[str, sabnzbd.config.ConfigRSS]"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 999,
+        "func_name": "get_filename",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 1010,
+        "func_name": "encode_password",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 1025,
+        "func_name": "decode_password",
+        "type_comments": [
+            "(str, Tuple[List[str], str]) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 1043,
+        "func_name": "no_nonsense",
+        "type_comments": [
+            "(str) -> Tuple[None, str]"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 1051,
+        "func_name": "all_lowercase",
+        "type_comments": [
+            "(List[str]) -> Tuple[None, List[str]]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 1059,
+        "func_name": "validate_octal",
+        "type_comments": [
+            "(str) -> Tuple[None, str]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 1070,
+        "func_name": "validate_no_unc",
+        "type_comments": [
+            "(str, str, str) -> Tuple[None, str]"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 1079,
+        "func_name": "validate_safedir",
+        "type_comments": [
+            "(str, str, str) -> Tuple[None, str]"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 1091,
+        "func_name": "validate_notempty",
+        "type_comments": [
+            "(str, str, str) -> Tuple[None, str]"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 1099,
+        "func_name": "validate_single_tag",
+        "type_comments": [
+            "(List) -> Tuple[None, List]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\config.py",
+        "line": 1109,
+        "func_name": "create_api_key",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\constants.py",
+        "line": 128,
+        "func_name": "Status",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\database.py",
+        "line": 63,
+        "func_name": "HistoryDB",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\database.py",
+        "line": 82,
+        "func_name": "HistoryDB.connect",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "sabnzbd\\database.py",
+        "line": 114,
+        "func_name": "HistoryDB.execute",
+        "type_comments": [
+            "(str, Tuple[str, int, int], bool) -> bool",
+            "(str, Tuple[], bool) -> bool",
+            "(str, Tuple[str], bool) -> bool"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "sabnzbd\\database.py",
+        "line": 193,
+        "func_name": "HistoryDB.close",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\database.py",
+        "line": 258,
+        "func_name": "HistoryDB.add_history_db",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbObject, str, str, int, str, str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\database.py",
+        "line": 268,
+        "func_name": "HistoryDB.fetch_history",
+        "type_comments": [
+            "(int, int, None, int, None) -> Tuple[List[Dict[str, Union[int, str]]], int, int]",
+            "(int, int, str, int, None) -> Tuple[List[Dict[str, Union[int, str]]], int, int]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\database.py",
+        "line": 426,
+        "func_name": "dict_factory",
+        "type_comments": [
+            "(sqlite3.Cursor, Tuple[int, int, str, str, str, str, str, str, str, str]) -> Dict[str, Union[int, str]]",
+            "(sqlite3.Cursor, Tuple[int]) -> Dict[str, int]"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "sabnzbd\\database.py",
+        "line": 435,
+        "func_name": "build_history_info",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbObject, str, str, int, str, str) -> Tuple[int, str, str, str, str, str, str, str, str, str]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\database.py",
+        "line": 473,
+        "func_name": "unpack_history_info",
+        "type_comments": [
+            "(Dict[str, Union[int, str]]) -> Dict[str, Union[int, str]]"
+        ],
+        "samples": 13
+    },
+    {
+        "path": "sabnzbd\\decoder.py",
+        "line": 49,
+        "func_name": "CrcError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\decoder.py",
+        "line": 58,
+        "func_name": "BadYenc",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\decoder.py",
+        "line": 67,
+        "func_name": "Decoder",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\decoder.py",
+        "line": 69,
+        "func_name": "Decoder.__init__",
+        "type_comments": [
+            "(List[sabnzbd.downloader.Server], queue.Queue) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\decoder.py",
+        "line": 76,
+        "func_name": "Decoder.stop",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\decoder.py",
+        "line": 209,
+        "func_name": "Decoder.decode",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.Article, List, List[bytes]) -> bytes",
+            "(sabnzbd.nzbstuff.Article, List, List[bytes]) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 49
+    },
+    {
+        "path": "sabnzbd\\decoder.py",
+        "line": 242,
+        "func_name": "Decoder.verify_filename",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.Article, bytes, str) -> None"
+        ],
+        "samples": 50
+    },
+    {
+        "path": "sabnzbd\\decorators.py",
+        "line": 32,
+        "func_name": "synchronized",
+        "type_comments": [
+            "(_thread.RLock) -> function",
+            "(_thread.lock) -> function"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "sabnzbd\\decorators.py",
+        "line": 33,
+        "func_name": "wrap",
+        "type_comments": [
+            "(function) -> function"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "sabnzbd\\decorators.py",
+        "line": 34,
+        "func_name": "call_func",
+        "type_comments": [
+            "(*Union[float, int, sabnzbd.nzbstuff.NzbObject, str]) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(*Union[sabnzbd.rating.Rating, str]) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(*Union[sabnzbd.nzbstuff.NzbFile, sabnzbd.nzbstuff.NzbObject]) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(*Union[sabnzbd.config.ConfigCat, str]) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(*Union[bool, sabnzbd.nzbstuff.Article, sabnzbd.nzbstuff.NzbObject]) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(*str) -> pyannotate_runtime.collect_types.UnknownType",
+            "(*Union[List, sabnzbd.articlecache.ArticleCache]) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(*Union[sabnzbd.articlecache.ArticleCache, sabnzbd.nzbstuff.Article]) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 500
+    },
+    {
+        "path": "sabnzbd\\decorators.py",
+        "line": 46,
+        "func_name": "NzbQueueLocker",
+        "type_comments": [
+            "(function) -> function"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\decorators.py",
+        "line": 49,
+        "func_name": "call_func",
+        "type_comments": [
+            "(*Union[sabnzbd.nzbqueue.NzbQueue, sabnzbd.nzbstuff.NzbObject]) -> pyannotate_runtime.collect_types.UnknownType",
+            "(*Union[sabnzbd.nzbqueue.NzbQueue, sabnzbd.nzbstuff.NzbObject]) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(*Optional[str]) -> pyannotate_runtime.collect_types.UnknownType",
+            "(*sabnzbd.nzbqueue.NzbQueue) -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\directunpacker.py",
+        "line": 50,
+        "func_name": "DirectUnpacker",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\directunpacker.py",
+        "line": 52,
+        "func_name": "DirectUnpacker.__init__",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbObject) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\directunpacker.py",
+        "line": 80,
+        "func_name": "DirectUnpacker.reset_active",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\directunpacker.py",
+        "line": 86,
+        "func_name": "DirectUnpacker.check_requirements",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "sabnzbd\\directunpacker.py",
+        "line": 91,
+        "func_name": "DirectUnpacker.set_volumes_for_nzo",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\directunpacker.py",
+        "line": 110,
+        "func_name": "add",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbFile) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "sabnzbd\\directunpacker.py",
+        "line": 149,
+        "func_name": "DirectUnpacker.run",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\directunpacker.py",
+        "line": 294,
+        "func_name": "DirectUnpacker.have_next_volume",
+        "type_comments": [
+            "() -> bool",
+            "() -> sabnzbd.nzbstuff.NzbFile"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "sabnzbd\\directunpacker.py",
+        "line": 304,
+        "func_name": "DirectUnpacker.wait_for_next_volume",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "sabnzbd\\directunpacker.py",
+        "line": 312,
+        "func_name": "create_unrar_instance",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\directunpacker.py",
+        "line": 376,
+        "func_name": "abort",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\directunpacker.py",
+        "line": 435,
+        "func_name": "DirectUnpacker.get_formatted_stats",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\directunpacker.py",
+        "line": 461,
+        "func_name": "abort_all",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\dirscanner.py",
+        "line": 42,
+        "func_name": "name_to_cat",
+        "type_comments": [
+            "(str, str) -> Tuple[str, str]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\dirscanner.py",
+        "line": 101,
+        "func_name": "clean_file_list",
+        "type_comments": [
+            "(Dict, str, List) -> None",
+            "(Dict, str, List[str]) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "sabnzbd\\dirscanner.py",
+        "line": 323,
+        "func_name": "DirScanner.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\dirscanner.py",
+        "line": 347,
+        "func_name": "DirScanner.newdir",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\dirscanner.py",
+        "line": 359,
+        "func_name": "DirScanner.stop",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\dirscanner.py",
+        "line": 364,
+        "func_name": "DirScanner.save",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\dirscanner.py",
+        "line": 387,
+        "func_name": "run_dir",
+        "type_comments": [
+            "(str, str) -> None",
+            "(str, None) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\downloader.py",
+        "line": 61,
+        "func_name": "Server",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\downloader.py",
+        "line": 63,
+        "func_name": "Server.__init__",
+        "type_comments": [
+            "(str, str, str, int, int, int, int, int, int, str, int, str, str, int, float) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\downloader.py",
+        "line": 140,
+        "func_name": "Server.stop",
+        "type_comments": [
+            "(Dict, Dict) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\downloader.py",
+        "line": 157,
+        "func_name": "Downloader",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\downloader.py",
+        "line": 161,
+        "func_name": "Downloader.__init__",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\downloader.py",
+        "line": 212,
+        "func_name": "Downloader.init_server",
+        "type_comments": [
+            "(None, str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\downloader.py",
+        "line": 266,
+        "func_name": "resume",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\downloader.py",
+        "line": 299,
+        "func_name": "resume_from_postproc",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\downloader.py",
+        "line": 304,
+        "func_name": "Downloader.disconnect",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\downloader.py",
+        "line": 307,
+        "func_name": "Downloader.limit_speed",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\downloader.py",
+        "line": 331,
+        "func_name": "Downloader.get_limit",
+        "type_comments": [
+            "() -> float",
+            "() -> int"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\downloader.py",
+        "line": 334,
+        "func_name": "Downloader.get_limit_abs",
+        "type_comments": [
+            "() -> float"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\downloader.py",
+        "line": 337,
+        "func_name": "Downloader.speed_set",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\downloader.py",
+        "line": 347,
+        "func_name": "Downloader.is_paused",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 62
+    },
+    {
+        "path": "sabnzbd\\downloader.py",
+        "line": 356,
+        "func_name": "Downloader.highest_server",
+        "type_comments": [
+            "(sabnzbd.downloader.Server) -> bool"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "sabnzbd\\downloader.py",
+        "line": 368,
+        "func_name": "Downloader.maybe_block_server",
+        "type_comments": [
+            "(sabnzbd.downloader.Server) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\downloader.py",
+        "line": 399,
+        "func_name": "Downloader.decode",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.Article, List, List[bytes]) -> None"
+        ],
+        "samples": 51
+    },
+    {
+        "path": "sabnzbd\\downloader.py",
+        "line": 407,
+        "func_name": "Downloader.run",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\downloader.py",
+        "line": 763,
+        "func_name": "__reset_nw",
+        "type_comments": [
+            "(sabnzbd.newswrapper.NewsWrapper, str, bool, bool, bool, bool) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "sabnzbd\\downloader.py",
+        "line": 808,
+        "func_name": "__request_article",
+        "type_comments": [
+            "(sabnzbd.newswrapper.NewsWrapper) -> None"
+        ],
+        "samples": 51
+    },
+    {
+        "path": "sabnzbd\\downloader.py",
+        "line": 882,
+        "func_name": "check_timers",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\downloader.py",
+        "line": 908,
+        "func_name": "wakeup",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\downloader.py",
+        "line": 913,
+        "func_name": "Downloader.stop",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\downloader.py",
+        "line": 918,
+        "func_name": "stop",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\encoding.py",
+        "line": 37,
+        "func_name": "ubtou",
+        "type_comments": [
+            "(str) -> str",
+            "(bytes) -> str"
+        ],
+        "samples": 127
+    },
+    {
+        "path": "sabnzbd\\encoding.py",
+        "line": 44,
+        "func_name": "platform_btou",
+        "type_comments": [
+            "(bytes) -> str"
+        ],
+        "samples": 126
+    },
+    {
+        "path": "sabnzbd\\encoding.py",
+        "line": 58,
+        "func_name": "correct_unknown_encoding",
+        "type_comments": [
+            "(bytes) -> str",
+            "(str) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 38,
+        "func_name": "get_ext",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 46,
+        "func_name": "get_filename",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 54,
+        "func_name": "setname_from_path",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 59,
+        "func_name": "is_writable",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 93,
+        "func_name": "replace_win_devices",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 112,
+        "func_name": "has_win_device",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 129,
+        "func_name": "sanitize_filename",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 168,
+        "func_name": "sanitize_foldername",
+        "type_comments": [
+            "(str, bool) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 211,
+        "func_name": "sanitize_and_trim_path",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 237,
+        "func_name": "sanitize_files_in_folder",
+        "type_comments": [
+            "(str) -> List[str]"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 255,
+        "func_name": "is_obfuscated_filename",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 262,
+        "func_name": "create_all_dirs",
+        "type_comments": [
+            "(str, bool) -> bool"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 295,
+        "func_name": "real_path",
+        "type_comments": [
+            "(str, str) -> str"
+        ],
+        "samples": 18
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 332,
+        "func_name": "create_real_path",
+        "type_comments": [
+            "(str, str, str, bool, bool) -> Tuple[bool, str]"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 358,
+        "func_name": "same_file",
+        "type_comments": [
+            "(str, str) -> int"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 387,
+        "func_name": "check_mount",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 407,
+        "func_name": "safe_fnmatch",
+        "type_comments": [
+            "(str, str) -> bool"
+        ],
+        "samples": 14
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 417,
+        "func_name": "globber",
+        "type_comments": [
+            "(str, str) -> List[str]"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 425,
+        "func_name": "globber_full",
+        "type_comments": [
+            "(str, str) -> List",
+            "(str, str) -> List[str]"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 433,
+        "func_name": "trim_win_path",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 444,
+        "func_name": "fix_unix_encoding",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 460,
+        "func_name": "make_script_path",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 472,
+        "func_name": "get_admin_path",
+        "type_comments": [
+            "(str, bool) -> str"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 494,
+        "func_name": "set_permissions",
+        "type_comments": [
+            "(str, bool) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 525,
+        "func_name": "clip_path",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 532,
+        "func_name": "long_path",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 22
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 550,
+        "func_name": "get_unique_path",
+        "type_comments": [
+            "(str, int, bool) -> str"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 570,
+        "func_name": "get_unique_filename",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 585,
+        "func_name": "create_dirs",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 596,
+        "func_name": "recursive_listdir",
+        "type_comments": [
+            "(str) -> List[str]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 612,
+        "func_name": "move_to_path",
+        "type_comments": [
+            "(str, str) -> Tuple[bool, str]"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 674,
+        "func_name": "get_filepath",
+        "type_comments": [
+            "(str, sabnzbd.nzbstuff.NzbObject, str) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 711,
+        "func_name": "renamer",
+        "type_comments": [
+            "(str, str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 754,
+        "func_name": "remove_file",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 760,
+        "func_name": "remove_dir",
+        "type_comments": [
+            "(str) -> pyannotate_runtime.collect_types.NoReturnType",
+            "(str) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 783,
+        "func_name": "remove_all",
+        "type_comments": [
+            "(str, str, bool, bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 811,
+        "func_name": "find_dir",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 827,
+        "func_name": "diskspace_base",
+        "type_comments": [
+            "(str) -> Tuple[float, float]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\filesystem.py",
+        "line": 871,
+        "func_name": "diskspace",
+        "type_comments": [
+            "(bool) -> Dict[str, Tuple[float, float]]"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\getipaddress.py",
+        "line": 33,
+        "func_name": "timeout",
+        "type_comments": [
+            "(float) -> function"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\getipaddress.py",
+        "line": 36,
+        "func_name": "timeout_decorator",
+        "type_comments": [
+            "(function) -> function"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\getipaddress.py",
+        "line": 57,
+        "func_name": "addresslookup4",
+        "type_comments": [
+            "(str) -> List[Tuple[socket.AddressFamily, int, int, str, Tuple[str, int]]]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\getipaddress.py",
+        "line": 62,
+        "func_name": "addresslookup6",
+        "type_comments": [
+            "(str) -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\getipaddress.py",
+        "line": 67,
+        "func_name": "localipv4",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\getipaddress.py",
+        "line": 79,
+        "func_name": "publicipv4",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\getipaddress.py",
+        "line": 122,
+        "func_name": "ipv6",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 81,
+        "func_name": "secured_expose",
+        "type_comments": [
+            "(function, bool, bool) -> function",
+            "(None, bool, bool) -> functools.partial"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 89,
+        "func_name": "internal_wrap",
+        "type_comments": [
+            "(*sabnzbd.interface.ConfigPage) -> str",
+            "(*sabnzbd.interface.MainPage) -> str"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 144,
+        "func_name": "check_hostname",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 221,
+        "func_name": "check_login",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 243,
+        "func_name": "set_auth",
+        "type_comments": [
+            "(cherrypy._cpconfig.Config) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 272,
+        "func_name": "check_apikey",
+        "type_comments": [
+            "(Dict[str, str], bool) -> None"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 360,
+        "func_name": "MainPage",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 362,
+        "func_name": "MainPage.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 374,
+        "func_name": "index",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 428,
+        "func_name": "MainPage.tapi",
+        "type_comments": [
+            "() -> bytes",
+            "() -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 436,
+        "func_name": "MainPage.api",
+        "type_comments": [
+            "() -> bytes"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 499,
+        "func_name": "Wizard",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 501,
+        "func_name": "Wizard.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 662,
+        "func_name": "LoginPage",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 708,
+        "func_name": "NzoPage",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 710,
+        "func_name": "NzoPage.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 893,
+        "func_name": "QueuePage",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 895,
+        "func_name": "QueuePage.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 1019,
+        "func_name": "HistoryPage",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 1021,
+        "func_name": "HistoryPage.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 1120,
+        "func_name": "ConfigPage",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 1122,
+        "func_name": "ConfigPage.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 1135,
+        "func_name": "index",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 1185,
+        "func_name": "ConfigFolders",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 1187,
+        "func_name": "ConfigFolders.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 1243,
+        "func_name": "ConfigSwitches",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 1245,
+        "func_name": "ConfigSwitches.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 1306,
+        "func_name": "ConfigSpecial",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 1308,
+        "func_name": "ConfigSpecial.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 1344,
+        "func_name": "ConfigGeneral",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 1346,
+        "func_name": "ConfigGeneral.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 1473,
+        "func_name": "ConfigServer",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 1475,
+        "func_name": "ConfigServer.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 1623,
+        "func_name": "ConfigRss",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 1625,
+        "func_name": "ConfigRss.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 1958,
+        "func_name": "ConfigScheduling",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 1960,
+        "func_name": "ConfigScheduling.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 2126,
+        "func_name": "ConfigCats",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 2128,
+        "func_name": "ConfigCats.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 2191,
+        "func_name": "ConfigSorting",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 2193,
+        "func_name": "ConfigSorting.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 2243,
+        "func_name": "Status",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 2245,
+        "func_name": "Status.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 2549,
+        "func_name": "ConfigNotify",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\interface.py",
+        "line": 2551,
+        "func_name": "ConfigNotify.__init__",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\lang.py",
+        "line": 54,
+        "func_name": "set_language",
+        "type_comments": [
+            "(str) -> None",
+            "(None) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\misc.py",
+        "line": 58,
+        "func_name": "calc_age",
+        "type_comments": [
+            "(datetime.datetime, bool) -> str"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\misc.py",
+        "line": 101,
+        "func_name": "safe_lower",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\misc.py",
+        "line": 109,
+        "func_name": "cmp",
+        "type_comments": [
+            "(str, str) -> int"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "sabnzbd\\misc.py",
+        "line": 121,
+        "func_name": "cat_to_opts",
+        "type_comments": [
+            "(str, None, str, int) -> Tuple[str, str, str, int]",
+            "(str, None, None, str) -> Tuple[str, str, str, str]"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\misc.py",
+        "line": 218,
+        "func_name": "windows_variant",
+        "type_comments": [
+            "() -> Tuple[bool, bool]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\misc.py",
+        "line": 285,
+        "func_name": "get_from_url",
+        "type_comments": [
+            "(str) -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\misc.py",
+        "line": 294,
+        "func_name": "convert_version",
+        "type_comments": [
+            "(str) -> Tuple[int, bool]",
+            "(bytes) -> Tuple[int, bool]"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\misc.py",
+        "line": 313,
+        "func_name": "check_latest_version",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\misc.py",
+        "line": 398,
+        "func_name": "from_units",
+        "type_comments": [
+            "(str) -> float"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\misc.py",
+        "line": 422,
+        "func_name": "to_units",
+        "type_comments": [
+            "(int, str) -> str",
+            "(float, str) -> str"
+        ],
+        "samples": 41
+    },
+    {
+        "path": "sabnzbd\\misc.py",
+        "line": 451,
+        "func_name": "caller_name",
+        "type_comments": [
+            "(int) -> str"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "sabnzbd\\misc.py",
+        "line": 618,
+        "func_name": "loadavg",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\misc.py",
+        "line": 633,
+        "func_name": "format_time_string",
+        "type_comments": [
+            "(int) -> str",
+            "(float) -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\misc.py",
+        "line": 636,
+        "func_name": "unit",
+        "type_comments": [
+            "(str, int) -> str"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\misc.py",
+        "line": 669,
+        "func_name": "int_conv",
+        "type_comments": [
+            "(int) -> int",
+            "(str) -> int"
+        ],
+        "samples": 23
+    },
+    {
+        "path": "sabnzbd\\misc.py",
+        "line": 764,
+        "func_name": "probablyipv4",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\misc.py",
+        "line": 771,
+        "func_name": "probablyipv6",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\newsunpack.py",
+        "line": 90,
+        "func_name": "find_programs",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\newsunpack.py",
+        "line": 92,
+        "func_name": "check",
+        "type_comments": [
+            "(str, str) -> str"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "sabnzbd\\newsunpack.py",
+        "line": 222,
+        "func_name": "unpack_magic",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbObject, str, str, bool, bool, List, List, List[str], List, List, int) -> Tuple[None, List]",
+            "(sabnzbd.nzbstuff.NzbObject, str, str, bool, bool, Tuple[], Tuple[], Tuple[], Tuple[], Tuple[], int) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\newsunpack.py",
+        "line": 455,
+        "func_name": "rar_unpack",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbObject, str, str, bool, bool, List[str]) -> Tuple[bool, List[str]]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\newsunpack.py",
+        "line": 1075,
+        "func_name": "par2_repair",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbFile, sabnzbd.nzbstuff.NzbObject, str, str, bool) -> Tuple[bool, bool]"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\newsunpack.py",
+        "line": 1982,
+        "func_name": "build_command",
+        "type_comments": [
+            "(List[str], bool) -> Tuple[subprocess.STARTUPINFO, bool, str, int]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\newsunpack.py",
+        "line": 2035,
+        "func_name": "rar_volumelist",
+        "type_comments": [
+            "(str, None, List[str]) -> List[str]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\newsunpack.py",
+        "line": 2065,
+        "func_name": "rar_sort",
+        "type_comments": [
+            "(str, str) -> int"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\newsunpack.py",
+        "line": 2080,
+        "func_name": "build_filelists",
+        "type_comments": [
+            "(str, str, bool, bool) -> Tuple[List, List, List, List, List]",
+            "(str, None, bool, bool) -> Tuple[List, List, List, List, List]",
+            "(str, None, bool, bool) -> Tuple[List, List, List[str], List, List]"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\newsunpack.py",
+        "line": 2125,
+        "func_name": "QuickCheck",
+        "type_comments": [
+            "(str, sabnzbd.nzbstuff.NzbObject) -> bool"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\newsunpack.py",
+        "line": 2273,
+        "func_name": "analyse_show",
+        "type_comments": [
+            "(str) -> Tuple[str, str, str, str]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\newsunpack.py",
+        "line": 2288,
+        "func_name": "pre_queue",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbObject, None, str) -> List[Optional[Union[int, str]]]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\newsunpack.py",
+        "line": 2344,
+        "func_name": "list2cmdline",
+        "type_comments": [
+            "(List[str]) -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\newsunpack.py",
+        "line": 2360,
+        "func_name": "SevenZip",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\newswrapper.py",
+        "line": 44,
+        "func_name": "_retrieve_info",
+        "type_comments": [
+            "(sabnzbd.downloader.Server) -> None",
+            "(sabnzbd.downloader.Server) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\newswrapper.py",
+        "line": 56,
+        "func_name": "request_server_info",
+        "type_comments": [
+            "(sabnzbd.downloader.Server) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\newswrapper.py",
+        "line": 63,
+        "func_name": "GetServerParms",
+        "type_comments": [
+            "(str, int) -> List[Tuple[socket.AddressFamily, socket.SocketKind, int, str, Tuple[str, int]]]",
+            "(str, int) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\newswrapper.py",
+        "line": 98,
+        "func_name": "con",
+        "type_comments": [
+            "(socket.socket, str, int, int, Dict, sabnzbd.newswrapper.NNTP) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "sabnzbd\\newswrapper.py",
+        "line": 133,
+        "func_name": "NNTP",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\newswrapper.py",
+        "line": 137,
+        "func_name": "NNTP.__init__",
+        "type_comments": [
+            "(str, int, List[Tuple[socket.AddressFamily, socket.SocketKind, int, str, Tuple[str, int]]], int, sabnzbd.newswrapper.NewsWrapper, bool, Dict) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\newswrapper.py",
+        "line": 255,
+        "func_name": "NewsWrapper",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\newswrapper.py",
+        "line": 260,
+        "func_name": "NewsWrapper.__init__",
+        "type_comments": [
+            "(sabnzbd.downloader.Server, int, bool) -> None"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\newswrapper.py",
+        "line": 285,
+        "func_name": "status_code",
+        "type_comments": [
+            "() -> int"
+        ],
+        "samples": 202
+    },
+    {
+        "path": "sabnzbd\\newswrapper.py",
+        "line": 293,
+        "func_name": "NewsWrapper.init_connect",
+        "type_comments": [
+            "(Dict) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\newswrapper.py",
+        "line": 305,
+        "func_name": "NewsWrapper.finish_connect",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\newswrapper.py",
+        "line": 359,
+        "func_name": "NewsWrapper.body",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 51
+    },
+    {
+        "path": "sabnzbd\\newswrapper.py",
+        "line": 379,
+        "func_name": "NewsWrapper.recv_chunk",
+        "type_comments": [
+            "(bool) -> Tuple[int, bool, bool]"
+        ],
+        "samples": 246
+    },
+    {
+        "path": "sabnzbd\\newswrapper.py",
+        "line": 419,
+        "func_name": "NewsWrapper.soft_reset",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 51
+    },
+    {
+        "path": "sabnzbd\\newswrapper.py",
+        "line": 424,
+        "func_name": "NewsWrapper.clear_data",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 53
+    },
+    {
+        "path": "sabnzbd\\newswrapper.py",
+        "line": 429,
+        "func_name": "NewsWrapper.hard_reset",
+        "type_comments": [
+            "(bool, bool) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "sabnzbd\\newswrapper.py",
+        "line": 449,
+        "func_name": "NewsWrapper.terminate",
+        "type_comments": [
+            "(bool) -> None"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "sabnzbd\\notifier.py",
+        "line": 112,
+        "func_name": "have_ntfosd",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\notifier.py",
+        "line": 117,
+        "func_name": "check_classes",
+        "type_comments": [
+            "(str, str) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\notifier.py",
+        "line": 135,
+        "func_name": "check_cat",
+        "type_comments": [
+            "(str, str, None) -> bool"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\notifier.py",
+        "line": 151,
+        "func_name": "send_notification",
+        "type_comments": [
+            "(str, str, str, str) -> None",
+            "(str, str, str, None) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\notifier.py",
+        "line": 384,
+        "func_name": "hostname",
+        "type_comments": [
+            "(bool) -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\notifier.py",
+        "line": 552,
+        "func_name": "send_windows",
+        "type_comments": [
+            "(str, str, str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\nzbqueue.py",
+        "line": 49,
+        "func_name": "NzbQueue",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\nzbqueue.py",
+        "line": 60,
+        "func_name": "NzbQueue.read_queue",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\nzbqueue.py",
+        "line": 117,
+        "func_name": "scan_jobs",
+        "type_comments": [
+            "(bool, bool) -> List"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\nzbqueue.py",
+        "line": 223,
+        "func_name": "save",
+        "type_comments": [
+            "(None) -> None",
+            "(sabnzbd.nzbstuff.NzbObject) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "sabnzbd\\nzbqueue.py",
+        "line": 306,
+        "func_name": "add",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbObject, bool, bool) -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\nzbqueue.py",
+        "line": 362,
+        "func_name": "remove",
+        "type_comments": [
+            "(str, bool, bool, bool, bool, bool) -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\nzbqueue.py",
+        "line": 678,
+        "func_name": "NzbQueue.has_forced_items",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\nzbqueue.py",
+        "line": 687,
+        "func_name": "NzbQueue.get_article",
+        "type_comments": [
+            "(sabnzbd.downloader.Server, List[sabnzbd.downloader.Server]) -> sabnzbd.nzbstuff.Article",
+            "(sabnzbd.downloader.Server, List[sabnzbd.downloader.Server]) -> None"
+        ],
+        "samples": 101
+    },
+    {
+        "path": "sabnzbd\\nzbqueue.py",
+        "line": 704,
+        "func_name": "NzbQueue.register_article",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.Article, bool) -> None",
+            "(sabnzbd.nzbstuff.Article, bool) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 51
+    },
+    {
+        "path": "sabnzbd\\nzbqueue.py",
+        "line": 746,
+        "func_name": "NzbQueue.end_job",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbObject) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\nzbqueue.py",
+        "line": 767,
+        "func_name": "NzbQueue.actives",
+        "type_comments": [
+            "(bool) -> int"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\nzbqueue.py",
+        "line": 780,
+        "func_name": "NzbQueue.queue_info",
+        "type_comments": [
+            "(None, int, int) -> sabnzbd.constants.QNFO",
+            "(str, int, int) -> sabnzbd.constants.QNFO"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\nzbqueue.py",
+        "line": 813,
+        "func_name": "NzbQueue.remaining",
+        "type_comments": [
+            "() -> int"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\nzbqueue.py",
+        "line": 823,
+        "func_name": "NzbQueue.is_empty",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\nzbqueue.py",
+        "line": 831,
+        "func_name": "NzbQueue.cleanup_nzo",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbObject, bool, bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\nzbqueue.py",
+        "line": 837,
+        "func_name": "NzbQueue.stop_idle_jobs",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\nzbqueue.py",
+        "line": 886,
+        "func_name": "NzbQueue.get_urls",
+        "type_comments": [
+            "() -> List"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 64,
+        "func_name": "TryList",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 70,
+        "func_name": "TryList.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 52
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 74,
+        "func_name": "TryList.server_in_try_list",
+        "type_comments": [
+            "(sabnzbd.downloader.Server) -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 217
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 79,
+        "func_name": "TryList.add_to_try_list",
+        "type_comments": [
+            "(sabnzbd.downloader.Server) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 85,
+        "func_name": "TryList.reset_try_list",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 90,
+        "func_name": "TryList.__getstate__",
+        "type_comments": [
+            "() -> List[str]",
+            "() -> List"
+        ],
+        "samples": 60
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 109,
+        "func_name": "Article",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 114,
+        "func_name": "Article.__init__",
+        "type_comments": [
+            "(str, int, int, sabnzbd.nzbstuff.NzbFile) -> None"
+        ],
+        "samples": 51
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 125,
+        "func_name": "Article.get_article",
+        "type_comments": [
+            "(sabnzbd.downloader.Server, List[sabnzbd.downloader.Server]) -> sabnzbd.nzbstuff.Article",
+            "(sabnzbd.downloader.Server, List[sabnzbd.downloader.Server]) -> None"
+        ],
+        "samples": 500
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 181,
+        "func_name": "Article.get_art_id",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 187,
+        "func_name": "Article.__getstate__",
+        "type_comments": [
+            "() -> Dict[str, Union[bool, int, str]]",
+            "() -> Dict[str, Optional[Union[bool, int, str]]]"
+        ],
+        "samples": 58
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 224,
+        "func_name": "NzbFile",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 229,
+        "func_name": "NzbFile.__init__",
+        "type_comments": [
+            "(datetime.datetime, str, Dict[int, Tuple[str, int]], int, sabnzbd.nzbstuff.NzbObject) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 281,
+        "func_name": "NzbFile.finish_import",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 296,
+        "func_name": "NzbFile.add_article",
+        "type_comments": [
+            "(Tuple[str, int], int) -> sabnzbd.nzbstuff.Article"
+        ],
+        "samples": 51
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 303,
+        "func_name": "NzbFile.remove_article",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.Article, bool) -> bool"
+        ],
+        "samples": 51
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 312,
+        "func_name": "NzbFile.set_par2",
+        "type_comments": [
+            "(str, str, str) -> None",
+            "(str, int, int) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 319,
+        "func_name": "NzbFile.get_article",
+        "type_comments": [
+            "(sabnzbd.downloader.Server, List[sabnzbd.downloader.Server]) -> sabnzbd.nzbstuff.Article",
+            "(sabnzbd.downloader.Server, List[sabnzbd.downloader.Server]) -> None"
+        ],
+        "samples": 51
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 338,
+        "func_name": "NzbFile.remove_admin",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 346,
+        "func_name": "NzbFile.__getstate__",
+        "type_comments": [
+            "() -> Dict[str, Optional[Union[bool, datetime.datetime, str]]]"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 386,
+        "func_name": "NzbObject",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 388,
+        "func_name": "NzbObject.__init__",
+        "type_comments": [
+            "(str, None, None, str, bool, str, str, str, str, str, None, bool, bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 720,
+        "func_name": "update_download_stats",
+        "type_comments": [
+            "(float, str, int) -> None"
+        ],
+        "samples": 246
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 730,
+        "func_name": "remove_nzf",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbFile) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 740,
+        "func_name": "NzbObject.sort_nzfs",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 781,
+        "func_name": "postpone_pars",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbFile, str) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 815,
+        "func_name": "handle_par2",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbFile, str) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 923,
+        "func_name": "remove_article",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.Article, bool) -> Tuple[bool, bool]"
+        ],
+        "samples": 51
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 992,
+        "func_name": "remove_saved_article",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.Article) -> None"
+        ],
+        "samples": 51
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1068,
+        "func_name": "pp",
+        "type_comments": [
+            "() -> int"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1082,
+        "func_name": "NzbObject.set_priority",
+        "type_comments": [
+            "(int) -> None",
+            "(str) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1099,
+        "func_name": "final_name_labeled",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1132,
+        "func_name": "final_name_pw_clean",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1139,
+        "func_name": "NzbObject.set_final_name_pw",
+        "type_comments": [
+            "(str, None) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1191,
+        "func_name": "remove_extrapar",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbFile) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1222,
+        "func_name": "NzbObject.add_to_direct_unpacker",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbFile) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1228,
+        "func_name": "NzbObject.abort_direct_unpacker",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1233,
+        "func_name": "NzbObject.check_availability_ratio",
+        "type_comments": [
+            "(int) -> Tuple[bool, int]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1265,
+        "func_name": "NzbObject.check_first_article_availability",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1278,
+        "func_name": "set_download_report",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1333,
+        "func_name": "NzbObject.get_article",
+        "type_comments": [
+            "(sabnzbd.downloader.Server, List[sabnzbd.downloader.Server]) -> sabnzbd.nzbstuff.Article"
+        ],
+        "samples": 51
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1452,
+        "func_name": "NzbObject.verify_nzf_filename",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbFile, None) -> None",
+            "(sabnzbd.nzbstuff.NzbFile, str) -> None"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1479,
+        "func_name": "NzbObject.verify_all_filenames_and_resort",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1487,
+        "func_name": "renamed_file",
+        "type_comments": [
+            "(Dict[str, str], None) -> None",
+            "(str, str) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1500,
+        "func_name": "update_rating",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1519,
+        "func_name": "workpath",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1524,
+        "func_name": "downpath",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1539,
+        "func_name": "remaining",
+        "type_comments": [
+            "() -> int"
+        ],
+        "samples": 10
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1544,
+        "func_name": "purge_data",
+        "type_comments": [
+            "(bool, bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1576,
+        "func_name": "NzbObject.gather_info",
+        "type_comments": [
+            "(bool) -> sabnzbd.constants.PNFO"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1597,
+        "func_name": "set_unpack_info",
+        "type_comments": [
+            "(str, str, None, bool) -> None",
+            "(str, str, str, bool) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1614,
+        "func_name": "NzbObject.set_action_line",
+        "type_comments": [
+            "(str, str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1622,
+        "func_name": "repair_opts",
+        "type_comments": [
+            "() -> Tuple[bool, bool, bool]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1626,
+        "func_name": "save_to_disk",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1633,
+        "func_name": "NzbObject.save_attribs",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1656,
+        "func_name": "NzbObject.has_duplicates",
+        "type_comments": [
+            "() -> Tuple[bool, bool]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1693,
+        "func_name": "NzbObject.is_gone",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 98
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1697,
+        "func_name": "NzbObject.__getstate__",
+        "type_comments": [
+            "() -> Dict[str, Union[bool, int, str]]"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1748,
+        "func_name": "nzf_get_filename",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbFile) -> str"
+        ],
+        "samples": 12
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1767,
+        "func_name": "nzf_cmp_name",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbFile, sabnzbd.nzbstuff.NzbFile, bool) -> int"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1808,
+        "func_name": "create_work_name",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1823,
+        "func_name": "scan_password",
+        "type_comments": [
+            "(str) -> Tuple[str, None]"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1883,
+        "func_name": "set_attrib_file",
+        "type_comments": [
+            "(str, Tuple[str, int, str, int, str, None, str]) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1896,
+        "func_name": "name_extractor",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\nzbstuff.py",
+        "line": 1906,
+        "func_name": "matcher",
+        "type_comments": [
+            "(str, str) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\panic.py",
+        "line": 191,
+        "func_name": "launch_a_browser",
+        "type_comments": [
+            "(str, bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\par2file.py",
+        "line": 35,
+        "func_name": "is_parfile",
+        "type_comments": [
+            "(str) -> pyannotate_runtime.collect_types.NoReturnType"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\par2file.py",
+        "line": 46,
+        "func_name": "analyse_par2",
+        "type_comments": [
+            "(str, None) -> Tuple[str, int, int]",
+            "(str, None) -> Tuple[str, str, str]"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "sabnzbd\\par2file.py",
+        "line": 79,
+        "func_name": "parse_par2_file",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbFile, str) -> Dict[str, bytes]"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\par2file.py",
+        "line": 128,
+        "func_name": "parse_par2_file_packet",
+        "type_comments": [
+            "(_io.BufferedReader, bytes) -> Tuple[None, None, None]",
+            "(_io.BufferedReader, bytes) -> Tuple[str, bytes, bytes]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\postproc.py",
+        "line": 59,
+        "func_name": "PostProcessor",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\postproc.py",
+        "line": 63,
+        "func_name": "PostProcessor.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\postproc.py",
+        "line": 92,
+        "func_name": "PostProcessor.save",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "sabnzbd\\postproc.py",
+        "line": 97,
+        "func_name": "PostProcessor.load",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\postproc.py",
+        "line": 127,
+        "func_name": "PostProcessor.process",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbObject) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\postproc.py",
+        "line": 140,
+        "func_name": "PostProcessor.remove",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbObject) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\postproc.py",
+        "line": 149,
+        "func_name": "PostProcessor.stop",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\postproc.py",
+        "line": 165,
+        "func_name": "PostProcessor.empty",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\postproc.py",
+        "line": 169,
+        "func_name": "PostProcessor.get_queue",
+        "type_comments": [
+            "() -> List"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\postproc.py",
+        "line": 180,
+        "func_name": "PostProcessor.run",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\postproc.py",
+        "line": 257,
+        "func_name": "process_job",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbObject) -> bool"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\postproc.py",
+        "line": 590,
+        "func_name": "prepare_extraction_path",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbObject) -> Tuple[str, str, sabnzbd.sorting.Sorter, bool, str]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\postproc.py",
+        "line": 644,
+        "func_name": "parring",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbObject, str) -> Tuple[bool, bool]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\postproc.py",
+        "line": 790,
+        "func_name": "handle_empty_queue",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\postproc.py",
+        "line": 806,
+        "func_name": "cleanup_list",
+        "type_comments": [
+            "(str, bool) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\postproc.py",
+        "line": 834,
+        "func_name": "prefix",
+        "type_comments": [
+            "(str, str) -> str"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\postproc.py",
+        "line": 842,
+        "func_name": "nzb_redirect",
+        "type_comments": [
+            "(str, str, int, str, str, int) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\postproc.py",
+        "line": 864,
+        "func_name": "one_file_or_folder",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\postproc.py",
+        "line": 910,
+        "func_name": "rename_and_collapse_folder",
+        "type_comments": [
+            "(str, str, List[str]) -> List[str]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\postproc.py",
+        "line": 936,
+        "func_name": "set_marker",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\rating.py",
+        "line": 35,
+        "func_name": "OrderedSetQueue",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\rating.py",
+        "line": 39,
+        "func_name": "OrderedSetQueue._put",
+        "type_comments": [
+            "(None) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\rating.py",
+        "line": 62,
+        "func_name": "NzbRating",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\rating.py",
+        "line": 79,
+        "func_name": "NzbRatingV2",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\rating.py",
+        "line": 93,
+        "func_name": "Rating",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\rating.py",
+        "line": 114,
+        "func_name": "Rating.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\rating.py",
+        "line": 135,
+        "func_name": "Rating.stop",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\rating.py",
+        "line": 139,
+        "func_name": "Rating.run",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\rating.py",
+        "line": 157,
+        "func_name": "save",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\rating.py",
+        "line": 243,
+        "func_name": "get_rating_by_nzo",
+        "type_comments": [
+            "(str) -> None"
+        ],
+        "samples": 15
+    },
+    {
+        "path": "sabnzbd\\rss.py",
+        "line": 46,
+        "func_name": "init",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\rss.py",
+        "line": 51,
+        "func_name": "stop",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\rss.py",
+        "line": 85,
+        "func_name": "run_method",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\rss.py",
+        "line": 93,
+        "func_name": "next_run",
+        "type_comments": [
+            "(float) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\rss.py",
+        "line": 104,
+        "func_name": "save",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\rss.py",
+        "line": 170,
+        "func_name": "RSSQueue",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\rss.py",
+        "line": 171,
+        "func_name": "RSSQueue.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\rss.py",
+        "line": 211,
+        "func_name": "RSSQueue.stop",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\rss.py",
+        "line": 548,
+        "func_name": "RSSQueue.run",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\rss.py",
+        "line": 584,
+        "func_name": "save",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\rss.py",
+        "line": 638,
+        "func_name": "patch_feedparser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\sabtray.py",
+        "line": 38,
+        "func_name": "SABTrayThread",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\sabtray.py",
+        "line": 45,
+        "func_name": "SABTrayThread.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\sabtray.py",
+        "line": 77,
+        "func_name": "SABTrayThread.set_texts",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\sabtray.py",
+        "line": 84,
+        "func_name": "SABTrayThread.doUpdates",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 29
+    },
+    {
+        "path": "sabnzbd\\sabtray.py",
+        "line": 179,
+        "func_name": "SABTrayThread.shutdown",
+        "type_comments": [
+            "(sabnzbd.sabtray.SABTrayThread) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\scheduler.py",
+        "line": 61,
+        "func_name": "init",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\scheduler.py",
+        "line": 215,
+        "func_name": "start",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\scheduler.py",
+        "line": 223,
+        "func_name": "restart",
+        "type_comments": [
+            "(bool) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\scheduler.py",
+        "line": 253,
+        "func_name": "abort",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\scheduler.py",
+        "line": 261,
+        "func_name": "sort_schedules",
+        "type_comments": [
+            "(bool, None) -> List[Tuple[int, str, None, str, str]]"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\scheduler.py",
+        "line": 306,
+        "func_name": "analyse",
+        "type_comments": [
+            "(bool, int) -> bool",
+            "(int, None) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\scheduler.py",
+        "line": 436,
+        "func_name": "plan_resume",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\scheduler.py",
+        "line": 449,
+        "func_name": "pause_int",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\scheduler.py",
+        "line": 466,
+        "func_name": "pause_check",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\scheduler.py",
+        "line": 494,
+        "func_name": "reset_guardian",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "sabnzbd\\scheduler.py",
+        "line": 500,
+        "func_name": "sched_guardian",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "sabnzbd\\scheduler.py",
+        "line": 505,
+        "func_name": "sched_check",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\sorting.py",
+        "line": 92,
+        "func_name": "Sorter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\sorting.py",
+        "line": 95,
+        "func_name": "Sorter.__init__",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbObject, str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\sorting.py",
+        "line": 103,
+        "func_name": "Sorter.detect",
+        "type_comments": [
+            "(str, str) -> str"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\sorting.py",
+        "line": 176,
+        "func_name": "SeriesSorter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\sorting.py",
+        "line": 179,
+        "func_name": "SeriesSorter.__init__",
+        "type_comments": [
+            "(None, str, None, None) -> None",
+            "(sabnzbd.nzbstuff.NzbObject, str, str, str) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\sorting.py",
+        "line": 202,
+        "func_name": "SeriesSorter.match",
+        "type_comments": [
+            "(bool) -> None"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\sorting.py",
+        "line": 212,
+        "func_name": "SeriesSorter.is_match",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\sorting.py",
+        "line": 241,
+        "func_name": "SeriesSorter.get_shownames",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\sorting.py",
+        "line": 247,
+        "func_name": "SeriesSorter.get_seasons",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\sorting.py",
+        "line": 267,
+        "func_name": "SeriesSorter.get_episodes",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\sorting.py",
+        "line": 289,
+        "func_name": "SeriesSorter.get_showdescriptions",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\sorting.py",
+        "line": 293,
+        "func_name": "SeriesSorter.get_values",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\sorting.py",
+        "line": 500,
+        "func_name": "MovieSorter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\sorting.py",
+        "line": 503,
+        "func_name": "MovieSorter.__init__",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbObject, str, str, str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\sorting.py",
+        "line": 526,
+        "func_name": "MovieSorter.match",
+        "type_comments": [
+            "(bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\sorting.py",
+        "line": 707,
+        "func_name": "DateSorter",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\sorting.py",
+        "line": 710,
+        "func_name": "DateSorter.__init__",
+        "type_comments": [
+            "(sabnzbd.nzbstuff.NzbObject, str, str, str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\sorting.py",
+        "line": 733,
+        "func_name": "DateSorter.match",
+        "type_comments": [
+            "(bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\sorting.py",
+        "line": 919,
+        "func_name": "get_titles",
+        "type_comments": [
+            "(None, re.Match, str, bool) -> Tuple[str, str, str]"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\sorting.py",
+        "line": 995,
+        "func_name": "replace_word",
+        "type_comments": [
+            "(str, str, str) -> str"
+        ],
+        "samples": 11
+    },
+    {
+        "path": "sabnzbd\\sorting.py",
+        "line": 1005,
+        "func_name": "get_descriptions",
+        "type_comments": [
+            "(None, re.Match, str) -> Tuple[str, str, str]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\urlgrabber.py",
+        "line": 50,
+        "func_name": "URLGrabber",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\urlgrabber.py",
+        "line": 77,
+        "func_name": "URLGrabber.stop",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\urlgrabber.py",
+        "line": 82,
+        "func_name": "URLGrabber.run",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\checkdir.py",
+        "line": 13,
+        "func_name": "isFAT",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\getperformance.py",
+        "line": 7,
+        "func_name": "getcpu",
+        "type_comments": [
+            "() -> str"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 85,
+        "func_name": "method",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 91,
+        "func_name": "Scheduler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 94,
+        "func_name": "Scheduler.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 98,
+        "func_name": "__delayfunc",
+        "type_comments": [
+            "(int) -> None",
+            "(float) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 124,
+        "func_name": "Scheduler.add_interval_task",
+        "type_comments": [
+            "(function, str, int, int, str, None, None) -> sabnzbd.utils.kronos.IntervalTask"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 151,
+        "func_name": "Scheduler.add_single_task",
+        "type_comments": [
+            "(function, str, int, str, None, None) -> sabnzbd.utils.kronos.SingleTask"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 172,
+        "func_name": "Scheduler.add_daytime_task",
+        "type_comments": [
+            "(method, str, List[int], None, Tuple[int, int], str, List, None) -> sabnzbd.utils.kronos.WeekdayTask",
+            "(function, str, Tuple[int], None, Tuple[int, int], str, List, None) -> sabnzbd.utils.kronos.WeekdayTask",
+            "(function, str, List[int], None, Tuple[int, int], str, List, None) -> sabnzbd.utils.kronos.WeekdayTask"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 208,
+        "func_name": "Scheduler.schedule_task",
+        "type_comments": [
+            "(sabnzbd.utils.kronos.SingleTask, int) -> None",
+            "(sabnzbd.utils.kronos.IntervalTask, int) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 224,
+        "func_name": "Scheduler.schedule_task_abs",
+        "type_comments": [
+            "(sabnzbd.utils.kronos.WeekdayTask, float) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 255,
+        "func_name": "Scheduler._getqueuetoptime",
+        "type_comments": [
+            "() -> float"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 287,
+        "func_name": "Task",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 290,
+        "func_name": "Task.__init__",
+        "type_comments": [
+            "(str, function, List, Dict) -> None",
+            "(str, method, List, Dict) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 297,
+        "func_name": "Task.__call__",
+        "type_comments": [
+            "(weakref) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 309,
+        "func_name": "Task.execute",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 318,
+        "func_name": "SingleTask",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 321,
+        "func_name": "SingleTask.reschedule",
+        "type_comments": [
+            "(sabnzbd.utils.kronos.ThreadedScheduler) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 325,
+        "func_name": "IntervalTask",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 328,
+        "func_name": "IntervalTask.__init__",
+        "type_comments": [
+            "(str, int, function, List, Dict) -> None"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 332,
+        "func_name": "IntervalTask.reschedule",
+        "type_comments": [
+            "(sabnzbd.utils.kronos.ThreadedScheduler) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 337,
+        "func_name": "DayTaskRescheduler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 340,
+        "func_name": "DayTaskRescheduler.__init__",
+        "type_comments": [
+            "(Tuple[int, int]) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 343,
+        "func_name": "DayTaskRescheduler.get_schedule_time",
+        "type_comments": [
+            "(bool) -> float"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 372,
+        "func_name": "WeekdayTask",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 378,
+        "func_name": "WeekdayTask.__init__",
+        "type_comments": [
+            "(str, Tuple[int], Tuple[int, int], function, List, Dict) -> None",
+            "(str, List[int], Tuple[int, int], function, List, Dict) -> None",
+            "(str, List[int], Tuple[int, int], method, List, Dict) -> None"
+        ],
+        "samples": 4
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 395,
+        "func_name": "MonthdayTask",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 420,
+        "func_name": "ThreadedScheduler",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 423,
+        "func_name": "ThreadedScheduler.__init__",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 428,
+        "func_name": "ThreadedScheduler.start",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 442,
+        "func_name": "ThreadedScheduler._acquire_lock",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 446,
+        "func_name": "ThreadedScheduler._release_lock",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 450,
+        "func_name": "ThreadedTaskMixin",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 466,
+        "func_name": "ThreadedIntervalTask",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 471,
+        "func_name": "ThreadedSingleTask",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 476,
+        "func_name": "ThreadedWeekdayTask",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\kronos.py",
+        "line": 481,
+        "func_name": "ThreadedMonthdayTask",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\pybonjour.py",
+        "line": 70,
+        "func_name": "_DummyLock",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\pystone.py",
+        "line": 44,
+        "func_name": "Record",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\pystone.py",
+        "line": 45,
+        "func_name": "Record.__init__",
+        "type_comments": [
+            "(sabnzbd.utils.pystone.Record, int, int, int, str) -> None",
+            "(None, int, int, int, int) -> None"
+        ],
+        "samples": 65
+    },
+    {
+        "path": "sabnzbd\\utils\\pystone.py",
+        "line": 52,
+        "func_name": "Record.copy",
+        "type_comments": [
+            "() -> sabnzbd.utils.pystone.Record"
+        ],
+        "samples": 64
+    },
+    {
+        "path": "sabnzbd\\utils\\pystone.py",
+        "line": 66,
+        "func_name": "pystones",
+        "type_comments": [
+            "(int) -> Tuple[float, float]"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\utils\\pystone.py",
+        "line": 80,
+        "func_name": "Proc0",
+        "type_comments": [
+            "(int) -> Tuple[float, float]"
+        ],
+        "samples": 2
+    },
+    {
+        "path": "sabnzbd\\utils\\pystone.py",
+        "line": 139,
+        "func_name": "Proc1",
+        "type_comments": [
+            "(sabnzbd.utils.pystone.Record) -> sabnzbd.utils.pystone.Record"
+        ],
+        "samples": 64
+    },
+    {
+        "path": "sabnzbd\\utils\\pystone.py",
+        "line": 156,
+        "func_name": "Proc2",
+        "type_comments": [
+            "(int) -> int"
+        ],
+        "samples": 64
+    },
+    {
+        "path": "sabnzbd\\utils\\pystone.py",
+        "line": 168,
+        "func_name": "Proc3",
+        "type_comments": [
+            "(sabnzbd.utils.pystone.Record) -> sabnzbd.utils.pystone.Record"
+        ],
+        "samples": 64
+    },
+    {
+        "path": "sabnzbd\\utils\\pystone.py",
+        "line": 179,
+        "func_name": "Proc4",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 64
+    },
+    {
+        "path": "sabnzbd\\utils\\pystone.py",
+        "line": 187,
+        "func_name": "Proc5",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 64
+    },
+    {
+        "path": "sabnzbd\\utils\\pystone.py",
+        "line": 195,
+        "func_name": "Proc6",
+        "type_comments": [
+            "(int) -> int"
+        ],
+        "samples": 64
+    },
+    {
+        "path": "sabnzbd\\utils\\pystone.py",
+        "line": 215,
+        "func_name": "Proc7",
+        "type_comments": [
+            "(int, int) -> int"
+        ],
+        "samples": 184
+    },
+    {
+        "path": "sabnzbd\\utils\\pystone.py",
+        "line": 221,
+        "func_name": "Proc8",
+        "type_comments": [
+            "(List[int], List[List[int]], int, int) -> None"
+        ],
+        "samples": 64
+    },
+    {
+        "path": "sabnzbd\\utils\\pystone.py",
+        "line": 235,
+        "func_name": "Func1",
+        "type_comments": [
+            "(str, str) -> int"
+        ],
+        "samples": 184
+    },
+    {
+        "path": "sabnzbd\\utils\\pystone.py",
+        "line": 244,
+        "func_name": "Func2",
+        "type_comments": [
+            "(str, str) -> int"
+        ],
+        "samples": 64
+    },
+    {
+        "path": "sabnzbd\\utils\\pystone.py",
+        "line": 262,
+        "func_name": "Func3",
+        "type_comments": [
+            "(int) -> int"
+        ],
+        "samples": 64
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 116,
+        "func_name": "AES_CBC_Decrypt",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 392,
+        "func_name": "_get_rar_version",
+        "type_comments": [
+            "(str) -> int"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 409,
+        "func_name": "is_rarfile",
+        "type_comments": [
+            "(str) -> None",
+            "(str) -> str"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 419,
+        "func_name": "Error",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 423,
+        "func_name": "BadRarFile",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 427,
+        "func_name": "NotRarFile",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 431,
+        "func_name": "BadRarName",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 435,
+        "func_name": "NoRarEntry",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 439,
+        "func_name": "PasswordRequired",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 443,
+        "func_name": "NeedFirstVolume",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 447,
+        "func_name": "NoCrypto",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 451,
+        "func_name": "RarExecError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 455,
+        "func_name": "RarWarning",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 459,
+        "func_name": "RarFatalError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 463,
+        "func_name": "RarCRCError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 467,
+        "func_name": "RarLockedArchiveError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 471,
+        "func_name": "RarWriteError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 475,
+        "func_name": "RarOpenError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 479,
+        "func_name": "RarUserError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 483,
+        "func_name": "RarMemoryError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 487,
+        "func_name": "RarCreateError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 491,
+        "func_name": "RarNoFilesError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 495,
+        "func_name": "RarUserBreak",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 499,
+        "func_name": "RarWrongPassword",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 503,
+        "func_name": "RarUnknownError",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 507,
+        "func_name": "RarSignalExit",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 511,
+        "func_name": "RarCannotExec",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 515,
+        "func_name": "RarInfo",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 650,
+        "func_name": "RarInfo.needs_password",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 658,
+        "func_name": "RarFile",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 665,
+        "func_name": "RarFile.__init__",
+        "type_comments": [
+            "(str, str, None, None, bool, str, bool) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 723,
+        "func_name": "RarFile.needs_password",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 727,
+        "func_name": "RarFile.namelist",
+        "type_comments": [
+            "() -> List[str]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 735,
+        "func_name": "RarFile.infolist",
+        "type_comments": [
+            "() -> List[sabnzbd.utils.rarfile.Rar3Info]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 739,
+        "func_name": "RarFile.volumelist",
+        "type_comments": [
+            "() -> List[str]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 811,
+        "func_name": "RarFile.close",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 888,
+        "func_name": "RarFile._parse",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 952,
+        "func_name": "CommonParser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 964,
+        "func_name": "CommonParser.__init__",
+        "type_comments": [
+            "(str, None, bool, str, bool, None, bool) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 990,
+        "func_name": "CommonParser.volumelist",
+        "type_comments": [
+            "() -> List[str]"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 994,
+        "func_name": "CommonParser.needs_password",
+        "type_comments": [
+            "() -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 1002,
+        "func_name": "CommonParser.infolist",
+        "type_comments": [
+            "() -> List[sabnzbd.utils.rarfile.Rar3Info]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 1025,
+        "func_name": "CommonParser.parse",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 1035,
+        "func_name": "CommonParser._parse_real",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 1126,
+        "func_name": "CommonParser._parse_header",
+        "type_comments": [
+            "(sabnzbd.utils.rarfile.XFile) -> sabnzbd.utils.rarfile.Rar3Info"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 1141,
+        "func_name": "CommonParser._next_volname",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 1148,
+        "func_name": "CommonParser._set_error",
+        "type_comments": [
+            "(str, *str) -> None"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 1255,
+        "func_name": "Rar3Info",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 1284,
+        "func_name": "RAR3Parser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 1303,
+        "func_name": "RAR3Parser._parse_block_header",
+        "type_comments": [
+            "(sabnzbd.utils.rarfile.XFile) -> sabnzbd.utils.rarfile.Rar3Info"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 1382,
+        "func_name": "RAR3Parser._parse_file_header",
+        "type_comments": [
+            "(sabnzbd.utils.rarfile.Rar3Info, bytes, int) -> int"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 1485,
+        "func_name": "RAR3Parser._decode",
+        "type_comments": [
+            "(bytes) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 1496,
+        "func_name": "RAR3Parser.process_entry",
+        "type_comments": [
+            "(sabnzbd.utils.rarfile.XFile, sabnzbd.utils.rarfile.Rar3Info) -> None"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 1548,
+        "func_name": "Rar5Info",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 1573,
+        "func_name": "Rar5BaseFile",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 1598,
+        "func_name": "Rar5FileInfo",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 1605,
+        "func_name": "Rar5ServiceInfo",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 1612,
+        "func_name": "Rar5MainInfo",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 1626,
+        "func_name": "Rar5EncryptionInfo",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 1641,
+        "func_name": "Rar5EndArcInfo",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 1649,
+        "func_name": "RAR5Parser",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 1976,
+        "func_name": "UnicodeFilename",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 2040,
+        "func_name": "RarExtFile",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 2218,
+        "func_name": "PipeReader",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 2304,
+        "func_name": "DirectReader",
+        "type_comments": [
+            "() -> cell"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 2429,
+        "func_name": "HeaderDecrypt",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 2474,
+        "func_name": "XFile",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 2480,
+        "func_name": "XFile.__init__",
+        "type_comments": [
+            "(str, int) -> None"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 2489,
+        "func_name": "XFile.read",
+        "type_comments": [
+            "(int) -> bytes"
+        ],
+        "samples": 12
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 2493,
+        "func_name": "XFile.tell",
+        "type_comments": [
+            "() -> int"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 2497,
+        "func_name": "XFile.seek",
+        "type_comments": [
+            "(int, int) -> int"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 2505,
+        "func_name": "XFile.close",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 8
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 2510,
+        "func_name": "XFile.__enter__",
+        "type_comments": [
+            "() -> sabnzbd.utils.rarfile.XFile"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 2513,
+        "func_name": "XFile.__exit__",
+        "type_comments": [
+            "(None, None, None) -> None"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 2517,
+        "func_name": "NoHashContext",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 2533,
+        "func_name": "CRC32Context",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 2556,
+        "func_name": "Blake2SP",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 2649,
+        "func_name": "load_byte",
+        "type_comments": [
+            "(bytes, int) -> Tuple[int, int]"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 2657,
+        "func_name": "load_le32",
+        "type_comments": [
+            "(bytes, int) -> Tuple[int, int]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 2665,
+        "func_name": "load_bytes",
+        "type_comments": [
+            "(bytes, int, int) -> Tuple[bytes, int]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 2716,
+        "func_name": "_next_oldvol",
+        "type_comments": [
+            "(str) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 2724,
+        "func_name": "_inc_volname",
+        "type_comments": [
+            "(str, int) -> str"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 2736,
+        "func_name": "_parse_ext_time",
+        "type_comments": [
+            "(sabnzbd.utils.rarfile.Rar3Info, bytes, int) -> int"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 2754,
+        "func_name": "_parse_xtime",
+        "type_comments": [
+            "(int, bytes, int, datetime.datetime) -> Tuple[datetime.datetime, int]",
+            "(int, bytes, int, None) -> Tuple[None, int]"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 2780,
+        "func_name": "is_filelike",
+        "type_comments": [
+            "(str) -> bool"
+        ],
+        "samples": 9
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 2863,
+        "func_name": "to_datetime",
+        "type_comments": [
+            "(Tuple[int, int, int, int, int, int]) -> datetime.datetime"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 2902,
+        "func_name": "parse_dos_time",
+        "type_comments": [
+            "(int) -> Tuple[int, int, int, int, int, int]"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\utils\\rarfile.py",
+        "line": 3020,
+        "func_name": "XTempFile",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\systrayiconthread.py",
+        "line": 24,
+        "func_name": "SysTrayIconThread",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\systrayiconthread.py",
+        "line": 31,
+        "func_name": "SysTrayIconThread.__init__",
+        "type_comments": [
+            "(str, str, Tuple[Tuple[str, None, method], Tuple[str, None, method], Tuple[str, None, None], Tuple[str, None, method], Tuple[str, None, Tuple[Tuple[str, None, method], Tuple[str, None, method], Tuple[str, None, method], Tuple[str, None, method], Tuple[str, None, method], Tuple[str, None, method]]], Tuple[str, None, None], Tuple[str, None, method], Tuple[str, None, None], Tuple[str, None, Tuple[Tuple[str, None, method], Tuple[str, None, method], Tuple[str, None, method]]], Tuple[str, None, method]], None, int, str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\systrayiconthread.py",
+        "line": 51,
+        "func_name": "SysTrayIconThread.initialize",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\systrayiconthread.py",
+        "line": 86,
+        "func_name": "SysTrayIconThread.run",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\systrayiconthread.py",
+        "line": 99,
+        "func_name": "SysTrayIconThread.sendnotification",
+        "type_comments": [
+            "(str, str) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\systrayiconthread.py",
+        "line": 106,
+        "func_name": "SysTrayIconThread._add_ids_to_menu_options",
+        "type_comments": [
+            "(Tuple[Tuple[str, None, method], Tuple[str, None, method], Tuple[str, None, method]]) -> List[Tuple[str, None, method, int]]",
+            "(Tuple[Tuple[str, None, method], Tuple[str, None, method], Tuple[str, None, method], Tuple[str, None, method], Tuple[str, None, method], Tuple[str, None, method]]) -> List[Tuple[str, None, method, int]]",
+            "(List[Union[Tuple[str, None, None], Tuple[str, None, method]]]) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\utils\\systrayiconthread.py",
+        "line": 125,
+        "func_name": "SysTrayIconThread.get_icon",
+        "type_comments": [
+            "(str) -> int"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\utils\\systrayiconthread.py",
+        "line": 142,
+        "func_name": "SysTrayIconThread.refresh_icon",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 7
+    },
+    {
+        "path": "sabnzbd\\utils\\systrayiconthread.py",
+        "line": 172,
+        "func_name": "SysTrayIconThread.notify",
+        "type_comments": [
+            "(int, int, int, int) -> bool"
+        ],
+        "samples": 6
+    },
+    {
+        "path": "sabnzbd\\utils\\systrayiconthread.py",
+        "line": 188,
+        "func_name": "SysTrayIconThread.show_menu",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\systrayiconthread.py",
+        "line": 214,
+        "func_name": "SysTrayIconThread.create_menu",
+        "type_comments": [
+            "(int, List[Tuple[str, None, method, int]]) -> None",
+            "(int, List[Union[Tuple[str, None, None, int], Tuple[str, None, method, int]]]) -> pyannotate_runtime.collect_types.UnknownType"
+        ],
+        "samples": 3
+    },
+    {
+        "path": "sabnzbd\\utils\\systrayiconthread.py",
+        "line": 256,
+        "func_name": "SysTrayIconThread.command",
+        "type_comments": [
+            "(int, int, int, int) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\systrayiconthread.py",
+        "line": 260,
+        "func_name": "SysTrayIconThread.execute_menu_option",
+        "type_comments": [
+            "(int) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\utils\\systrayiconthread.py",
+        "line": 268,
+        "func_name": "non_string_iterable",
+        "type_comments": [
+            "(Tuple[Tuple[str, None, method], Tuple[str, None, method], Tuple[str, None, method]]) -> bool",
+            "(None) -> bool",
+            "(Tuple[Tuple[str, None, method], Tuple[str, None, method], Tuple[str, None, method], Tuple[str, None, method], Tuple[str, None, method], Tuple[str, None, method]]) -> bool"
+        ],
+        "samples": 5
+    },
+    {
+        "path": "sabnzbd\\zconfig.py",
+        "line": 58,
+        "func_name": "set_bonjour",
+        "type_comments": [
+            "(str, int) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "sabnzbd\\zconfig.py",
+        "line": 112,
+        "func_name": "remove_server",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "util\\apireg.py",
+        "line": 66,
+        "func_name": "set_connection_info",
+        "type_comments": [
+            "(str, bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "util\\apireg.py",
+        "line": 87,
+        "func_name": "del_connection_info",
+        "type_comments": [
+            "(bool) -> None"
+        ],
+        "samples": 1
+    },
+    {
+        "path": "util\\mailslot.py",
+        "line": 35,
+        "func_name": "MailSlot",
+        "type_comments": [
+            "() -> None"
+        ],
+        "samples": 1
+    }
+]


### PR DESCRIPTION
@thezoggy @sanderjo @Hellowlol and anyone else that has an opinion 👍 

Python 3.5+ supports a way to be more clear about what kind of parameters functions expect, just like almost every other programming language.
More background information can be found here:
https://dev.to/dstarner/using-pythons-type-annotations-4cfe

For this discussion I ran the `pyannotate` tool and applied it's automatically deducted types to `misc.py` and `encoding.py`.
Is this something we would like to start using?