### PR TITLE
rar password file: clearer fault messages

### DIFF
--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -802,6 +802,10 @@ def get_all_passwords(nzo):
                         "Your password file contains more than 30 passwords, testing all these passwords takes a lot of time. Try to only list useful passwords."
                     )
                 )
+        except UnicodeDecodeError:
+            logging.warning("Specified password file %s is not a plain text file", pw_file)
+        except FileNotFoundError:
+            logging.warning("Specified password file %s not found", pw_file)
         except:
             logging.warning(T("Failed to read the password file %s"), pw_file)
             logging.info("Traceback: ", exc_info=True)


### PR DESCRIPTION
I find the current message "Failed to read the password file %s" too ambiguous and not useful to users. Therefor this PR.

If specified rar password does not exist at all:


![image](https://user-images.githubusercontent.com/1273502/114281583-67cc6e00-9a3f-11eb-8ef9-b7c066280a87.png)


File does exist, but is not a plain text file (not ASCII, not Unicode, see https://github.com/sabnzbd/sabnzbd/issues/1852 ), for example user saved as a Word file.

![image](https://user-images.githubusercontent.com/1273502/114281541-33f14880-9a3f-11eb-8517-beb9806210cb.png)

I think the message is printed twice because there are two rar files. Not nice if there are 10 - 100 rar files. 

Feedback welcome


