### PR TITLE
Py3: Replace xrange with range

### DIFF
--- a/interfaces/Plush/templates/nzo.tmpl
+++ b/interfaces/Plush/templates/nzo.tmpl
@@ -11,7 +11,7 @@
 
   <div>
   <select name="index"><optgroup label="$T('order')">
-  <!--#for $i in xrange($noofslots)#-->
+  <!--#for $i in range($noofslots)#-->
     <option value=$i <!--#if $i == $index then "selected" else ""#-->>$i</option>
   <!--#end for#-->
   </select>


### PR DESCRIPTION
https://docs.python.org/3.0/whatsnew/3.0.html#views-and-iterators-instead-of-lists says:

- range() now behaves like xrange() used to behave, except it works with values of arbitrary size. The latter no longer exists.