### PR TITLE
Show cpu architecture

### DIFF
--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1184,6 +1184,8 @@ def main():
             logging.info("Platform = %s <unknown>", suffix)
     else:
         logging.info("Platform = %s", os.name)
+    cpu_architecture = platform.uname().machine # as platform.uname().processor is not always filled out
+    logging.info("CPU architecture = %s", cpu_architecture)
     logging.info("Python-version = %s", sys.version)
     logging.info("Arguments = %s", sabnzbd.CMDLINE)
     if sabnzbd.DOCKER:

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1184,7 +1184,7 @@ def main():
             logging.info("Platform = %s <unknown>", suffix)
     else:
         logging.info("Platform = %s", os.name)
-    cpu_architecture = platform.uname().machine # as .processor is not always filled out
+    cpu_architecture = platform.uname().machine  # as .processor is not always filled out
     logging.info("CPU architecture = %s", cpu_architecture)
     logging.info("Python-version = %s", sys.version)
     logging.info("Arguments = %s", sabnzbd.CMDLINE)

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1184,7 +1184,7 @@ def main():
             logging.info("Platform = %s <unknown>", suffix)
     else:
         logging.info("Platform = %s", os.name)
-    cpu_architecture = platform.uname().machine # as platform.uname().processor is not always filled out
+    cpu_architecture = platform.uname().machine  # as .processor is not always filled out
     logging.info("CPU architecture = %s", cpu_architecture)
     logging.info("Python-version = %s", sys.version)
     logging.info("Arguments = %s", sabnzbd.CMDLINE)

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1184,7 +1184,7 @@ def main():
             logging.info("Platform = %s <unknown>", suffix)
     else:
         logging.info("Platform = %s", os.name)
-    cpu_architecture = platform.uname().machine # as platform.uname().processor is not always filled out
+    cpu_architecture = platform.uname().machine # as .processor is not always filled out
     logging.info("CPU architecture = %s", cpu_architecture)
     logging.info("Python-version = %s", sys.version)
     logging.info("Arguments = %s", sabnzbd.CMDLINE)

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1184,8 +1184,7 @@ def main():
             logging.info("Platform = %s <unknown>", suffix)
     else:
         logging.info("Platform = %s", os.name)
-    cpu_architecture = platform.uname().machine  # as .processor is not always filled out
-    logging.info("CPU architecture = %s", cpu_architecture)
+    logging.info("CPU architecture = %s", platform.uname().machine)  # as .processor is not always filled out
     logging.info("Python-version = %s", sys.version)
     logging.info("Arguments = %s", sabnzbd.CMDLINE)
     if sabnzbd.DOCKER:

--- a/tests/test_functional_adding_nzbs.py
+++ b/tests/test_functional_adding_nzbs.py
@@ -474,7 +474,7 @@ class TestAddingNZBs:
 
         nzb_basedir, nzb_basename = os.path.split(VAR.NZB_FILE)
         nzb_size = os.stat(VAR.NZB_FILE).st_size
-        part_size = round(randint(20, 80) / 100 * nzb_size)
+        part_size = round(randint(40, 70) / 100 * nzb_size)
         first_part = os.path.join(nzb_basedir, "part1_of_" + nzb_basename)
         second_part = os.path.join(nzb_basedir, "part2_of_" + nzb_basename)
 


### PR DESCRIPTION
We show platform (POSIX, Windows), but we need CPU architecture too for analysis.

Note: this is something else than the CPU model we show under the Wrench.

platform.uname().machine always gives the CPU architecture, as shown below.

Example logging:

```
2021-05-01 17:04:14,151::INFO::[SABnzbd:1186] Platform = posix
2021-05-01 17:04:14,151::INFO::[SABnzbd:1188] CPU architecture = x86_64

2021-05-01 17:04:14,678::DEBUG::[SABnzbd:1254] CPU Pystone available performance = 134103
2021-05-01 17:04:14,697::DEBUG::[SABnzbd:1259] CPU model = Intel(R) Core(TM) i3-6006U CPU @ 2.00GHz
```


  
result of .processor resp .name on different CPU architectures:

```
[root@fedora-riscv sabnzbd-3.2.1]# python3 -c "import platform; print(platform.uname()); print(platform.uname().processor); print(platform.uname().machine)"
uname_result(system='Linux', node='fedora-riscv', release='5.5.0-0.rc5.git0.1.1.riscv64.fc32.riscv64', version='#1 SMP Mon Jan 6 17:31:22 UTC 2020', machine='riscv64')
riscv64
riscv64
# processor seems not available in namedtuple, but correct output anyway, and the same as machine
```

sander@nanopineo2:~$

```
$ python3 -c "import platform; print(platform.uname()); print(platform.uname().processor); print(platform.uname().machine)"
uname_result(system='Linux', node='nanopineo2', release='5.10.16-sunxi64', version='#21.02.2 SMP Sun Feb 14 21:17:31 CET 2021', machine='aarch64', processor='aarch64')
aarch64
aarch64
# processor available, and the same as machine
```

```
C:\>python -c "import platform; print(platform.uname()); print(platform.uname().processor); print(platform.uname().machine)"
uname_result(system='Windows', node='LT000373', release='10', version='10.0.19041', machine='AMD64')
Intel64 Family 6 Model 142 Stepping 11, GenuineIntel
AMD64
# processor is TMI
```


```
admin@DiskStation:/$ /volume1/@appstore/python3/bin/python3  -c "import platform; print(platform.uname()); print(platform.uname().processor); print(platform.uname().machine)"
uname_result(system='Linux', node='DiskStation', release='2.6.32.12', version='#25556 Thu Mar 4 17:56:48 CST 2021', machine='armv5tel', processor='')

armv5tel

# processor is empty!
```