### PR TITLE
cut closer to the middle to avoid random test failures

### DIFF
--- a/tests/test_functional_adding_nzbs.py
+++ b/tests/test_functional_adding_nzbs.py
@@ -474,7 +474,7 @@ class TestAddingNZBs:
 
         nzb_basedir, nzb_basename = os.path.split(VAR.NZB_FILE)
         nzb_size = os.stat(VAR.NZB_FILE).st_size
-        part_size = round(randint(20, 80) / 100 * nzb_size)
+        part_size = round(randint(40, 70) / 100 * nzb_size)
         first_part = os.path.join(nzb_basedir, "part1_of_" + nzb_basename)
         second_part = os.path.join(nzb_basedir, "part2_of_" + nzb_basename)
 


### PR DESCRIPTION
It appears the cutoff in [test_adding_nzbs_partial](https://github.com/sabnzbd/sabnzbd/blob/75deb9d678e74e640653a8b39a90c5f2de69dacb/tests/test_functional_adding_nzbs.py#L477) isn't strict enough and may cause either part to still constitute a valid nzb file. This change cuts closer to the middle of the nzb, which should prevent random failures such as this:
```
2021-04-29T09:41:23.7264236Z =================================== FAILURES ===================================
2021-04-29T09:41:23.7264885Z ___________________ TestAddingNZBs.test_adding_nzbs_partial ____________________
2021-04-29T09:41:23.7265525Z 
2021-04-29T09:41:23.7266224Z self = <tests.test_functional_adding_nzbs.TestAddingNZBs object at 0x7f0dc50bc310>
2021-04-29T09:41:23.7266866Z 
2021-04-29T09:41:23.7267324Z     def test_adding_nzbs_partial(self):
2021-04-29T09:41:23.7268060Z         """Test adding parts of an NZB file, cut off somewhere in the middle to simulate
2021-04-29T09:41:23.7269009Z         the effects of an interrupted download or bad hardware. Should fail, of course."""
2021-04-29T09:41:23.7269716Z         if not VAR.NZB_FILE:
2021-04-29T09:41:23.7270267Z             VAR.NZB_FILE = self._create_random_nzb()
2021-04-29T09:41:23.7270747Z     
2021-04-29T09:41:23.7271296Z         nzb_basedir, nzb_basename = os.path.split(VAR.NZB_FILE)
2021-04-29T09:41:23.7272036Z         nzb_size = os.stat(VAR.NZB_FILE).st_size
2021-04-29T09:41:23.7272667Z         part_size = round(randint(20, 80) / 100 * nzb_size)
2021-04-29T09:41:23.7273401Z         first_part = os.path.join(nzb_basedir, "part1_of_" + nzb_basename)
2021-04-29T09:41:23.7274219Z         second_part = os.path.join(nzb_basedir, "part2_of_" + nzb_basename)
2021-04-29T09:41:23.7274798Z     
2021-04-29T09:41:23.7275247Z         with open(VAR.NZB_FILE, "rb") as nzb_in:
2021-04-29T09:41:23.7276654Z             for nzb_part, chunk in (first_part, part_size), (second_part, -1):
2021-04-29T09:41:23.7277320Z                 with open(nzb_part, "wb") as nzb_out:
2021-04-29T09:41:23.7277899Z                     nzb_out.write(nzb_in.read(chunk))
2021-04-29T09:41:23.7278420Z     
2021-04-29T09:41:23.7278913Z         for nzb_part in first_part, second_part:
2021-04-29T09:41:23.7279683Z             json = get_api_result(mode="addlocalfile", extra_arguments={"name": nzb_part})
2021-04-29T09:41:23.7280423Z >           assert json["status"] is False
2021-04-29T09:41:23.7280939Z E           assert True is False
2021-04-29T09:41:23.7281254Z 
2021-04-29T09:41:23.7281815Z tests/test_functional_adding_nzbs.py:488: AssertionError
```