### PR TITLE
adding requests for sickGear support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,9 @@ portend
 chardet
 notify2
 
+# Support for SickGear https://github.com/SickGear/SickGear/blob/master/autoProcessTV/autoProcessTV.py
+requests>=2.25.0
+
 # Windows system integration
 pywin32>=227; sys_platform == 'win32'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,8 @@ portend
 chardet
 notify2
 
-# Support for SickGear https://github.com/SickGear/SickGear/blob/master/autoProcessTV/autoProcessTV.py
+# Support for SickGear
+# https://github.com/SickGear/SickGear/blob/master/autoProcessTV/autoProcessTV.py
 requests>=2.25.0
 
 # Windows system integration


### PR DESCRIPTION
Hi folks,

I had a bit of a battle with sickGear/sabNZBD compatibility which I finally solved as an issue with requests missing from python venv within sabNZBD. Once I sourced /env and pip3 installed requests, this resolved the issue.

I've included the link to the job runner in the comment inside requirements.txt

Adding this into a PR for future.