### PR TITLE
fix use of dir

### DIFF
--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -363,10 +363,10 @@ class TestCheckMountLinux(ffs.TestCase):
         self.setUpPyfakefs()
         self.fs.path_separator = "/"
         self.fs.is_case_sensitive = True
-        for dir in self.test_dirs:
-            self.fs.create_dir(dir, perm_bits=755)
+        for test_dir in self.test_dirs:
+            self.fs.create_dir(test_dir, perm_bits=755)
             # Sanity check the fake filesystem
-            assert os.path.exists(dir) is True
+            assert os.path.exists(test_dir) is True
 
     @set_platform("linux")
     def test_bare_mountpoint_linux(self):
@@ -778,7 +778,7 @@ class TestCreateAllDirsWin(ffs.TestCase):
 
     @set_platform("win32")
     def test_create_all_dirs(self):
-        self.dir = self.fs.create_dir(r"C:\Downloads")
+        self.directory = self.fs.create_dir(r"C:\Downloads")
         # Also test for no crash when folder already exists
         for folder in (r"C:\Downloads", r"C:\Downloads\Show\Test", r"C:\Downloads\Show\Test2", r"C:\Downloads\Show"):
             assert filesystem.create_all_dirs(folder) == folder
@@ -924,9 +924,9 @@ class TestSetPermissions(ffs.TestCase, PermissionCheckerHelper):
 
         # Check the results
         for root, dirs, files in os.walk(test_dir):
-            for dir in [os.path.join(root, d) for d in dirs]:
+            for directory in [os.path.join(root, d) for d in dirs]:
                 # Permissions on directories should now match perms_after
-                self.assert_dir_perms(dir, perms_after)
+                self.assert_dir_perms(directory, perms_after)
             for file in [os.path.join(root, f) for f in files]:
                 # Files also shouldn't have any executable or special bits set
                 assert (

--- a/tests/test_functional_api.py
+++ b/tests/test_functional_api.py
@@ -59,15 +59,15 @@ class ApiTestFunctions:
         extra.update(extra_args)
         return get_api_result(mode=mode, host=SAB_HOST, port=SAB_PORT, extra_arguments=extra)
 
-    def _setup_script_dir(self, dir, script=None):
+    def _setup_script_dir(self, dir_name, script=None):
         """
         Set the script_dir relative to SAB_CACHE_DIR, copy the example scripts
         there, and add an optional extra script with the given name. To unset
-        the script_dir set the value of dir to an empty string.
+        the script_dir set the value of dir_name to an empty string.
         """
         script_dir_extra = {"section": "misc", "keyword": "script_dir", "value": ""}
-        if dir:
-            script_dir = os.path.join(SAB_CACHE_DIR, dir)
+        if dir_name:
+            script_dir = os.path.join(SAB_CACHE_DIR, dir_name)
             script_dir_extra["value"] = script_dir
             try:
                 if not os.path.exists(script_dir):
@@ -545,10 +545,10 @@ class TestQueueApi(ApiTestFunctions):
         self._create_random_queue(minimum_size=1)
 
         # Setup the script_dir as ordered
-        dir = ""
+        script_dir = ""
         if set_scriptsdir:
-            dir = "scripts"
-        self._setup_script_dir(dir, script="my_script_for_sab.py")
+            script_dir = "scripts"
+        self._setup_script_dir(script_dir, script="my_script_for_sab.py")
 
         # Run the queue complete action api call
         prev_value = self._get_api_json("queue")["queue"]["finishaction"]


### PR DESCRIPTION
Replace use of `dir` as a variable name in the tests, collides with the built-in function of the same name.