### PR TITLE
if minissdpd is running, use that instead of self-sending broadcasts

### DIFF
--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1529,13 +1529,10 @@ def main():
                 console.setLevel(level)
 
         # 300 sec polling tasks
-        if not timer % 10:
+        if not timer % 100:
             if sabnzbd.LOG_ALL:
                 logging.debug("Triggering Python garbage collection")
-            n = gc.collect()
-            if sabnzbd.LOG_ALL:
-                logging.debug("gc.collect yielded %s unreachable objects %s", n)
-            # print("gc.collect yielded unreachable objects", n)
+            gc.collect()
             timer = 0
 
         # 30 sec polling tasks

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1529,10 +1529,13 @@ def main():
                 console.setLevel(level)
 
         # 300 sec polling tasks
-        if not timer % 100:
+        if not timer % 10:
             if sabnzbd.LOG_ALL:
                 logging.debug("Triggering Python garbage collection")
-            gc.collect()
+            n = gc.collect()
+            if sabnzbd.LOG_ALL:
+                logging.debug("gc.collect yielded %s unreachable objects %s", n)
+            #print("gc.collect yielded unreachable objects", n)
             timer = 0
 
         # 30 sec polling tasks

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1535,7 +1535,7 @@ def main():
             n = gc.collect()
             if sabnzbd.LOG_ALL:
                 logging.debug("gc.collect yielded %s unreachable objects %s", n)
-            #print("gc.collect yielded unreachable objects", n)
+            # print("gc.collect yielded unreachable objects", n)
             timer = 0
 
         # 30 sec polling tasks

--- a/sabnzbd/utils/ssdp.py
+++ b/sabnzbd/utils/ssdp.py
@@ -158,20 +158,24 @@ OPT: "http://schemas.upnp.org/upnp/1/0/"; ns=01
 
         logging.info("Trying if miniSSDPd is there")
         rc, message = submit_to_minissdpd(
-            "upnp:rootdevice", # b"urn:schemas-upnp-org:device:InternetGatewayDevice:1",
+            "upnp:rootdevice",  # b"urn:schemas-upnp-org:device:InternetGatewayDevice:1",
             "uuid:" + str(self.__uuid) + "::upnp:rootdevice",
             self.__server_name,
             self.__url + "/description.xml",
         )
 
         # to be sure
-        '''
+        """
         and now something like:
         http://192.168.1.217:80/description.xml
         urn:schemas-upnp-org:device:basic:1
         uuid:2f402f80-da50-11e1-9b23-001788721f4f
-        '''
-        rc, message = submit_to_minissdpd("urn:schemas-upnp-org:device:basic:1",             "uuid:" + str(self.__uuid),            self.__server_name,             self.__url + "/description.xml",
+        """
+        rc, message = submit_to_minissdpd(
+            "urn:schemas-upnp-org:device:basic:1",
+            "uuid:" + str(self.__uuid),
+            self.__server_name,
+            self.__url + "/description.xml",
         )
 
         if rc == 0:

--- a/sabnzbd/utils/ssdp.py
+++ b/sabnzbd/utils/ssdp.py
@@ -171,7 +171,7 @@ OPT: "http://schemas.upnp.org/upnp/1/0/"; ns=01
         urn:schemas-upnp-org:device:basic:1
         uuid:2f402f80-da50-11e1-9b23-001788721f4f
         '''
-        rc, message = submit_to_minissdpd(            "urn:schemas-upnp-org:device:basic:1", # b"urn:schemas-upnp-org:device:InternetGatewayDevice:1",            "uuid:" + str(self.__uuid),            self.__server_name,             self.__url + "/description.xml",
+        rc, message = submit_to_minissdpd("urn:schemas-upnp-org:device:basic:1",             "uuid:" + str(self.__uuid),            self.__server_name,             self.__url + "/description.xml",
         )
 
         if rc == 0:

--- a/sabnzbd/utils/ssdp.py
+++ b/sabnzbd/utils/ssdp.py
@@ -224,7 +224,6 @@ def stop_ssdp():
 
 def server_ssdp_xml():
     """Returns the description.xml if the server is alive, empty otherwise"""
-    logging.debug("request for description.xml")
     if __SSDP and __SSDP.is_alive():
         return __SSDP.serve_xml()
     return ""

--- a/sabnzbd/utils/ssdp.py
+++ b/sabnzbd/utils/ssdp.py
@@ -175,7 +175,7 @@ OPT: "http://schemas.upnp.org/upnp/1/0/"; ns=01
         MULTICAST_TTL = 2
 
         if rc == 0:
-            # TODO is this necessary to keep the class alive? Or can we quit this.
+            # TODO is this necessary to keep the class alive? Or can we leave this out?
             logging.info("We have miniSSPDd running, so no SSDP broadcasts sending needed")
             while True and not self.__stop:
                 time.sleep(20)

--- a/sabnzbd/utils/ssdp.py
+++ b/sabnzbd/utils/ssdp.py
@@ -171,11 +171,7 @@ OPT: "http://schemas.upnp.org/upnp/1/0/"; ns=01
         urn:schemas-upnp-org:device:basic:1
         uuid:2f402f80-da50-11e1-9b23-001788721f4f
         '''
-        rc, message = submit_to_minissdpd(
-            "urn:schemas-upnp-org:device:basic:1", # b"urn:schemas-upnp-org:device:InternetGatewayDevice:1",
-            "uuid:" + str(self.__uuid),
-            self.__server_name,
-            self.__url + "/description.xml",
+        rc, message = submit_to_minissdpd(            "urn:schemas-upnp-org:device:basic:1", # b"urn:schemas-upnp-org:device:InternetGatewayDevice:1",            "uuid:" + str(self.__uuid),            self.__server_name,             self.__url + "/description.xml",
         )
 
         if rc == 0:

--- a/sabnzbd/utils/ssdp.py
+++ b/sabnzbd/utils/ssdp.py
@@ -158,11 +158,26 @@ OPT: "http://schemas.upnp.org/upnp/1/0/"; ns=01
 
         logging.info("Trying if miniSSDPd is there")
         rc, message = submit_to_minissdpd(
-            b"urn:schemas-upnp-org:device:InternetGatewayDevice:1",
+            "upnp:rootdevice", # b"urn:schemas-upnp-org:device:InternetGatewayDevice:1",
             "uuid:" + str(self.__uuid) + "::upnp:rootdevice",
             self.__server_name,
             self.__url + "/description.xml",
         )
+
+        # to be sure
+        '''
+        and now something like:
+        http://192.168.1.217:80/description.xml
+        urn:schemas-upnp-org:device:basic:1
+        uuid:2f402f80-da50-11e1-9b23-001788721f4f
+        '''
+        rc, message = submit_to_minissdpd(
+            "urn:schemas-upnp-org:device:basic:1", # b"urn:schemas-upnp-org:device:InternetGatewayDevice:1",
+            "uuid:" + str(self.__uuid),
+            self.__server_name,
+            self.__url + "/description.xml",
+        )
+
         if rc == 0:
             logging.info("miniSSDPd OK: submitting to MiniSSDPD went OK")
         else:

--- a/sabnzbd/utils/ssdp.py
+++ b/sabnzbd/utils/ssdp.py
@@ -68,6 +68,7 @@ def codelength(s):
 
 
 def submit_to_minissdpd(st, usn, server, url, sockpath="/var/run/minissdpd.sock"):
+
     """ submits the specified service to MiniSSDPD (if running)"""
     """
     ST = Search Target of the service that is responding.
@@ -163,10 +164,10 @@ OPT: "http://schemas.upnp.org/upnp/1/0/"; ns=01
             b"urn:schemas-upnp-org:device:InternetGatewayDevice:1",
             "uuid:" + str(self.__uuid) + "::upnp:rootdevice",
             self.__server_name,
-            self.__url + "/description.xml"
+            self.__url + "/description.xml",
         )
         if rc == 0:
-            logging.info("miniSSDPd OK: submitting to MiniSSDPD went well")
+            logging.info("miniSSDPd OK: submitting to MiniSSDPD went OK")
         else:
             logging.info("miniSSDPd not there")
             logging.debug("miniSSDPd Not OK. Error message is: %s", message)
@@ -176,9 +177,8 @@ OPT: "http://schemas.upnp.org/upnp/1/0/"; ns=01
         MCAST_PORT = 1900
         MULTICAST_TTL = 2
 
-
-
         if rc == 0:
+            # TODO is this necessary?
             logging.info("We have miniSSPDd running, so no SSDP broadcasts sending needed")
             while True and not self.__stop:
                 time.sleep(20)


### PR DESCRIPTION
If minissdpd is running, use that instead of self-sending broadcasts from SABnzbd: less work for SABnzbd, and minissdpd will answer SSDP requests from other devices/clients (which current SABnzbd's ssdp.py implementation does not).

miniSSDPd (http://miniupnp.free.fr/minissdpd.html) runs on Synology, and possibly other NAS/Linux/POSIX devices

```
admin@DiskStation:/$ ps -ef | grep -i ssdp
root      5397     1  0  2020 ?        00:04:22 /usr/bin/minissdpd -i eth0
```

Source of python part: https://github.com/miniupnp/miniupnp/blob/master/minissdpd/submit_to_minissdpd.py 

To see which SSDP device are on the host and the LAN:

```
sander@witte2004:~/git/miniupnp/minissdpd$ ./testminissdpd

0 - http://192.168.1.3:8080/sabnzbd/description.xml
    upnp:rootdevice
    uuid:2222bede-b2da-3338-816c-4c1ac3aada7e::upnp:rootdevice
1 - https://127.0.0.1:8080/sabnzbd/description.xml
    upnp:rootdevice
    uuid:ff574a0d-6362-391c-a112-554e9d4ab397::upnp:rootdevice
2 - http://192.168.1.4:8080/sabnzbd/description.xml
    upnp:rootdevice
    uuid:3b4a6975-b36a-3b30-a51e-c5acbd16cdc1::upnp:rootdevice
3 - http://192.168.1.217:80/description.xml
    urn:schemas-upnp-org:device:basic:1
    uuid:2f402f80-da50-11e1-9b23-001788721f4f
4 - http://192.168.1.217:80/description.xml
    uuid:2f402f80-da50-11e1-9b23-001788721f4f
    uuid:2f402f80-da50-11e1-9b23-001788721f4f
...

```
EDIT:

Run minissdpd in the foreground to see all what is going on:

```
sander@witte2004:~/git/miniupnp/minissdpd$ sudo ./minissdpd -d -i wlo1

minissdpd[46260]: SSDP request: 'HTTP' (2) ssdp:alive nt=upnp:rootdevice
minissdpd[46260]: new device discovered : uuid:73796E6F-6473-6D00-0000-001132157f60::upnp:rootdevice
minissdpd[46260]: ** i=1 deltadev=0 **
minissdpd[46260]: SSDP request: 'HTTP' (2) ssdp:alive nt=upnp:rootdevice
minissdpd[46260]: device updated : uuid:73796E6F-6473-6D00-0000-001132157f60::upnp:rootdevice
minissdpd[46260]: ** i=0 deltadev=1 **
minissdpd[46260]: 1 new devices added
minissdpd[46260]: SSDP request: 'HTTP' (2) ssdp:alive nt=upnp:rootdevice
```



