### PR TITLE
checkdir -> isFAT(): solve ResourceWarning

### DIFF
--- a/sabnzbd/utils/checkdir.py
+++ b/sabnzbd/utils/checkdir.py
@@ -9,6 +9,11 @@ import os
 
 debug = False
 
+def getcmdoutput(cmd):
+    """ execectue cmd, and give back output lines as array """
+    with os.popen(cmd) as p:
+        outputlines = p.readlines()
+    return outputlines
 
 def isFAT(check_dir):
     """ Check if "check_dir" is on FAT. FAT considered harmful (for big files)
@@ -30,8 +35,8 @@ def isFAT(check_dir):
             /dev/sda1      vfat 488263616 163545248 324718368  34% /media/sander/INTENSO
             """
 
-            cmd = "df -T " + check_dir + " 2>&1"
-            for thisline in os.popen(cmd).readlines():
+            dfcmd = "df -T " + check_dir + " 2>&1"
+            for thisline in getcmdoutput(dfcmd):
                 if thisline.find("/") == 0:
                     # Starts with /, so a real, local device
                     fstype = thisline.split()[1]
@@ -74,7 +79,7 @@ def isFAT(check_dir):
 
             """
             dfcmd = "df " + check_dir
-            for thisline in os.popen(dfcmd).readlines():
+            for thisline in getcmdoutput(dfcmd):
                 if thisline.find("/") == 0:
                     if debug:
                         print(thisline)


### PR DESCRIPTION
Solves two ResourceWarnings:

```
$ python3 -X dev -X tracemalloc=5  -c "import sabnzbd.utils; print(sabnzbd.utils.checkdir.isFAT('/home/sander/'))"
/usr/lib/python3.8/subprocess.py:942: ResourceWarning: subprocess 19960 is still running
  _warn("subprocess %s is still running" % self.pid,
Object allocated at (most recent call last):
  File "<string>", lineno 1
  File "/home/sander/git/sjo-sab-28april---twee/sabnzbd/utils/checkdir.py", lineno 34
    for thisline in os.popen(cmd).readlines():
  File "/usr/lib/python3.8/os.py", lineno 983
    proc = subprocess.Popen(cmd,
/home/sander/git/sjo-sab-28april---twee/sabnzbd/utils/checkdir.py:34: ResourceWarning: unclosed file <_io.TextIOWrapper name=3 encoding='UTF-8'>
  for thisline in os.popen(cmd).readlines():
Object allocated at (most recent call last):
  File "<string>", lineno 1
  File "/home/sander/git/sjo-sab-28april---twee/sabnzbd/utils/checkdir.py", lineno 34
    for thisline in os.popen(cmd).readlines():
  File "/usr/lib/python3.8/os.py", lineno 987
    return _wrap_close(io.TextIOWrapper(proc.stdout), proc)
False
```

Clean after patch:

```
$ python3 -X dev -X tracemalloc=5  -c "import sabnzbd.utils; print(sabnzbd.utils.checkdir.isFAT('/home/sander/'))"
False
```
