### PR TITLE
Use __slots__ on Server object

### DIFF
--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -57,6 +57,40 @@ TIMER_LOCK = RLock()
 
 
 class Server:
+    # Pre-define attributes to save memory and improve get/set performance
+    __slots__ = (
+        "id",
+        "newid",
+        "restart",
+        "displayname",
+        "host",
+        "port",
+        "timeout",
+        "threads",
+        "priority",
+        "ssl",
+        "ssl_verify",
+        "ssl_ciphers",
+        "optional",
+        "retention",
+        "send_group",
+        "username",
+        "password",
+        "busy_threads",
+        "next_busy_threads_check",
+        "idle_threads",
+        "next_article_search",
+        "active",
+        "bad_cons",
+        "errormsg",
+        "warning",
+        "info",
+        "ssl_info",
+        "request",
+        "have_body",
+        "have_stat",
+    )
+
     def __init__(
         self,
         server_id,


### PR DESCRIPTION
@puzzledsab I think you like this.
It shows with my tiny test-script about ~15% improvement in accessing attributes of the `Server` object, which we do a lot of course.

```python
import timeit
import sabnzbd.downloader
from statistics import mean

total = []
a=sabnzbd.downloader.Server('a','test','test',80,30,1,1,1,1,1,1)
what="a.idle_threads"

for _ in range(10):
    total.append(timeit.timeit(what, number=10000000,
                        setup="import sabnzbd.downloader; a=sabnzbd.downloader.Server('a','test','test',80,30,1,1,1,1,1,1)"))


print(mean(total))
```