### PR TITLE
Validate input value for scripts

### DIFF
--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -645,7 +645,7 @@ def add_nzbfile(
     """
     if pp == "-1":
         pp = None
-    if script and script.lower() == "default":
+    if script and (script.lower() == "default" or not filesystem.is_valid_script(script)):
         script = None
     if cat and cat.lower() == "default":
         cat = None
@@ -792,7 +792,7 @@ def change_queue_complete_action(action, new=True):
     """
     _action = None
     _argument = None
-    if action.startswith("script_"):
+    if action.startswith("script_") and filesystem.is_valid_script(action.replace("script_", "", 1)):
         # all scripts are labeled script_xxx
         _action = run_script
         _argument = action.replace("script_", "", 1)

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -83,12 +83,6 @@ _MSG_NO_SUCH_CONFIG = "Config item does not exist"
 _MSG_CONFIG_LOCKED = "Configuration locked"
 _MSG_BAD_SERVER_PARMS = "Incorrect server settings"
 
-# For Windows: determine executable extensions
-if os.name == "nt":
-    PATHEXT = os.environ.get("PATHEXT", "").lower().split(";")
-else:
-    PATHEXT = []
-
 
 def api_handler(kwargs):
     """ API Dispatcher """

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -31,12 +31,6 @@ import locale
 from threading import Thread
 from typing import List, Tuple
 
-try:
-    import win32api
-    import win32file
-except ImportError:
-    pass
-
 import sabnzbd
 from sabnzbd.constants import (
     VALID_ARCHIVES,
@@ -64,7 +58,7 @@ from sabnzbd.misc import (
     calc_age,
     opts_to_pp,
 )
-from sabnzbd.filesystem import diskspace, get_ext, globber_full, clip_path, remove_all, userxbit
+from sabnzbd.filesystem import diskspace, get_ext, clip_path, remove_all, list_scripts
 from sabnzbd.encoding import xml_name
 from sabnzbd.utils.servertests import test_nntp_server_dict
 from sabnzbd.getipaddress import localipv4, publicipv4, ipv6, addresslookup
@@ -1865,32 +1859,6 @@ def calc_timeleft(bytesleft, bps):
             return "%s:%s:%s" % (hours, minutes, seconds)
     except:
         return "0:00:00"
-
-
-def list_scripts(default: bool = False, none: bool = True) -> List[str]:
-    """ Return a list of script names, optionally with 'Default' added """
-    lst = []
-    path = cfg.script_dir.get_path()
-    if path and os.access(path, os.R_OK):
-        for script in globber_full(path):
-            if os.path.isfile(script):
-                if (
-                    (
-                        sabnzbd.WIN32
-                        and os.path.splitext(script)[1].lower() in PATHEXT
-                        and not win32api.GetFileAttributes(script) & win32file.FILE_ATTRIBUTE_HIDDEN
-                    )
-                    or script.endswith(".py")
-                    or (not sabnzbd.WIN32 and userxbit(script) and not os.path.basename(script).startswith("."))
-                ):
-                    lst.append(os.path.basename(script))
-            # Make sure capitalization is ignored to avoid strange results
-            lst = sorted(lst, key=str.casefold)
-        if none:
-            lst.insert(0, "None")
-        if default:
-            lst.insert(0, "Default")
-    return lst
 
 
 def list_cats(default=True):

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -77,10 +77,19 @@ def validate_server(value):
         return None, value
 
 
+def validate_script(value):
+    """ Check if value is a valid script """
+    if value and sabnzbd.filesystem.is_valid_script(value):
+        return None, value
+    elif (value and value == "None") or not value:
+        return None, "None"
+    return T("%s is not a valid script") % value, None
+
+
 ##############################################################################
 # Special settings
 ##############################################################################
-pre_script = OptionStr("misc", "pre_script", "None")
+pre_script = OptionStr("misc", "pre_script", "None", validation=validate_script)
 queue_complete = OptionStr("misc", "queue_complete")
 queue_complete_pers = OptionBool("misc", "queue_complete_pers", False)
 bandwidth_perc = OptionNumber("misc", "bandwidth_perc", 100, 0, 100)
@@ -425,7 +434,7 @@ pushbullet_prio_other = OptionBool("pushbullet", "pushbullet_prio_other", True)
 # [nscript]
 nscript_enable = OptionBool("nscript", "nscript_enable")
 nscript_cats = OptionList("nscript", "nscript_cats", ["*"])
-nscript_script = OptionStr("nscript", "nscript_script")
+nscript_script = OptionStr("nscript", "nscript_script", validation=validate_script)
 nscript_parameters = OptionStr("nscript", "nscript_parameters")
 nscript_prio_startup = OptionBool("nscript", "nscript_prio_startup", True)
 nscript_prio_download = OptionBool("nscript", "nscript_prio_download", False)

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -472,7 +472,7 @@ def fix_unix_encoding(folder: str):
                         logging.info("Cannot correct name of %s", os.path.join(root, name))
 
 
-def is_valid_script(basename):
+def is_valid_script(basename: str) -> bool:
     """ Determine if 'basename' is a valid script """
     return basename in sabnzbd.api.list_scripts(default=False, none=False)
 

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -43,6 +43,12 @@ from sabnzbd.constants import FUTURE_Q_FOLDER, JOB_ADMIN, GIGI, DEF_FILE_MAX
 from sabnzbd.encoding import correct_unknown_encoding
 from sabnzbd.utils import rarfile
 
+# For Windows: determine executable extensions
+if os.name == "nt":
+    PATHEXT = os.environ.get("PATHEXT", "").lower().split(";")
+else:
+    PATHEXT = []
+
 
 def get_ext(filename: str) -> str:
     """ Return lowercased file extension """

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -472,12 +472,17 @@ def fix_unix_encoding(folder: str):
                         logging.info("Cannot correct name of %s", os.path.join(root, name))
 
 
+def is_valid_script(basename):
+    """ Determine if 'basename' is a valid script """
+    return basename in sabnzbd.api.list_scripts(default=False, none=False)
+
+
 def make_script_path(script: str) -> Optional[str]:
     """ Return full script path, if any valid script exists, else None """
     script_path = None
     script_dir = sabnzbd.cfg.script_dir.get_path()
     if script_dir and script:
-        if script.lower() not in ("none", "default"):
+        if script.lower() not in ("none", "default") and is_valid_script(script):
             script_path = os.path.join(script_dir, script)
             if not os.path.exists(script_path):
                 script_path = None

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -29,7 +29,7 @@ from typing import List, Dict, Union, Tuple, Optional
 import sabnzbd
 from sabnzbd.nzbstuff import NzbObject, Article
 from sabnzbd.misc import exit_sab, cat_to_opts, int_conv, caller_name, cmp, safe_lower
-from sabnzbd.filesystem import get_admin_path, remove_all, globber_full, remove_file
+from sabnzbd.filesystem import get_admin_path, remove_all, globber_full, remove_file, is_valid_script
 from sabnzbd.nzbparser import process_single_nzb
 from sabnzbd.panic import panic_queue
 from sabnzbd.decorators import NzbQueueLocker
@@ -276,11 +276,12 @@ class NzbQueue:
 
     def change_script(self, nzo_ids: str, script: str) -> int:
         result = 0
-        for nzo_id in [item.strip() for item in nzo_ids.split(",")]:
-            if nzo_id in self.__nzo_table:
-                self.__nzo_table[nzo_id].script = script
-                logging.info("Set script=%s for job %s", script, self.__nzo_table[nzo_id].final_name)
-                result += 1
+        if is_valid_script(script):
+            for nzo_id in [item.strip() for item in nzo_ids.split(",")]:
+                if nzo_id in self.__nzo_table:
+                    self.__nzo_table[nzo_id].script = script
+                    logging.info("Set script=%s for job %s", script, self.__nzo_table[nzo_id].final_name)
+                    result += 1
         return result
 
     def change_cat(self, nzo_ids: str, cat: str, explicit_priority=None):

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -77,6 +77,7 @@ from sabnzbd.filesystem import (
     get_filepath,
     make_script_path,
     globber,
+    is_valid_script,
 )
 from sabnzbd.decorators import synchronized
 import sabnzbd.config as config
@@ -623,6 +624,8 @@ class NzbObject(TryList):
         self.unpack: bool = u  # True if we want to unpack this set
         self.delete: bool = d  # True if we want to delete this set
         self.script: str = script  # External script for this set
+        if not is_valid_script(self.script):
+            self.script = None
         self.cat = cat  # User-set category
 
         # Information fields
@@ -818,7 +821,7 @@ class NzbObject(TryList):
                 priority = int(priority)
             except:
                 priority = DEFAULT_PRIORITY
-            if script_pp:
+            if script_pp and is_valid_script(script_pp):
                 script = script_pp
             if group:
                 self.groups = [str(group)]

--- a/tests/test_functional_api.py
+++ b/tests/test_functional_api.py
@@ -521,7 +521,6 @@ class TestQueueApi(ApiTestFunctions):
         for nzo_id in deleted_nzo_ids:
             assert nzo_id not in remaining_nzo_ids
 
-    @pytest.mark.xfail(reason="Script values aren't sanitized, see issue #1650")
     @pytest.mark.parametrize(
         "should_work, set_scriptsdir, value",
         [
@@ -533,8 +532,11 @@ class TestQueueApi(ApiTestFunctions):
             (False, False, "invalid_option"),
             (False, True, "script_foobar.py"),  # Doesn't exist, see issue #1650
             (False, True, "script_" + os.path.join("..", "SABnzbd.py")),  # Outside the scriptsdir, #1650 again
+            (False, True, "script_" + os.path.join("..", "..", "SABnzbd.py")),
+            (False, True, "script_" + os.path.join("..", "..", "..", "SABnzbd.py")),
             (False, True, "script_"),  # Empty after removal of the prefix
-            (True, True, "my_script_for_sab.py"),  # Test for #1651
+            (True, True, "script_my_script_for_sab.py"),  # Test for #1651
+            (False, True, "my_script_for_sab.py"),
         ],
     )
     def test_api_queue_change_complete_action(self, should_work, set_scriptsdir, value):


### PR DESCRIPTION
Ensure the input points to a valid script, present in the script dir; refuse to set/run it if doesn't. The check should apply whenever script values are set or changed, and again when the script is eventually run.

Fixes #1650