### PR TITLE
only replace the first occurence of "script_"

### DIFF
--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -799,7 +799,7 @@ def change_queue_complete_action(action, new=True):
     """
     _action = None
     _argument = None
-    if "script_" in action:
+    if action.startswith("script_"):
         # all scripts are labeled script_xxx
         _action = run_script
         _argument = action.replace("script_", "", 1)

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -802,7 +802,7 @@ def change_queue_complete_action(action, new=True):
     if "script_" in action:
         # all scripts are labeled script_xxx
         _action = run_script
-        _argument = action.replace("script_", "")
+        _argument = action.replace("script_", "", 1)
     elif new or cfg.queue_complete_pers.get():
         if action == "shutdown_pc":
             _action = system_shutdown


### PR DESCRIPTION
Use of str.replace() without a count replaces all occurences. As a result, scripts with filenames such as "my_script_for_sab.py" would be mangled when trying to set them as action on queue completion.