### PR TITLE
show active connections by default

### DIFF
--- a/interfaces/Glitter/templates/static/javascripts/glitter.main.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.main.js
@@ -19,7 +19,7 @@ function ViewModel() {
     self.confirmDeleteHistory = ko.observable(true).extend({ persist: 'confirmDeleteHistory' });
     self.extraQueueColumn = ko.observable('').extend({ persist: 'extraColumn' });
     self.extraHistoryColumn = ko.observable('').extend({ persist: 'extraHistoryColumn' });
-    self.showActiveConnections = ko.observable(false).extend({ persist: 'showActiveConnections' });
+    self.showActiveConnections = ko.observable(true).extend({ persist: 'showActiveConnections' });
     self.speedMetrics = { K: "KB/s", M: "MB/s", G: "GB/s" };
 
     // Set information varibales


### PR DESCRIPTION
Show active connections by default under in Glitter's _Status and interface options // Connections_. It seems to me that's the main reason anyone would take a look at that tab, yet the checkbox is unchecked by default.