### PR TITLE
fix urllib deprecation warning, base64 encoding in _build_request()

### DIFF
--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -329,7 +329,11 @@ def _build_request(url):
     user_passwd = None
     u = urllib.parse.urlparse(url)
     if u.username or u.password:
-        user_passwd, host_port = u.netloc.split('@')
+        if u.username and u.password:
+            user_passwd = '%s:%s' % (u.username, u.password)
+        host_port = u.hostname
+        if u.port:
+            host_port += ':' + str(u.port)
         url = urllib.parse.urlunparse(
             urllib.parse.ParseResult(u.scheme, host_port, u.path, u.params, u.query, u.fragment)
         )


### PR DESCRIPTION
Removed the deprecation warning by using urllib.parse.urlparse() and tried to keep url handling the same as the old code.

Came across another bug while testing some urls: `str.encode("base64")` is py2-only and results in `LookupError: 'base64' is not a text encoding; use codecs.encode() to handle arbitrary codecs` with py3. Solution looks a bit ugly with the double string/bytes conversion but that seems unavoidable.

Closes #1415.