### PR TITLE
Set nzo.deleted before calling logging.info

### DIFF
--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -773,8 +773,8 @@ class NzbQueue:
         """ Send NZO to the post-processing queue """
         # Notify assembler to call postprocessor
         if not nzo.deleted:
-            logging.info("[%s] Ending job %s", caller_name(), nzo.final_name)
             nzo.deleted = True
+            logging.info("[%s] Ending job %s", caller_name(), nzo.final_name)
             if nzo.precheck:
                 nzo.save_to_disk()
                 # Check result


### PR DESCRIPTION
I think this fixes #1861. I tested it many times and I could never make it happen when nzo.delete was set before logging.info.

I frequently got the problem with multiple items as well without this change, but for me I would get one that finished properly and one or two hanging and never finishing. They could not be deleted manually, but disappeared after a reset. Maybe this can help the issue some have seen with downloads that never finishes as well. Curiously I got 1 item that never finished when I had num_decoders=2 and 2 when it was set to 3, but that may have been a coincidence.