### PR TITLE
use svg logo as icon for notify_osd

### DIFF
--- a/sabnzbd/notifier.py
+++ b/sabnzbd/notifier.py
@@ -167,7 +167,7 @@ def send_notify_osd(title, message):
         return T("Not available")  # : Function is not available on this OS
 
     error = "NotifyOSD not working"
-    icon = os.path.join(sabnzbd.DIR_PROG, "icons", "sabnzbd.ico")
+    icon = os.path.join(sabnzbd.DIR_PROG, "interfaces/Config/templates/staticcfg/images/logo-arrow.svg")
     _NTFOSD = _NTFOSD or notify2.init("icon-summary-body")
     if _NTFOSD:
         logging.info("Send to NotifyOSD: %s / %s", title, message)


### PR DESCRIPTION
the ico file it replaces appears distorted or corrupted in notifications on multiple desktop environments