### PR TITLE
Separate email message lines are with CRLF

### DIFF
--- a/sabnzbd/emailer.py
+++ b/sabnzbd/emailer.py
@@ -27,6 +27,7 @@ import glob
 
 from Cheetah.Template import Template
 from email.message import EmailMessage
+from email import policy
 
 from sabnzbd.constants import *
 import sabnzbd
@@ -296,4 +297,4 @@ def _prepare_message(txt):
                 msg[keyword] = value
 
     msg.set_content("\n".join(payload))
-    return msg.as_bytes()
+    return msg.as_bytes(policy=msg.policy.clone(linesep="\r\n"))


### PR DESCRIPTION
SMTP protocol dictates that all lines are supposed to be separated
with CRLF and not LF (even on LF-based systems). This change ensures
that even if the original byte string message is using `\n` for line
separators, the SMTP protocol will still work properly.

This resolves sabnzbd#1669