### PR TITLE
directunpacker: process and filehandles are closed nicely

### DIFF
--- a/sabnzbd/directunpacker.py
+++ b/sabnzbd/directunpacker.py
@@ -78,6 +78,15 @@ class DirectUnpacker(threading.Thread):
         pass
 
     def reset_active(self):
+        # make sure the process and filehandles are closed nicely:
+        try:
+            # Creation was done via "self.active_instance = Popen()", so:
+            self.active_instance.stdout.close()
+            self.active_instance.stdin.close()
+            self.active_instance.wait(timeout=2)
+        except:
+            logging.debug("Exception in reset_active()")
+            pass
         self.active_instance = None
         self.cur_setname = None
         self.cur_volume = 0

--- a/sabnzbd/directunpacker.py
+++ b/sabnzbd/directunpacker.py
@@ -85,7 +85,7 @@ class DirectUnpacker(threading.Thread):
             self.active_instance.stdin.close()
             self.active_instance.wait(timeout=2)
         except:
-            logging.debug("Exception in reset_active()")
+            logging.debug("Exception in reset_active()", exc_info=True)
             pass
         self.active_instance = None
         self.cur_setname = None


### PR DESCRIPTION
Closes https://github.com/sabnzbd/sabnzbd/issues/1416
So solves ResourceWarning: subprocess still running Popen() & unclosed file when running with `python3 -X dev -X tracemalloc=5 ./SABnzbd.py`