### PR TITLE
switch prepend to sys.executable in misc.build_and_run_command

### DIFF
--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -1011,7 +1011,7 @@ def build_and_run_command(command: List[str], flatten_command=False, **kwargs):
                     raise IOError
                 elif script_file.read(2) != "#!":
                     # No shebang (#!) defined, add default python
-                    command.insert(0, "python")
+                    command.insert(0, sys.executable if sys.executable else "python")
 
         if sabnzbd.newsunpack.IONICE_COMMAND and cfg.ionice():
             ionice = cfg.ionice().split()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -434,7 +434,11 @@ class TestBuildAndRunCommand:
         temp_file_fd, temp_file_path = tempfile.mkstemp(suffix=".py")
         os.close(temp_file_fd)
         misc.build_and_run_command([temp_file_path, "input 1"])
-        assert mock_subproc_popen.call_args[0][0] == ["python", temp_file_path, "input 1"]
+        assert mock_subproc_popen.call_args[0][0] == [
+            sys.executable if sys.executable else "python",
+            temp_file_path,
+            "input 1",
+        ]
         os.remove(temp_file_path)
 
         # Have to fake these for it to work


### PR DESCRIPTION
Prepend with sys.executable rather than "python", because there may be no such a thing on the PATH (for example if an OS vendor decided to provide only explicit python2 and/or python3 commands). I did keep "python" around as a fallback, since the [docs](https://docs.python.org/3/library/sys.html#sys.executable) mention that _if Python is unable to retrieve the real path to its executable, sys.executable will be an empty string or None_ in which case it's still better than nothing.