### PR TITLE
Don't slice data

### DIFF
--- a/sabnzbd/par2file.py
+++ b/sabnzbd/par2file.py
@@ -100,6 +100,8 @@ def parse_par2_file(fname: str, md5of16k: Dict[bytes, str]) -> Dict[str, bytes]:
             while header:
                 name, filehash, hash16k = parse_par2_file_packet(f, header)
                 if name:
+                    if name in table:
+                        break
                     table[name] = filehash
                     if hash16k not in md5of16k:
                         md5of16k[hash16k] = name


### PR DESCRIPTION
I noticed the 16 byte offset too, I wasn't 100% sure if it could be trusted to always read the data from the right spot. That's why I kept the loop. However, the slicing is quite costly too, so my version was actually still faster (1.76 CPU time in `parse_par2_file_packet` instead of 4.15 for the current develop). This version takes it down to 1.72 seconds.