### PR TITLE
prevent repetition of unwanted extension warnings

### DIFF
--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -135,11 +135,13 @@ class Assembler(Thread):
                                 sabnzbd.NzbQueue.end_job(nzo)
 
                         if unwanted_file:
-                            logging.warning(
-                                T('In "%s" unwanted extension in RAR file. Unwanted file is %s '),
-                                nzo.final_name,
-                                unwanted_file,
-                            )
+                            # Don't repeat the warning after a user override of an unwanted extension pause
+                            if nzo.unwanted_ext == 0:
+                                logging.warning(
+                                    T('In "%s" unwanted extension in RAR file. Unwanted file is %s '),
+                                    nzo.final_name,
+                                    unwanted_file,
+                                )
                             logging.debug(T("Unwanted extension is in rar file %s"), filepath)
                             if cfg.action_on_unwanted_extensions() == 1 and nzo.unwanted_ext == 0:
                                 logging.debug("Unwanted extension ... pausing")


### PR DESCRIPTION
Fixes #1686

A minor disadvantage of this change may be that there'll be no further warnings in case a single jobs packs multiple unwanted extensions and the user has overridden the pause triggered by whatever extension caused the first hit. That was already the case for the pause itself though.