### PR TITLE
Filename limit in sanitize_filename() to avoid traceback

### DIFF
--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -46,6 +46,7 @@ from sabnzbd.constants import (
     DEF_SCANRATE,
     DEF_COMPLETE_DIR,
     DEF_FOLDER_MAX,
+    DEF_FILE_MAX,
 )
 
 ##############################################################################

--- a/sabnzbd/constants.py
+++ b/sabnzbd/constants.py
@@ -40,7 +40,7 @@ ANFO = namedtuple("ANFO", "article_sum cache_size cache_limit")
 # Leave some space for "_UNPACK_" which we append during post-proc
 # Or, when extra ".1", ".2" etc. are added for identically named jobs
 DEF_FOLDER_MAX = 256 - 10
-DEF_FILE_MAX = 255 - 6  # max filename length on modern filesystems, minus 6 positions
+DEF_FILE_MAX = 255 - 10  # max filename length on modern filesystems, minus some room for extra chars later on
 
 GIGI = float(2 ** 30)
 MEBI = float(2 ** 20)

--- a/sabnzbd/constants.py
+++ b/sabnzbd/constants.py
@@ -40,7 +40,7 @@ ANFO = namedtuple("ANFO", "article_sum cache_size cache_limit")
 # Leave some space for "_UNPACK_" which we append during post-proc
 # Or, when extra ".1", ".2" etc. are added for identically named jobs
 DEF_FOLDER_MAX = 256 - 10
-DEF_FILE_MAX = 255 - 6 # max filename length on modern filesystems, minus 6 positions
+DEF_FILE_MAX = 255 - 6  # max filename length on modern filesystems, minus 6 positions
 
 GIGI = float(2 ** 30)
 MEBI = float(2 ** 20)

--- a/sabnzbd/constants.py
+++ b/sabnzbd/constants.py
@@ -40,6 +40,7 @@ ANFO = namedtuple("ANFO", "article_sum cache_size cache_limit")
 # Leave some space for "_UNPACK_" which we append during post-proc
 # Or, when extra ".1", ".2" etc. are added for identically named jobs
 DEF_FOLDER_MAX = 256 - 10
+DEF_FILE_MAX = 256 - 10
 
 GIGI = float(2 ** 30)
 MEBI = float(2 ** 20)

--- a/sabnzbd/constants.py
+++ b/sabnzbd/constants.py
@@ -40,7 +40,7 @@ ANFO = namedtuple("ANFO", "article_sum cache_size cache_limit")
 # Leave some space for "_UNPACK_" which we append during post-proc
 # Or, when extra ".1", ".2" etc. are added for identically named jobs
 DEF_FOLDER_MAX = 256 - 10
-DEF_FILE_MAX = 255 # max filename length on modern filesystems
+DEF_FILE_MAX = 255 - 6 # max filename length on modern filesystems, minus 6 positions
 
 GIGI = float(2 ** 30)
 MEBI = float(2 ** 20)

--- a/sabnzbd/constants.py
+++ b/sabnzbd/constants.py
@@ -40,7 +40,7 @@ ANFO = namedtuple("ANFO", "article_sum cache_size cache_limit")
 # Leave some space for "_UNPACK_" which we append during post-proc
 # Or, when extra ".1", ".2" etc. are added for identically named jobs
 DEF_FOLDER_MAX = 256 - 10
-DEF_FILE_MAX = 256 - 10
+DEF_FILE_MAX = 255 # max filename length on modern filesystems
 
 GIGI = float(2 ** 30)
 MEBI = float(2 ** 20)

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -177,7 +177,7 @@ def sanitize_filename(name: str) -> str:
         name = str(name.encode("ascii", "ignore"), "utf-8")
         if len(name) + len(ext) > DEF_FILE_MAX:
             # still too long, limit the extension
-            maxextlength = 100 # max length of an extension
+            maxextlength = 100  # max length of an extension
             if len(ext) > maxextlength:
                 # allow first <maxextlength> chars, including the starting dot
                 ext = ext[:maxextlength]

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -169,7 +169,8 @@ def sanitize_filename(name: str) -> str:
     # now split name into name, ext
     name, ext = os.path.splitext(name)
 
-    # If filename is too long (more than DEF_FILE_MAX bytes), brute-force truncate it.
+    # If filename is too long (more than DEF_FILE_MAX bytes), brute-force truncate it,
+    # preserving the extension (max ext length 20)
     # Note: some filesystem can handle up to 255 UTF chars (which is more than 255 bytes) in the filename,
     # but we stay on the safe side: max DEF_FILE_MAX bytes
     if len(name.encode("utf8")) + len(ext.encode("utf8")) > DEF_FILE_MAX:

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -169,15 +169,22 @@ def sanitize_filename(name: str) -> str:
     # now split name into name, ext
     name, ext = os.path.splitext(name)
 
-    # If filename is too long, truncate it:
-    if len(name) + len(ext) > 222:
+    # If filename is too long, brute-force truncate it:
+    maxlength = 222
+    if len(name) + len(ext) > maxlength:
         logging.debug("Filename %s is too long, so truncating", name + ext)
         # Too long filenames are often caused by incorrect non-ascii chars,
-        # so brute-force remove those non-ascii chars, and only keep 222 chars
-        # ... keeping in place the original extension
+        # so brute-force remove those non-ascii chars
         name = str(name.encode("ascii", "ignore"), "utf-8")
-        name = ''.join( c for c in name if  ord(c) >= 32 and ord(c)<128 )
-        name = name[: 222 - len(ext)]
+        if len(name) + len(ext) > maxlength:
+            # still too long, limit the extension
+            maxextlength = 100
+            if len(ext) > maxextlength:
+                # allow first 150 chars, including the starting dot
+                ext = ext[:maxextlength]
+            if len(name) + len(ext) > maxlength:
+                # Still too long, limit the basename
+                name = name[: maxlength - len(ext)]
 
     lowext = ext.lower()
     if lowext == ".par2" and lowext != ext:

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -169,8 +169,10 @@ def sanitize_filename(name: str) -> str:
     # now split name into name, ext
     name, ext = os.path.splitext(name)
 
-    # If filename is too long (in bytes), brute-force truncate it:
-    if len(str.encode(name)) + len(str.encode(ext)) > DEF_FILE_MAX:
+    # If filename is too long (more than DEF_FILE_MAX bytes), brute-force truncate it.
+    # Note: some filesystem can handle up to 255 UTF chars (which is more than 255 bytes) in the filename,
+    # but we stay on the safe side: max DEF_FILE_MAX bytes
+    if len(name.encode("utf8")) + len(ext.encode("utf8")) > DEF_FILE_MAX:
         logging.debug("Filename %s is too long, so truncating", name + ext)
         # Too long filenames are often caused by incorrect non-ascii chars,
         # so brute-force remove those non-ascii chars

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -175,7 +175,9 @@ def sanitize_filename(name: str) -> str:
         # Too long filenames are often caused by incorrect non-ascii chars,
         # so brute-force remove those non-ascii chars, and only keep 222 chars
         # ... keeping in place the original extension
-        name = str(name.encode("ascii", "ignore"), "utf-8")[: 222 - len(ext)]
+        name = str(name.encode("ascii", "ignore"), "utf-8")
+        name = ''.join( c for c in name if  ord(c) >= 32 and ord(c)<128 )
+        name = name[: 222 - len(ext)]
 
     lowext = ext.lower()
     if lowext == ".par2" and lowext != ext:

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -169,15 +169,16 @@ def sanitize_filename(name: str) -> str:
     # now split name into name, ext
     name, ext = os.path.splitext(name)
 
-    # If filename is too long, brute-force truncate it:
-    if len(name) + len(ext) > DEF_FILE_MAX:
+    # If filename is too long (in bytes), brute-force truncate it:
+    if len(str.encode(name)) + len(str.encode(ext)) > DEF_FILE_MAX:
         logging.debug("Filename %s is too long, so truncating", name + ext)
         # Too long filenames are often caused by incorrect non-ascii chars,
         # so brute-force remove those non-ascii chars
         name = str(name.encode("ascii", "ignore"), "utf-8")
+        # Now it's plain ASCII, so no need for len(str.encode()) anymore; plain len() is enough
         if len(name) + len(ext) > DEF_FILE_MAX:
             # still too long, limit the extension
-            maxextlength = 100  # max length of an extension
+            maxextlength = 20  # max length of an extension
             if len(ext) > maxextlength:
                 # allow first <maxextlength> chars, including the starting dot
                 ext = ext[:maxextlength]

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -171,10 +171,10 @@ def sanitize_filename(name: str) -> str:
 
     # If filename is too long, truncate it:
     if len(name) + len(ext) > 222:
-        # We hope not to get here, but if so ... solve it:
-        logging.debug("Filename %s is too long, so truncating", name)
+        logging.debug("Filename %s is too long, so truncating", name + ext)
         # Too long filenames are often caused by incorrect non-ascii chars,
-        # so brute-force remove those non-ascii chars, and only keep first 222 chars
+        # so brute-force remove those non-ascii chars, and only keep 222 chars
+        # ... keeping in place the original extension
         name = str(name.encode("ascii", "ignore"), "utf-8")[: 222 - len(ext)]
 
     lowext = ext.lower()

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -166,7 +166,18 @@ def sanitize_filename(name: str) -> str:
     if not name:
         name = "unknown"
 
+    # now split name into name, ext
     name, ext = os.path.splitext(name)
+
+    # If filename is too long, truncate it:
+    if len(name) + len(ext) > 222:
+        # We hope not to get here, but if so ... solve it:
+        logging.debug("Resulting filename from %s is too long, so truncating", url)
+        # Too long filenames are often caused by incorrect non-ascii chars,
+        # so brute-force remove those non-ascii chars, and only keep first 222 chars
+        ame = str(name.encode("ascii", "ignore"), "utf-8")[:222-len(ext)]
+
+
     lowext = ext.lower()
     if lowext == ".par2" and lowext != ext:
         ext = lowext

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -180,7 +180,7 @@ def sanitize_filename(name: str) -> str:
             # still too long, limit the extension
             maxextlength = 100
             if len(ext) > maxextlength:
-                # allow first 150 chars, including the starting dot
+                # allow first <maxextlength> chars, including the starting dot
                 ext = ext[:maxextlength]
             if len(name) + len(ext) > maxlength:
                 # Still too long, limit the basename

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -38,10 +38,9 @@ except ImportError:
 
 import sabnzbd
 from sabnzbd.decorators import synchronized
-from sabnzbd.constants import FUTURE_Q_FOLDER, JOB_ADMIN, GIGI
+from sabnzbd.constants import FUTURE_Q_FOLDER, JOB_ADMIN, GIGI, DEF_FILE_MAX
 from sabnzbd.encoding import correct_unknown_encoding
 from sabnzbd.utils import rarfile
-from sabnzbd.constants import DEF_FILE_MAX
 
 
 def get_ext(filename: str) -> str:
@@ -171,21 +170,20 @@ def sanitize_filename(name: str) -> str:
     name, ext = os.path.splitext(name)
 
     # If filename is too long, brute-force truncate it:
-    maxlength = DEF_FILE_MAX
-    if len(name) + len(ext) > maxlength:
+    if len(name) + len(ext) > DEF_FILE_MAX:
         logging.debug("Filename %s is too long, so truncating", name + ext)
         # Too long filenames are often caused by incorrect non-ascii chars,
         # so brute-force remove those non-ascii chars
         name = str(name.encode("ascii", "ignore"), "utf-8")
-        if len(name) + len(ext) > maxlength:
+        if len(name) + len(ext) > DEF_FILE_MAX:
             # still too long, limit the extension
-            maxextlength = 100
+            maxextlength = 100 # max length of an extension
             if len(ext) > maxextlength:
                 # allow first <maxextlength> chars, including the starting dot
                 ext = ext[:maxextlength]
-            if len(name) + len(ext) > maxlength:
+            if len(name) + len(ext) > DEF_FILE_MAX:
                 # Still too long, limit the basename
-                name = name[: maxlength - len(ext)]
+                name = name[: DEF_FILE_MAX - len(ext)]
 
     lowext = ext.lower()
     if lowext == ".par2" and lowext != ext:

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -172,11 +172,10 @@ def sanitize_filename(name: str) -> str:
     # If filename is too long, truncate it:
     if len(name) + len(ext) > 222:
         # We hope not to get here, but if so ... solve it:
-        logging.debug("Resulting filename from %s is too long, so truncating", url)
+        logging.debug("Filename %s is too long, so truncating", name)
         # Too long filenames are often caused by incorrect non-ascii chars,
         # so brute-force remove those non-ascii chars, and only keep first 222 chars
-        ame = str(name.encode("ascii", "ignore"), "utf-8")[:222-len(ext)]
-
+        name = str(name.encode("ascii", "ignore"), "utf-8")[: 222 - len(ext)]
 
     lowext = ext.lower()
     if lowext == ".par2" and lowext != ext:

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -41,6 +41,7 @@ from sabnzbd.decorators import synchronized
 from sabnzbd.constants import FUTURE_Q_FOLDER, JOB_ADMIN, GIGI
 from sabnzbd.encoding import correct_unknown_encoding
 from sabnzbd.utils import rarfile
+from sabnzbd.constants import DEF_FILE_MAX
 
 
 def get_ext(filename: str) -> str:
@@ -170,7 +171,7 @@ def sanitize_filename(name: str) -> str:
     name, ext = os.path.splitext(name)
 
     # If filename is too long, brute-force truncate it:
-    maxlength = 222
+    maxlength = DEF_FILE_MAX
     if len(name) + len(ext) > maxlength:
         logging.debug("Filename %s is too long, so truncating", name + ext)
         # Too long filenames are often caused by incorrect non-ascii chars,

--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -251,6 +251,12 @@ class URLGrabber(Thread):
                 if not filename:
                     filename = sabnzbd.get_new_id("url", os.path.join(cfg.admin_dir.get_path(), FUTURE_Q_FOLDER))
 
+                if len(filename) > 250:
+                    logging.info("Resulting filename from %s is too long, so truncating", url)
+                    # Too long filenames are often caused by incorrect non-ascii chars,
+                    # so brute-force remove non-ascii chars, and only keep first 250 chars
+                    filename = str(filename.encode("ascii", "ignore"),'utf-8')[:250]
+
                 # Write data to temp file
                 path = os.path.join(cfg.admin_dir.get_path(), FUTURE_Q_FOLDER, filename)
                 with open(path, "wb") as temp_nzb:

--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -251,12 +251,12 @@ class URLGrabber(Thread):
                 if not filename:
                     filename = sabnzbd.get_new_id("url", os.path.join(cfg.admin_dir.get_path(), FUTURE_Q_FOLDER))
 
-                if len(filename) > 250:
+                if len(filename) > 245:
                     # We hope not to get here, but if so ... solve it:
                     logging.info("Resulting filename from %s is too long, so truncating", url)
                     # Too long filenames are often caused by incorrect non-ascii chars,
                     # so brute-force remove those non-ascii chars, and only keep first 250 chars
-                    filename = str(filename.encode("ascii", "ignore"), "utf-8")[:250]
+                    filename = str(filename.encode("ascii", "ignore"), "utf-8")[:245]
 
                 # Write data to temp file
                 path = os.path.join(cfg.admin_dir.get_path(), FUTURE_Q_FOLDER, filename)

--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -251,13 +251,6 @@ class URLGrabber(Thread):
                 if not filename:
                     filename = sabnzbd.get_new_id("url", os.path.join(cfg.admin_dir.get_path(), FUTURE_Q_FOLDER))
 
-                if len(filename) > 245:
-                    # We hope not to get here, but if so ... solve it:
-                    logging.info("Resulting filename from %s is too long, so truncating", url)
-                    # Too long filenames are often caused by incorrect non-ascii chars,
-                    # so brute-force remove those non-ascii chars, and only keep first 250 chars
-                    filename = str(filename.encode("ascii", "ignore"), "utf-8")[:245]
-
                 # Write data to temp file
                 path = os.path.join(cfg.admin_dir.get_path(), FUTURE_Q_FOLDER, filename)
                 with open(path, "wb") as temp_nzb:

--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -252,6 +252,7 @@ class URLGrabber(Thread):
                     filename = sabnzbd.get_new_id("url", os.path.join(cfg.admin_dir.get_path(), FUTURE_Q_FOLDER))
 
                 if len(filename) > 250:
+                    # We hope not to get here, but if so ... solve it:
                     logging.info("Resulting filename from %s is too long, so truncating", url)
                     # Too long filenames are often caused by incorrect non-ascii chars,
                     # so brute-force remove those non-ascii chars, and only keep first 250 chars

--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -254,8 +254,8 @@ class URLGrabber(Thread):
                 if len(filename) > 250:
                     logging.info("Resulting filename from %s is too long, so truncating", url)
                     # Too long filenames are often caused by incorrect non-ascii chars,
-                    # so brute-force remove non-ascii chars, and only keep first 250 chars
-                    filename = str(filename.encode("ascii", "ignore"),'utf-8')[:250]
+                    # so brute-force remove those non-ascii chars, and only keep first 250 chars
+                    filename = str(filename.encode("ascii", "ignore"), "utf-8")[:250]
 
                 # Write data to temp file
                 path = os.path.join(cfg.admin_dir.get_path(), FUTURE_Q_FOLDER, filename)

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -191,9 +191,12 @@ class TestFileFolderNameSanitizer:
     def test_filename_too_long(self):
         # Should be truncated, keeping extension in place
         assert len(filesystem.sanitize_filename("a" * 300)) < 255
+        assert len(filesystem.sanitize_filename("a" * 300 + "." + "e"*300)) < 255
         assert (filesystem.sanitize_filename("a" * 300 + ".ext")).endswith(".ext")
+        assert (filesystem.sanitize_filename("a" * 300 + ".superlongextension")).endswith(".superlongextension")
         newname = filesystem.sanitize_filename("aaaa" + str(os.urandom(300)) + "bbbb.ext")
         assert newname.startswith("aaaa") and newname.endswith(".ext") and len(newname) < 255
+
         # Nothing should happen:
         assert len(filesystem.sanitize_filename("a" * 200)) == 200
         assert len(filesystem.sanitize_filename("你" * 200)) == 200

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -190,12 +190,12 @@ class TestFileFolderNameSanitizer:
 
     def test_filename_too_long(self):
         # Should be truncated, keeping extension in place
-        assert len(filesystem.sanitize_filename("a"*300)) < 255
-        assert (filesystem.sanitize_filename("a"*300 + ".ext")).endswith(".ext")
+        assert len(filesystem.sanitize_filename("a" * 300)) < 255
+        assert (filesystem.sanitize_filename("a" * 300 + ".ext")).endswith(".ext")
         newname = filesystem.sanitize_filename("aaaa" + str(os.urandom(300)) + "bbbb.ext")
         assert newname.startswith("aaaa") and newname.endswith(".ext") and len(newname) < 255
         # Nothing should happen:
-        assert len(filesystem.sanitize_filename("a"*200)) == 200
+        assert len(filesystem.sanitize_filename("a" * 200)) == 200
         assert len(filesystem.sanitize_filename("你" * 200)) == 200
 
 

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -191,7 +191,7 @@ class TestFileFolderNameSanitizer:
     def test_filename_too_long(self):
         # Should be truncated, keeping extension in place
         assert len(filesystem.sanitize_filename("a" * 300)) < 255
-        assert len(filesystem.sanitize_filename("a" * 300 + "." + "e"*300)) < 255
+        assert len(filesystem.sanitize_filename("a" * 300 + "." + "e" * 300)) < 255
         assert (filesystem.sanitize_filename("a" * 300 + ".ext")).endswith(".ext")
         assert (filesystem.sanitize_filename("a" * 300 + ".superlongextension")).endswith(".superlongextension")
         newname = filesystem.sanitize_filename("aaaa" + str(os.urandom(300)) + "bbbb.ext")

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -188,6 +188,16 @@ class TestFileFolderNameSanitizer:
         assert filesystem.sanitize_foldername(" ") == "unknown"
         assert filesystem.sanitize_foldername("  ") == "unknown"
 
+    def test_filename_too_long(self):
+        # Should be truncated, keeping extension in place
+        assert len(filesystem.sanitize_filename("a"*300)) < 255
+        assert (filesystem.sanitize_filename("a"*300 + ".ext")).endswith(".ext")
+        newname = filesystem.sanitize_filename("aaaa" + str(os.urandom(300)) + "bbbb.ext")
+        assert newname.startswith("aaaa") and newname.endswith(".ext") and len(newname) < 255
+        # Nothing should happen:
+        assert len(filesystem.sanitize_filename("a"*200)) == 200
+        assert len(filesystem.sanitize_filename("你" * 200)) == 200
+
 
 class TestSameFile:
     def test_nothing_in_common_win_paths(self):


### PR DESCRIPTION
I got tracebacks in urlgrabber with strange, 255+ char, non-ascii filenames, resulting in a no-download.
This patch solves that by brute-force removing non-ascii chars, and limiting to 250 chars. 

```
2020-12-26 22:30:51,461::ERROR::[urlgrabber:299] URLGRABBER CRASHED
Traceback (most recent call last):
  File "/usr/share/sabnzbdplus/sabnzbd/urlgrabber.py", line 261, in run
    with open(path, "wb") as temp_nzb:
OSError: [Errno 36] File name too long: "/home/sander/.sabnzbd/admin/future/[GuodongSubs]
```