### PR TITLE
allow missing extension for unwanted check

### DIFF
--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -73,7 +73,10 @@ def has_unwanted_extension(filename: str) -> bool:
             and extension not in sabnzbd.cfg.unwanted_extensions()
         )
     else:
-        return bool(sabnzbd.cfg.unwanted_extensions_mode())
+        # Don't consider missing extensions unwanted to prevent indiscriminate blocking of
+        # obfuscated jobs in whitelist mode. If there is an extension but nothing listed as
+        # (un)wanted, the result only depends on the configured mode.
+        return bool(extension and sabnzbd.cfg.unwanted_extensions_mode())
 
 
 def get_filename(path: str) -> str:

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1124,7 +1124,11 @@ class TestUnwantedExtensions:
     @set_config({"unwanted_extensions_mode": 1, "unwanted_extensions": test_extensions})
     def test_has_unwanted_extension_whitelist_mode(self):
         for filename, result in self.test_params:
-            assert filesystem.has_unwanted_extension(filename) is not result
+            if filesystem.get_ext(filename):
+                assert filesystem.has_unwanted_extension(filename) is not result
+            else:
+                # missing extension is never considered unwanted
+                assert filesystem.has_unwanted_extension(filename) is False
 
     @set_config({"unwanted_extensions_mode": 0, "unwanted_extensions": ""})
     def test_has_unwanted_extension_empty_blacklist(self):
@@ -1134,4 +1138,8 @@ class TestUnwantedExtensions:
     @set_config({"unwanted_extensions_mode": 1, "unwanted_extensions": ""})
     def test_has_unwanted_extension_empty_whitelist(self):
         for filename, result in self.test_params:
-            assert filesystem.has_unwanted_extension(filename) is True
+            if filesystem.get_ext(filename):
+                assert filesystem.has_unwanted_extension(filename) is True
+            else:
+                # missing extension is never considered unwanted
+                assert filesystem.has_unwanted_extension(filename) is False


### PR DESCRIPTION
This prevents triggering on every fully obfuscated job in whitelist mode. Only files that actually don't have an extension get a pass now while they didn't before; everything else still gets caught at deobfuscation/unpacking. That could result in an minor annoyance every once in a while, but isn't going to cause problems with the infamous windows explorer extension hiding default setting.