### PR TITLE
Stop reading par2 when all files have been found

### DIFF
--- a/sabnzbd/par2file.py
+++ b/sabnzbd/par2file.py
@@ -93,6 +93,7 @@ def parse_par2_file(fname: str, md5of16k: Dict[bytes, str]) -> Dict[str, bytes]:
     """
     table = {}
     duplicates16k = []
+    seenfiles = []
 
     try:
         with open(fname, "rb") as f:
@@ -100,6 +101,9 @@ def parse_par2_file(fname: str, md5of16k: Dict[bytes, str]) -> Dict[str, bytes]:
             while header:
                 name, filehash, hash16k = parse_par2_file_packet(f, header)
                 if name:
+                    if name in seenfiles:
+                        break
+                    seenfiles.append(name)
                     table[name] = filehash
                     if hash16k not in md5of16k:
                         md5of16k[hash16k] = name


### PR DESCRIPTION
I figured that there can theoretically be shared files between par2 sets but if the same filename is found again in the same par2 file then it must have finished reading one set of packets and found a duplicate. In my test case it reduced the CPU time spent in `parse_par2_file_packet` from 364 to 84 seconds.