### PR TITLE
BPSMeter optimizations

### DIFF
--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -218,6 +218,26 @@ class Server:
 class Downloader(Thread):
     """Singleton Downloader Thread"""
 
+    # Improves get/set performance, even though it's inherited from Thread
+    # Due to the huge number of get-calls in run(), it can actually make a difference
+    __slots__ = (
+        "paused",
+        "bandwidth_limit",
+        "bandwidth_perc",
+        "can_be_slowed",
+        "can_be_slowed_timer",
+        "sleep_time",
+        "paused_for_postproc",
+        "shutdown",
+        "server_restarts",
+        "force_disconnect",
+        "read_fds",
+        "servers",
+        "server_dict",
+        "server_nr",
+        "timers",
+    )
+
     def __init__(self, paused=False):
         super().__init__()
 


### PR DESCRIPTION
Reduces CPU usage from `BPSMeter.update()` from 22 to 2.5 seconds in my tests. `Downloader.run` does not seem to use more CPU when updating the caching variables directly.

You should probably wait with this until 3.3.0 is released. I may have missed some obscure call which leaves variables uninitialized.