### PR TITLE
pre-create subdir if needed (POSIX, par2)

### DIFF
--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -823,11 +823,18 @@ def get_filepath(path: str, nzo, filename: str):
 
 
 @synchronized(DIR_LOCK)
-def renamer(old: str, new: str):
+def renamer(old: str, new: str, create_local_directories=False):
     """ Rename file/folder with retries for Win32 """
     # Sanitize last part of new name
     path, name = os.path.split(new)
     new = os.path.join(path, sanitize_filename(name))
+
+    oldpath, _ = os.path.split(old)
+    if same_file(oldpath, path) == 2 and create_local_directories:
+        try:
+            os.makedirs(path)
+        except:
+            logging.error("Failed to create %s", path)
 
     # Skip if nothing changes
     if old == new:

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -844,12 +844,7 @@ def renamer(old: str, new: str, create_local_directories=False):
         # check if subdir
         elif same_file(oldpath, path) == 2:
             # sub-directory, so create if does not yet exist:
-            if not os.path.exists(path):
-                try:
-                    os.makedirs(path)
-                except:
-                    logging.error("Failed to create %s", path)
-                    raise OSError("Failed to rename")
+            create_all_dirs(path)
         # in case of "same_file(oldpath, path) == 1": same directory, so nothing to do
 
     logging.debug('Renaming "%s" to "%s"', old, new)

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -829,16 +829,19 @@ def renamer(old: str, new: str, create_local_directories=False):
     path, name = os.path.split(new)
     new = os.path.join(path, sanitize_filename(name))
 
+    # Skip if nothing changes
+    if old == new:
+        return
+
+    # check for subdir creation
     oldpath, _ = os.path.split(old)
-    if same_file(oldpath, path) == 2 and create_local_directories:
+    if same_file(oldpath, path) == 2 and create_local_directories and not os.path.exists(path):
+        # Yes, subdir specified, and allowed, and does not yet exist
         try:
             os.makedirs(path)
         except:
             logging.error("Failed to create %s", path)
-
-    # Skip if nothing changes
-    if old == new:
-        return
+            raise OSError("Failed to rename")
 
     logging.debug('Renaming "%s" to "%s"', old, new)
     if sabnzbd.WIN32:

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -836,11 +836,12 @@ def renamer(old: str, new: str, create_local_directories=False):
     # in case of create_local_directories=True, check for directory escape (forbidden), and create subdir if needed
     if create_local_directories:
         oldpath, _ = os.path.split(old)
-        # check that new path is same directory or sub-directory, but not outside directory
+        # check not outside directory
         if same_file(oldpath, path) == 0:
             # outside current directory, which we do not allow with create_local_directories=True
             logging.error("Refusing to go outside directory %s", path)
             raise OSError("Reusing to go outside directory")
+        # check if subdir
         elif same_file(oldpath, path) == 2:
             # sub-directory, so create if does not yet exist:
             if not os.path.exists(path):

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -833,15 +833,23 @@ def renamer(old: str, new: str, create_local_directories=False):
     if old == new:
         return
 
-    # check for subdir creation
-    oldpath, _ = os.path.split(old)
-    if same_file(oldpath, path) == 2 and create_local_directories and not os.path.exists(path):
-        # Yes, subdir specified, and allowed, and does not yet exist
-        try:
-            os.makedirs(path)
-        except:
-            logging.error("Failed to create %s", path)
-            raise OSError("Failed to rename")
+    # in case of create_local_directories=True, check for directory escape (forbidden), and create subdir if needed
+    if create_local_directories:
+        oldpath, _ = os.path.split(old)
+        # check that new path is same directory or sub-directory, but not outside directory
+        if same_file(oldpath, path) == 0:
+            # outside current directory, which we do not allow with create_local_directories=True
+            logging.error("Refusing to go outside directory %s", path)
+            raise OSError("Reusing to go outside directory")
+        elif same_file(oldpath, path) == 2:
+            # sub-directory, so create if does not yet exist:
+            if not os.path.exists(path):
+                try:
+                    os.makedirs(path)
+                except:
+                    logging.error("Failed to create %s", path)
+                    raise OSError("Failed to rename")
+        # in case of "same_file(oldpath, path) == 1": same directory, which is OK
 
     logging.debug('Renaming "%s" to "%s"', old, new)
     if sabnzbd.WIN32:

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -2078,16 +2078,16 @@ def quick_check_set(set, nzo):
                 try:
                     logging.debug("Quick-check will rename %s to %s", nzf.filename, file)
 
-                    # Let's check if there is a subdir in 'file'
-                    relative_new_path = re.search(r"(.*)(\\|/)", file)  # find directory separator \ or /
+                    # Let's check if there is a subdir in 'file', which SABs needs to create
+                    relative_new_path = re.search(r"(.*)[\\|/]", file)  # find directory before separator \ or /
                     # Proceed if subdir specified, and no malicous '..' in it
                     if relative_new_path and not os.pardir in relative_new_path.group(1):
                         full_new_path = os.path.join(nzo.download_path, relative_new_path.group(1))
-                        # to be sure, check again that subdir within path
+                        # to be sure, check again that subdir is within path
                         within_path = (
                             os.path.commonpath([nzo.download_path, os.path.abspath(full_new_path)]) == nzo.download_path
                         )
-                        if within_path and not os.path.exists(full_new_path):
+                        if (not os.path.exists(full_new_path)) and within_path:
                             logging.debug("Creating subdir %s", full_new_path)
                             try:
                                 os.makedirs(full_new_path)

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -2077,6 +2077,20 @@ def quick_check_set(set, nzo):
             if nzf.md5sum == md5pack[file]:
                 try:
                     logging.debug("Quick-check will rename %s to %s", nzf.filename, file)
+
+                    # Let's check if there is a subdir in 'file' (only needed on POSIX so '/')
+                    new_path = re.search("(.*)/", file)
+                    if new_path:
+                        new_path = os.path.join(nzo.download_path, new_path.group(1))
+                        logging.debug("mkdir %s", new_path)
+                        try:
+                            os.mkdir(new_path)
+                        except:
+                            logging.debug("Failed to make path")
+                    else:
+                        logging.debug("No path found")
+
+
                     renamer(os.path.join(nzo.download_path, nzf.filename), os.path.join(nzo.download_path, file))
                     renames[file] = nzf.filename
                     nzf.filename = file

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -2082,10 +2082,6 @@ def quick_check_set(set, nzo):
                     # Note: file can and is allowed to have a subdir.
                     # This will only happen on POSIX (with par2), and as
                     # subdirs in par2 always contain "/" (not "\"), we're fine
-                    # Just for logging:
-                    relative_new_path = re.search(r"(.*)/", file)  # find directory before separator "/"
-                    if relative_new_path:
-                        logging.debug("Subdir found: %s", relative_new_path.group(1))
 
                     renamer(
                         os.path.join(nzo.download_path, nzf.filename),

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -2079,27 +2079,19 @@ def quick_check_set(set, nzo):
                 try:
                     logging.debug("Quick-check will rename %s to %s", nzf.filename, file)
 
-                    # Let's check if there is a subdir in 'file', which SABs needs to create
-                    # This will only happen on POSIX (with par2)
-                    # subdirs in par2 always contain "/" (not "\")
+                    # Note: file can and is allowed to have a subdir.
+                    # This will only happen on POSIX (with par2), and as
+                    # subdirs in par2 always contain "/" (not "\"), we're fine
+                    # Just for logging:
                     relative_new_path = re.search(r"(.*)/", file)  # find directory before separator "/"
-                    # Proceed if subdir specified
                     if relative_new_path:
                         logging.debug("Subdir found: %s", relative_new_path.group(1))
-                        full_new_path = os.path.join(nzo.download_path, relative_new_path.group(1))
-                        # Only create subdir if it does not yet exist, and it's a valid subdir
-                        if not os.path.exists(full_new_path):
-                            if same_file(nzo.download_path, full_new_path) == 2:
-                                # Yes, a subdirectory
-                                logging.debug("Creating subdir %s", full_new_path)
-                                try:
-                                    os.makedirs(full_new_path)
-                                except:
-                                    logging.warning("Failed to create subdir path %s", full_new_path)
-                            else:
-                                logging.warning("par2 wanted to create a directory outside of main directory")
 
-                    renamer(os.path.join(nzo.download_path, nzf.filename), os.path.join(nzo.download_path, file))
+                    renamer(
+                        os.path.join(nzo.download_path, nzf.filename),
+                        os.path.join(nzo.download_path, file),
+                        create_local_directories=True,
+                    )
                     renames[file] = nzf.filename
                     nzf.filename = file
                     result &= True

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -2078,8 +2078,8 @@ def quick_check_set(set, nzo):
                 try:
                     logging.debug("Quick-check will rename %s to %s", nzf.filename, file)
 
-                    # Let's check if there is a subdir in 'file', and if so, pre-create it
-                    relative_new_path = re.search("(.*)/", file)
+                    # Let's check if there is a subdir in 'file'
+                    relative_new_path = re.search(r"(.*)(\\|/)", file) # find directory separator \ or /
                     # Proceed if subdir specified, and no malicous '..' in it
                     if relative_new_path and not os.pardir in relative_new_path.group(1):
                         full_new_path = os.path.join(nzo.download_path, relative_new_path.group(1))

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -2079,10 +2079,8 @@ def quick_check_set(set, nzo):
                 try:
                     logging.debug("Quick-check will rename %s to %s", nzf.filename, file)
 
-                    # Note: file can and is allowed to have a subdir.
-                    # This will only happen on POSIX (with par2), and as
-                    # subdirs in par2 always contain "/" (not "\"), we're fine
-
+                    # Note: file can and is allowed to be in a subdirectory.
+                    # Subdirectories in par2 always contain "/", not "\"
                     renamer(
                         os.path.join(nzo.download_path, nzf.filename),
                         os.path.join(nzo.download_path, file),

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -2085,7 +2085,7 @@ def quick_check_set(set, nzo):
                         if not os.path.exists(new_path):
                             logging.debug("Creating subdir %s", new_path)
                             try:
-                                os.mkdir(new_path)
+                                os.makedirs(new_path)
                             except:
                                 logging.debug("Failed to creating subdir path")
 

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -2078,18 +2078,16 @@ def quick_check_set(set, nzo):
                 try:
                     logging.debug("Quick-check will rename %s to %s", nzf.filename, file)
 
-                    # Let's check if there is a subdir in 'file' (only needed on POSIX so '/')
+                    # Let's check if there is a subdir in 'file', and if so, pre-create it
                     new_path = re.search("(.*)/", file)
                     if new_path:
                         new_path = os.path.join(nzo.download_path, new_path.group(1))
-                        logging.debug("mkdir %s", new_path)
-                        try:
-                            os.mkdir(new_path)
-                        except:
-                            logging.debug("Failed to make path")
-                    else:
-                        logging.debug("No path found")
-
+                        if not os.path.exists(new_path):
+                            logging.debug("Creating subdir %s", new_path)
+                            try:
+                                os.mkdir(new_path)
+                            except:
+                                logging.debug("Failed to creating subdir path")
 
                     renamer(os.path.join(nzo.download_path, nzf.filename), os.path.join(nzo.download_path, file))
                     renames[file] = nzf.filename

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -2079,21 +2079,25 @@ def quick_check_set(set, nzo):
                 try:
                     logging.debug("Quick-check will rename %s to %s", nzf.filename, file)
 
-                    # Let's check if there is a subdir in 'file', which SABs needs to created
+                    # Let's check if there is a subdir in 'file', which SABs needs to create
                     # This will only happen on POSIX (with par2)
                     # subdirs in par2 always contain "/" (not "\")
                     relative_new_path = re.search(r"(.*)/", file)  # find directory before separator "/"
-                    logging.debug("Subdir found: %s", relative_new_path)
                     # Proceed if subdir specified
                     if relative_new_path:
+                        logging.debug("Subdir found: %s", relative_new_path.group(1))
                         full_new_path = os.path.join(nzo.download_path, relative_new_path.group(1))
                         # Only create subdir if it does not yet exist, and it's a valid subdir
-                        if (not os.path.exists(full_new_path)) and same_file(nzo.download_path, full_new_path)==2:
-                            logging.debug("Creating subdir %s", full_new_path)
-                            try:
-                                os.makedirs(full_new_path)
-                            except:
-                                logging.warning("Failed to create subdir path %s", full_new_path)
+                        if not os.path.exists(full_new_path):
+                            if same_file(nzo.download_path, full_new_path) == 2:
+                                # Yes, a subdirectory
+                                logging.debug("Creating subdir %s", full_new_path)
+                                try:
+                                    os.makedirs(full_new_path)
+                                except:
+                                    logging.warning("Failed to create subdir path %s", full_new_path)
+                            else:
+                                logging.warning("par2 wanted to create a directory outside of main directory")
 
                     renamer(os.path.join(nzo.download_path, nzf.filename), os.path.join(nzo.download_path, file))
                     renames[file] = nzf.filename

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -2079,16 +2079,20 @@ def quick_check_set(set, nzo):
                     logging.debug("Quick-check will rename %s to %s", nzf.filename, file)
 
                     # Let's check if there is a subdir in 'file'
-                    relative_new_path = re.search(r"(.*)(\\|/)", file) # find directory separator \ or /
+                    relative_new_path = re.search(r"(.*)(\\|/)", file)  # find directory separator \ or /
                     # Proceed if subdir specified, and no malicous '..' in it
                     if relative_new_path and not os.pardir in relative_new_path.group(1):
                         full_new_path = os.path.join(nzo.download_path, relative_new_path.group(1))
-                        if not os.path.exists(full_new_path):
+                        # to be sure, check again that subdir within path
+                        within_path = (
+                            os.path.commonpath([nzo.download_path, os.path.abspath(full_new_path)]) == nzo.download_path
+                        )
+                        if within_path and not os.path.exists(full_new_path):
                             logging.debug("Creating subdir %s", full_new_path)
                             try:
                                 os.makedirs(full_new_path)
                             except:
-                                logging.warning("Failed to creating subdir path %s", full_new_path)
+                                logging.warning("Failed to create subdir path %s", full_new_path)
 
                     renamer(os.path.join(nzo.download_path, nzf.filename), os.path.join(nzo.download_path, file))
                     renames[file] = nzf.filename

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -2079,15 +2079,16 @@ def quick_check_set(set, nzo):
                     logging.debug("Quick-check will rename %s to %s", nzf.filename, file)
 
                     # Let's check if there is a subdir in 'file', and if so, pre-create it
-                    new_path = re.search("(.*)/", file)
-                    if new_path:
-                        new_path = os.path.join(nzo.download_path, new_path.group(1))
-                        if not os.path.exists(new_path):
-                            logging.debug("Creating subdir %s", new_path)
+                    relative_new_path = re.search("(.*)/", file)
+                    # Proceed if subdir specified, and no malicous '..' in it
+                    if relative_new_path and not os.pardir in relative_new_path.group(1):
+                        full_new_path = os.path.join(nzo.download_path, relative_new_path.group(1))
+                        if not os.path.exists(full_new_path):
+                            logging.debug("Creating subdir %s", full_new_path)
                             try:
-                                os.makedirs(new_path)
+                                os.makedirs(full_new_path)
                             except:
-                                logging.debug("Failed to creating subdir path")
+                                logging.warning("Failed to creating subdir path %s", full_new_path)
 
                     renamer(os.path.join(nzo.download_path, nzf.filename), os.path.join(nzo.download_path, file))
                     renames[file] = nzf.filename

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1031,6 +1031,7 @@ class TestRenamer:
             filesystem.renamer(filename, newfilename, create_local_directories=True)
         except:
             pass
+        # Renaming should happen, so:
         assert not os.path.isfile(filename)
         assert os.path.isfile(newfilename)
 
@@ -1041,6 +1042,7 @@ class TestRenamer:
             filesystem.renamer(filename, newfilename, create_local_directories=True)
         except:
             pass
+        # Renaming should happen, so:
         assert not os.path.isfile(filename)
         assert os.path.isfile(newfilename)
 
@@ -1051,10 +1053,26 @@ class TestRenamer:
             filesystem.renamer(filename, newfilename, create_local_directories=True)
         except:
             pass
+        # the renaming should not happen, so:
         assert os.path.isfile(filename)
         assert not os.path.isfile(newfilename)
 
-        # Cleanup working directory
+        # same-level, existing other dir ... not allowed if using create_local_directories=True
+        filename = os.path.join(dirname, "myfile.txt")
+        Path(filename).touch()  # create file
+        sameleveldirname = os.path.join(SAB_DATA_DIR, "othertestdir" + str(random.randint(10000, 99999)))
+        os.mkdir(sameleveldirname)
+        newfilename = os.path.join(sameleveldirname, "newfile.txt")
+        try:
+            filesystem.renamer(filename, newfilename, create_local_directories=True)
+        except:
+            pass
+        # the renaming should not happen, so:
+        assert os.path.isfile(filename)
+        assert not os.path.isfile(newfilename)
+        shutil.rmtree(sameleveldirname)
+
+        # Cleanup overall working directory
         shutil.rmtree(dirname)
 
 

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1046,7 +1046,7 @@ class TestRenamer:
 
         # ... escaping the directory plus subdir creation is not allowed
         Path(filename).touch()
-        newfilename = os.path.join(dirname, os.pardir, "newsubdir", "newfile.txt")
+        newfilename = os.path.join(dirname, ".." , "newsubdir", "newfile.txt")
         try:
             filesystem.renamer(filename, newfilename, create_local_directories=True)
         except:

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1046,7 +1046,7 @@ class TestRenamer:
 
         # ... escaping the directory plus subdir creation is not allowed
         Path(filename).touch()
-        newfilename = os.path.join(dirname, ".." , "newsubdir", "newfile.txt")
+        newfilename = os.path.join(dirname, "..", "newsubdir", "newfile.txt")
         try:
             filesystem.renamer(filename, newfilename, create_local_directories=True)
         except:


### PR DESCRIPTION
This is based on the code from @puzzledsab from https://forums.sabnzbd.org/viewtopic.php?f=2&t=25155&p=123748#p123748

It solves the problem with Sample/ and other subdirs in a post with par2 files

Reference NZB with subdir (plus a bonus subdir in that): https://raw.githubusercontent.com/sanderjo/NZBs/master/unique_files_with_subdir_in_subdir_73698be2fe48.nzb


```
$ cat .sabnzbd/logs/sabnzbd.log | grep -i -e mkdir -e "quick-check will rename" -e "no path found"


2021-02-20 07:58:26,778::DEBUG::[newsunpack:2079] Quick-check will rename mysubdir+insub1 to mysubdir/insub1
2021-02-20 07:58:26,779::DEBUG::[newsunpack:2084] mkdir /home/sander/Downloads/incomplete/unique_files_with_subdir_ee0fba9604e5/mysubdir
2021-02-20 07:58:26,781::DEBUG::[newsunpack:2079] Quick-check will rename mysubdir+insub2 to mysubdir/insub2
2021-02-20 07:58:26,782::DEBUG::[newsunpack:2084] mkdir /home/sander/Downloads/incomplete/unique_files_with_subdir_ee0fba9604e5/mysubdir

2021-02-20 08:05:13,466::DEBUG::[newsunpack:2079] Quick-check will rename 63ccfd15f5bce5e6d7c782cde0a000a6 to xxx.s10e13.hog.heaven.720p.web.h264-caffeine.nfo
2021-02-20 08:05:13,466::DEBUG::[newsunpack:2090] No path found
2021-02-20 08:05:13,467::DEBUG::[newsunpack:2079] Quick-check will rename Sample+sample-xxx.s10e13.hog.heaven.720p.web.h264-caffeine.mkv to Sample/sample-xxx.s10e13.hog.heaven.720p.web.h264-caffeine.mkv
2021-02-20 08:05:13,467::DEBUG::[newsunpack:2084] mkdir /home/sander/Downloads/incomplete/moon-wth-pre-create-dir/Sample
```