### PR TITLE
Fix nzbstuff scan_password, expand tests

### DIFF
--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -2086,9 +2086,11 @@ def scan_password(name: str) -> Tuple[str, Optional[str]]:
     if "http://" in name or "https://" in name:
         return name, None
 
-    braces = name[1:].find("{{") + 1
+    braces = name[1:].find("{{")
     if braces < 0:
         braces = len(name)
+    else:
+        braces += 1
     slash = name.find("/")
 
     # Look for name/password, but make sure that '/' comes before any {{

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -2086,34 +2086,33 @@ def scan_password(name: str) -> Tuple[str, Optional[str]]:
     if "http://" in name or "https://" in name:
         return name, None
 
-    braces = name.find("{{")
+    braces = name[1:].find("{{") + 1
     if braces < 0:
         braces = len(name)
     slash = name.find("/")
 
     # Look for name/password, but make sure that '/' comes before any {{
-    if 0 <= slash < braces and "password=" not in name:
+    if 0 < slash < braces and "password=" not in name:
         # Is it maybe in 'name / password' notation?
-        if slash == name.find(" / ") + 1:
+        if slash == name.find(" / ") + 1 and name[: slash - 1].strip(". "):
             # Remove the extra space after name and before password
             return name[: slash - 1].strip(". "), name[slash + 2 :]
-        return name[:slash].strip(". "), name[slash + 1 :]
+        if name[:slash].strip(". "):
+            return name[:slash].strip(". "), name[slash + 1 :]
 
     # Look for "name password=password"
     pw = name.find("password=")
-    if pw >= 0:
+    if pw > 0 and name[:pw].strip(". "):
         return name[:pw].strip(". "), name[pw + 9 :]
 
     # Look for name{{password}}
-    if braces < len(name) and "}}" in name:
-        closing_braces = name.find("}}")
-        if closing_braces < 0:
-            closing_braces = len(name)
-
-        return name[:braces].strip(". "), name[braces + 2 : closing_braces]
+    if braces < len(name):
+        closing_braces = name.rfind("}}")
+        if closing_braces > braces and name[:braces].strip(". "):
+            return name[:braces].strip(". "), name[braces + 2 : closing_braces]
 
     # Look again for name/password
-    if slash >= 0:
+    if slash > 0 and name[:slash].strip(". "):
         return name[:slash].strip(". "), name[slash + 1 :]
 
     # No password found

--- a/tests/test_nzbstuff.py
+++ b/tests/test_nzbstuff.py
@@ -58,7 +58,7 @@ class TestNZBStuffHelpers:
             ("my_awesome_nzb_file{{password}}", "my_awesome_nzb_file", "password"),
             ("file_with_text_after_pw{{passw0rd}}_[180519]", "file_with_text_after_pw", "passw0rd"),
             ("file_without_pw", "file_without_pw", None),
-            ("multiple_pw{{first-pw}}_{{second-pw}}", "multiple_pw", "first-pw}}_{{second-pw",),  # Greed is Good
+            ("multiple_pw{{first-pw}}_{{second-pw}}", "multiple_pw", "first-pw}}_{{second-pw"),  # Greed is Good
             ("デビアン", "デビアン", None),  # Unicode
             ("Gentoo_Hobby_Edition {{secret}}", "Gentoo_Hobby_Edition", "secret"),  # Space between name and password
             ("Mandrake{{top{{secret}}", "Mandrake", "top{{secret"),  # Double opening {{

--- a/tests/test_nzbstuff.py
+++ b/tests/test_nzbstuff.py
@@ -52,27 +52,32 @@ class TestNZO:
 
 
 class TestNZBStuffHelpers:
-    def test_scan_passwords(self):
-        file_names = {
-            "my_awesome_nzb_file{{password}}": "password",
-            "file_with_text_after_pw{{passw0rd}}_[180519]": "passw0rd",
-            "file_without_pw": None,
-            "file_with_multiple_pw{{first-pw}}_{{second-pw}}": "first-pw",
-        }
-
-        for file_name, password in file_names.items():
-            assert nzbstuff.scan_password(file_name)[1] == password
-
-    def test_scan_passwords_filenames(self):
-        file_names = {
-            "my_awesome_nzb_file{{password}}": "my_awesome_nzb_file",
-            "file_with_text_after_pw{{passw0rd}}_[310313]": "file_with_text_after_pw",
-            "file_without_pw": "file_without_pw",
-            "file_with_multiple_pw{{first-pw}}_{{second-pw}}": "file_with_multiple_pw",
-        }
-
-        for file_name, clean_file_name in file_names.items():
-            assert nzbstuff.scan_password(file_name)[0] == clean_file_name
+    @pytest.mark.parametrize(
+        "argument, name, password",
+        [
+            ("my_awesome_nzb_file{{password}}", "my_awesome_nzb_file", "password"),
+            ("file_with_text_after_pw{{passw0rd}}_[180519]", "file_with_text_after_pw", "passw0rd"),
+            ("file_without_pw", "file_without_pw", None),
+            ("multiple_pw{{first-pw}}_{{second-pw}}", "multiple_pw", "first-pw}}_{{second-pw",),  # Greed is Good
+            ("デビアン", "デビアン", None),  # Unicode
+            ("Gentoo_Hobby_Edition {{secret}}", "Gentoo_Hobby_Edition", "secret"),  # Space between name and password
+            ("Mandrake{{top{{secret}}", "Mandrake", "top{{secret"),  # Double opening {{
+            ("Красная}}{{Шляпа}}", "Красная}}", "Шляпа"),  # Double closing }}
+            ("{{Jobname{{PassWord}}", "{{Jobname", "PassWord"),  # {{ at start
+            ("Hello/kITTY", "Hello", "kITTY"),  # Notation with slash
+            ("/Jobname", "/Jobname", None),  # Slash at start
+            ("Jobname/Top{{Secret}}", "Jobname", "Top{{Secret}}"),  # Slash with braces
+            ("Jobname / Top{{Secret}}", "Jobname", "Top{{Secret}}"),  # Slash with braces and extra spaces
+            ("לינוקס/معلومات سرية", "לינוקס", "معلومات سرية"),  # LTR with slash
+            ("לינוקס{{معلومات سرية}}", "לינוקס", "معلومات سرية"),  # LTR with brackets
+            ("thư điện tử password=mật_khẩu", "thư điện tử", "mật_khẩu"),  # Password= notation
+            ("password=PartOfTheJobname", "password=PartOfTheJobname", None),  # Password= at the start
+            ("Job}}Name{{FTW", "Job}}Name{{FTW", None),  # Both {{ and }} present but incorrect order (no password)
+            ("./Text", "./Text", None),  # Name would end up empty after the function strips the dot
+        ],
+    )
+    def test_scan_password(self, argument, name, password):
+        assert nzbstuff.scan_password(argument) == (name, password)
 
     def test_create_work_name(self):
         # Only test stuff specific for create_work_name


### PR DESCRIPTION
Came across some weird results testing the api job rename function, traced back to issues in scan_password.

Bug fixes:
* ensure `{{` and `}}` appear in the correct order; necessary now that #1562 removed the requirement for the password to appear at the end;
* guard against returning an empty filename in favour of a non-empty password, i.e. consider the entire input as the password when a delimiter is found at the start (affects all delimiter styles);
* no longer strip a char off the end of the name if it starts with `/`;
* for multiple occurrences of `{{...}}` do a greedy match (restoring old behaviour) instead of picking the first.

Tests:
* Rename to match the function name;
* Collapse functions into a single one and parametrise;
* Add a bunch of tests for corner cases, Unicode input, empty output.