### PR TITLE
fix order for sorting queue by avg_age

### DIFF
--- a/interfaces/Glitter/templates/static/javascripts/glitter.queue.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.queue.js
@@ -228,11 +228,11 @@ function QueueListModel(parent) {
         switch($(event.currentTarget).data('action')) {
             case 'sortAgeAsc':
                 sort = 'avg_age';
-                dir = 'asc';
+                dir = 'desc';
                 break;
             case 'sortAgeDesc':
                 sort = 'avg_age';
-                dir = 'desc';
+                dir = 'asc';
                 break;
             case 'sortNameAsc':
                 sort = 'name';

--- a/interfaces/Plush/templates/static/javascripts/plush.js
+++ b/interfaces/Plush/templates/static/javascripts/plush.js
@@ -306,8 +306,8 @@ jQuery(function($){
   $('#queue_sort_list .queue_sort').click(function(event) {
     var sort, dir;
     switch ($(this).attr('id')) {
-      case 'sortAgeAsc':    sort='avg_age'; dir='asc';  break;
-      case 'sortAgeDesc':   sort='avg_age'; dir='desc'; break;
+      case 'sortAgeAsc':    sort='avg_age'; dir='desc';  break;
+      case 'sortAgeDesc':   sort='avg_age'; dir='asc'; break;
       case 'sortNameAsc':   sort='name';    dir='asc';  break;
       case 'sortNameDesc':  sort='name';    dir='desc'; break;
       case 'sortSizeAsc':   sort='size';    dir='asc';  break;

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -587,7 +587,7 @@ class NzbQueue:
         elif field.lower() == "size" or field.lower() == "bytes":
             self.sort_by_size(reverse)
         elif field.lower() == "avg_age":
-            self.sort_by_avg_age(reverse)
+            self.sort_by_avg_age(not reverse)
         else:
             logging.debug("Sort: %s not recognized", field)
 


### PR DESCRIPTION
Doing an api call to sort the queue in ascending order of avg_age actually sorts it in descending order, and vice versa. The other sorting methods (size and name) are not affected. The root cause is `nzbqueue.sort_queue()` not accounting for job ages being stored in the form of unix timestamps, where higher values equal lower age.

This is easily fixed by reversing the 'reverse' variable when for sorting by avg_age. In the interface templates, sorting options were correctly described towards the user in terms of oldest->newest but the underlying javascript vars embed the incorrect sort order in their names. As a result, the changes make for some weird reading (variables with "asc" in their names now set "desc"), but everything still does what it says on the tin and changes to the translations are avoided.