### PR TITLE
JSON response types are mismatched

### DIFF
--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1340,13 +1340,13 @@ def build_queue(start=0, limit=0, trans=False, output=None, search=None):
         slot['filename'] = converter(pnfo.filename)
         slot['password'] = converter(pnfo.password) if pnfo.password else ''
         slot['cat'] = converter(pnfo.category) if pnfo.category else 'None'
-        slot['mbleft'] = "%.2f" % mbleft
-        slot['mb'] = "%.2f" % mb
+        slot['mbleft'] = round(mbleft, 2)
+        slot['mb'] = round(mb, 2)
         slot['size'] = format_bytes(bytes)
         slot['sizeleft'] = format_bytes(bytesleft)
-        slot['percentage'] = "%s" % (int(((mb - mbleft) / mb) * 100)) if mb != mbleft else '0'
-        slot['mbmissing'] = "%.2f" % (pnfo.bytes_missing / MEBI)
-        slot['direct_unpack'] = pnfo.direct_unpack
+        slot['percentage'] = int(((mb - mbleft) / mb) * 100) if mb != mbleft else 0
+        slot['mbmissing'] = round(pnfo.bytes_missing / MEBI, 2)
+        slot['direct_unpack'] = pnfo.direct_unpack if direct_unpack != 0 else "0"
         if not output:
             slot['mb_fmt'] = locale.format('%d', int(mb), True)
             slot['mbdone_fmt'] = locale.format('%d', int(mb - mbleft), True)


### PR DESCRIPTION
JSON provides types for int and float.  Changing these values to a string before returning them requires the user/consumer of the API to write conversions.  Seems counter-intuitive.  I think it makes more sense to actually respond with the type expected.  It'll make consumers in static typed languages easier to implement.

Also direct_unpack would sometimes be a string, and other times be an integer.  This makes for more code to static type language consumers.

I looked through the code, and didn't see any reason this would break, except for other API consumers who can now rid themselves of any conversion code.

There are a few more, but I haven't begun consuming them yet so I didn't fix them.

One could also make a good argument that the size should be the numbers, and the mb value should be the string, but that's not a hill to die on.