### PR TITLE
docs: fix simple typo, sturct -> struct

### DIFF
--- a/sabnzbd/utils/rarfile.py
+++ b/sabnzbd/utils/rarfile.py
@@ -1568,7 +1568,7 @@ class Rar5Info(RarInfo):
 
 
 class Rar5BaseFile(Rar5Info):
-    """Shared sturct for file & service record."""
+    """Shared struct for file & service record."""
 
     type = -1
     file_flags = None


### PR DESCRIPTION
There is a small typo in sabnzbd/utils/rarfile.py.

Should read `struct` rather than `sturct`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md