### PR TITLE
Detect and reports whether running inside Docker

### DIFF
--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1107,6 +1107,11 @@ def main():
         logging.info('Platform = %s', os.name)
     logging.info('Python-version = %s', sys.version)
     logging.info('Arguments = %s', sabnzbd.CMDLINE)
+    sabnzbd.IN_DOCKER = sabnzbd.in_docker()
+    if sabnzbd.IN_DOCKER:
+        logging.info("Running inside a docker container")
+    else:
+        logging.info("Not inside a docker container")
 
     # Find encoding; relevant for external processing activities
     logging.info('Preferred encoding = %s', sabnzbd.encoding.CODEPAGE)

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1107,8 +1107,7 @@ def main():
         logging.info('Platform = %s', os.name)
     logging.info('Python-version = %s', sys.version)
     logging.info('Arguments = %s', sabnzbd.CMDLINE)
-    sabnzbd.IN_DOCKER = sabnzbd.in_docker()
-    if sabnzbd.IN_DOCKER:
+    if sabnzbd.DOCKER:
         logging.info("Running inside a docker container")
     else:
         logging.info("Not inside a docker container")

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -36,7 +36,7 @@ from threading import Lock, Thread
 ##############################################################################
 # Determine platform flags
 ##############################################################################
-WIN32 = DARWIN = FOUNDATION = WIN64 = False
+WIN32 = DARWIN = FOUNDATION = WIN64 = DOCKER = False
 KERNEL32 = None
 
 if os.name == "nt":
@@ -52,8 +52,15 @@ if os.name == "nt":
 elif os.name == "posix":
     ORG_UMASK = os.umask(18)
     os.umask(ORG_UMASK)
-    import platform
 
+    # Check if running in a Docker container
+    try:
+        with open('/proc/1/cgroup', 'rt') as ifh:
+            DOCKER = ':/docker/' in ifh.read()
+    except:
+        pass
+
+    import platform
     if platform.system().lower() == "darwin":
         DARWIN = True
         # 12 = Sierra, 11 = ElCaptain, 10 = Yosemite, 9 = Mavericks, 8 = MountainLion
@@ -1154,13 +1161,4 @@ def history_updated():
     # Never go over the limit
     if sabnzbd.LAST_HISTORY_UPDATE + 1 >= sys.maxsize:
         sabnzbd.LAST_HISTORY_UPDATE = 1
-
-def in_docker():
-    """ Returns: True if running in a Docker container, else False """
-    try:
-        with open('/proc/1/cgroup', 'rt') as ifh:
-            return ':/docker/' in ifh.read()
-    except:
-        # probably not on Linux at all, so not Docker
-        return False
 

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -55,12 +55,13 @@ elif os.name == "posix":
 
     # Check if running in a Docker container
     try:
-        with open('/proc/1/cgroup', 'rt') as ifh:
-            DOCKER = ':/docker/' in ifh.read()
+        with open("/proc/1/cgroup", "rt") as ifh:
+            DOCKER = ":/docker/" in ifh.read()
     except:
         pass
 
     import platform
+
     if platform.system().lower() == "darwin":
         DARWIN = True
         # 12 = Sierra, 11 = ElCaptain, 10 = Yosemite, 9 = Mavericks, 8 = MountainLion
@@ -1161,4 +1162,3 @@ def history_updated():
     # Never go over the limit
     if sabnzbd.LAST_HISTORY_UPDATE + 1 >= sys.maxsize:
         sabnzbd.LAST_HISTORY_UPDATE = 1
-

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -1154,3 +1154,13 @@ def history_updated():
     # Never go over the limit
     if sabnzbd.LAST_HISTORY_UPDATE + 1 >= sys.maxsize:
         sabnzbd.LAST_HISTORY_UPDATE = 1
+
+def in_docker():
+    """ Returns: True if running in a Docker container, else False """
+    try:
+        with open('/proc/1/cgroup', 'rt') as ifh:
+            return ':/docker/' in ifh.read()
+    except:
+        # probably not on Linux at all, so not Docker
+        return False
+


### PR DESCRIPTION
In case of problems or user's help requests, it's relevant to know whether SAB is inside a docker container. So SAB now detects and reports that in the logging at startup.

This PR puts the info into sabnzbd.DOCKER so that it can be used elsewhere, for example the SAB GUI

Background info from https://stackoverflow.com/a/20012536

> The most reliable way is to check /proc/1/cgroup. It will tell you the control groups of the init process, and when you are not in a container, that will be / for all hierarchies. When you are inside a container, you will see the name of the anchor point. With LXC/Docker containers, it will be something like /lxc/<containerid> or /docker/<containerid> respectively.