### PR TITLE
explicitly set mode for gzip.GzipFile()

### DIFF
--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -611,7 +611,7 @@ def save_compressed(folder: str, filename: str, data: AnyStr):
     try:
         # Have to get around the path being put inside the tgz
         with open(os.path.join(folder, filename), "wb") as tgz_file:
-            f = gzip.GzipFile(filename, fileobj=tgz_file)
+            f = gzip.GzipFile(filename, fileobj=tgz_file, mode="wb")
             f.write(encoding.utob(data))
             f.flush()
             f.close()


### PR DESCRIPTION
Currently defaults to the mode of the open() just above, but:
```
sabnzbd/__init__.py:634: FutureWarning: GzipFile was opened for writing, but this will change in future Python releases.  Specify the mode argument for opening it for writing.
    f = gzip.GzipFile(filename, fileobj=tgz_file)
```

[Docs](https://docs.python.org/3/library/gzip.html):
> The mode argument can be any of 'r', 'rb', 'a', 'ab', 'w', 'wb', 'x', or 'xb', depending on whether the file will be read or written. The default is the mode of fileobj if discernible; otherwise, the default is 'rb'. In future Python releases the mode of fileobj will not be used. It is better to always specify mode for writing.