### PR TITLE
can_be_slowed with some modifications

### DIFF
--- a/sabnzbd/bpsmeter.py
+++ b/sabnzbd/bpsmeter.py
@@ -372,6 +372,32 @@ class BPSMeter:
         # We record every second, but display at the user's refresh-rate
         return self.bps_list[::refresh_rate]
 
+    def get_stable_speed(self, timespan=10):
+        """See if there is a stable speed the last <timespan> seconds
+        None: indicates it can't determine yet
+        False: the speed was not stable during <timespan>
+        """
+        if len(self.bps_list) < timespan:
+            return None
+
+        # Calculate the variance in the speed
+        avg = sum(self.bps_list[-timespan:]) / timespan
+        vari = 0
+        for bps in self.bps_list[-timespan:]:
+            vari += abs(bps - avg)
+        vari = vari / timespan
+
+        try:
+            # See if the variance is less than 5%
+            if (vari / (self.bps / KIBI)) < 0.05:
+                return avg
+            else:
+                return False
+        except:
+            # Probably one of the values was 0
+            pass
+        return None
+
     def reset_quota(self, force: bool = False):
         """Check if it's time to reset the quota, optionally resuming
         Return True, when still paused or should be paused


### PR DESCRIPTION
I kept the configurable sleep time so that it can be set to 0 in case of problems. I also made the required number of reads depend on the number of active connections, so it will trigger somewhat differently than before. It will start working for systems that use less than 8 connections, but there might still be problems if anyone are using 40-50 connections and never can get more than 1-3 results. Hopefully the speed test will disable the sleep in those cases. I also reduced the BPS limit sleep to 0.01 in order to work better with the same cases.