### PR TITLE
make .cbr a well-known extension, so that no extension (".rar") is added

### DIFF
--- a/sabnzbd/utils/file_extension.py
+++ b/sabnzbd/utils/file_extension.py
@@ -169,6 +169,7 @@ DOWNLOAD_EXT = (
     "bdmv",
     "bin",
     "bup",
+    "cbr",
     "clpi",
     "crx",
     "db",


### PR DESCRIPTION
Solves https://forums.sabnzbd.org/viewtopic.php?p=126007#p126007 