### PR TITLE
Reduce the number of full BPSMeter.update calls by caching the amounts

### DIFF
--- a/sabnzbd/bpsmeter.py
+++ b/sabnzbd/bpsmeter.py
@@ -25,7 +25,8 @@ import re
 from typing import List, Dict, Optional
 
 import sabnzbd
-from sabnzbd.constants import BYTES_FILE_NAME, KIBI, MEBI
+from sabnzbd.constants import BYTES_FILE_NAME, KIBI
+from sabnzbd.misc import to_units
 import sabnzbd.cfg as cfg
 
 DAY = float(24 * 60 * 60)
@@ -297,7 +298,7 @@ class BPSMeter:
             self.reset()
 
         elif self.log_time < check_time:
-            logging.debug("MB/s: %.2f", self.bps / MEBI)
+            logging.debug("Speed: %sB/s", to_units(self.bps))
             self.log_time = t
 
         if self.speed_log_time < (t - 1.0):

--- a/sabnzbd/bpsmeter.py
+++ b/sabnzbd/bpsmeter.py
@@ -102,6 +102,7 @@ class BPSMeter:
 
         self.server_bps: Dict[str, float] = {}
         self.cached_amount: Dict[str, int] = {}
+        self.sum_cached_amount: int = 0
         self.day_total: Dict[str, int] = {}
         self.week_total: Dict[str, int] = {}
         self.month_total: Dict[str, int] = {}
@@ -216,6 +217,7 @@ class BPSMeter:
                 self.cached_amount[server] = 0
                 self.server_bps[server] = 0.0
             self.cached_amount[server] += amount
+            self.sum_cached_amount += amount
 
         # Wait at least 0.05 seconds between each full update
         if not force_full_update and t - self.last_update < 0.05:
@@ -236,12 +238,10 @@ class BPSMeter:
                 self.end_of_month = next_month(t) - 1.0
 
         # Add amounts that have been stored temporarily to statistics
-        total_amount = 0
         for srv in self.cached_amount:
             cached_amount = self.cached_amount[srv]
             if cached_amount:
                 self.cached_amount[srv] = 0
-                total_amount += cached_amount
                 if srv not in self.day_total:
                     self.day_total[srv] = 0
                 self.day_total[srv] += cached_amount
@@ -274,7 +274,7 @@ class BPSMeter:
 
         # Quota check
         if self.have_quota and self.quota_enabled:
-            self.left -= total_amount
+            self.left -= self.sum_cached_amount
             if self.left <= 0.0:
                 if not sabnzbd.Downloader.paused:
                     sabnzbd.Downloader.pause()
@@ -282,7 +282,9 @@ class BPSMeter:
 
         # Speedometer
         try:
-            self.bps = (self.bps * (self.last_update - self.start_time) + total_amount) / (t - self.start_time)
+            self.bps = (self.bps * (self.last_update - self.start_time) + self.sum_cached_amount) / (
+                t - self.start_time
+            )
         except:
             self.bps = 0.0
             self.server_bps = {}
@@ -290,6 +292,7 @@ class BPSMeter:
         self.last_update = t
 
         check_time = t - 5.0
+        self.sum_cached_amount = 0
 
         if self.start_time < check_time:
             self.start_time = check_time

--- a/sabnzbd/bpsmeter.py
+++ b/sabnzbd/bpsmeter.py
@@ -218,7 +218,7 @@ class BPSMeter:
             self.cached_amount[server] += amount
 
         # Wait at least 0.05 seconds between each full update
-        if not force_full_update and t - self.last_update < 0.25:
+        if not force_full_update and t - self.last_update < 0.05:
             return
 
         if t > self.end_of_day:

--- a/sabnzbd/bpsmeter.py
+++ b/sabnzbd/bpsmeter.py
@@ -25,7 +25,7 @@ import re
 from typing import List, Dict, Optional
 
 import sabnzbd
-from sabnzbd.constants import BYTES_FILE_NAME, KIBI
+from sabnzbd.constants import BYTES_FILE_NAME, KIBI, MEBI
 import sabnzbd.cfg as cfg
 
 DAY = float(24 * 60 * 60)
@@ -297,7 +297,7 @@ class BPSMeter:
             self.reset()
 
         elif self.log_time < check_time:
-            logging.debug("bps: %s", self.bps)
+            logging.debug("MB/s: %.2f", self.bps / MEBI)
             self.log_time = t
 
         if self.speed_log_time < (t - 1.0):

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -659,7 +659,7 @@ class Downloader(Thread):
                         if bytes_received + sabnzbd.BPSMeter.bps > limit:
                             while sabnzbd.BPSMeter.bps > limit:
                                 time.sleep(0.01)
-                                sabnzbd.BPSMeter.update()
+                                sabnzbd.BPSMeter.update(force=True)
                     sabnzbd.BPSMeter.update(server.id, bytes_received)
 
                 if not done and nw.status_code != 222:

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -581,7 +581,9 @@ class Downloader(Thread):
                     # Make sure server address resolution is refreshed
                     server.info = None
                 self.force_disconnect = False
-                sabnzbd.BPSMeter.update(force=True)
+
+                # Make sure we update the stats
+                sabnzbd.BPSMeter.update()
 
                 # Exit-point
                 if self.shutdown:
@@ -627,7 +629,7 @@ class Downloader(Thread):
                         DOWNLOADER_CV.wait()
 
             if not read:
-                sabnzbd.BPSMeter.update()
+                sabnzbd.BPSMeter.update(force_full_update=False)
                 continue
 
             for selected in read:
@@ -641,7 +643,7 @@ class Downloader(Thread):
                     bytes_received, done, skip = (0, False, False)
 
                 if skip:
-                    sabnzbd.BPSMeter.update()
+                    sabnzbd.BPSMeter.update(force_full_update=False)
                     continue
 
                 if bytes_received < 1:
@@ -660,8 +662,8 @@ class Downloader(Thread):
                         if bytes_received + sabnzbd.BPSMeter.bps > limit:
                             while sabnzbd.BPSMeter.bps > limit:
                                 time.sleep(0.01)
-                                sabnzbd.BPSMeter.update(force=True)
-                    sabnzbd.BPSMeter.update(server.id, bytes_received)
+                                sabnzbd.BPSMeter.update()
+                    sabnzbd.BPSMeter.update(server.id, bytes_received, force_full_update=False)
 
                 if not done and nw.status_code != 222:
                     if not nw.connected or nw.status_code == 480:

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -657,13 +657,11 @@ class Downloader(Thread):
                         # In case nzf has disappeared because the file was deleted before the update could happen
                         pass
 
+                    sabnzbd.BPSMeter.update(server.id, bytes_received, force_full_update=self.bandwidth_limit)
                     if self.bandwidth_limit:
-                        limit = self.bandwidth_limit
-                        if bytes_received + sabnzbd.BPSMeter.bps > limit:
-                            while sabnzbd.BPSMeter.bps > limit:
-                                time.sleep(0.01)
-                                sabnzbd.BPSMeter.update()
-                    sabnzbd.BPSMeter.update(server.id, bytes_received, force_full_update=False)
+                        while sabnzbd.BPSMeter.bps > self.bandwidth_limit:
+                            time.sleep(0.01)
+                            sabnzbd.BPSMeter.update()
 
                 if not done and nw.status_code != 222:
                     if not nw.connected or nw.status_code == 480:

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -657,11 +657,13 @@ class Downloader(Thread):
                         # In case nzf has disappeared because the file was deleted before the update could happen
                         pass
 
-                    sabnzbd.BPSMeter.update(server.id, bytes_received, force_full_update=self.bandwidth_limit)
+                    sabnzbd.BPSMeter.update(server.id, bytes_received, force_full_update=False)
                     if self.bandwidth_limit:
-                        while sabnzbd.BPSMeter.bps > self.bandwidth_limit:
-                            time.sleep(0.01)
+                        if sabnzbd.BPSMeter.sum_cached_amount + sabnzbd.BPSMeter.bps > self.bandwidth_limit:
                             sabnzbd.BPSMeter.update()
+                            while sabnzbd.BPSMeter.bps > self.bandwidth_limit:
+                                time.sleep(0.01)
+                                sabnzbd.BPSMeter.update()
 
                 if not done and nw.status_code != 222:
                     if not nw.connected or nw.status_code == 480:

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -581,6 +581,7 @@ class Downloader(Thread):
                     # Make sure server address resolution is refreshed
                     server.info = None
                 self.force_disconnect = False
+                sabnzbd.BPSMeter.update(force=True)
 
                 # Exit-point
                 if self.shutdown:


### PR DESCRIPTION
The sums of the amounts are stored in BPSMeter.temp_amount[server] and used when a full update is required.