### PR TITLE
BPSMeter optimalizations

### DIFF
--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -657,22 +657,23 @@ class Downloader(Thread):
             if readkeys:
                 read, _, _ = select.select(readkeys, (), (), 1.0)
 
-                # Add a sleep if there are too few results compared to the number of active connections
-                if self.can_be_slowed and len(read) < 1 + len(readkeys) / 10:
-                    time.sleep(self.sleep_time)
+                if self.can_be_slowed != 0:
+                    # Add a sleep if there are too few results compared to the number of active connections
+                    if self.can_be_slowed:
+                        if len(read) < 1 + len(readkeys) / 10:
+                            time.sleep(self.sleep_time)
+                    else:
+                        # Need to initialize the check during first 20 seconds
+                        # Wait for stable speed to start testing
+                        if not self.can_be_slowed_timer and BPSMeter.get_stable_speed(timespan=10):
+                            self.can_be_slowed_timer = now
 
-                # Need to initialize the check during first 20 seconds
-                if self.can_be_slowed is None or self.can_be_slowed_timer:
-                    # Wait for stable speed to start testing
-                    if not self.can_be_slowed_timer and BPSMeter.get_stable_speed(timespan=10):
-                        self.can_be_slowed_timer = time.time()
-
-                    # Check 10 seconds after enabling slowdown
-                    if self.can_be_slowed_timer and time.time() > self.can_be_slowed_timer + 10:
-                        # Now let's check if it was stable in the last 10 seconds
-                        self.can_be_slowed = BPSMeter.get_stable_speed(timespan=10)
-                        self.can_be_slowed_timer = 0
-                        logging.debug("Downloader-slowdown: %r", self.can_be_slowed)
+                        # Check 10 seconds after enabling slowdown
+                        if self.can_be_slowed_timer and now > self.can_be_slowed_timer + 10:
+                            # Now let's check if it was stable in the last 10 seconds
+                            self.can_be_slowed = BPSMeter.get_stable_speed(timespan=10)
+                            self.can_be_slowed_timer = 0
+                            logging.debug("Downloader-slowdown: %r", self.can_be_slowed)
 
             else:
                 read = []

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -142,6 +142,7 @@ class Server:
         self.request: bool = False  # True if a getaddrinfo() request is pending
         self.have_body: bool = True  # Assume server has "BODY", until proven otherwise
         self.have_stat: bool = True  # Assume server has "STAT", until proven otherwise
+        sabnzbd.BPSMeter.init_server_stats(server_id)
 
         for i in range(threads):
             self.idle_threads.append(NewsWrapper(self, i + 1))
@@ -524,7 +525,9 @@ class Downloader(Thread):
         logging.debug("SSL verification test: %s", sabnzbd.CERTIFICATE_VALIDATION)
 
         # Kick BPS-Meter to check quota
-        sabnzbd.BPSMeter.update()
+        BPSMeter = sabnzbd.BPSMeter
+        BPSMeter.update()
+        next_bpsmeter_update = 0
 
         # Check server expiration dates
         check_server_expiration()
@@ -642,7 +645,7 @@ class Downloader(Thread):
                 self.force_disconnect = False
 
                 # Make sure we update the stats
-                sabnzbd.BPSMeter.update()
+                BPSMeter.update()
 
                 # Exit-point
                 if self.shutdown:
@@ -661,20 +664,20 @@ class Downloader(Thread):
                 # Need to initialize the check during first 20 seconds
                 if self.can_be_slowed is None or self.can_be_slowed_timer:
                     # Wait for stable speed to start testing
-                    if not self.can_be_slowed_timer and sabnzbd.BPSMeter.get_stable_speed(timespan=10):
+                    if not self.can_be_slowed_timer and BPSMeter.get_stable_speed(timespan=10):
                         self.can_be_slowed_timer = time.time()
 
                     # Check 10 seconds after enabling slowdown
                     if self.can_be_slowed_timer and time.time() > self.can_be_slowed_timer + 10:
                         # Now let's check if it was stable in the last 10 seconds
-                        self.can_be_slowed = sabnzbd.BPSMeter.get_stable_speed(timespan=10)
+                        self.can_be_slowed = BPSMeter.get_stable_speed(timespan=10)
                         self.can_be_slowed_timer = 0
                         logging.debug("Downloader-slowdown: %r", self.can_be_slowed)
 
             else:
                 read = []
 
-                sabnzbd.BPSMeter.reset()
+                BPSMeter.reset()
 
                 time.sleep(1.0)
 
@@ -687,8 +690,11 @@ class Downloader(Thread):
                     ):
                         DOWNLOADER_CV.wait()
 
+            if now > next_bpsmeter_update:
+                BPSMeter.update()
+                next_bpsmeter_update = now + 0.05
+
             if not read:
-                sabnzbd.BPSMeter.update(force_full_update=False)
                 continue
 
             for selected in read:
@@ -702,7 +708,6 @@ class Downloader(Thread):
                     bytes_received, done, skip = (0, False, False)
 
                 if skip:
-                    sabnzbd.BPSMeter.update(force_full_update=False)
                     continue
 
                 if bytes_received < 1:
@@ -711,22 +716,23 @@ class Downloader(Thread):
 
                 else:
                     try:
-                        article.nzf.nzo.update_download_stats(sabnzbd.BPSMeter.bps, server.id, bytes_received)
+                        article.nzf.nzo.update_download_stats(BPSMeter.bps, server.id, bytes_received)
                     except AttributeError:
                         # In case nzf has disappeared because the file was deleted before the update could happen
                         pass
 
-                    sabnzbd.BPSMeter.update(server.id, bytes_received, force_full_update=False)
+                    BPSMeter.cached_amount[server.id] += bytes_received
+                    BPSMeter.sum_cached_amount += bytes_received
+
                     if self.bandwidth_limit:
-                        if sabnzbd.BPSMeter.sum_cached_amount + sabnzbd.BPSMeter.bps > self.bandwidth_limit:
-                            sabnzbd.BPSMeter.update()
-                            while sabnzbd.BPSMeter.bps > self.bandwidth_limit:
+                        if BPSMeter.sum_cached_amount + BPSMeter.bps > self.bandwidth_limit:
+                            BPSMeter.update()
+                            while BPSMeter.bps > self.bandwidth_limit:
                                 time.sleep(0.01)
-                                sabnzbd.BPSMeter.update()
+                                BPSMeter.update()
 
                 if not done and nw.status_code != 222:
                     if not nw.connected or nw.status_code == 480:
-                        done = False
                         try:
                             nw.finish_connect(nw.status_code)
                             if sabnzbd.LOG_ALL:
@@ -827,7 +833,6 @@ class Downloader(Thread):
                         logging.debug("Article <%s> is present", article.article)
 
                     elif nw.status_code == 211:
-                        done = False
                         logging.debug("group command ok -> %s", nntp_to_msg(nw.data))
                         nw.group = nw.article.nzf.nzo.group
                         nw.clear_data()

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -721,8 +721,7 @@ class Downloader(Thread):
                         # In case nzf has disappeared because the file was deleted before the update could happen
                         pass
 
-                    BPSMeter.cached_amount[server.id] += bytes_received
-                    BPSMeter.sum_cached_amount += bytes_received
+                    BPSMeter.update(server.id, bytes_received, force_full_update=False)
 
                     if self.bandwidth_limit:
                         if BPSMeter.sum_cached_amount + BPSMeter.bps > self.bandwidth_limit:
@@ -731,7 +730,7 @@ class Downloader(Thread):
                                 time.sleep(0.01)
                                 BPSMeter.update()
 
-                if not done and nw.status_code != 222:
+                if nw.status_code != 222 and not done:
                     if not nw.connected or nw.status_code == 480:
                         try:
                             nw.finish_connect(nw.status_code)


### PR DESCRIPTION
Same as last time, but without the stats initialization. This version used 2.7 CPU seconds in my test, 0.2 up from the previous version but still a lot down from the 22 seconds in the current develop.