### PR TITLE
newsunpack -> run_simple(): solves ResourceWarning: unclosed file on Popen()

### DIFF
--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -2406,7 +2406,7 @@ class SevenZip:
 
 def run_simple(cmd):
     """ Run simple external command and return output """
-    p = Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    txt = platform_btou(p.stdout.read())
-    p.wait()
+    with Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as p:
+        txt = platform_btou(p.stdout.read())
+        p.wait()
     return txt


### PR DESCRIPTION
Solves this ResourceWarning: unclosed file on Popen():

```
$ python3 -X dev -X tracemalloc=5  -c "import sabnzbd.newsunpack; print(sabnzbd.newsunpack.run_simple('rar')[:100])"
<string>:1: ResourceWarning: unclosed file <_io.BufferedReader name=3>
Object allocated at (most recent call last):
  File "<string>", lineno 1
  File "/home/sander/git/sjo-sab-28april/sabnzbd/newsunpack.py", lineno 2409
    p = Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
  File "/usr/lib/python3.8/subprocess.py", lineno 844
    self.stdout = io.open(c2pread, 'rb', bufsize)
<string>:1: ResourceWarning: unclosed file <_io.BufferedReader name=5>
Object allocated at (most recent call last):
  File "<string>", lineno 1
  File "/home/sander/git/sjo-sab-28april/sabnzbd/newsunpack.py", lineno 2409
    p = Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
  File "/usr/lib/python3.8/subprocess.py", lineno 849
    self.stderr = io.open(errread, 'rb', bufsize)

RAR 5.50   Copyright (c) 1993-2017 Alexander Roshal   11 Aug 2017
Trial version             Type 'r
```

Clean & working after patch:

```
$ python3 -X dev -X tracemalloc=5  -c "import sabnzbd.newsunpack; print(sabnzbd.newsunpack.run_simple('rar')[:100])"

RAR 5.50   Copyright (c) 1993-2017 Alexander Roshal   11 Aug 2017
Trial version             Type 'r
```



```
$ python3 -X dev -X tracemalloc=5  -c "import sabnzbd.newsunpack; print(sabnzbd.newsunpack.unrar_check('rar')[:100])"
(550, True)
```


