### PR TITLE
fix config auto_sort setting, broken by #1666

### DIFF
--- a/interfaces/Config/templates/config_switches.tmpl
+++ b/interfaces/Config/templates/config_switches.tmpl
@@ -140,8 +140,8 @@
                         <label class="config" for="auto_sort">$T('opt-auto_sort')</label>
                         <select name="auto_sort" id="auto_sort">
                             <option value="">$T('default')</option>
-                            <option value="avg_age asc" <!--#if $auto_sort == "avg_age asc" then 'selected="selected"' else ""#--> >$T('Glitter-sortAgeAsc')</option>
-                            <option value="avg_age desc" <!--#if $auto_sort == "avg_age desc" then 'selected="selected"' else ""#--> >$T('Glitter-sortAgeDesc')</option>
+                            <option value="avg_age desc" <!--#if $auto_sort == "avg_age asc" then 'selected="selected"' else ""#--> >$T('Glitter-sortAgeAsc')</option>
+                            <option value="avg_age asc" <!--#if $auto_sort == "avg_age desc" then 'selected="selected"' else ""#--> >$T('Glitter-sortAgeDesc')</option>
                             <option value="name asc" <!--#if $auto_sort == "name asc" then 'selected="selected"' else ""#--> >$T('Glitter-sortNameAsc')</option>
                             <option value="name desc" <!--#if $auto_sort == "name desc" then 'selected="selected"' else ""#--> >$T('Glitter-sortNameDesc')</option>
                             <option value="size asc" <!--#if $auto_sort == "size asc" then 'selected="selected"' else ""#--> >$T('Glitter-sortSizeAsc')</option>

--- a/interfaces/Config/templates/config_switches.tmpl
+++ b/interfaces/Config/templates/config_switches.tmpl
@@ -140,8 +140,8 @@
                         <label class="config" for="auto_sort">$T('opt-auto_sort')</label>
                         <select name="auto_sort" id="auto_sort">
                             <option value="">$T('default')</option>
-                            <option value="avg_age desc" <!--#if $auto_sort == "avg_age asc" then 'selected="selected"' else ""#--> >$T('Glitter-sortAgeAsc')</option>
-                            <option value="avg_age asc" <!--#if $auto_sort == "avg_age desc" then 'selected="selected"' else ""#--> >$T('Glitter-sortAgeDesc')</option>
+                            <option value="avg_age desc" <!--#if $auto_sort == "avg_age desc" then 'selected="selected"' else ""#--> >$T('Glitter-sortAgeAsc')</option>
+                            <option value="avg_age asc" <!--#if $auto_sort == "avg_age asc" then 'selected="selected"' else ""#--> >$T('Glitter-sortAgeDesc')</option>
                             <option value="name asc" <!--#if $auto_sort == "name asc" then 'selected="selected"' else ""#--> >$T('Glitter-sortNameAsc')</option>
                             <option value="name desc" <!--#if $auto_sort == "name desc" then 'selected="selected"' else ""#--> >$T('Glitter-sortNameDesc')</option>
                             <option value="size asc" <!--#if $auto_sort == "size asc" then 'selected="selected"' else ""#--> >$T('Glitter-sortSizeAsc')</option>


### PR DESCRIPTION
Same problem as with the javascript in the interface templates: things were written to work with the broken sorting function. Wish I spotted this one earlier so breaking user settings could have been avoided. :disappointed: