### PR TITLE
getcpu(): solves unclosed '/proc/cpuinfo'

### DIFF
--- a/sabnzbd/utils/getperformance.py
+++ b/sabnzbd/utils/getperformance.py
@@ -22,12 +22,13 @@ def getcpu():
             cputype = subprocess.check_output(["sysctl", "-n", "machdep.cpu.brand_string"]).strip()
 
         elif platform.system() == "Linux":
-            for myline in open("/proc/cpuinfo"):
-                if myline.startswith("model name"):
-                    # Typical line:
-                    # model name      : Intel(R) Xeon(R) CPU           E5335  @ 2.00GHz
-                    cputype = myline.split(":", 1)[1]  # get everything after the first ":"
-                    break  # we're done
+            with open("/proc/cpuinfo") as fp:
+                for myline in fp.readlines():
+                    if myline.startswith("model name"):
+                        # Typical line:
+                        # model name      : Intel(R) Xeon(R) CPU           E5335  @ 2.00GHz
+                        cputype = myline.split(":", 1)[1]  # get everything after the first ":"
+                        break  # we're done
         cputype = cputype.decode(locale.getpreferredencoding())
     except:
         # An exception, maybe due to a subprocess call gone wrong


### PR DESCRIPTION
Solves the warning below

```
$ python3 -X dev -X tracemalloc=5 -c "from sabnzbd.utils.getperformance import getpystone, getcpu; print(getcpu())" 

/home/sander/git/sab-25april2020/sabnzbd/utils/getperformance.py:30: ResourceWarning: unclosed file <_io.TextIOWrapper name='/proc/cpuinfo' mode='r' encoding='UTF-8'>
  break  # we're done
Object allocated at (most recent call last):
  File "<string>", lineno 1
  File "/home/sander/git/sab-25april2020/sabnzbd/utils/getperformance.py", lineno 25
    for myline in open("/proc/cpuinfo"):
Intel(R) Core(TM) i3-6006U CPU @ 2.00GHz
```