### PR TITLE
Pre-check HTTPS CERT and KEY files. Give warning if not good.

### DIFF
--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1230,7 +1230,7 @@ def main():
             trialcontext.load_cert_chain(https_cert, https_key)
             logging.info("HTTPS keys are OK")
         except:
-            logging.warning(T('Disabled HTTPS because of invalid CERT and KEY files'))
+            logging.warning(T('Disabled HTTPS because of invalid CERT and KEY files: %s'), sys.exc_info()[0:2])
             enable_https = False
 
     # Starting of the webserver

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1224,6 +1224,15 @@ def main():
             logging.warning(T('Disabled HTTPS because of missing CERT and KEY files'))
             enable_https = False
 
+        # So the cert and key files do exist, now let's check if they are valid:
+        trialcontext = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        try:
+            trialcontext.load_cert_chain(https_cert, https_key)
+            logging.info("HTTPS keys are OK")
+        except:
+            logging.warning(T('Disabled HTTPS because of invalid CERT and KEY files'))
+            enable_https = False
+
     # Starting of the webserver
     # Determine if this system has multiple definitions for 'localhost'
     hosts = all_localhosts()

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1223,6 +1223,7 @@ def main():
         if not (os.path.exists(https_cert) and os.path.exists(https_key)):
             logging.warning(T('Disabled HTTPS because of missing CERT and KEY files'))
             enable_https = False
+            sabnzbd.cfg.enable_https.set(False)
 
         # So the cert and key files do exist, now let's check if they are valid:
         trialcontext = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
@@ -1230,8 +1231,10 @@ def main():
             trialcontext.load_cert_chain(https_cert, https_key)
             logging.info("HTTPS keys are OK")
         except:
-            logging.warning(T('Disabled HTTPS because of invalid CERT and KEY files: %s'), sys.exc_info()[0:2])
+            logging.warning(T('Disabled HTTPS because of invalid CERT and KEY files'))
+            logging.info("Traceback: ", exc_info=True)
             enable_https = False
+            sabnzbd.cfg.enable_https.set(False)
 
     # Starting of the webserver
     # Determine if this system has multiple definitions for 'localhost'


### PR DESCRIPTION
Pre-check HTTPS CERT and KEY files. Give warning if not good and fallback to plain HTTP.

Solves uncaught traceback as discussed https://github.com/sabnzbd/sabnzbd/issues/1391