### PR TITLE
handle gracefully if no malloc_trim() available

### DIFF
--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -59,7 +59,10 @@ elif os.name == "posix":
     # See if we have Linux memory functions
     try:
         LIBC = ctypes.CDLL("libc.so.6")
+        LIBC.malloc_trim(0)
     except:
+        # No malloc_trim(), probably because no libc
+        LIBC = None
         pass
 
     # Parse macOS version numbers


### PR DESCRIPTION
Solves postprocessor crashes and thus SABnzbd restarts on Alpine Linux, hotio docker image, and other non-libc Linux environments.

See https://forums.sabnzbd.org/viewtopic.php?f=11&t=25205&start=15


Tested within the hotio / Alpine image, and it works well:

```
2021-02-18 19:36:19,123::INFO::[notifier:122] Sending notification: SABnzbd - Queue finished (type=queue_done, job_cat=None)
2021-02-18 19:36:19,124::DEBUG::[postproc:1042] Triggering garbage collection and release of memory

2021-02-18 19:37:57,229::INFO::[__init__:548] Fetching https://sabnzbd.org/tests/test_download_100MB.nzb
```

So no crash anymore from malloc_trim() because it is not called anymore, and gc_collect() still happens nicely.
