### PR TITLE
Don't crash if nzf is gone

### DIFF
--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -629,6 +629,10 @@ class Downloader(Thread):
                     continue
 
                 else:
+                    try:
+                        article.nzf.nzo.update_download_stats(sabnzbd.BPSMeter.bps, server.id, bytes_received)
+                    except:
+                        pass
                     if self.bandwidth_limit:
                         limit = self.bandwidth_limit
                         if bytes_received + sabnzbd.BPSMeter.bps > limit:
@@ -636,7 +640,6 @@ class Downloader(Thread):
                                 time.sleep(0.05)
                                 sabnzbd.BPSMeter.update()
                     sabnzbd.BPSMeter.update(server.id, bytes_received)
-                    article.nzf.nzo.update_download_stats(sabnzbd.BPSMeter.bps, server.id, bytes_received)
 
                 if not done and nw.status_code != 222:
                     if not nw.connected or nw.status_code == 480:

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -631,8 +631,10 @@ class Downloader(Thread):
                 else:
                     try:
                         article.nzf.nzo.update_download_stats(sabnzbd.BPSMeter.bps, server.id, bytes_received)
-                    except:
+                    except AttributeError:
+                        # In case nzf has disappeared because the file was deleted before the update could happen
                         pass
+
                     if self.bandwidth_limit:
                         limit = self.bandwidth_limit
                         if bytes_received + sabnzbd.BPSMeter.bps > limit:


### PR DESCRIPTION
Should fix #1728. I considered logging the error instead, but it's not very important as long as it happens rarely and doesn't cause a crash. Putting the update before the loop should reduce the chance of it happening to ~0.

The reason why it has started happening is probably that until 3 months ago a reference to the nzo was fetched before the loop started.