### PR TITLE
Regex for unwanted extensions

### DIFF
--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -65,7 +65,7 @@ def is_listed_ext(ext: str, ext_list: list) -> bool:
     thus return false for extentions such as 'r007' despite the substring match on 'r00').
     """
     for item in ext_list:
-        RE_EXT = sabnzbd.rss.convert_filter(item)
+        RE_EXT = sabnzbd.misc.convert_filter(item)
         if RE_EXT:
             try:
                 if len(RE_EXT.match(ext).group()) == len(ext):

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -59,7 +59,7 @@ def get_ext(filename: str) -> str:
         return ""
 
 
-def ext_is_listed(ext: str, ext_list: list) -> bool:
+def is_listed_ext(ext: str, ext_list: list) -> bool:
     """Check if the extension is listed. In case of a regexp the entire extension must be matched;
     partial matches aren't accepted (e.g. 'r[0-9]{2}' will be treated the same as '^r[0-9]{2}$' and
     thus return false for extentions such as 'r007' despite the substring match on 'r00').
@@ -85,11 +85,11 @@ def has_unwanted_extension(filename: str) -> bool:
         return (
             # Blacklisted
             sabnzbd.cfg.unwanted_extensions_mode() == 0
-            and ext_is_listed(extension, sabnzbd.cfg.unwanted_extensions())
+            and is_listed_ext(extension, sabnzbd.cfg.unwanted_extensions())
         ) or (
             # Not whitelisted
             sabnzbd.cfg.unwanted_extensions_mode() == 1
-            and not ext_is_listed(extension, sabnzbd.cfg.unwanted_extensions())
+            and not is_listed_ext(extension, sabnzbd.cfg.unwanted_extensions())
         )
     else:
         # Don't consider missing extensions unwanted to prevent indiscriminate blocking of

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -63,15 +63,12 @@ def ext_is_listed(ext: str, ext_list: list) -> bool:
     """Check if the extension is listed. In case of a regexp the entire extension must be matched;
     partial matches aren't accepted (e.g. 'r[0-9]{2}' will be treated the same as '^r[0-9]{2}$' and
     thus return false for extentions such as 'r007' despite the substring match on 'r00').
-
-    Since the extension list is stored as a comma-separated list in the config, regular expressions
-    cannot use a comma or they'll be split and interpreted as multiple listed extensions.
     """
     for item in ext_list:
-        if item.startswith("re:"):
+        RE_EXT = sabnzbd.rss.convert_filter(item)
+        if RE_EXT:
             try:
-                # Case-insensitive match, extensions from both cfg and get_ext are always lowercase
-                if len(re.compile(item[3:], re.I).match(ext).group()) == len(ext):
+                if len(RE_EXT.match(ext).group()) == len(ext):
                     return True
             except Exception:
                 pass

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -75,9 +75,8 @@ def ext_is_listed(ext: str, ext_list: list) -> bool:
                     return True
             except Exception:
                 pass
-        else:
-            if ext in ext_list:
-                return True
+        elif item == ext:
+            return True
     # No match found
     return False
 

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -220,6 +220,23 @@ def wildcard_to_re(text):
     return "".join([_wildcard_to_regex.get(ch, ch) for ch in text])
 
 
+def convert_filter(text):
+    """Return compiled regex.
+    If string starts with re: it's a real regex
+    else quote all regex specials, replace '*' by '.*'
+    """
+    text = text.strip().lower()
+    if text.startswith("re:"):
+        txt = text[3:].strip()
+    else:
+        txt = wildcard_to_re(text)
+    try:
+        return re.compile(txt, re.I)
+    except:
+        logging.debug("Could not compile regex: %s", text)
+        return None
+
+
 def cat_convert(cat):
     """Convert indexer's category/group-name to user categories.
     If no match found, but indexer-cat equals user-cat, then return user-cat

--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -31,7 +31,7 @@ from sabnzbd.constants import RSS_FILE_NAME, DEFAULT_PRIORITY, DUP_PRIORITY
 from sabnzbd.decorators import synchronized
 import sabnzbd.config as config
 import sabnzbd.cfg as cfg
-from sabnzbd.misc import cat_convert, wildcard_to_re, cat_to_opts, match_str, from_units, int_conv, get_base_url
+from sabnzbd.misc import cat_convert, convert_filter, cat_to_opts, match_str, from_units, int_conv, get_base_url
 import sabnzbd.emailer as emailer
 
 import feedparser
@@ -45,23 +45,6 @@ import feedparser
 def notdefault(item):
     """Return True if not 'Default|''|*'"""
     return bool(item) and str(item).lower() not in ("default", "*", "", str(DEFAULT_PRIORITY))
-
-
-def convert_filter(text):
-    """Return compiled regex.
-    If string starts with re: it's a real regex
-    else quote all regex specials, replace '*' by '.*'
-    """
-    text = text.strip().lower()
-    if text.startswith("re:"):
-        txt = text[3:].strip()
-    else:
-        txt = wildcard_to_re(text)
-    try:
-        return re.compile(txt, re.I)
-    except:
-        logging.debug("Could not compile regex: %s", text)
-        return None
 
 
 def remove_obsolete(jobs, new_jobs):

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1094,7 +1094,7 @@ class TestRenamer:
 class TestUnwantedExtensions:
     # Only test lowercase extensions without a leading dot: the unwanted_extensions
     # setting is sanitized accordingly in interface.saveSwitches() before saving.
-    test_extensions = "iso, cmd, bat, sh"
+    test_extensions = "iso, cmd, bat, sh, re:r[0-9]{2}"
     # Test parameters as (filename, result) tuples, with result given for blacklist mode
     test_params = [
         ("ubuntu.iso", True),
@@ -1109,7 +1109,16 @@ class TestUnwantedExtensions:
         ("par2.cmd.notcmd", False),
         ("freedos.tab", False),
         (".SH.hs", False),
+        ("regexp.r0611", False),
+        ("regexp.007", False),
+        ("regexp.A01", False),
+        ("regexp.r9", False),
+        ("regexp.r2d2", False),
+        ("regexp.r2d", False),
+        ("regexp.r00", True),
+        ("regexp.R42", True),
         ("No_Extension", False),
+        ("r42", False),
         (480, False),
         (None, False),
         ("", False),

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1094,7 +1094,7 @@ class TestRenamer:
 class TestUnwantedExtensions:
     # Only test lowercase extensions without a leading dot: the unwanted_extensions
     # setting is sanitized accordingly in interface.saveSwitches() before saving.
-    test_extensions = "iso, cmd, bat, sh, re:r[0-9]{2}"
+    test_extensions = "iso, cmd, bat, sh, re:r[0-9]{2}, sab*"
     # Test parameters as (filename, result) tuples, with result given for blacklist mode
     test_params = [
         ("ubuntu.iso", True),
@@ -1117,6 +1117,9 @@ class TestUnwantedExtensions:
         ("regexp.r2d", False),
         ("regexp.r00", True),
         ("regexp.R42", True),
+        ("test.sabnzbd", True),
+        ("pass.sab", True),
+        ("fail.sb", False),
         ("No_Extension", False),
         ("r42", False),
         (480, False),


### PR DESCRIPTION
Can be used to avoid long lists of similar extensions such as r00-r99.

The only annoyance I came across is that certain chars (comma, ...) cannot be used in the regexp because of how the setting is stored and handled. Similar limitations seem to exist with rss feed filters, so I assume there's no easy way to avoid this.

Yes, I'll update the docs too. :grin: