### PR TITLE
Add typing hints to some SABnzbd-specific objects and general functions

### DIFF
--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1232,7 +1232,7 @@ def main():
     if autobrowser is not None:
         sabnzbd.cfg.autobrowser.set(autobrowser)
 
-    sabnzbd.initialize(pause, clean_up, evalSched=True, repair=repair)
+    sabnzbd.initialize(pause, clean_up, evaluate_schedules=True, repair=repair)
 
     os.chdir(sabnzbd.DIR_PROG)
 

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1529,7 +1529,7 @@ def main():
             # Shutdown
             sabnzbd.shutdown_program()
 
-            if sabnzbd.downloader.Downloader.do.paused:
+            if sabnzbd.Downloader.paused:
                 sabnzbd.RESTART_ARGS.append("-p")
             if autorestarted:
                 sabnzbd.RESTART_ARGS.append("--autorestarted")

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -31,6 +31,7 @@ import sys
 import re
 import ssl
 from threading import Lock, Thread
+from typing import Any
 
 ##############################################################################
 # Determine platform flags
@@ -975,7 +976,7 @@ def load_data(data_id, path, remove=True, do_pickle=True, silent=False):
     return data
 
 
-def remove_data(_id, path):
+def remove_data(_id: str, path: str):
     """ Remove admin file """
     path = os.path.join(path, _id)
     try:
@@ -985,13 +986,13 @@ def remove_data(_id, path):
         logging.debug("Failed to remove %s", path)
 
 
-def save_admin(data, data_id):
+def save_admin(data: Any, data_id: str):
     """ Save data in admin folder in specified format """
     logging.debug("[%s] Saving data for %s", misc.caller_name(), data_id)
     save_data(data, data_id, cfg.admin_dir.get_path())
 
 
-def load_admin(data_id, remove=False, silent=False):
+def load_admin(data_id: str, remove=False, silent=False) -> Any:
     """ Read data in admin folder in specified format """
     logging.debug("[%s] Loading data for %s", misc.caller_name(), data_id)
     return load_data(data_id, cfg.admin_dir.get_path(), remove=remove, silent=silent)

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1407,7 +1407,7 @@ def fast_queue():
     return paused, bytes_left, bpsnow, time_left
 
 
-def build_file_list(nzo_id):
+def build_file_list(nzo_id: str):
     """Build file lists for specified job"""
     jobs = []
     nzo = NzbQueue.do.get_nzo(nzo_id)

--- a/sabnzbd/articlecache.py
+++ b/sabnzbd/articlecache.py
@@ -22,6 +22,7 @@ sabnzbd.articlecache - Article cache handling
 import logging
 import threading
 import struct
+from typing import Dict
 
 import sabnzbd
 from sabnzbd.decorators import synchronized
@@ -39,7 +40,7 @@ class ArticleCache:
         self.__cache_limit_org = 0
         self.__cache_limit = 0
         self.__cache_size = 0
-        self.__article_table = {}  # Dict of buffered articles
+        self.__article_table: Dict[sabnzbd.nzbstuff.Article, bytes] = {}  # Dict of buffered articles
 
         # Limit for the decoder is based on the total available cache
         # so it can be larger on memory-rich systems

--- a/sabnzbd/articlecache.py
+++ b/sabnzbd/articlecache.py
@@ -52,8 +52,6 @@ class ArticleCache:
         if sabnzbd.DARWIN or sabnzbd.WIN64 or (struct.calcsize("P") * 8) == 64:
             self.__cache_upper_limit = 4 * GIGI
 
-        ArticleCache.do = self
-
     def cache_info(self):
         return ANFO(len(self.__article_table), abs(self.__cache_size), self.__cache_limit_org)
 
@@ -171,7 +169,3 @@ class ArticleCache:
         # Save data, but don't complain when destination folder is missing
         # because this flush may come after completion of the NZO.
         sabnzbd.save_data(data, article.get_art_id(), nzo.workpath, do_pickle=False, silent=True)
-
-
-# Create the instance
-ArticleCache()

--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -26,6 +26,7 @@ import re
 from threading import Thread
 from time import sleep
 import hashlib
+from typing import Tuple
 
 import sabnzbd
 from sabnzbd.misc import get_all_passwords
@@ -34,6 +35,7 @@ from sabnzbd.constants import Status, GIGI, MAX_ASSEMBLER_QUEUE
 import sabnzbd.cfg as cfg
 from sabnzbd.articlecache import ArticleCache
 from sabnzbd.postproc import PostProcessor
+from sabnzbd.nzbstuff import NzbObject, NzbFile
 import sabnzbd.downloader
 import sabnzbd.par2file as par2file
 import sabnzbd.utils.rarfile as rarfile
@@ -45,7 +47,7 @@ class Assembler(Thread):
 
     def __init__(self):
         Thread.__init__(self)
-        self.queue = queue.Queue()
+        self.queue: queue.Queue[Tuple[NzbObject, NzbFile, bool]] = queue.Queue()
         Assembler.do = self
 
     def stop(self):

--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -180,7 +180,7 @@ class Assembler(Thread):
                 sabnzbd.PostProcessor.process(nzo)
 
     @staticmethod
-    def assemble(nzf, file_done):
+    def assemble(nzf: NzbFile, file_done):
         """Assemble a NZF from its table of articles
         1) Partial write: write what we have
         2) Nothing written before: write all
@@ -224,7 +224,7 @@ class Assembler(Thread):
             nzf.md5sum = nzf.md5.digest()
 
 
-def file_has_articles(nzf):
+def file_has_articles(nzf: NzbFile):
     """Do a quick check to see if any articles are present for this file.
     Destructive: only to be used to differentiate between unknown encoding and no articles.
     """
@@ -241,7 +241,7 @@ RE_SUBS = re.compile(r"\W+sub|subs|subpack|subtitle|subtitles(?![a-z])", re.I)
 SAFE_EXTS = (".mkv", ".mp4", ".avi", ".wmv", ".mpg", ".webm")
 
 
-def is_cloaked(nzo, path, names):
+def is_cloaked(nzo: NzbObject, path, names):
     """ Return True if this is likely to be a cloaked encrypted post """
     fname = os.path.splitext(get_filename(path.lower()))[0]
     for name in names:
@@ -270,7 +270,7 @@ def is_cloaked(nzo, path, names):
     return False
 
 
-def check_encrypted_and_unwanted_files(nzo, filepath):
+def check_encrypted_and_unwanted_files(nzo: NzbObject, filepath):
     """ Combines check for unwanted and encrypted files to save on CPU and IO """
     encrypted = False
     unwanted = None

--- a/sabnzbd/bpsmeter.py
+++ b/sabnzbd/bpsmeter.py
@@ -118,7 +118,6 @@ class BPSMeter:
         self.q_hour = 0  # Quota reset hour
         self.q_minute = 0  # Quota reset minute
         self.quota_enabled = True  # Scheduled quota enable/disable
-        BPSMeter.do = self
 
     def save(self):
         """ Save admin to disk """
@@ -235,8 +234,8 @@ class BPSMeter:
             if self.have_quota and self.quota_enabled:
                 self.left -= amount
                 if self.left <= 0.0:
-                    if sabnzbd.downloader.Downloader.do and not sabnzbd.downloader.Downloader.do.paused:
-                        sabnzbd.downloader.Downloader.do.pause()
+                    if sabnzbd.Downloader.do and not sabnzbd.Downloader.paused:
+                        sabnzbd.Downloader.pause()
                         logging.warning(T("Quota spent, pausing downloading"))
 
         # Speedometer
@@ -355,8 +354,8 @@ class BPSMeter:
             logging.info("Quota was reset to %s", self.quota)
             if cfg.quota_resume():
                 logging.info("Auto-resume due to quota reset")
-                if sabnzbd.downloader.Downloader.do:
-                    sabnzbd.downloader.Downloader.do.resume()
+                if sabnzbd.Downloader.do:
+                    sabnzbd.Downloader.resume()
             self.next_reset()
             return False
         else:
@@ -464,8 +463,8 @@ class BPSMeter:
     @staticmethod
     def resume():
         """ Resume downloading """
-        if cfg.quota_resume() and sabnzbd.downloader.Downloader.do and sabnzbd.downloader.Downloader.do.paused:
-            sabnzbd.downloader.Downloader.do.resume()
+        if cfg.quota_resume() and sabnzbd.Downloader.paused:
+            sabnzbd.Downloader.resume()
 
     def midnight(self):
         """ Midnight action: dummy update for all servers """
@@ -476,12 +475,4 @@ class BPSMeter:
 def quota_handler():
     """ To be called from scheduler """
     logging.debug("Checking quota")
-    BPSMeter.do.reset_quota()
-
-
-def midnight_action():
-    if BPSMeter.do:
-        BPSMeter.do.midnight()
-
-
-BPSMeter()
+    sabnzbd.BPSMeter.reset_quota()

--- a/sabnzbd/config.py
+++ b/sabnzbd/config.py
@@ -25,6 +25,7 @@ import re
 import shutil
 import threading
 import uuid
+from typing import List, Dict, Union
 from urllib.parse import urlparse
 
 import configobj
@@ -912,7 +913,7 @@ def define_categories():
         pass
 
 
-def get_categories(cat=0):
+def get_categories() -> Dict[str, ConfigCat]:
     """Return link to categories section.
     This section will always contain special category '*'
     When 'cat' is given, a link to that category or to '*' is returned
@@ -933,15 +934,19 @@ def get_categories(cat=0):
 
         # Save config for future use
         save_config(True)
-    if not isinstance(cat, int):
-        try:
-            cats = cats[cat]
-        except KeyError:
-            cats = cats["*"]
     return cats
 
 
-def get_ordered_categories():
+def get_category(cat: str = "*") -> ConfigCat:
+    """Get one specific category or if not found the default one"""
+    cats = get_categories()
+    try:
+        return cats[cat]
+    except KeyError:
+        return cats["*"]
+
+
+def get_ordered_categories() -> List[Dict]:
     """Return list-copy of categories section that's ordered
     by user's ordering including Default-category
     """

--- a/sabnzbd/config.py
+++ b/sabnzbd/config.py
@@ -25,7 +25,7 @@ import re
 import shutil
 import threading
 import uuid
-from typing import List, Dict, Union
+from typing import List, Dict
 from urllib.parse import urlparse
 
 import configobj
@@ -39,7 +39,7 @@ CONFIG_LOCK = threading.Lock()
 SAVE_CONFIG_LOCK = threading.Lock()
 
 
-CFG = {}  # Holds INI structure
+CFG: configobj.ConfigObj  # Holds INI structure
 # during re-write this variable is global
 # to allow direct access to INI structure
 
@@ -1112,7 +1112,7 @@ def validate_safedir(root, value, default):
     """
     if sabnzbd.WIN32 and value and len(real_path(root, value)) >= MAX_WIN_DFOLDER:
         return T("Error: Path length should be below %s.") % MAX_WIN_DFOLDER, None
-    if sabnzbd.empty_queues():
+    if sabnzbd.__INITIALIZED__ and sabnzbd.PostProcessor.empty() and sabnzbd.NzbQueue.is_empty():
         return validate_no_unc(root, value, default)
     else:
         return T("Error: Queue not empty, cannot change folder."), None

--- a/sabnzbd/database.py
+++ b/sabnzbd/database.py
@@ -506,7 +506,7 @@ def build_history_info(nzo, workdir_complete="", postproc_time=0, script_output=
         nzo.status,
         nzo.nzo_id,
         clip_path(workdir_complete),
-        clip_path(nzo.downpath),
+        clip_path(nzo.download_path),
         script_output,
         script_line,
         download_time,

--- a/sabnzbd/decoder.py
+++ b/sabnzbd/decoder.py
@@ -23,12 +23,14 @@ import logging
 import hashlib
 import queue
 from threading import Thread
+from typing import Tuple, List
 
 import sabnzbd
 from sabnzbd.constants import SABYENC_VERSION_REQUIRED
 from sabnzbd.articlecache import ArticleCache
 from sabnzbd.downloader import Downloader
 from sabnzbd.nzbqueue import NzbQueue
+from sabnzbd.nzbstuff import Article
 import sabnzbd.cfg as cfg
 from sabnzbd.misc import match_str
 
@@ -116,7 +118,7 @@ class DecoderWorker(Thread):
         Thread.__init__(self)
         logging.debug("Initializing decoder %s", self.name)
 
-        self.decoder_queue = decoder_queue
+        self.decoder_queue: queue.Queue[Tuple[Article, List[bytes]]] = decoder_queue
 
     def stop(self):
         # Put multiple to stop all decoders

--- a/sabnzbd/decoder.py
+++ b/sabnzbd/decoder.py
@@ -26,9 +26,9 @@ from threading import Thread
 from typing import Tuple, List
 
 import sabnzbd
+import sabnzbd.cfg as cfg
 from sabnzbd.constants import SABYENC_VERSION_REQUIRED
 from sabnzbd.nzbstuff import Article
-import sabnzbd.cfg as cfg
 from sabnzbd.misc import match_str
 
 # Check for correct SABYenc version
@@ -97,7 +97,7 @@ class Decoder:
             except:
                 pass
 
-    def process(self, article, raw_data):
+    def process(self, article: Article, raw_data: List[bytes]):
         # We use reported article-size, just like sabyenc does
         sabnzbd.ArticleCache.reserve_space(article.bytes)
         self.decoder_queue.put((article, raw_data))
@@ -222,7 +222,7 @@ class DecoderWorker(Thread):
             sabnzbd.NzbQueue.register_article(article, article_success)
 
 
-def decode(article, raw_data):
+def decode(article: Article, raw_data: List[bytes]):
     # Let SABYenc do all the heavy lifting
     decoded_data, yenc_filename, crc, crc_expected, crc_correct = sabyenc3.decode_usenet_chunks(raw_data, article.bytes)
 
@@ -249,7 +249,7 @@ def decode(article, raw_data):
     return decoded_data
 
 
-def search_new_server(article):
+def search_new_server(article: Article):
     """ Shorthand for searching new server or else increasing bad_articles """
     # Continue to the next one if we found new server
     if not article.search_new_server():

--- a/sabnzbd/directunpacker.py
+++ b/sabnzbd/directunpacker.py
@@ -21,6 +21,7 @@ sabnzbd.directunpacker
 
 import os
 import re
+import subprocess
 import time
 import threading
 import logging
@@ -29,6 +30,7 @@ import sabnzbd
 import sabnzbd.cfg as cfg
 from sabnzbd.misc import int_conv, format_time_string, build_and_run_command
 from sabnzbd.filesystem import clip_path, long_path, remove_all, real_path, remove_file
+from sabnzbd.nzbstuff import NzbObject, NzbFile
 from sabnzbd.encoding import platform_btou
 from sabnzbd.decorators import synchronized
 from sabnzbd.newsunpack import EXTRACTFROM_RE, EXTRACTED_RE, rar_volumelist
@@ -49,13 +51,13 @@ class DirectUnpacker(threading.Thread):
     def __init__(self, nzo):
         threading.Thread.__init__(self)
 
-        self.nzo = nzo
-        self.active_instance = None
+        self.nzo: NzbObject = nzo
+        self.active_instance: subprocess.Popen = None
         self.killed = False
         self.next_file_lock = threading.Condition(threading.RLock())
 
         self.unpack_dir_info = None
-        self.rarfile_nzf = None
+        self.rarfile_nzf: NzbFile = None
         self.cur_setname = None
         self.cur_volume = 0
         self.total_volumes = {}

--- a/sabnzbd/dirscanner.py
+++ b/sabnzbd/dirscanner.py
@@ -89,7 +89,6 @@ class DirScanner(threading.Thread):
         self.trigger = False
         cfg.dirscan_dir.callback(self.newdir)
         cfg.dirscan_speed.callback(self.newspeed)
-        DirScanner.do = self
 
     def newdir(self):
         """ We're notified of a dir change """
@@ -213,9 +212,3 @@ class DirScanner(threading.Thread):
                     if os.path.isdir(dpath) and dd.lower() in cats:
                         run_dir(dpath, dd.lower())
             self.busy = False
-
-
-def dirscan():
-    """ Wrapper required for scheduler """
-    logging.info("Scheduled or manual watched folder scan")
-    DirScanner.do.scan()

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -27,6 +27,7 @@ from nntplib import NNTPPermanentError
 import socket
 import random
 import sys
+from typing import List, Dict
 
 import sabnzbd
 from sabnzbd.decorators import synchronized, NzbQueueLocker, DOWNLOADER_CV
@@ -202,8 +203,8 @@ class Downloader(Thread):
         self.read_fds = {}
         self.write_fds = {}
 
-        self.servers = []
-        self.server_dict = {}  # For faster lookups, but is not updated later!
+        self.servers: List[Server] = []
+        self.server_dict: Dict[str, Server] = {}  # For faster lookups, but is not updated later!
         self.server_nr = 0
         self._timers = {}
 

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -162,7 +162,7 @@ class Server:
         self.idle_threads = []
 
     def __repr__(self):
-        return "%s:%s" % (self.host, self.port)
+        return "<%s:%s>" % (self.host, self.port)
 
 
 class Downloader(Thread):
@@ -199,8 +199,8 @@ class Downloader(Thread):
 
         self.force_disconnect = False
 
-        self.read_fds = {}
-        self.write_fds = {}
+        self.read_fds: Dict[int, NewsWrapper] = {}
+        self.write_fds: Dict[int, NewsWrapper] = {}
 
         self.servers: List[Server] = []
         self.server_dict: Dict[str, Server] = {}  # For faster lookups, but is not updated later!
@@ -271,8 +271,6 @@ class Downloader(Thread):
 
         # Update server-count
         self.server_nr = len(self.servers)
-
-        return
 
     @NzbQueueLocker
     def set_paused_state(self, state):
@@ -360,7 +358,7 @@ class Downloader(Thread):
             else:
                 return True
 
-    def highest_server(self, me):
+    def highest_server(self, me: Server):
         """Return True when this server has the highest priority of the active ones
         0 is the highest priority
         """
@@ -829,7 +827,7 @@ class Downloader(Thread):
         # Empty SSL info, it might change on next connect
         server.ssl_info = ""
 
-    def __request_article(self, nw):
+    def __request_article(self, nw: NewsWrapper):
         try:
             nzo = nw.article.nzf.nzo
             if nw.server.send_group and nzo.group != nw.group:

--- a/sabnzbd/encoding.py
+++ b/sabnzbd/encoding.py
@@ -22,26 +22,27 @@ sabnzbd.encoding - Unicode/byte translation functions
 import locale
 import chardet
 from xml.sax.saxutils import escape
+from typing import Union
 
 
 CODEPAGE = locale.getpreferredencoding()
 
 
-def utob(str_in):
+def utob(str_in: Union[str, bytes]) -> bytes:
     """ Shorthand for converting UTF-8 to bytes """
     if isinstance(str_in, bytes):
         return str_in
     return str_in.encode("utf-8")
 
 
-def ubtou(str_in):
+def ubtou(str_in: Union[str, bytes]) -> str:
     """ Shorthand for converting unicode bytes to UTF-8 """
     if not isinstance(str_in, bytes):
         return str_in
     return str_in.decode("utf-8")
 
 
-def platform_btou(str_in):
+def platform_btou(str_in: Union[str, bytes]) -> str:
     """Return Unicode, if not already Unicode, decode with locale encoding.
     NOTE: Used for POpen because universal_newlines/text parameter doesn't
     always work! We cannot use encoding-parameter because it's Python 3.7+
@@ -55,7 +56,7 @@ def platform_btou(str_in):
         return str_in
 
 
-def correct_unknown_encoding(str_or_bytes_in):
+def correct_unknown_encoding(str_or_bytes_in: Union[str, bytes]) -> str:
     """Files created on Windows but unpacked/repaired on
     linux can result in invalid filenames. Try to fix this
     encoding by going to bytes and then back to unicode again.

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -29,6 +29,7 @@ import time
 import fnmatch
 import stat
 import zipfile
+from typing import Union, List, Tuple, Any, Dict
 
 import sabnzbd
 from sabnzbd.decorators import synchronized
@@ -37,7 +38,7 @@ from sabnzbd.encoding import correct_unknown_encoding
 from sabnzbd.utils import rarfile
 
 
-def get_ext(filename):
+def get_ext(filename: str) -> str:
     """ Return lowercased file extension """
     try:
         return os.path.splitext(filename)[1].lower()
@@ -45,7 +46,7 @@ def get_ext(filename):
         return ""
 
 
-def get_filename(path):
+def get_filename(path: str) -> str:
     """ Return path without the file extension """
     try:
         return os.path.split(path)[1]
@@ -53,12 +54,12 @@ def get_filename(path):
         return ""
 
 
-def setname_from_path(path):
+def setname_from_path(path: str) -> str:
     """ Get the setname from a path """
     return os.path.splitext(os.path.basename(path))[0]
 
 
-def is_writable(path):
+def is_writable(path: str) -> bool:
     """ Return True is file is writable (also when non-existent) """
     if os.path.isfile(path):
         return bool(os.stat(path).st_mode & stat.S_IWUSR)
@@ -92,7 +93,7 @@ _DEVICES = (
 )
 
 
-def replace_win_devices(name):
+def replace_win_devices(name: str) -> str:
     """Remove reserved Windows device names from a name.
     aux.txt ==> _aux.txt
     txt.aux ==> txt.aux
@@ -111,13 +112,13 @@ def replace_win_devices(name):
     return name
 
 
-def has_win_device(p):
+def has_win_device(filename: str) -> bool:
     """Return True if filename part contains forbidden name
     Before and after sanitizing
     """
-    p = os.path.split(p)[1].lower()
+    filename = os.path.split(filename)[1].lower()
     for dev in _DEVICES:
-        if p == dev or p.startswith(dev + ".") or p.startswith("_" + dev + "."):
+        if filename == dev or filename.startswith(dev + ".") or filename.startswith("_" + dev + "."):
             return True
     return False
 
@@ -128,7 +129,7 @@ CH_ILLEGAL_WIN = '\\/<>?*|"\t:'
 CH_LEGAL_WIN = "++{}!@#'+-"
 
 
-def sanitize_filename(name):
+def sanitize_filename(name: str) -> str:
     """Return filename with illegal chars converted to legal ones
     and with the par2 extension always in lowercase
     """
@@ -167,7 +168,7 @@ def sanitize_filename(name):
     return name + ext
 
 
-def sanitize_foldername(name):
+def sanitize_foldername(name: str) -> str:
     """Return foldername with dodgy chars converted to safe ones
     Remove any leading and trailing dot and space characters
     """
@@ -209,7 +210,7 @@ def sanitize_foldername(name):
     return name
 
 
-def sanitize_and_trim_path(path):
+def sanitize_and_trim_path(path: str) -> str:
     """ Remove illegal characters and trim element size """
     path = path.strip()
     new_path = ""
@@ -252,14 +253,14 @@ def sanitize_files_in_folder(folder):
     return lst
 
 
-def is_obfuscated_filename(filename):
+def is_obfuscated_filename(filename: str) -> bool:
     """Check if this file has an extension, if not, it's
     probably obfuscated and we don't use it
     """
     return len(get_ext(filename)) < 2
 
 
-def real_path(loc, path):
+def real_path(loc: str, path: str) -> str:
     """When 'path' is relative, return normalized join of 'loc' and 'path'
     When 'path' is absolute, return normalized path
     A path starting with ~ will be located in the user's Home folder
@@ -296,7 +297,9 @@ def real_path(loc, path):
     return long_path(os.path.normpath(os.path.abspath(path)))
 
 
-def create_real_path(name, loc, path, umask=False, writable=True):
+def create_real_path(
+    name: str, loc: str, path: str, umask: bool = False, writable: bool = True
+) -> Tuple[bool, str, Union[str, None]]:
     """When 'path' is relative, create join of 'loc' and 'path'
     When 'path' is absolute, create normalized path
     'name' is used for logging.
@@ -324,7 +327,7 @@ def create_real_path(name, loc, path, umask=False, writable=True):
         return False, path, None
 
 
-def same_file(a, b):
+def same_file(a: str, b: str) -> int:
     """Return 0 if A and B have nothing in common
     return 1 if A and B are actually the same path
     return 2 if B is a subfolder of A
@@ -353,7 +356,7 @@ def same_file(a, b):
             return is_subfolder
 
 
-def is_archive(path):
+def is_archive(path: str) -> Tuple[int, Any, str]:
     """Check if file in path is an ZIP, RAR or 7z file
     :param path: path to file
     :return: (zf, status, expected_extension)
@@ -387,7 +390,7 @@ def is_archive(path):
         return 1, None, ""
 
 
-def check_mount(path):
+def check_mount(path: str) -> bool:
     """Return False if volume isn't mounted on Linux or macOS
     Retry 6 times with an interval of 1 sec.
     """
@@ -407,7 +410,7 @@ def check_mount(path):
     return not m
 
 
-def safe_fnmatch(f, pattern):
+def safe_fnmatch(f: str, pattern: str) -> bool:
     """fnmatch will fail if the pattern contains any of it's
     key characters, like [, ] or !.
     """
@@ -417,7 +420,7 @@ def safe_fnmatch(f, pattern):
         return False
 
 
-def globber(path, pattern="*"):
+def globber(path: str, pattern: str = "*") -> List[str]:
     """ Return matching base file/folder names in folder `path` """
     # Cannot use glob.glob() because it doesn't support Windows long name notation
     if os.path.exists(path):
@@ -425,7 +428,7 @@ def globber(path, pattern="*"):
     return []
 
 
-def globber_full(path, pattern="*"):
+def globber_full(path: str, pattern: str = "*") -> List[str]:
     """ Return matching full file/folder names in folder `path` """
     # Cannot use glob.glob() because it doesn't support Windows long name notation
     if os.path.exists(path):
@@ -433,7 +436,7 @@ def globber_full(path, pattern="*"):
     return []
 
 
-def trim_win_path(path):
+def trim_win_path(path: str) -> str:
     """ Make sure Windows path stays below 70 by trimming last part """
     if sabnzbd.WIN32 and len(path) > 69:
         path, folder = os.path.split(path)
@@ -444,7 +447,7 @@ def trim_win_path(path):
     return path
 
 
-def fix_unix_encoding(folder):
+def fix_unix_encoding(folder: str):
     """Fix bad name encoding for Unix systems
     This happens for example when files are created
     on Windows but unpacked/repaired on linux
@@ -460,7 +463,7 @@ def fix_unix_encoding(folder):
                         logging.info("Cannot correct name of %s", os.path.join(root, name))
 
 
-def make_script_path(script):
+def make_script_path(script: str) -> Union[str, None]:
     """ Return full script path, if any valid script exists, else None """
     script_path = None
     script_dir = sabnzbd.cfg.script_dir.get_path()
@@ -475,7 +478,7 @@ def make_script_path(script):
     return script_path
 
 
-def get_admin_path(name, future):
+def get_admin_path(name: str, future: bool):
     """Return news-style full path to job-admin folder of names job
     or else the old cache path
     """
@@ -485,7 +488,7 @@ def get_admin_path(name, future):
         return os.path.join(os.path.join(sabnzbd.cfg.download_dir.get_path(), name), JOB_ADMIN)
 
 
-def set_chmod(path, permissions, report):
+def set_chmod(path: str, permissions: int, report: bool):
     """ Set 'permissions' on 'path', report any errors when 'report' is True """
     try:
         logging.debug("Applying permissions %s (octal) to %s", oct(permissions), path)
@@ -497,7 +500,7 @@ def set_chmod(path, permissions, report):
             logging.info("Traceback: ", exc_info=True)
 
 
-def set_permissions(path, recursive=True):
+def set_permissions(path: str, recursive: bool = True):
     """ Give folder tree and its files their proper permissions """
     if not sabnzbd.WIN32:
         umask = sabnzbd.cfg.umask()
@@ -528,7 +531,7 @@ def set_permissions(path, recursive=True):
             set_chmod(path, umask_file, report)
 
 
-def userxbit(filename):
+def userxbit(filename: str) -> bool:
     """Returns boolean if the x-bit for user is set on the given file.
     This is a workaround: os.access(filename, os.X_OK) does not work
     on certain mounted file systems. Does not work at all on Windows.
@@ -542,14 +545,14 @@ def userxbit(filename):
     return xbitset
 
 
-def clip_path(path):
+def clip_path(path: str) -> str:
     r""" Remove \\?\ or \\?\UNC\ prefix from Windows path """
     if sabnzbd.WIN32 and path and "?" in path:
         path = path.replace("\\\\?\\UNC\\", "\\\\", 1).replace("\\\\?\\", "", 1)
     return path
 
 
-def long_path(path):
+def long_path(path: str) -> str:
     """ For Windows, convert to long style path; others, return same path """
     if sabnzbd.WIN32 and path and not path.startswith("\\\\?\\"):
         if path.startswith("\\\\"):
@@ -568,7 +571,7 @@ DIR_LOCK = threading.RLock()
 
 
 @synchronized(DIR_LOCK)
-def create_all_dirs(path, apply_umask=False):
+def create_all_dirs(path: str, apply_umask: bool = False) -> Union[str, bool]:
     """Create all required path elements and set umask on all
     The umask argument is ignored on Windows
     Return path if elements could be made or exists
@@ -606,7 +609,7 @@ def create_all_dirs(path, apply_umask=False):
 
 
 @synchronized(DIR_LOCK)
-def get_unique_path(dirpath, n=0, create_dir=True):
+def get_unique_path(dirpath: str, n: int = 0, create_dir: bool = True) -> str:
     """ Determine a unique folder or filename """
 
     if not check_mount(dirpath):
@@ -626,7 +629,7 @@ def get_unique_path(dirpath, n=0, create_dir=True):
 
 
 @synchronized(DIR_LOCK)
-def get_unique_filename(path):
+def get_unique_filename(path: str) -> str:
     """Check if path is unique.
     If not, add number like: "/path/name.NUM.ext".
     """
@@ -641,7 +644,7 @@ def get_unique_filename(path):
 
 
 @synchronized(DIR_LOCK)
-def listdir_full(input_dir, recursive=True):
+def listdir_full(input_dir: str, recursive: bool = True) -> List[str]:
     """ List all files in dirs and sub-dirs """
     filelist = []
     for root, dirs, files in os.walk(input_dir):
@@ -655,7 +658,7 @@ def listdir_full(input_dir, recursive=True):
 
 
 @synchronized(DIR_LOCK)
-def move_to_path(path, new_path):
+def move_to_path(path: str, new_path: str) -> Tuple[bool, Union[str, None]]:
     """Move a file to a new path, optionally give unique filename
     Return (ok, new_path)
     """
@@ -695,7 +698,7 @@ def move_to_path(path, new_path):
 
 
 @synchronized(DIR_LOCK)
-def cleanup_empty_directories(path):
+def cleanup_empty_directories(path: str):
     """ Remove all empty folders inside (and including) 'path' """
     path = os.path.normpath(path)
     while 1:
@@ -719,7 +722,7 @@ def cleanup_empty_directories(path):
 
 
 @synchronized(DIR_LOCK)
-def get_filepath(path, nzo, filename):
+def get_filepath(path: str, nzo, filename: str):
     """ Create unique filepath """
     # This procedure is only used by the Assembler thread
     # It does no umask setting
@@ -756,7 +759,7 @@ def get_filepath(path, nzo, filename):
 
 
 @synchronized(DIR_LOCK)
-def renamer(old, new):
+def renamer(old: str, new: str):
     """ Rename file/folder with retries for Win32 """
     # Sanitize last part of new name
     path, name = os.path.split(new)
@@ -799,14 +802,14 @@ def renamer(old, new):
         shutil.move(old, new)
 
 
-def remove_file(path):
+def remove_file(path: str):
     """ Wrapper function so any file removal is logged """
     logging.debug("[%s] Deleting file %s", sabnzbd.misc.caller_name(), path)
     os.remove(path)
 
 
 @synchronized(DIR_LOCK)
-def remove_dir(path):
+def remove_dir(path: str):
     """ Remove directory with retries for Win32 """
     logging.debug("[%s] Removing dir %s", sabnzbd.misc.caller_name(), path)
     if sabnzbd.WIN32:
@@ -829,7 +832,7 @@ def remove_dir(path):
 
 
 @synchronized(DIR_LOCK)
-def remove_all(path, pattern="*", keep_folder=False, recursive=False):
+def remove_all(path: str, pattern: str = "*", keep_folder: bool = False, recursive: bool = False):
     """ Remove folder and all its content (optionally recursive) """
     if path and os.path.exists(path):
         # Fast-remove the whole tree if recursive
@@ -863,7 +866,7 @@ def remove_all(path, pattern="*", keep_folder=False, recursive=False):
 ##############################################################################
 # Diskfree
 ##############################################################################
-def find_dir(p):
+def find_dir(p: str) -> str:
     """ Return first folder level that exists in this path """
     x = "x"
     while x and not os.path.exists(p):
@@ -879,7 +882,7 @@ if sabnzbd.WIN32:
     except:
         pass
 
-    def diskspace_base(_dir):
+    def diskspace_base(_dir: str) -> Tuple[float, float]:
         """ Return amount of free and used diskspace in GBytes """
         _dir = find_dir(_dir)
         try:
@@ -893,7 +896,7 @@ else:
     try:
         os.statvfs
         # posix diskfree
-        def diskspace_base(_dir):
+        def diskspace_base(_dir: str) -> Tuple[float, float]:
             """ Return amount of free and used diskspace in GBytes """
             _dir = find_dir(_dir)
             try:
@@ -912,18 +915,18 @@ else:
 
     except ImportError:
 
-        def diskspace_base(_dir):
+        def diskspace_base(_dir: str) -> Tuple[float, float]:
             return 20.0, 10.0
 
 
 # Store all results to speed things up
 __DIRS_CHECKED = []
 __DISKS_SAME = None
-__LAST_DISK_RESULT = {"download_dir": [], "complete_dir": []}
+__LAST_DISK_RESULT = {"download_dir": (0.0, 0.0), "complete_dir": (0.0, 0.0)}
 __LAST_DISK_CALL = 0
 
 
-def diskspace(force=False):
+def diskspace(force: bool = False) -> Dict[str, Tuple[float, float]]:
     """ Wrapper to cache results """
     global __DIRS_CHECKED, __DISKS_SAME, __LAST_DISK_RESULT, __LAST_DISK_CALL
 

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -29,7 +29,7 @@ import time
 import fnmatch
 import stat
 import zipfile
-from typing import Union, List, Tuple, Any, Dict
+from typing import Union, List, Tuple, Any, Dict, Optional
 
 import sabnzbd
 from sabnzbd.decorators import synchronized
@@ -299,7 +299,7 @@ def real_path(loc: str, path: str) -> str:
 
 def create_real_path(
     name: str, loc: str, path: str, umask: bool = False, writable: bool = True
-) -> Tuple[bool, str, Union[str, None]]:
+) -> Tuple[bool, str, Optional[str]]:
     """When 'path' is relative, create join of 'loc' and 'path'
     When 'path' is absolute, create normalized path
     'name' is used for logging.
@@ -463,7 +463,7 @@ def fix_unix_encoding(folder: str):
                         logging.info("Cannot correct name of %s", os.path.join(root, name))
 
 
-def make_script_path(script: str) -> Union[str, None]:
+def make_script_path(script: str) -> Optional[str]:
     """ Return full script path, if any valid script exists, else None """
     script_path = None
     script_dir = sabnzbd.cfg.script_dir.get_path()
@@ -658,7 +658,7 @@ def listdir_full(input_dir: str, recursive: bool = True) -> List[str]:
 
 
 @synchronized(DIR_LOCK)
-def move_to_path(path: str, new_path: str) -> Tuple[bool, Union[str, None]]:
+def move_to_path(path: str, new_path: str) -> Tuple[bool, Optional[str]]:
     """Move a file to a new path, optionally give unique filename
     Return (ok, new_path)
     """

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -30,7 +30,7 @@ import time
 import datetime
 import inspect
 import ctypes
-from typing import Union, Tuple, Any
+from typing import Union, Tuple, Any, Optional
 
 import sabnzbd
 from sabnzbd.constants import DEFAULT_PRIORITY, MEBI, DEF_ARTICLE_CACHE_DEFAULT, DEF_ARTICLE_CACHE_MAX
@@ -343,7 +343,7 @@ def set_serv_parms(service, args):
     return True
 
 
-def get_from_url(url: str) -> Union[str, None]:
+def get_from_url(url: str) -> Optional[str]:
     """ Retrieve URL and return content """
     try:
         req = urllib.request.Request(url)

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -283,7 +283,7 @@ class NewsWrapper:
     )
 
     def __init__(self, server, thrdnum, block=False):
-        self.server = server
+        self.server: sabnzbd.downloader.Server = server
         self.thrdnum = thrdnum
         self.blocking = block
 
@@ -292,7 +292,7 @@ class NewsWrapper:
         self.data = []
         self.last_line = ""
 
-        self.nntp = None
+        self.nntp: NNTP = None
         self.recv = None
 
         self.connected = False

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -50,7 +50,7 @@ def _retrieve_info(server):
     else:
         server.bad_cons = 0
     (server.info, server.request) = (info, False)
-    sabnzbd.downloader.Downloader.do.wakeup()
+    sabnzbd.Downloader.wakeup()
 
 
 def request_server_info(server):

--- a/sabnzbd/nzbparser.py
+++ b/sabnzbd/nzbparser.py
@@ -234,10 +234,10 @@ def process_nzb_archive_file(
                     if nzo:
                         if nzo_id:
                             # Re-use existing nzo_id, when a "future" job gets it payload
-                            sabnzbd.nzbqueue.NzbQueue.do.remove(nzo_id, add_to_history=False, delete_all_data=False)
+                            sabnzbd.NzbQueue.remove(nzo_id, add_to_history=False, delete_all_data=False)
                             nzo.nzo_id = nzo_id
                             nzo_id = None
-                        nzo_ids.append(sabnzbd.nzbqueue.NzbQueue.do.add(nzo))
+                        nzo_ids.append(sabnzbd.NzbQueue.add(nzo))
                         nzo.update_rating()
         zf.close()
         try:
@@ -329,7 +329,7 @@ def process_single_nzb(
     except TypeError:
         # Duplicate, ignore
         if nzo_id:
-            sabnzbd.nzbqueue.NzbQueue.do.remove(nzo_id, add_to_history=False)
+            sabnzbd.NzbQueue.remove(nzo_id, add_to_history=False)
         nzo = None
     except ValueError:
         # Empty
@@ -346,9 +346,9 @@ def process_single_nzb(
     if nzo:
         if nzo_id:
             # Re-use existing nzo_id, when a "future" job gets it payload
-            sabnzbd.nzbqueue.NzbQueue.do.remove(nzo_id, add_to_history=False, delete_all_data=False)
+            sabnzbd.NzbQueue.remove(nzo_id, add_to_history=False, delete_all_data=False)
             nzo.nzo_id = nzo_id
-        nzo_ids.append(sabnzbd.nzbqueue.NzbQueue.do.add(nzo, quiet=reuse))
+        nzo_ids.append(sabnzbd.NzbQueue.add(nzo, quiet=reuse))
         nzo.update_rating()
 
     try:

--- a/sabnzbd/nzbparser.py
+++ b/sabnzbd/nzbparser.py
@@ -139,7 +139,7 @@ def nzbfile_parser(raw_data, nzo):
         else:
             logging.info("Error importing %s, skipping", file_name)
             if nzf.nzf_id:
-                sabnzbd.remove_data(nzf.nzf_id, nzo.workpath)
+                sabnzbd.remove_data(nzf.nzf_id, nzo.admin_path)
             skipped_files += 1
 
     # Final bookkeeping

--- a/sabnzbd/par2file.py
+++ b/sabnzbd/par2file.py
@@ -23,6 +23,7 @@ import logging
 import os
 import re
 import struct
+from typing import Dict, Optional, Tuple
 
 from sabnzbd.encoding import correct_unknown_encoding
 
@@ -82,7 +83,7 @@ def analyse_par2(name, filepath=None):
     return setname, vol, block
 
 
-def parse_par2_file(fname, md5of16k):
+def parse_par2_file(fname: str, md5of16k: Dict[bytes, str]) -> Dict[str, bytes]:
     """Get the hash table and the first-16k hash table from a PAR2 file
     Return as dictionary, indexed on names or hashes for the first-16 table
     The input md5of16k is modified in place and thus not returned!
@@ -128,7 +129,7 @@ def parse_par2_file(fname, md5of16k):
     return table
 
 
-def parse_par2_file_packet(f, header):
+def parse_par2_file_packet(f, header) -> Tuple[Optional[str], Optional[bytes], Optional[bytes]]:
     """ Look up and analyze a FileDesc package """
 
     nothing = None, None, None

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -21,12 +21,13 @@ sabnzbd.postproc - threaded post-processing of jobs
 
 import os
 import logging
-import sabnzbd
 import functools
 import time
 import re
 import queue
+from typing import List
 
+import sabnzbd
 from sabnzbd.newsunpack import (
     unpack_magic,
     par2_repair,
@@ -105,16 +106,14 @@ class PostProcessor(Thread):
         Thread.__init__(self)
 
         # This history queue is simply used to log what active items to display in the web_ui
+        self.history_queue: List[sabnzbd.nzbstuff.NzbObject] = []
         self.load()
 
-        if self.history_queue is None:
-            self.history_queue = []
-
         # Fast-queue for jobs already finished by DirectUnpack
-        self.fast_queue = queue.Queue()
+        self.fast_queue: queue.Queue[sabnzbd.nzbstuff.NzbObject] = queue.Queue()
 
         # Regular queue for jobs that might need more attention
-        self.slow_queue = queue.Queue()
+        self.slow_queue: queue.Queue[sabnzbd.nzbstuff.NzbObject] = queue.Queue()
 
         # Load all old jobs
         for nzo in self.history_queue:
@@ -136,7 +135,6 @@ class PostProcessor(Thread):
 
     def load(self):
         """ Save postproc queue """
-        self.history_queue = []
         logging.info("Loading postproc queue")
         data = sabnzbd.load_admin(POSTPROC_QUEUE_FILE_NAME)
         if data is None:
@@ -674,7 +672,7 @@ def prepare_extraction_path(nzo):
     one_folder = False
     marker_file = None
     # Determine class directory
-    catdir = config.get_categories(nzo.cat).dir()
+    catdir = config.get_category(nzo.cat).dir()
     if catdir.endswith("*"):
         catdir = catdir.strip("*")
         one_folder = True

--- a/sabnzbd/rating.py
+++ b/sabnzbd/rating.py
@@ -113,7 +113,6 @@ class Rating(Thread):
     do = None
 
     def __init__(self):
-        Rating.do = self
         self.shutdown = False
         self.queue = OrderedSetQueue()
         try:

--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -232,7 +232,6 @@ class RSSQueue:
 
         uris = feeds.uri()
         defCat = feeds.cat()
-        import sabnzbd.api
 
         if not notdefault(defCat) or defCat not in sabnzbd.api.list_cats(default=False):
             defCat = None

--- a/sabnzbd/sabtray.py
+++ b/sabnzbd/sabtray.py
@@ -27,7 +27,6 @@ import sabnzbd
 from sabnzbd.panic import launch_a_browser
 import sabnzbd.api as api
 import sabnzbd.scheduler as scheduler
-from sabnzbd.downloader import Downloader
 import sabnzbd.cfg as cfg
 from sabnzbd.misc import to_units
 
@@ -194,7 +193,7 @@ class SABTrayThread(SysTrayIconThread):
 
     def pause(self):
         scheduler.plan_resume(0)
-        Downloader.do.pause()
+        sabnzbd.Downloader.pause()
 
     def resume(self):
         scheduler.plan_resume(0)

--- a/sabnzbd/sabtraylinux.py
+++ b/sabnzbd/sabtraylinux.py
@@ -43,7 +43,6 @@ import sabnzbd
 from sabnzbd.panic import launch_a_browser
 import sabnzbd.api as api
 import sabnzbd.scheduler as scheduler
-from sabnzbd.downloader import Downloader
 import sabnzbd.cfg as cfg
 from sabnzbd.misc import to_units
 
@@ -196,7 +195,7 @@ class StatusIcon(Thread):
 
     def pause(self):
         scheduler.plan_resume(0)
-        Downloader.do.pause()
+        sabnzbd.Downloader.pause()
 
     def resume(self):
         scheduler.plan_resume(0)

--- a/sabnzbd/sorting.py
+++ b/sabnzbd/sorting.py
@@ -39,6 +39,7 @@ from sabnzbd.filesystem import (
 )
 from sabnzbd.constants import series_match, date_match, year_match, sample_match
 import sabnzbd.cfg as cfg
+from sabnzbd.nzbstuff import NzbObject
 
 RE_SAMPLE = re.compile(sample_match, re.I)
 # Do not rename .vob files as they are usually DVD's
@@ -147,7 +148,7 @@ def move_to_parent_folder(workdir):
 class Sorter:
     """ Generic Sorter class """
 
-    def __init__(self, nzo, cat):
+    def __init__(self, nzo: NzbObject, cat):
         self.sorter = None
         self.type = None
         self.sort_file = False
@@ -231,7 +232,7 @@ class Sorter:
 class SeriesSorter:
     """ Methods for Series Sorting """
 
-    def __init__(self, nzo, job_name, path, cat):
+    def __init__(self, nzo: NzbObject, job_name, path, cat):
         self.matched = False
 
         self.original_job_name = job_name
@@ -570,7 +571,7 @@ def check_for_sequence(regex, files):
 class MovieSorter:
     """ Methods for Generic Sorting """
 
-    def __init__(self, nzo, job_name, path, cat):
+    def __init__(self, nzo: NzbObject, job_name, path, cat):
         self.matched = False
 
         self.original_job_name = job_name
@@ -784,7 +785,7 @@ class MovieSorter:
 class DateSorter:
     """ Methods for Date Sorting """
 
-    def __init__(self, nzo, job_name, path, cat):
+    def __init__(self, nzo: NzbObject, job_name, path, cat):
         self.matched = False
 
         self.original_job_name = job_name
@@ -1001,7 +1002,7 @@ def path_subst(path, mapping):
     return "".join(newpath)
 
 
-def get_titles(nzo, match, name, titleing=False):
+def get_titles(nzo: NzbObject, match, name, titleing=False):
     """The title will be the part before the match
     Clean it up and title() it
 
@@ -1082,12 +1083,12 @@ def replace_word(word_input, one, two):
     regex = re.compile(r"\W(%s)(\W|$)" % one, re.I)
     matches = regex.findall(word_input)
     if matches:
-        for unused in matches:
+        for _ in matches:
             word_input = word_input.replace(one, two)
     return word_input
 
 
-def get_descriptions(nzo, match, name):
+def get_descriptions(nzo: NzbObject, match, name):
     """If present, get a description from the nzb name.
     A description has to be after the matched item, separated either
     like ' - Description' or '_-_Description'

--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -30,6 +30,7 @@ import urllib.parse
 from http.client import IncompleteRead
 from threading import Thread
 import base64
+from typing import Tuple
 
 import sabnzbd
 from sabnzbd.constants import DEF_TIMEOUT, FUTURE_Q_FOLDER, VALID_NZB_FILES, Status, VALID_ARCHIVES
@@ -65,7 +66,7 @@ class URLGrabber(Thread):
 
     def __init__(self):
         Thread.__init__(self)
-        self.queue = queue.Queue()
+        self.queue: queue.Queue[Tuple[str, sabnzbd.nzbstuff.NzbObject]] = queue.Queue()
         for tup in NzbQueue.do.get_urls():
             url, nzo = tup
             self.queue.put((url, nzo))

--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -40,7 +40,7 @@ import sabnzbd.cfg as cfg
 import sabnzbd.emailer as emailer
 import sabnzbd.notifier as notifier
 from sabnzbd.encoding import ubtou, utob
-
+from sabnzbd.nzbstuff import NzbObject
 
 _RARTING_FIELDS = (
     "x-rating-id",
@@ -64,13 +64,13 @@ class URLGrabber(Thread):
 
     def __init__(self):
         Thread.__init__(self)
-        self.queue: queue.Queue[Tuple[str, sabnzbd.nzbstuff.NzbObject]] = queue.Queue()
+        self.queue: queue.Queue[Tuple[str, NzbObject]] = queue.Queue()
         for tup in sabnzbd.NzbQueue.get_urls():
             url, nzo = tup
             self.queue.put((url, nzo))
         self.shutdown = False
 
-    def add(self, url, future_nzo, when=None):
+    def add(self, url, future_nzo: NzbObject, when=None):
         """ Add an URL to the URLGrabber queue, 'when' is seconds from now """
         if future_nzo and when:
             # Always increase counter
@@ -298,7 +298,7 @@ class URLGrabber(Thread):
                 logging.debug("URLGRABBER Traceback: ", exc_info=True)
 
     @staticmethod
-    def fail_to_history(nzo, url, msg="", content=False):
+    def fail_to_history(nzo: NzbObject, url, msg="", content=False):
         """Create History entry for failed URL Fetch
         msg: message to be logged
         content: report in history that cause is a bad NZB file

--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -36,8 +36,6 @@ import sabnzbd
 from sabnzbd.constants import DEF_TIMEOUT, FUTURE_Q_FOLDER, VALID_NZB_FILES, Status, VALID_ARCHIVES
 import sabnzbd.misc as misc
 import sabnzbd.filesystem
-from sabnzbd.nzbqueue import NzbQueue
-from sabnzbd.postproc import PostProcessor
 import sabnzbd.cfg as cfg
 import sabnzbd.emailer as emailer
 import sabnzbd.notifier as notifier
@@ -67,11 +65,10 @@ class URLGrabber(Thread):
     def __init__(self):
         Thread.__init__(self)
         self.queue: queue.Queue[Tuple[str, sabnzbd.nzbstuff.NzbObject]] = queue.Queue()
-        for tup in NzbQueue.do.get_urls():
+        for tup in sabnzbd.NzbQueue.get_urls():
             url, nzo = tup
             self.queue.put((url, nzo))
         self.shutdown = False
-        URLGrabber.do = self
 
     def add(self, url, future_nzo, when=None):
         """ Add an URL to the URLGrabber queue, 'when' is seconds from now """
@@ -330,8 +327,8 @@ class URLGrabber(Thread):
         nzo.cat, _, nzo.script, _ = misc.cat_to_opts(nzo.cat, script=nzo.script)
 
         # Add to history and run script if desired
-        NzbQueue.do.remove(nzo.nzo_id, add_to_history=False)
-        PostProcessor.do.process(nzo)
+        sabnzbd.NzbQueue.remove(nzo.nzo_id, add_to_history=False)
+        sabnzbd.PostProcessor.process(nzo)
 
 
 def _build_request(url):

--- a/tests/test_nzbstuff.py
+++ b/tests/test_nzbstuff.py
@@ -40,11 +40,11 @@ class TestNZO:
 
         # work_name can be trimmed in Windows due to max-path-length
         assert "test_basic_data".startswith(nzo.work_name)
-        assert os.path.exists(nzo.workpath)
+        assert os.path.exists(nzo.admin_path)
 
         # Check if there's an nzf file and the backed-up nzb
-        assert globber(nzo.workpath, "*.nzb.gz")
-        assert globber(nzo.workpath, "SABnzbd_nzf*")
+        assert globber(nzo.admin_path, "*.nzb.gz")
+        assert globber(nzo.admin_path, "SABnzbd_nzf*")
 
         # Should have picked up the default category settings
         assert nzo.cat == "*"

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -20,9 +20,10 @@ tests.test_misc - Testing functions in misc.py
 """
 import datetime
 import time
+import configobj
 
 import sabnzbd.rss as rss
-from sabnzbd.config import CFG, define_rss, ConfigCat
+import sabnzbd.config
 
 
 class TestRSS:
@@ -30,16 +31,18 @@ class TestRSS:
     def setup_rss(feed_name, feed_url):
         """ Setup the basic settings to get things going"""
         # Setup the config settings
+        CFG = configobj.ConfigObj()
         CFG["rss"] = {}
         CFG["rss"][feed_name] = {}
         CFG["rss"][feed_name]["uri"] = feed_url
-        define_rss()
+        sabnzbd.config.CFG = CFG
+        sabnzbd.config.define_rss()
 
         # Need to create the Default category
         # Otherwise it will try to save the config
-        ConfigCat("*", {})
-        ConfigCat("tv", {})
-        ConfigCat("movies", {})
+        sabnzbd.config.ConfigCat("*", {})
+        sabnzbd.config.ConfigCat("tv", {})
+        sabnzbd.config.ConfigCat("movies", {})
 
     def test_rss_newznab_parser(self):
         """Test basic RSS-parsing of custom elements


### PR DESCRIPTION
With IDE's like PyCharm these type-hints turn out to be a very usefull tool. It will highlight when you try to supply variables to functions that don't match the specifications. Additionally, the auto-complete actually knows what kind of objects you are working with.
Also includes fixes that I found because I added these type hints!

I think I also want to work on changing a bit of the structure, so we no longer need these `NzbQueue.do.xxx` structures, which are very weird.