### PR TITLE
add selecting by nzo_id(s) for api queue and history output

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -54,7 +54,7 @@ jobs:
         name: Windows installer
     - name: Import codesign certificates
       uses: apple-actions/import-codesign-certs@v1
-      if: runner.os == 'macOS'
+      if: runner.os == 'macOS' && github.event_name == 'push'
       with:
         p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
         p12-password: ${{ secrets.CERTIFICATES_P12_PASSWORD }}

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -487,7 +487,7 @@ def _api_fullstatus(name, output, kwargs):
 
 
 def _api_history(name, output, kwargs):
-    """ API: accepts output, value(=nzo_id), start, limit, search """
+    """ API: accepts output, value(=nzo_id), start, limit, search, nzo_ids """
     value = kwargs.get("value", "")
     start = int_conv(kwargs.get("start"))
     limit = int_conv(kwargs.get("limit"))
@@ -495,6 +495,7 @@ def _api_history(name, output, kwargs):
     search = kwargs.get("search")
     failed_only = int_conv(kwargs.get("failed_only"))
     categories = kwargs.get("category")
+    nzo_ids = kwargs.get("nzo_ids")
 
     # Do we need to send anything?
     if last_history_update == sabnzbd.LAST_HISTORY_UPDATE:
@@ -537,7 +538,7 @@ def _api_history(name, output, kwargs):
             to_units(day),
         )
         history["slots"], fetched_items, history["noofslots"] = build_history(
-            start=start, limit=limit, search=search, failed_only=failed_only, categories=categories
+            start=start, limit=limit, search=search, failed_only=failed_only, categories=categories, nzo_ids=nzo_ids
         )
         history["last_history_update"] = sabnzbd.LAST_HISTORY_UPDATE
         history["version"] = sabnzbd.__version__
@@ -1683,7 +1684,7 @@ def build_queue_header(search=None, start=0, limit=0, output=None):
     return header, qnfo.list, bytespersec, qnfo.q_fullsize, qnfo.bytes_left_previous_page
 
 
-def build_history(start=0, limit=0, search=None, failed_only=0, categories=None):
+def build_history(start=0, limit=0, search=None, failed_only=0, categories=None, nzo_ids=None):
     """Combine the jobs still in post-processing and the database history"""
     if not limit:
         limit = 1000000
@@ -1736,12 +1737,12 @@ def build_history(start=0, limit=0, search=None, failed_only=0, categories=None)
     # Fetch history items
     if not database_history_limit:
         items, fetched_items, total_items = history_db.fetch_history(
-            database_history_start, 1, search, failed_only, categories
+            database_history_start, 1, search, failed_only, categories, nzo_ids
         )
         items = []
     else:
         items, fetched_items, total_items = history_db.fetch_history(
-            database_history_start, database_history_limit, search, failed_only, categories
+            database_history_start, database_history_limit, search, failed_only, categories, nzo_ids
         )
 
     # Reverse the queue to add items to the top (faster than insert)

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -292,8 +292,9 @@ def _api_queue_default(output, value, kwargs):
     start = int_conv(kwargs.get("start"))
     limit = int_conv(kwargs.get("limit"))
     search = kwargs.get("search")
+    nzo_ids = kwargs.get("nzo_ids")
 
-    info, pnfo_list, bytespersec = build_queue(start=start, limit=limit, output=output, search=search)
+    info, pnfo_list, bytespersec = build_queue(start=start, limit=limit, output=output, search=search, nzo_ids=nzo_ids)
     return report(output, keyword="queue", data=info)
 
 
@@ -1297,10 +1298,10 @@ def build_status(skip_dashboard=False, output=None):
     return info
 
 
-def build_queue(start=0, limit=0, trans=False, output=None, search=None):
+def build_queue(start=0, limit=0, trans=False, output=None, search=None, nzo_ids=None):
     # build up header full of basic information
     info, pnfo_list, bytespersec, q_size, bytes_left_previous_page = build_queue_header(
-        search=search, start=start, limit=limit, output=output
+        search=search, start=start, limit=limit, output=output, nzo_ids=nzo_ids
     )
 
     datestart = datetime.datetime.now()
@@ -1646,13 +1647,13 @@ def build_header(webdir="", output=None, trans_functions=True):
     return header
 
 
-def build_queue_header(search=None, start=0, limit=0, output=None):
+def build_queue_header(search=None, nzo_ids=None, start=0, limit=0, output=None):
     """ Build full queue header """
 
     header = build_header(output=output)
 
     bytespersec = sabnzbd.BPSMeter.bps
-    qnfo = sabnzbd.NzbQueue.queue_info(search=search, start=start, limit=limit)
+    qnfo = sabnzbd.NzbQueue.queue_info(search=search, nzo_ids=nzo_ids, start=start, limit=limit)
 
     bytesleft = qnfo.bytes_left
     bytes_total = qnfo.bytes

--- a/sabnzbd/database.py
+++ b/sabnzbd/database.py
@@ -290,7 +290,7 @@ class HistoryDB:
         )
         logging.info("Added job %s to history", nzo.final_name)
 
-    def fetch_history(self, start=None, limit=None, search=None, failed_only=0, categories=None):
+    def fetch_history(self, start=None, limit=None, search=None, failed_only=0, categories=None, nzo_ids=None):
         """ Return records for specified jobs """
         command_args = [convert_search(search)]
 
@@ -301,6 +301,12 @@ class HistoryDB:
             post += " OR CATEGORY = ? " * (len(categories) - 1)
             post += ")"
             command_args.extend(categories)
+        if nzo_ids:
+            nzo_ids = nzo_ids.split(",")
+            post += " AND (NZO_ID = ?"
+            post += " OR NZO_ID = ? " * (len(nzo_ids) - 1)
+            post += ")"
+            command_args.extend(nzo_ids)
         if failed_only:
             post += " AND STATUS = ?"
             command_args.append(Status.FAILED)

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -806,13 +806,15 @@ class NzbQueue:
                 n += 1
         return n
 
-    def queue_info(self, search=None, start=0, limit=0):
+    def queue_info(self, search=None, nzo_ids=None, start=0, limit=0):
         """Return list of queued jobs,
-        optionally filtered by 'search' and limited by start and limit.
+        optionally filtered by 'search' and 'nzo_ids', and limited by start and limit.
         Not locked for performance, only reads the queue
         """
         if search:
             search = search.lower()
+        if nzo_ids:
+            nzo_ids = nzo_ids.split(",")
         bytes_left = 0
         bytes_total = 0
         bytes_left_previous_page = 0
@@ -831,11 +833,12 @@ class NzbQueue:
                     bytes_left_previous_page += b_left
 
             if (not search) or search in nzo.final_name.lower():
-                if (not limit) or (start <= n < start + limit):
-                    pnfo_list.append(nzo.gather_info())
-                n += 1
+                if (not nzo_ids) or nzo.nzo_id in nzo_ids:
+                    if (not limit) or (start <= n < start + limit):
+                        pnfo_list.append(nzo.gather_info())
+                    n += 1
 
-        if not search:
+        if not search and not nzo_ids:
             n = len(self.__nzo_list)
         return QNFO(bytes_total, bytes_left, bytes_left_previous_page, pnfo_list, q_size, n)
 


### PR DESCRIPTION
This change adds an _nzo_ids_ option to the queue and history api calls that limits output to jobs with matching ids, along the lines of what the _search_ parameter does based on a job name. Unlike job names, nzo_ids are unique and not subject to user changes which makes them more reliable as a job identifier.