### PR TITLE
Fix ImportError when win32api fails to load dll

### DIFF
--- a/SABHelper.py
+++ b/SABHelper.py
@@ -25,13 +25,13 @@ import subprocess
 
 
 try:
+    import pywintypes
     import win32api
     import win32file
     import win32serviceutil
     import win32evtlogutil
     import win32event
     import win32service
-    import pywintypes
 except ImportError:
     print("Sorry, requires Python module PyWin32.")
     sys.exit(1)

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -72,12 +72,12 @@ import sabnzbd.notifier as notifier
 import sabnzbd.zconfig
 
 try:
+    import pywintypes
     import win32api
     import win32serviceutil
     import win32evtlogutil
     import win32event
     import win32service
-    import pywintypes
     win32api.SetConsoleCtrlHandler(sabnzbd.sig_handler, True)
     from util.mailslot import MailSlot
     from util.apireg import get_connection_info, set_connection_info, del_connection_info

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -31,6 +31,7 @@ import locale
 from threading import Thread
 
 try:
+    import pywintypes
     import win32api
     import win32file
 except ImportError:

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -792,6 +792,7 @@ if sabnzbd.WIN32:
     # windows diskfree
     try:
         # Careful here, because win32api test hasn't been done yet!
+        import pywintypes
         import win32api
     except:
         pass

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -219,6 +219,7 @@ def windows_variant():
     """ Determine Windows variant
         Return vista_plus, x64
     """
+    import pywintypes
     from win32api import GetVersionEx
     from win32con import VER_PLATFORM_WIN32_NT
     import winreg

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -43,6 +43,7 @@ from sabnzbd.constants import Status
 
 if sabnzbd.WIN32:
     try:
+        import pywintypes
         import win32api
         import win32con
         import win32process

--- a/sabnzbd/powersup.py
+++ b/sabnzbd/powersup.py
@@ -29,6 +29,7 @@ import time
 # Power management for Windows
 ##############################################################################
 try:
+    import pywintypes
     import win32security
     import win32api
     import ntsecuritycon

--- a/sabnzbd/utils/checkdir.py
+++ b/sabnzbd/utils/checkdir.py
@@ -43,6 +43,7 @@ def isFAT(check_dir):
                             print("FAT found")
                         break
         elif "win32" in sys.platform:
+            import pywintypes
             import win32api
 
             if "?" in check_dir:

--- a/sabnzbd/utils/pathbrowser.py
+++ b/sabnzbd/utils/pathbrowser.py
@@ -22,6 +22,7 @@ import os
 import sabnzbd
 
 if os.name == "nt":
+    import pywintypes
     import win32api
     import win32con
     import win32file


### PR DESCRIPTION
importing pywintypes before win32api fixes #1340

See https://github.com/mhammond/pywin32/issues/1327 for more details