### PR TITLE
IPv4 IPv6 library based testing

### DIFF
--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -849,6 +849,7 @@ def probablyipv4(ip):
     except:
         return False
 
+
 def probablyipv6(ip):
     # Returns True if the given input is probably an IPv6 address
     # Square Brackets like '[2001::1]' are OK
@@ -858,7 +859,7 @@ def probablyipv6(ip):
     except:
         try:
             # Remove '[' and ']' and test again:
-            ip = re.search(r'^\[(.*)\]$', ip).group(1)
+            ip = re.search(r"^\[(.*)\]$", ip).group(1)
             return ipaddress.ip_address(ip).version == 6
         except:
             # No, not an IPv6 address

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -30,6 +30,7 @@ import time
 import datetime
 import inspect
 import ctypes
+import ipaddress
 from typing import Union, Tuple, Any, Optional
 
 import sabnzbd
@@ -843,19 +844,25 @@ def find_on_path(targets):
 
 
 def probablyipv4(ip):
-    if ip.count(".") == 3 and re.sub("[0123456789.]", "", ip) == "":
-        return True
-    else:
+    try:
+        return ipaddress.ip_address(ip).version == 4
+    except:
         return False
-
 
 def probablyipv6(ip):
     # Returns True if the given input is probably an IPv6 address
     # Square Brackets like '[2001::1]' are OK
-    if ip.count(":") >= 2 and re.sub(r"[0123456789abcdefABCDEF:\[\]]", "", ip) == "":
-        return True
-    else:
-        return False
+    try:
+        # Check for plain IPv6 address
+        return ipaddress.ip_address(ip).version == 6
+    except:
+        try:
+            # Remove '[' and ']' and test again:
+            ip = re.search(r'^\[(.*)\]$', ip).group(1)
+            return ipaddress.ip_address(ip).version == 6
+        except:
+            # No, not an IPv6 address
+            return False
 
 
 def ip_extract():

--- a/tests/test_probablyip.py
+++ b/tests/test_probablyip.py
@@ -1,0 +1,46 @@
+#!/usr/bin/python3 -OO
+# Copyright 2007-2020 The SABnzbd-Team <team@sabnzbd.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+tests.test_utils.test_probablyip - Testing SABnzbd's probablyipX() functions
+"""
+
+from sabnzbd.misc import *
+
+
+class TestProbablyIP:
+    def test_probablyipv4(self):
+        # Positive testing
+        assert probablyipv4('1.2.3.4')
+        assert probablyipv4('255.255.255.255')
+        assert probablyipv4('0.0.0.0')
+        # Negative testing
+        assert not probablyipv4('400.500.600.700')
+        assert not probablyipv4('blabla')
+        assert not probablyipv4('2001::1')
+
+    def test_probablyipv6(self):
+        # Positive testing
+        assert probablyipv6('2001::1')
+        assert probablyipv6('[2001::1]')
+        assert probablyipv6('fdd6:5a2d:3f20:0:14b0:d8f4:ccb9:fab6')
+        # Negative testing
+        assert not probablyipv6('blabla')
+        assert not probablyipv6('1.2.3.4')
+        assert not probablyipv6('[1.2.3.4]')
+        assert not probablyipv6('2001:1')
+        assert not probablyipv6('2001::[2001::1]')

--- a/tests/test_probablyip.py
+++ b/tests/test_probablyip.py
@@ -25,22 +25,22 @@ from sabnzbd.misc import *
 class TestProbablyIP:
     def test_probablyipv4(self):
         # Positive testing
-        assert probablyipv4('1.2.3.4')
-        assert probablyipv4('255.255.255.255')
-        assert probablyipv4('0.0.0.0')
+        assert probablyipv4("1.2.3.4")
+        assert probablyipv4("255.255.255.255")
+        assert probablyipv4("0.0.0.0")
         # Negative testing
-        assert not probablyipv4('400.500.600.700')
-        assert not probablyipv4('blabla')
-        assert not probablyipv4('2001::1')
+        assert not probablyipv4("400.500.600.700")
+        assert not probablyipv4("blabla")
+        assert not probablyipv4("2001::1")
 
     def test_probablyipv6(self):
         # Positive testing
-        assert probablyipv6('2001::1')
-        assert probablyipv6('[2001::1]')
-        assert probablyipv6('fdd6:5a2d:3f20:0:14b0:d8f4:ccb9:fab6')
+        assert probablyipv6("2001::1")
+        assert probablyipv6("[2001::1]")
+        assert probablyipv6("fdd6:5a2d:3f20:0:14b0:d8f4:ccb9:fab6")
         # Negative testing
-        assert not probablyipv6('blabla')
-        assert not probablyipv6('1.2.3.4')
-        assert not probablyipv6('[1.2.3.4]')
-        assert not probablyipv6('2001:1')
-        assert not probablyipv6('2001::[2001::1]')
+        assert not probablyipv6("blabla")
+        assert not probablyipv6("1.2.3.4")
+        assert not probablyipv6("[1.2.3.4]")
+        assert not probablyipv6("2001:1")
+        assert not probablyipv6("2001::[2001::1]")


### PR DESCRIPTION
now uses python library "ipaddress" instead of regexp.
introduction of pytest unit testing

Closes https://github.com/sabnzbd/sabnzbd/issues/1662

