### PR TITLE
Add testable socks support

### DIFF
--- a/interfaces/Config/templates/config_general.tmpl
+++ b/interfaces/Config/templates/config_general.tmpl
@@ -217,6 +217,43 @@
             </fieldset>
         </div><!-- /col1 -->
     </div><!-- /section -->
+    <div class="section">
+        <div class="col2">
+            <h3>$T('proxy') <a href="$helpuri$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+        </div><!-- /col2 -->
+        <div class="col1">
+            <fieldset>
+                <div class="field-pair">
+                    <label class="config" for="proxy_enabled">$T('opt-proxy_enabled')</label>
+                    <input type="checkbox" name="proxy_enabled" id="proxy_enabled" value="1" <!--#if int($proxy_enabled) > 0 then 'checked="checked"' else ""#-->/>
+                    <span class="desc">$T('explain-proxy_enabled')</span>
+                </div>
+                <div class="field-pair advanced-settings">
+                    <label class="config" for="proxy_host">$T('opt-proxy_host')</label>
+                    <input type="text" name="proxy_host" id="proxy_host" value="$proxy_host" />
+                    <span class="desc">$T('explain-proxy_host')</span>
+                </div>
+                <div class="field-pair">
+                    <label class="config" for="proxy_port">$T('opt-proxy_port')</label>
+                    <input type="number" name="proxy_port" id="proxy_port" value="$proxy_port" size="8" />
+                    <span class="desc">$T('explain-proxy_port')</span>
+                </div>
+                <div class="field-pair advanced-settings">
+                    <label class="config" for="proxy_username">$T('opt-proxy_username')</label>
+                    <input type="text" name="proxy_username" id="proxy_username" value="$proxy_username" />
+                    <span class="desc">$T('explain-proxy_username')</span>
+                </div>
+                <div class="field-pair" advanced-settings">
+                    <label class="config" for="proxy_password">$T('opt-proxy_password')</label>
+                    <input type="text" name="proxy_password" id="proxy_password" value="$proxy_password" />
+                    <span class="desc">$T('explain-proxy_password')</span>
+                </div>
+                <div class="field-pair">
+                    <button class="btn btn-default saveButton"><span class="glyphicon glyphicon-ok"></span> $T('button-saveChanges')</button>
+                </div>
+            </fieldset>
+        </div><!-- /col1 -->
+    </div><!-- /section -->
 
     </form>
 </div><!-- /colmask -->

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ chardet
 notify2
 puremagic
 guessit>=3.1.0
+python-socks
 
 # Windows system integration
 pywin32>=227; sys_platform == 'win32'

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -134,6 +134,11 @@ enable_https = OptionBool("misc", "enable_https", False)
 inet_exposure = OptionNumber("misc", "inet_exposure", 0, protect=True)
 api_key = OptionStr("misc", "api_key", create_api_key())
 nzb_key = OptionStr("misc", "nzb_key", create_api_key())
+proxy_enabled = OptionBool("misc", "proxy_enabled", False)
+proxy_host = OptionStr("misc", "proxy_host")
+proxy_port = OptionStr("misc", "proxy_port")
+proxy_username = OptionStr("misc", "proxy_username")
+proxy_password = OptionPassword("misc", "proxy_password")
 
 
 ##############################################################################

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -994,6 +994,11 @@ GENERAL_LIST = (
     "enable_https_verification",
     "auto_browser",
     "check_new_rel",
+    "proxy_enabled",
+    "proxy_host",
+    "proxy_port",
+    "proxy_username",
+    "proxy_password",
 )
 
 


### PR DESCRIPTION
Originally posted by @puzzledsab in #1894 on May 14:
> Issue #206
> It was a bit frustrating to make it work so I'm not going to spend any time making it pretty until I have some confirmation that it is usable. Hopefully this will build installable versions. I tried PySocks first but I couldn't make it work with SSL. It currently only works for NNTP but HTTP requests shouldn't be too hard.
> 
> The configuration is at the bottom of the General config page. It uses blocking calls for making connections, so that takes longer than usual. I don't have a proxy that requires username and password so I haven't tested that.
> 
> Be aware that the username and password for the proxy server will be included in the log file if debug logging is enabled.
---

@puzzledsab closed this PR a couple weeks after opening it without any specific reason given, but it might've been due to a perceived lack of interest based on the comment given here: https://github.com/sabnzbd/sabnzbd/issues/1894#issuecomment-855385692

Given there seems to be a few people interested, myself included, I'm resubmitting it. If @puzzledsab comes back and would prefer to reopen their PR, that's probably better.

@jcfp reviewed the code (https://github.com/sabnzbd/sabnzbd/pull/1894#r633123349) and asked why the proxy type was hard-coded, given the module supports more than just SOCKS 5. @puzzledsab never answered, but, as for my reason, since I only have a SOCKS 5 proxy to test with, I'm leaving the code as-is. It can always be revised later.