### PR TITLE
Abort job if more than 50% of data is missing after trying x MB

### DIFF
--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -310,6 +310,7 @@ host_whitelist = OptionList("misc", "host_whitelist", validation=all_lowercase)
 max_url_retries = OptionNumber("misc", "max_url_retries", 10, 1)
 downloader_sleep_time = OptionNumber("misc", "downloader_sleep_time", 10, 0)
 ssdp_broadcast_interval = OptionNumber("misc", "ssdp_broadcast_interval", 15, 1, 600)
+missing_threshold_mbytes = OptionNumber("misc", "missing_threshold_mbytes", 0)
 
 
 ##############################################################################

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -296,6 +296,7 @@ num_decoders = OptionNumber("misc", "num_decoders", 3)
 # Text values
 rss_odd_titles = OptionList("misc", "rss_odd_titles", ["nzbindex.nl/", "nzbindex.com/", "nzbclub.com/"])
 req_completion_rate = OptionNumber("misc", "req_completion_rate", 100.2, 100, 200)
+missing_threshold_mbytes = OptionNumber("misc", "missing_threshold_mbytes", 0)
 selftest_host = OptionStr("misc", "selftest_host", "self-test.sabnzbd.org")
 movie_rename_limit = OptionStr("misc", "movie_rename_limit", "100M")
 size_limit = OptionStr("misc", "size_limit", "0")
@@ -310,7 +311,6 @@ host_whitelist = OptionList("misc", "host_whitelist", validation=all_lowercase)
 max_url_retries = OptionNumber("misc", "max_url_retries", 10, 1)
 downloader_sleep_time = OptionNumber("misc", "downloader_sleep_time", 10, 0)
 ssdp_broadcast_interval = OptionNumber("misc", "ssdp_broadcast_interval", 15, 1, 600)
-missing_threshold_mbytes = OptionNumber("misc", "missing_threshold_mbytes", 0)
 
 
 ##############################################################################

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -1343,6 +1343,7 @@ SPECIAL_VALUE_LIST = (
     "nomedia_marker",
     "max_url_retries",
     "req_completion_rate",
+    "missing_threshold_mbytes",
     "wait_ext_drive",
     "max_foldername_length",
     "show_sysload",
@@ -1352,7 +1353,6 @@ SPECIAL_VALUE_LIST = (
     "selftest_host",
     "rating_host",
     "ssdp_broadcast_interval",
-    "missing_threshold_mbytes",
 )
 SPECIAL_LIST_LIST = ("rss_odd_titles", "quick_check_ext_ignore", "host_whitelist")
 

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -1352,6 +1352,7 @@ SPECIAL_VALUE_LIST = (
     "selftest_host",
     "rating_host",
     "ssdp_broadcast_interval",
+    "missing_threshold_mbytes",
 )
 SPECIAL_LIST_LIST = ("rss_odd_titles", "quick_check_ext_ignore", "host_whitelist")
 

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -778,7 +778,7 @@ class NzbQueue:
             if nzo.precheck:
                 nzo.save_to_disk()
                 # Check result
-                enough, _ = nzo.check_availability_ratio()
+                enough, _ = nzo.check_availability()
                 if enough:
                     # Enough data present, do real download
                     self.send_back(nzo)

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -1174,7 +1174,7 @@ class NzbObject(TryList):
                 if cfg.fail_hopeless_jobs() and cfg.fast_fail():
                     job_can_succeed = self.check_first_article_availability()
                     if not job_can_succeed:
-                        abort_reason = "https://sabnzbd.org/not-complete (check_first_article_availability)"
+                        abort_reason = "check_first_article_availability"
 
         # Remove from file-tracking
         articles_left = nzf.remove_article(article, success)
@@ -1190,20 +1190,20 @@ class NzbObject(TryList):
 
         # Check if we can succeed when we have missing articles
         # Skip check if retry or first articles already deemed it hopeless
-        if not success and job_can_succeed and not self.reuse:
+        if not success and job_can_succeed and not self.reuse and cfg.fail_hopeless_jobs():
             # Abort if more than 50% is missing after reaching missing_threshold_mbytes
             job_can_succeed = self.check_missing_threshold_mbytes()
             if not job_can_succeed:
-                abort_reason = "https://sabnzbd.org/not-complete (missing_threshold_mbytes)"
+                abort_reason = "missing_threshold_mbytes"
 
-            if job_can_succeed and cfg.fail_hopeless_jobs():
+            if job_can_succeed:
                 job_can_succeed, _ = self.check_availability_ratio()
                 if not job_can_succeed:
-                    abort_reason = "https://sabnzbd.org/not-complete (check_availability_ratio)"
+                    abort_reason = "check_availability_ratio"
 
         # Abort the job due to failure
         if not job_can_succeed:
-            self.fail_msg = T("Aborted, cannot be completed") + " - " + abort_reason
+            self.fail_msg = T("Aborted, cannot be completed") + " - https://sabnzbd.org/not-complete"
             self.set_unpack_info("Download", self.fail_msg, unique=False)
             logging.debug('Abort job "%s", due to impossibility to complete it (%s)', self.final_name, abort_reason)
             return True, True, True

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -352,7 +352,7 @@ def process_job(nzo: NzbObject):
         # if no files are present (except __admin__), fail the job
         if all_ok and len(globber(workdir)) < 2:
             if nzo.precheck:
-                _, ratio = nzo.check_availability_ratio()
+                _, ratio = nzo.check_availability()
                 emsg = T("Download might fail, only %s of required %s available") % (ratio, cfg.req_completion_rate())
             else:
                 emsg = T("Download failed - Not on your server(s)")


### PR DESCRIPTION
https://forums.sabnzbd.org/viewtopic.php?f=4&t=25183

Sometimes you know the downloads will fail if there are a lot of missing articles early. After having tried `missing_threshold_mbytes` MB it will fail if the number of failed bytes exceeds the number of downloaded bytes.

I don't see any perfect solutions for this and it's a bit hackish so I didn't make a proper config. The threshold will have to be a guess, and if the user thinks it's a false positive they can retry. I'm very open for suggestions on how to improve it.