### PR TITLE
Make Pre-Check Work Again

### DIFF
--- a/sabnzbd/decoder.py
+++ b/sabnzbd/decoder.py
@@ -146,7 +146,7 @@ class Decoder(Thread):
                     # Handles precheck and badly formed articles
                     killed = False
                     found = False
-                    if nzo.precheck and raw_data and raw_data.startswith(b'223 '):
+                    if nzo.precheck and raw_data and raw_data[0].startswith(b'223 '):
                         # STAT was used, so we only get a status code
                         found = True
                     else:


### PR DESCRIPTION
raw_data is now a list, so we need the first element raw_data[0].

Example
`raw_data is [b'223 0 <OuIgBdRbTmOrXuAyFcSjDgTh-1584818153948@nyuu>\r\n']`

As discussed https://github.com/sabnzbd/sabnzbd/issues/1389
