### PR TITLE
Make num_decoders configurable through special variables

### DIFF
--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -1371,6 +1371,7 @@ SPECIAL_VALUE_LIST = (
     "max_foldername_length",
     "show_sysload",
     "url_base",
+    "num_decoders",
     "direct_unpack_threads",
     "ipv6_servers",
     "selftest_host",


### PR DESCRIPTION
Hopefully increasing it can increase the download speed for some users with more than 4 cores.