### PR TITLE
Make happyEyeballs work again on Python 3.8 / Ubuntu 20.04 with SSL

### DIFF
--- a/sabnzbd/utils/happyeyeballs.py
+++ b/sabnzbd/utils/happyeyeballs.py
@@ -50,7 +50,7 @@ def do_socket_connect(queue, ip, PORT, SSL, ipv4delay):
             s.close()
         else:
             # WRAP SOCKET
-            wrappedSocket = ssl.wrap_socket(s, ssl_version=ssl.PROTOCOL_TLSv1)
+            wrappedSocket = ssl.wrap_socket(s)
             # CONNECT
             wrappedSocket.connect((ip, PORT))
             # CLOSE SOCKET CONNECTION


### PR DESCRIPTION
wrap_socket(s) without extra parameter works on both Python 3.5 / Ubuntu 16.04 and Python 3.8 / Ubuntu 20.04
Solves https://github.com/sabnzbd/sabnzbd/issues/1396