### PR TITLE
Introduction of unittest for happyeyeballs()

### DIFF
--- a/tests/test_utils/test_happyeyeballs.py
+++ b/tests/test_utils/test_happyeyeballs.py
@@ -1,0 +1,51 @@
+#!/usr/bin/python3 -OO
+# Copyright 2007-2019 The SABnzbd-Team <team@sabnzbd.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+tests.test_utils.test_happyeyeballs - Testing SABnzbd happyeyeballs
+"""
+
+from sabnzbd.utils.happyeyeballs import happyeyeballs
+
+# happyeyeballs() returns the quickest IP address (IPv4, or IPv6 if available end-to-end), or None (if not resolvable, or not reachable)
+
+
+class TestHappyEyeballs:
+    """ Tests of happyeyeballs() against various websites/servers """
+    def test_google_http(self):
+        ip = happyeyeballs("www.google.com")
+        assert "." in ip or ":" in ip
+
+    def test_google_https(self):
+        ip = happyeyeballs("www.google.com", port=443, ssl=True)
+        assert "." in ip or ":" in ip
+
+    def test_not_resolvable(self):
+        ip = happyeyeballs("not.resolvable.at.all")
+        assert ip is None
+
+    def test_ipv6_only(self):
+        ip = happyeyeballs("ipv6.google.com")
+        assert ip is None or ":" in ip
+
+    def test_google_unreachable_port(self):
+        ip = happyeyeballs("www.google.com", port=33333)
+        assert ip is None
+
+    def test_newszilla_nttp(self):
+        ip = happyeyeballs("newszilla.xs4all.nl", port=119)
+        assert "." in ip or ":" in ip


### PR DESCRIPTION
To verify that happyeyeballs() is working correctly.
Will work correctly on IPv4-only and IPv6-IPV4 systems.

Usage: from sabnzbd root directory, run
`pytest tests/test_utils/test_happyeyeballs.py`
or
`pytest
`
```
~/git/sabnzbd $ pytest tests/test_utils/test_happyeyeballs.py
========================================= test session starts ==========================================
platform linux -- Python 3.8.2, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /home/sander/git/sabnzbd/
collected 6 items                                                                                      

tests/test_utils/test_happyeyeballs.py ......                                                    [100%]

========================================== 6 passed in 3.83s ===========================================
```

Closes https://github.com/sabnzbd/sabnzbd/issues/1396
