### PR TITLE
check existence of XApp.StatusIcon class

### DIFF
--- a/sabnzbd/sabtraylinux.py
+++ b/sabnzbd/sabtraylinux.py
@@ -25,9 +25,11 @@ import logging
 try:
     gi.require_version('XApp', '1.0')
     from gi.repository import XApp
+    if not hasattr(XApp, 'StatusIcon'):
+        raise ImportError
     HAVE_XAPP = True
     logging.debug("XApp found: %s" % XApp)
-except:
+except Exception:
     HAVE_XAPP = False
     logging.debug("XApp not available, falling back to Gtk.StatusIcon")
 from time import sleep


### PR DESCRIPTION
For lack of a proper version check (they all identify as '1.0'), verify the relevant feature instead. Without this extra check, the fallback to Gtk.StatusIcon would not be triggered on systems with old versions of gir1.2-xapp-1.0 installed.