### PR TITLE
Quick and dirty support for auto night mode switching in Glitter

### DIFF
--- a/interfaces/Glitter/templates/static/stylesheets/colorschemes/Auto.css
+++ b/interfaces/Glitter/templates/static/stylesheets/colorschemes/Auto.css
@@ -1,0 +1,1 @@
+@import url('Night.css') screen and (prefers-color-scheme: dark);


### PR DESCRIPTION
A quick and dirty css import that uses the prefers-color-scheme media query to only load the Night colour scheme when the UA is in dark mode.