### PR TITLE
set appname for notify2

### DIFF
--- a/sabnzbd/notifier.py
+++ b/sabnzbd/notifier.py
@@ -171,7 +171,7 @@ def send_notify_osd(title, message):
     # Wrap notify2.init to prevent blocking in dbus
     # when there's no active notification daemon
     try:
-        _NTFOSD = _NTFOSD or notify2.init("icon-summary-body")
+        _NTFOSD = _NTFOSD or notify2.init("SABnzbd")
     except:
         _NTFOSD = False
 


### PR DESCRIPTION
see the screenshot in https://github.com/sabnzbd/sabnzbd/issues/1570#issuecomment-673580276 ... this change makes the notification header say 'SABnzbd' instead.