### PR TITLE
On Linux 5.4+, "exfat" again correctly recognized as not FAT

### DIFF
--- a/sabnzbd/utils/checkdir.py
+++ b/sabnzbd/utils/checkdir.py
@@ -37,7 +37,8 @@ def isFAT(check_dir):
                     fstype = thisline.split()[1]
                     if debug:
                         print(("File system type:", fstype))
-                    if fstype.lower().find("fat") >= 0:
+                    if fstype.lower().find("fat") >= 0 and fstype.lower().find("exfat") < 0:
+                        # FAT, but not EXFAT
                         FAT = True
                         if debug:
                             print("FAT found")


### PR DESCRIPTION
Linux 5.4 brings a native driver for the `exfat` filesystem (thanks to Microsoft), so updated SABnzbd to recognize that not as FAT. And reason for that: exfat does not have the 4GB limitation like normal FAT, and that is what SAB is warning for.

Solves https://github.com/sabnzbd/sabnzbd/pull/859#issuecomment-605680724 