### PR TITLE
Docker check: Show whether SAB is running inside docker

### DIFF
--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1106,6 +1106,11 @@ def main():
     else:
         logging.info('Platform = %s', os.name)
     logging.info('Python-version = %s', sys.version)
+    sabnzbd.IN_DOCKER = sabnzbd.in_docker()
+    if sabnzbd.IN_DOCKER:
+        logging.info("Running inside a docker container")
+    else:
+        logging.info("Not inside a docker container")
     logging.info('Arguments = %s', sabnzbd.CMDLINE)
 
     # Find encoding; relevant for external processing activities

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -108,6 +108,8 @@ LINUX_POWER = powersup.HAVE_DBUS
 
 START = datetime.datetime.now()
 
+IN_DOCKER = None
+
 MY_NAME = None
 MY_FULLNAME = None
 RESTART_ARGS = []
@@ -1154,3 +1156,14 @@ def history_updated():
     # Never go over the limit
     if sabnzbd.LAST_HISTORY_UPDATE + 1 >= sys.maxsize:
         sabnzbd.LAST_HISTORY_UPDATE = 1
+
+
+def in_docker():
+    """ Returns: True if running in a Docker container, else False """
+    try:
+        with open('/proc/1/cgroup', 'rt') as ifh:
+            return ':/docker/' in ifh.read()
+    except:
+        # probably not on Linux at all, so not Docker
+        return False
+

--- a/sabnzbd/utils/rarvolinfo.py
+++ b/sabnzbd/utils/rarvolinfo.py
@@ -43,7 +43,7 @@ def get_rar_extension(myrarfile):
         rar_ver = rarfile.is_rarfile(myrarfile)
         with open(myrarfile, "rb") as fh:
             if rar_ver.endswith("3"):
-                # As it's rar3, let's first find the numbering scheme: old (rNNN) or new (partNNN.rar)
+                # As it's rar3, let's first find the numbering scheme: old (rNN) or new (partNN.rar)
                 mybuf = fh.read(100)  # first 100 bytes is enough
                 HEAD_FLAGS_LSB = mybuf[10]  # LSB = Least Significant Byte
                 newnumbering = HEAD_FLAGS_LSB & 0x10
@@ -54,13 +54,13 @@ def get_rar_extension(myrarfile):
                 volumenumber = 1 + mybuf[-9] + 256 * mybuf[-8]
 
                 if newnumbering:
-                    org_extension = "part%03d.rar" % volumenumber
+                    org_extension = "part%02d.rar" % volumenumber
                 else:
                     # 1, 2, 3, 4 resp refers to .rar, .r00, .r01, .r02 ...
                     if volumenumber == 1:
                         org_extension = "rar"
                     else:
-                        org_extension = "r%03d" % (volumenumber - 2)
+                        org_extension = "r%02d" % (volumenumber - 2)
 
             elif rar_ver.endswith("5"):
                 mybuf = fh.read(100)  # first 100 bytes is enough


### PR DESCRIPTION
In case of problems or user's help requests, it's relevant to know whether SAB inside a docker container. So SAB now detects and reports that in the logging at startup.

This PR puts the info into sabnzbd.IN_DOCKER so that it can be used elsewhere, for example the SAB GUI

Background info from https://stackoverflow.com/a/20012536

> The most reliable way is to check /proc/1/cgroup. It will tell you the control groups of the init process, and when you are not in a container, that will be / for all hierarchies. When you are inside a container, you will see the name of the anchor point. With LXC/Docker containers, it will be something like /lxc/<containerid> or /docker/<containerid> respectively.