### PR TITLE
Separate email message lines are with CRLF

### DIFF
--- a/sabnzbd/emailer.py
+++ b/sabnzbd/emailer.py
@@ -122,6 +122,7 @@ def send_email(message, email_to, test=None):
                 return errormsg(T("Unknown authentication failure in mail server"))
 
         try:
+            email_message = b'\r\n'.join(email_message.splitlines())
             mailconn.sendmail(email_from, email_to, email_message)
             msg = None
         except smtplib.SMTPHeloError:


### PR DESCRIPTION
SMTP protocol dictates that all lines are supposed to be separated with CRLF and not LF (even on LF-based systems). This change ensures that even if the original byte string message is using `\n` for line separators, the SMTP protocol will still work properly.

This resolves https://github.com/sabnzbd/sabnzbd/issues/1669