### PR TITLE
Correctly handle reference counting of SABnzbd-objects

### DIFF
--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -22,6 +22,7 @@ sabnzbd.api - api
 import os
 import logging
 import re
+import gc
 import datetime
 import time
 import json
@@ -902,6 +903,14 @@ def _api_server_stats(name, output, kwargs):
     return report(output, keyword="", data=stats)
 
 
+def _api_gc_stats(name, output, kwargs):
+    """Function only intended for internal testing of the memory handling"""
+    # Collect before we check
+    gc.collect()
+    # We cannot create any lists/dicts, as they would create a reference
+    return report(output, data=[str(obj) for obj in gc.get_objects() if isinstance(obj, sabnzbd.nzbstuff.TryList)])
+
+
 ##############################################################################
 _api_table = {
     "server_stats": (_api_server_stats, 2),
@@ -938,6 +947,7 @@ _api_table = {
     "restart_repair": (_api_restart_repair, 2),
     "disconnect": (_api_disconnect, 2),
     "osx_icon": (_api_osx_icon, 3),
+    "gc_stats": (_api_gc_stats, 3),
     "rescan": (_api_rescan, 2),
     "eval_sort": (_api_eval_sort, 2),
     "watched_now": (_api_watched_now, 2),

--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -56,7 +56,7 @@ class Assembler(Thread):
     def run(self):
         while 1:
             # Set NzbObject and NzbFile objects to None so references
-            # from this thread do not keep the objects alive (see #1472)
+            # from this thread do not keep the objects alive (see #1628)
             nzo = nzf = None
             nzo, nzf, file_done = self.queue.get()
             if not nzo:

--- a/sabnzbd/decoder.py
+++ b/sabnzbd/decoder.py
@@ -117,7 +117,7 @@ class DecoderWorker(Thread):
     def run(self):
         while 1:
             # Set Article and NzbObject objects to None so references from this
-            # thread do not keep the parent objects alive (see #1472)
+            # thread do not keep the parent objects alive (see #1628)
             raw_data = article = nzo = None
             article, raw_data = self.decoder_queue.get()
             if not article:

--- a/sabnzbd/decoder.py
+++ b/sabnzbd/decoder.py
@@ -75,7 +75,7 @@ class Decoder:
         for decoder_worker in self.decoder_workers:
             decoder_worker.start()
 
-    def is_alive(self):
+    def is_alive(self) -> bool:
         # Check all workers
         for decoder_worker in self.decoder_workers:
             if not decoder_worker.is_alive():
@@ -100,7 +100,7 @@ class Decoder:
         sabnzbd.ArticleCache.reserve_space(article.bytes)
         self.decoder_queue.put((article, raw_data))
 
-    def queue_full(self):
+    def queue_full(self) -> bool:
         # Check if the queue size exceeds the limits
         return self.decoder_queue.qsize() >= sabnzbd.ArticleCache.decoder_cache_article_limit
 
@@ -118,7 +118,7 @@ class DecoderWorker(Thread):
         while 1:
             # Set Article and NzbObject objects to None so references from this
             # thread do not keep the parent objects alive (see #1628)
-            raw_data = article = nzo = None
+            decoded_data = raw_data = article = nzo = None
             article, raw_data = self.decoder_queue.get()
             if not article:
                 logging.info("Shutting down decoder %s", self.name)
@@ -131,7 +131,6 @@ class DecoderWorker(Thread):
             sabnzbd.ArticleCache.free_reserved_space(article.bytes)
 
             # Keeping track
-            decoded_data = None
             article_success = False
 
             try:
@@ -216,7 +215,7 @@ class DecoderWorker(Thread):
             sabnzbd.NzbQueue.register_article(article, article_success)
 
 
-def decode(article: Article, raw_data: List[bytes]):
+def decode(article: Article, raw_data: List[bytes]) -> bytes:
     # Let SABYenc do all the heavy lifting
     decoded_data, yenc_filename, crc, crc_expected, crc_correct = sabyenc3.decode_usenet_chunks(raw_data, article.bytes)
 
@@ -243,7 +242,7 @@ def decode(article: Article, raw_data: List[bytes]):
     return decoded_data
 
 
-def search_new_server(article: Article):
+def search_new_server(article: Article) -> bool:
     """ Shorthand for searching new server or else increasing bad_articles """
     # Continue to the next one if we found new server
     if not article.search_new_server():

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -161,7 +161,7 @@ class Server:
         self.idle_threads = []
 
     def __repr__(self):
-        return "<%s:%s>" % (self.host, self.port)
+        return "<Server: %s:%s>" % (self.host, self.port)
 
 
 class Downloader(Thread):

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -601,9 +601,6 @@ class Downloader(Thread):
                 article = nw.article
                 server = nw.server
 
-                if article:
-                    nzo = article.nzf.nzo
-
                 try:
                     bytes_received, done, skip = nw.recv_chunk()
                 except:
@@ -625,7 +622,7 @@ class Downloader(Thread):
                                 time.sleep(0.05)
                                 sabnzbd.BPSMeter.update()
                     sabnzbd.BPSMeter.update(server.id, bytes_received)
-                    nzo.update_download_stats(sabnzbd.BPSMeter.bps, server.id, bytes_received)
+                    article.nzf.nzo.update_download_stats(sabnzbd.BPSMeter.bps, server.id, bytes_received)
 
                 if not done and nw.status_code != 222:
                     if not nw.connected or nw.status_code == 480:
@@ -747,7 +744,7 @@ class Downloader(Thread):
                         nw.clear_data()
 
                     elif nw.status_code == 500:
-                        if nzo.precheck:
+                        if article.nzf.nzo.precheck:
                             # Assume "STAT" command is not supported
                             server.have_stat = False
                             logging.debug("Server %s does not support STAT", server.host)

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -896,7 +896,7 @@ class QueuePage:
         uid = kwargs.get("uid")
         del_files = int_conv(kwargs.get("del_files"))
         if uid:
-            sabnzbd.NzbQueue.remove(uid, add_to_history=False, delete_all_data=del_files)
+            sabnzbd.NzbQueue.remove(uid, delete_all_data=del_files)
         raise queueRaiser(self.__root, kwargs)
 
     @secured_expose(check_api_key=True)

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -261,6 +261,9 @@ class NNTP:
             logging.info(msg)
             self.nw.server.warning = msg
 
+    def __repr__(self):
+        return "<NNTP: %s:%s>" % (self.host, self.port)
+
 
 class NewsWrapper:
     # Pre-define attributes to save memory
@@ -482,3 +485,11 @@ class NewsWrapper:
             except:
                 pass
         del self.nntp
+
+    def __repr__(self):
+        return "<NewsWrapper: server=%s:%s, thread=%s, connected=%s>" % (
+            self.server.host,
+            self.server.port,
+            self.thrdnum,
+            self.connected,
+        )

--- a/sabnzbd/nzbparser.py
+++ b/sabnzbd/nzbparser.py
@@ -234,7 +234,7 @@ def process_nzb_archive_file(
                     if nzo:
                         if nzo_id:
                             # Re-use existing nzo_id, when a "future" job gets it payload
-                            sabnzbd.NzbQueue.remove(nzo_id, add_to_history=False, delete_all_data=False)
+                            sabnzbd.NzbQueue.remove(nzo_id, delete_all_data=False)
                             nzo.nzo_id = nzo_id
                             nzo_id = None
                         nzo_ids.append(sabnzbd.NzbQueue.add(nzo))
@@ -329,7 +329,7 @@ def process_single_nzb(
     except TypeError:
         # Duplicate, ignore
         if nzo_id:
-            sabnzbd.NzbQueue.remove(nzo_id, add_to_history=False)
+            sabnzbd.NzbQueue.remove(nzo_id)
         nzo = None
     except ValueError:
         # Empty
@@ -346,7 +346,7 @@ def process_single_nzb(
     if nzo:
         if nzo_id:
             # Re-use existing nzo_id, when a "future" job gets it payload
-            sabnzbd.NzbQueue.remove(nzo_id, add_to_history=False, delete_all_data=False)
+            sabnzbd.NzbQueue.remove(nzo_id, delete_all_data=False)
             nzo.nzo_id = nzo_id
         nzo_ids.append(sabnzbd.NzbQueue.add(nzo, quiet=reuse))
         nzo.update_rating()

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -912,26 +912,6 @@ class NzbObject(TryList):
             # Raise error, so it's not added
             raise TypeError
 
-    def clear_object_references(self):
-        """Clear all object references to child objects so we
-        all be removed by the garbage collector (see #1472)"""
-        # Remove (circular) references from NzbFile objects
-        # Sub-lists need to be cleared individually
-        for setname in self.extrapars:
-            self.extrapars[setname].clear()
-        self.extrapars.clear()
-        self.partable.clear()
-        self.files.clear()
-        self.files_table.clear()
-        self.finished_files.clear()
-
-        # Clear articles, as they have references to NzbFile objects
-        self.saved_articles.clear()
-
-        # Need to clear the DirectUnpacker-NzbObject reference. If we don't,
-        # the NzbObject is kept in memory due to a reference from the stopped Thread.
-        self.direct_unpacker = None
-
     def update_download_stats(self, bps, serverid, bytes_received):
         if bps:
             self.avg_bps_total += bps / 1024
@@ -1815,7 +1795,6 @@ class NzbObject(TryList):
             sabnzbd.remove_data(self.nzo_id, self.admin_path)
         elif delete_all_data:
             remove_all(self.download_path, recursive=True)
-            self.clear_object_references()
         else:
             # We remove any saved articles and save the renames file
             remove_all(self.download_path, "SABnzbd_nz?_*", keep_folder=True)

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -912,6 +912,26 @@ class NzbObject(TryList):
             # Raise error, so it's not added
             raise TypeError
 
+    def clear_object_references(self):
+        """Clear all object references to child objects so we
+        all be removed by the garbage collector (see #1472)"""
+        # Remove (circular) references from NzbFile objects
+        # Sub-lists need to be cleared individually
+        for setname in self.extrapars:
+            self.extrapars[setname].clear()
+        self.extrapars.clear()
+        self.partable.clear()
+        self.files.clear()
+        self.files_table.clear()
+        self.finished_files.clear()
+
+        # Clear articles, as they have references to NzbFile objects
+        self.saved_articles.clear()
+
+        # Need to clear the DirectUnpacker-NzbObject reference. If we don't,
+        # the NzbObject is kept in memory due to a reference from the stopped Thread.
+        self.direct_unpacker = None
+
     def update_download_stats(self, bps, serverid, bytes_received):
         if bps:
             self.avg_bps_total += bps / 1024
@@ -1795,6 +1815,7 @@ class NzbObject(TryList):
             sabnzbd.remove_data(self.nzo_id, self.admin_path)
         elif delete_all_data:
             remove_all(self.download_path, recursive=True)
+            self.clear_object_references()
         else:
             # We remove any saved articles and save the renames file
             remove_all(self.download_path, "SABnzbd_nz?_*", keep_folder=True)

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -1662,7 +1662,7 @@ class NzbObject(TryList):
                         self.files[pos + 1] = nzf
                         self.files[pos] = tmp_nzf
 
-    def verify_nzf_filename(self, nzf: NzbFile, yenc_filename=None):
+    def verify_nzf_filename(self, nzf: NzbFile, yenc_filename: Optional[str] = None):
         """ Get filename from par2-info or from yenc """
         # Already done?
         if nzf.filename_checked:

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -245,6 +245,10 @@ class PostProcessor(Thread):
                 time.sleep(5)
                 continue
 
+            # Set NzbObject object to None so references from this thread do not keep the
+            # object alive until the next job is added to post-processing (see #1472)
+            nzo = None
+
             # Something in the fast queue?
             try:
                 # Every few fast-jobs we should check allow a

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -246,7 +246,7 @@ class PostProcessor(Thread):
                 continue
 
             # Set NzbObject object to None so references from this thread do not keep the
-            # object alive until the next job is added to post-processing (see #1472)
+            # object alive until the next job is added to post-processing (see #1628)
             nzo = None
 
             # Something in the fast queue?

--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -322,7 +322,7 @@ class URLGrabber(Thread):
         nzo.cat, _, nzo.script, _ = misc.cat_to_opts(nzo.cat, script=nzo.script)
 
         # Add to history and run script if desired
-        sabnzbd.NzbQueue.remove(nzo.nzo_id, add_to_history=False)
+        sabnzbd.NzbQueue.remove(nzo.nzo_id)
         sabnzbd.PostProcessor.process(nzo)
 
 

--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -90,7 +90,7 @@ class URLGrabber(Thread):
         self.shutdown = False
         while not self.shutdown:
             # Set NzbObject object to None so reference from this thread
-            # does not keep the object alive in the future (see #1472)
+            # does not keep the object alive in the future (see #1628)
             future_nzo = None
             url, future_nzo = self.queue.get()
 

--- a/tests/test_functional_downloads.py
+++ b/tests/test_functional_downloads.py
@@ -66,7 +66,10 @@ class TestDownloadFlow(SABnzbdBaseTest):
         self.selenium_wrapper(self.driver.find_element_by_css_selector, ".btn.btn-success").click()
         self.no_page_crash()
 
-    def add_test_nzb(self, nzb_dir, file_output):
+    def download_nzb(self, nzb_dir, file_output):
+        # Verify if the server was setup before we start
+        self.is_server_configured()
+
         # Create NZB
         nzb_path = create_nzb(nzb_dir)
 
@@ -102,31 +105,29 @@ class TestDownloadFlow(SABnzbdBaseTest):
         file_to_find = os.path.join(SAB_COMPLETE_DIR, test_job_name, file_output)
         assert os.path.exists(file_to_find)
 
+        # Verify if the garbage collection works (see #1472)
+        gc_results = get_api_result("gc_stats")["value"]
+        if gc_results:
+            pytest.fail(f"Objects were left in memory after the job finished! {gc_results}")
+
     def test_download_basic_rar5(self):
-        self.is_server_configured()
-        self.add_test_nzb("basic_rar5", "testfile.bin")
+        self.download_nzb("basic_rar5", "testfile.bin")
 
     def test_download_zip(self):
-        self.is_server_configured()
-        self.add_test_nzb("test_zip", "testfile.bin")
+        self.download_nzb("test_zip", "testfile.bin")
 
     def test_download_7zip(self):
-        self.is_server_configured()
-        self.add_test_nzb("test_7zip", "testfile.bin")
+        self.download_nzb("test_7zip", "testfile.bin")
 
     def test_download_passworded(self):
-        self.is_server_configured()
-        self.add_test_nzb("test_passworded{{secret}}", "testfile.bin")
+        self.download_nzb("test_passworded{{secret}}", "testfile.bin")
 
     def test_download_unicode_made_on_windows(self):
-        self.is_server_configured()
-        self.add_test_nzb("test_win_unicode", "frènch_german_demö.bin")
+        self.download_nzb("test_win_unicode", "frènch_german_demö.bin")
 
     def test_download_fully_obfuscated(self):
         # This is also covered by a unit test but added to test full flow
-        self.is_server_configured()
-        self.add_test_nzb("obfuscated_single_rar_set", "100k.bin")
+        self.download_nzb("obfuscated_single_rar_set", "100k.bin")
 
     def test_download_unicode_rar(self):
-        self.is_server_configured()
-        self.add_test_nzb("unicode_rar", "我喜欢编程.bin")
+        self.download_nzb("unicode_rar", "我喜欢编程.bin")

--- a/tests/test_functional_downloads.py
+++ b/tests/test_functional_downloads.py
@@ -105,7 +105,7 @@ class TestDownloadFlow(SABnzbdBaseTest):
         file_to_find = os.path.join(SAB_COMPLETE_DIR, test_job_name, file_output)
         assert os.path.exists(file_to_find)
 
-        # Verify if the garbage collection works (see #1472)
+        # Verify if the garbage collection works (see #1628)
         gc_results = get_api_result("gc_stats")["value"]
         if gc_results:
             pytest.fail(f"Objects were left in memory after the job finished! {gc_results}")


### PR DESCRIPTION
Triggered by #1472 I investigated the observed behavior that memory wasn't cleared after jobs were finished.
The root cause turned out to be treefold:

1. In all `Thread`'s, like the `Assembler`, `Decoder`, `PostProcessor` we use queues. We were using code like this: `nzo, nzf, file_done = self.queue.get()`. The result is that the reference to `nzo` and `nzf` is only cleared when the next job is picked up by the thread. For example in the case of the `PostProcessor` this means that the `NzbObject` (and all the `NzbFile`'s and `Article`'s in it) is kept alive until the next job is post-processed. This can be quite a while!
This is resolved by resetting these variables to `None` just before the `self.queue.get()`. IDE's like PyCharm indicate this as a useless statement that should be removed, so I added comments to all these resets.
2. Additionally, we start the `DirectUnpacker` in it's own thread and have a circular reference to/from the `NzbObject`. This resulted in the `NzbObject` staying alive because it was references from the dead `DirectUnpacker`. This was resolved by setting the reference to `None`.
3. In the `DecoderWorker` the raw and decoded data was preserved until the next article was offered to be decoded. Since we have 4 `DecoderWorker`-threads, this resulted in another 5MB of extra memory.

To prevent this in the future, I added a special `api?mode=gc_stats` that lists all the SABnzbd specific-objects that are alive (`NzbObject`/`NzbFile`/`Article`).
By checking after every functional download test if no objects are left alive we can make sure this is not reintroduced in the future!  

Using that test I actually found that also in the `URLGrabber` we had an unresolved reference.

On my Windows machine, this resulted in:

Action | `develop` | `bugfix/memusage`
------------ | ------------ | -------------
Start | 52MB | 52MB
After download 100MB | 61MB | 53MB

~So, there is still some memory increase, but less. I imagine it has something also to do with `cherrypy`. But that's for another day.~
This already took me almost a full weekend of manual debugging using the `gc` module (there are no packages that can handle a big multi-threaded application like SABnzbd).

I even wrote code like this below, but it actually turned out **not** to be needed after the 2 solutions mentioned above were implemented!
```python
    def clear_object_references(self):
        """Clear all object references to child objects so we
        all be removed by the garbage collector (see #1472)"""
        # Remove (circular) references from NzbFile objects
        # Sub-lists need to be cleared individually
        for setname in self.extrapars:
            self.extrapars[setname].clear()
        self.extrapars.clear()
        self.partable.clear()
        self.files.clear()
        self.files_table.clear()
        self.finished_files.clear()

        # Clear articles, as they have references to NzbFile objects
        self.saved_articles.clear()

        # Need to clear the DirectUnpacker-NzbObject reference. If we don't,
        # the NzbObject is kept in memory due to a reference from the stopped Thread.
        self.direct_unpacker = None
```

Closes #1472
