### PR TITLE
Implement regex to match the filename in the content-disposition header.

### DIFF
--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -192,7 +192,7 @@ class URLGrabber(Thread):
 
                         # Get filename from Content-Disposition header
                         if not filename and "filename=" in value:
-                            filename_match = re.match(r".*filename[*=]+(?:UTF-8''?)*([^=;]*);?", value")
+                            filename_match = re.match(r".*filename[*=]+(?:UTF-8''?)*([^=;]*);?", value)
                             if filename_match:
                                 filename = filename_match.group(1).strip('"')
 

--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -22,6 +22,7 @@ sabnzbd.urlgrabber - Queue for grabbing NZB files from websites
 import os
 import sys
 import time
+import re
 import logging
 import queue
 import urllib.request
@@ -191,7 +192,9 @@ class URLGrabber(Thread):
 
                         # Get filename from Content-Disposition header
                         if not filename and "filename=" in value:
-                            filename = value[value.index("filename=") + 9 :].strip(";").strip('"')
+                            filename_match = re.match(r".*filename[*=]+(?:UTF-8''?)*([^=;]*);?", value")
+                            if filename_match:
+                                filename = filename_match.group(1).strip('"')
 
                 if wait:
                     # For sites that have a rate-limiting attribute

--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -22,7 +22,6 @@ sabnzbd.urlgrabber - Queue for grabbing NZB files from websites
 import os
 import sys
 import time
-import re
 import logging
 import queue
 import urllib.request

--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -212,7 +212,7 @@ class URLGrabber(Thread):
                             nzo_info[item] = value
 
                         # Get filename from Content-Disposition header
-                        if not filename and 'filename' in value:
+                        if not filename and "filename" in value:
                             filename = filename_from_content_disposition(value)
 
                 if wait:

--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -212,7 +212,7 @@ class URLGrabber(Thread):
                             nzo_info[item] = value
 
                         # Get filename from Content-Disposition header
-                        if not filename:
+                        if not filename and 'filename' in value:
                             filename = filename_from_content_disposition(value)
 
                 if wait:

--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -29,6 +29,7 @@ import urllib.request
 import urllib.error
 import urllib.parse
 from http.client import IncompleteRead, HTTPResponse
+from mailbox import Message
 from threading import Thread
 import base64
 from typing import Tuple, Optional
@@ -58,6 +59,27 @@ _RARTING_FIELDS = (
     "x-rating-passworded",
     "x-rating-confirmed-passworded",
 )
+
+
+def filename_from_content_disposition(content_disposition):
+    """
+    Extract and validate filename from a Content-Disposition header.
+
+    Origin: https://github.com/httpie/httpie/blob/4c8633c6e51f388523ab4fa649040934402a4fc9/httpie/downloads.py#L98
+    :param content_disposition: Content-Disposition value
+    :type content_disposition: str
+    :return: the filename if present and valid, otherwise `None`
+    :example:
+        filename_from_content_disposition('attachment; filename=jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz')
+        should return: 'jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz'
+    """
+    msg = Message(f'Content-Disposition: {content_disposition}')
+    filename = msg.get_filename()
+    if filename:
+        # Basic sanitation.
+        filename = os.path.basename(filename).lstrip('.').strip()
+        if filename:
+            return filename
 
 
 class URLGrabber(Thread):
@@ -191,10 +213,8 @@ class URLGrabber(Thread):
                             nzo_info[item] = value
 
                         # Get filename from Content-Disposition header
-                        if not filename and "filename=" in value:
-                            filename_match = re.match(r".*filename[*=]+(?:UTF-8''?)*([^=;]*);?", value)
-                            if filename_match:
-                                filename = filename_match.group(1).strip('"')
+                        if not filename:
+                            filename = filename_from_content_disposition(value)
 
                 if wait:
                     # For sites that have a rate-limiting attribute

--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -73,7 +73,7 @@ def filename_from_content_disposition(content_disposition):
         filename_from_content_disposition('attachment; filename=jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz')
         should return: 'jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz'
     """
-    msg = Message(f'Content-Disposition: {content_disposition}')
+    msg = Message(f'Content-Disposition: attachment; {content_disposition}')
     filename = msg.get_filename()
     if filename:
         # Basic sanitation.

--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -72,11 +72,11 @@ def filename_from_content_disposition(content_disposition):
         filename_from_content_disposition('attachment; filename=jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz')
         should return: 'jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz'
     """
-    msg = Message(f'Content-Disposition: attachment; {content_disposition}')
+    msg = Message(f"Content-Disposition: attachment; {content_disposition}")
     filename = msg.get_filename()
     if filename:
         # Basic sanitation.
-        filename = os.path.basename(filename).lstrip('.').strip()
+        filename = os.path.basename(filename).lstrip(".").strip()
         if filename:
             return filename
 

--- a/tests/test_urlgrabber.py
+++ b/tests/test_urlgrabber.py
@@ -166,7 +166,7 @@ class TestFilenameFromDispositionHeader:
         [
             (
                 # In this case the first filename (not the UTF-8 encoded) is parsed.
-                "filename=Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD.nzb; filename*=UTF-8''Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD-utf.nzb",
+                "attachment; filename=Zombie.Land.Saga.Revenge.S02E12.1080p.WEB.H264-SENPAI.nzb; filename*=UTF-8''Zombie.Land.Saga.Revenge.S02E12.1080p.WEB.H264-SENPAI.nzb",
                 "Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD.nzb"
             ),
             (

--- a/tests/test_urlgrabber.py
+++ b/tests/test_urlgrabber.py
@@ -27,7 +27,6 @@ import pytest_httpbin
 import sabnzbd.urlgrabber as urlgrabber
 import sabnzbd.version
 from sabnzbd.cfg import selftest_host
-from sabnzbd.urlgrabber import filename_from_content_disposition
 from tests.testhelper import *
 
 
@@ -167,7 +166,7 @@ class TestFilenameFromDispositionHeader:
         [
             (
                 "filename=Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD.nzb; filename*=UTF-8''Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD-utf.nzb",
-                "Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD-utf.nzb"
+                "Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD.nzb"
             ),
             (
                 "filename=Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD.nzb;",
@@ -180,9 +179,17 @@ class TestFilenameFromDispositionHeader:
             (
                 "attachment; filename=jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz",
                 "jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz"
+            ),
+            (
+                "attachment; filename=\"jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz\"",
+                "jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz"
+            ),
+            (
+                "attachment; filename=",
+                None
             )
         ]
     )
     def test_filename_from_disposition_header(self, header, result):
         """Test the parsing of different disposition-headers."""
-        assert filename_from_content_disposition(header) == result
+        assert urlgrabber.filename_from_content_disposition(header) == result

--- a/tests/test_urlgrabber.py
+++ b/tests/test_urlgrabber.py
@@ -182,7 +182,7 @@ class TestFilenameFromDispositionHeader:
                 "jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz",
             ),
             (
-                "attachment; filename=\"jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz\"",
+                'attachment; filename="jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz"',
                 "jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz",
             ),
             (

--- a/tests/test_urlgrabber.py
+++ b/tests/test_urlgrabber.py
@@ -167,33 +167,33 @@ class TestFilenameFromDispositionHeader:
             (
                 # In this case the first filename (not the UTF-8 encoded) is parsed.
                 "attachment; filename=jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz; filename*=UTF-8''jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz",
-                "jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz"
+                "jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz",
             ),
             (
                 "filename=jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz;",
-                "jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz"
+                "jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz",
             ),
             (
                 "filename*=UTF-8''jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz",
-                "jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz"
+                "jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz",
             ),
             (
                 "attachment; filename=jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz",
-                "jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz"
+                "jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz",
             ),
             (
                 "attachment; filename=\"jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz\"",
-                "jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz"
+                "jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz",
             ),
             (
                 "attachment; filename=/what/ever/filename.tar.gz",
-                "filename.tar.gz"
+                "filename.tar.gz",
             ),
             (
                 "attachment; filename=",
-                None
-            )
-        ]
+                None,
+            ),
+        ],
     )
     def test_filename_from_disposition_header(self, header, result):
         """Test the parsing of different disposition-headers."""

--- a/tests/test_urlgrabber.py
+++ b/tests/test_urlgrabber.py
@@ -177,6 +177,10 @@ class TestFilenameFromDispositionHeader:
                 "filename*=UTF-8''Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD.nzb",
                 "Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD.nzb"
             ),
+            (
+                "attachment; filename=jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz",
+                "jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz"
+            )
         ]
     )
     def test_filename_from_disposition_header(self, header, result):

--- a/tests/test_urlgrabber.py
+++ b/tests/test_urlgrabber.py
@@ -166,16 +166,16 @@ class TestFilenameFromDispositionHeader:
         [
             (
                 # In this case the first filename (not the UTF-8 encoded) is parsed.
-                "attachment; filename=Zombie.Land.Saga.Revenge.S02E12.1080p.WEB.H264-SENPAI.nzb; filename*=UTF-8''Zombie.Land.Saga.Revenge.S02E12.1080p.WEB.H264-SENPAI.nzb",
-                "Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD.nzb"
+                "attachment; filename=jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz; filename*=UTF-8''jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz",
+                "jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz"
             ),
             (
-                "filename=Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD.nzb;",
-                "Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD.nzb"
+                "filename=jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz;",
+                "jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz"
             ),
             (
-                "filename*=UTF-8''Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD.nzb",
-                "Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD.nzb"
+                "filename*=UTF-8''jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz",
+                "jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz"
             ),
             (
                 "attachment; filename=jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz",

--- a/tests/test_urlgrabber.py
+++ b/tests/test_urlgrabber.py
@@ -165,6 +165,7 @@ class TestFilenameFromDispositionHeader:
         "header, result",
         [
             (
+                # In this case the first filename (not the UTF-8 encoded) is parsed.
                 "filename=Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD.nzb; filename*=UTF-8''Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD-utf.nzb",
                 "Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD.nzb"
             ),

--- a/tests/test_urlgrabber.py
+++ b/tests/test_urlgrabber.py
@@ -186,6 +186,10 @@ class TestFilenameFromDispositionHeader:
                 "jakubroztocil-httpie-0.4.1-20-g40bd8f6.tar.gz"
             ),
             (
+                "attachment; filename=/what/ever/filename.tar.gz",
+                "filename.tar.gz"
+            ),
+            (
                 "attachment; filename=",
                 None
             )

--- a/tests/test_urlgrabber.py
+++ b/tests/test_urlgrabber.py
@@ -27,6 +27,7 @@ import pytest_httpbin
 import sabnzbd.urlgrabber as urlgrabber
 import sabnzbd.version
 from sabnzbd.cfg import selftest_host
+from sabnzbd.urlgrabber import filename_from_content_disposition
 from tests.testhelper import *
 
 
@@ -158,3 +159,26 @@ class TestBuildRequest:
             self._runner(self.httpbin.url + "/status/404", 404)
         with pytest.raises(urllib.error.HTTPError):
             self._runner(self.httpbin.url + "/no/such/file", 404)
+
+
+class TestFilenameFromDispositionHeader:
+    @pytest.mark.parametrize(
+        "header, result",
+        [
+            (
+                "filename=Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD.nzb; filename*=UTF-8''Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD-utf.nzb",
+                "Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD-utf.nzb"
+            ),
+            (
+                "filename=Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD.nzb;",
+                "Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD.nzb"
+            ),
+            (
+                "filename*=UTF-8''Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD.nzb",
+                "Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD.nzb"
+            ),
+        ]
+    )
+    def test_filename_from_disposition_header(self, header, result):
+        """Test the parsing of different disposition-headers."""
+        assert filename_from_content_disposition(header) == result


### PR DESCRIPTION
With the chain of pymedusa -> prowlarr -> sabnzbd. Medusa sends prowlarr's nzb download url to sabnzbd.
Sabnzbd downloads the nzb and get's a `Content-Disposition` header.

An example header is: `filename=Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD.nzb; filename*=UTF-8''Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD.nzb`

Sabnzbd fails to properly parse this string. This PR fixes that, while also supporting the existing formats using a regular expression.

Forum issue: https://forums.sabnzbd.org/viewtopic.php?f=2&t=25496

The following strings will match:
filename=Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD.nzb; filename*=UTF-8''Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD.nzb
filename=Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD.nzb;
filename*=UTF-8''Zombie.Land.Saga.Revenge.S02E12.480p.x264-mSD.nzb