### PR TITLE
reintroduce uu support

### DIFF
--- a/sabnzbd/decoder.py
+++ b/sabnzbd/decoder.py
@@ -301,7 +301,7 @@ def decode_uu(article: Article, raw_data: List[bytes]) -> bytes:
             raise BadUu
 
     def is_uu_junk(line: bytes) -> bool:
-        """Determine if the lilne is empty or contains known junk data"""
+        """Determine if the line is empty or contains known junk data"""
         return (not line) or line == b"-- " or line.startswith(b"Posted via ")
 
     # Check the uu 'begin' line

--- a/sabnzbd/decoder.py
+++ b/sabnzbd/decoder.py
@@ -22,12 +22,15 @@ sabnzbd.decoder - article decoder
 import logging
 import hashlib
 import queue
+from binascii import a2b_uu
+from io import BytesIO
 from threading import Thread
 from typing import Tuple, List, Optional
 
 import sabnzbd
 import sabnzbd.cfg as cfg
 from sabnzbd.constants import SABYENC_VERSION_REQUIRED
+from sabnzbd.encoding import ubtou
 from sabnzbd.nzbstuff import Article
 from sabnzbd.misc import match_str
 
@@ -45,15 +48,18 @@ except ImportError:
     SABYENC_ENABLED = False
 
 
-class CrcError(Exception):
-    def __init__(self, needcrc: int, gotcrc: int, data: bytes):
+class BadData(Exception):
+    def __init__(self, data: bytes):
         super().__init__()
-        self.needcrc = needcrc
-        self.gotcrc = gotcrc
         self.data = data
 
 
 class BadYenc(Exception):
+    def __init__(self):
+        super().__init__()
+
+
+class BadUu(Exception):
     def __init__(self):
         super().__init__()
 
@@ -140,7 +146,9 @@ class DecoderWorker(Thread):
                 if sabnzbd.LOG_ALL:
                     logging.debug("Decoding %s", art_id)
 
-                decoded_data = decode(article, raw_data)
+                decoded_data = (
+                    decode_yenc(article, raw_data) if article.nzf.type != "uu" else decode_uu(article, raw_data)
+                )
                 article_success = True
 
             except MemoryError:
@@ -154,15 +162,20 @@ class DecoderWorker(Thread):
                 sabnzbd.NzbQueue.reset_try_lists(article)
                 continue
 
-            except CrcError as crc_error:
-                logging.info("CRC Error in %s" % art_id)
-
+            except BadData as error:
                 # Continue to the next one if we found new server
                 if search_new_server(article):
                     continue
 
                 # Store data, maybe par2 can still fix it
-                decoded_data = crc_error.data
+                decoded_data = error.data
+
+            except BadUu:
+                logging.info("Badly formed uu article in %s", art_id)
+
+                # Try the next server
+                if search_new_server(article):
+                    continue
 
             except (BadYenc, ValueError):
                 # Handles precheck and badly formed articles
@@ -170,9 +183,16 @@ class DecoderWorker(Thread):
                     # STAT was used, so we only get a status code
                     article_success = True
                 else:
+                    # Try uu-decoding
+                    if (not nzo.precheck) and article.nzf.type != "yenc":
+                        try:
+                            decoded_data = decode_uu(article, raw_data)
+                            logging.debug("Found uu-encoded article %s in job %s", art_id, nzo.final_name)
+                            article_success = True
+                        except Exception:
+                            pass
                     # Examine headers (for precheck) or body (for download)
                     # Look for DMCA clues (while skipping "X-" headers)
-                    # Detect potential UUencode
                     for line in raw_data:
                         lline = line.lower()
                         if b"message-id:" in lline:
@@ -182,12 +202,6 @@ class DecoderWorker(Thread):
                         ):
                             article_success = False
                             logging.info("Article removed from server (%s)", art_id)
-                            break
-                        if lline.find(b"\nbegin ") >= 0:
-                            logme = T("UUencode detected, only yEnc encoding is supported [%s]") % nzo.final_name
-                            logging.error(logme)
-                            nzo.fail_msg = logme
-                            sabnzbd.NzbQueue.end_job(nzo)
                             break
 
                 # Pre-check, proper article found so just register
@@ -218,7 +232,7 @@ class DecoderWorker(Thread):
             sabnzbd.NzbQueue.register_article(article, article_success)
 
 
-def decode(article: Article, raw_data: List[bytes]) -> bytes:
+def decode_yenc(article: Article, raw_data: List[bytes]) -> bytes:
     # Let SABYenc do all the heavy lifting
     decoded_data, yenc_filename, crc, crc_expected, crc_correct = sabyenc3.decode_usenet_chunks(raw_data, article.bytes)
 
@@ -240,9 +254,131 @@ def decode(article: Article, raw_data: List[bytes]) -> bytes:
 
     # CRC check
     if not crc_correct:
-        raise CrcError(crc_expected, crc, decoded_data)
+        logging.info("CRC Error in %s", article.article)
+        raise BadData(decoded_data)
 
     return decoded_data
+
+
+def decode_uu(article: Article, raw_data: List[bytes]) -> bytes:
+    if not raw_data:
+        logging.debug("No data to decode")
+        raise BadUu
+
+    # Line up the raw_data
+    with BytesIO() as encoded_data:
+        for data in raw_data:
+            encoded_data.write(data)
+        raw_data = encoded_data.getvalue().split(b"\r\n")
+
+    # The raw_data may or may not contain headers. If there are headers, they
+    # will be separated from the body by at least one empty line. In case of no
+    # headers, the first line seems to always be the nntp response code (222)
+    # directly followed by the msg body.
+
+    # Index of the uu payload start in raw_data
+    uu_start = 0
+
+    # Limit the number of lines to check for the onset of uu data
+    limit = min(len(raw_data), 32) - 1
+    if limit < 3:
+        logging.debug("Article too short to contain valid uu-encoded data")
+        raise BadUu
+
+    # Try to find an empty line separating the body from headers or response
+    # code and set the expected payload start to the next line.
+    try:
+        uu_start = raw_data[:limit].index(b"") + 1
+    except ValueError:
+        # No empty line, look for a response code instead
+        if raw_data[0].startswith(b"222 "):
+            uu_start = 1
+        else:
+            # Invalid data?
+            logging.debug("Failed to locate start of uu payload")
+            raise BadUu
+
+    def is_uu_junk(line: bytes) -> bool:
+        """Determine if the lilne is empty or contains known junk data"""
+        return (not line) or line == b"-- " or line.startswith(b"Posted via ")
+
+    # Check the uu 'begin' line
+    if article.lowest_partnum:
+        try:
+            # Make sure the line after the uu_start one isn't empty as well or
+            # detection of the 'begin' line won't work. For articles other than
+            # lowest_partnum, filtering out empty lines (and other junk) can
+            # wait until the actual decoding step.
+            for index in range(uu_start, limit):
+                if is_uu_junk(raw_data[index]):
+                    uu_start = index + 1
+                else:
+                    # Bingo
+                    break
+            else:
+                # Search reached the limit
+                raise IndexError
+
+            uu_begin_data = raw_data[uu_start].split(b" ")
+            uu_filename = ubtou(uu_begin_data[2].strip())
+
+            # Sanity check the 'begin' line
+            if (
+                len(uu_begin_data) != 3
+                or uu_begin_data[0] != b"begin"
+                or (not int(uu_begin_data[1], 8))
+                or (not uu_filename)
+            ):
+                raise ValueError
+
+            # Consider this enough proof to set the type, avoiding further
+            # futile attempts at decoding articles in this nzf as yenc.
+            article.nzf.type = "uu"
+
+            # Bump the pointer for the payload to the next line
+            uu_start += 1
+        except Exception:
+            logging.debug("Missing or invalid uu 'begin' line: %s", raw_data[uu_start] if uu_start < limit else None)
+            raise BadUu
+
+    # Do the actual decoding
+    with BytesIO() as decoded_data:
+        for line in raw_data[uu_start:]:
+            # Ignore junk
+            if is_uu_junk(line):
+                continue
+
+            # End of the article
+            if line in (b"`", b"end", b"."):
+                break
+
+            try:
+                decoded_line = a2b_uu(line)
+            except binascii.Error as msg:
+                try:
+                    # Workaround for broken uuencoders by Fredrik Lundh
+                    nbytes = (((ord(line[0]) - 32) & 63) * 4 + 5) / 3
+                    decoded_line = a2b_uu(line[:nbytes])
+                except binascii.Error as msg:
+                    logging.info("Error while uu-decoding %s: %s", article.article, msg)
+                    raise BadData(decoded_data.getvalue())
+
+            # Store the decoded data
+            decoded_data.write(decoded_line)
+
+        # Mark as decoded and set the type to uu; the latter is still needed in
+        # case the lowest_partnum article was damaged or slow to download.
+        article.decoded = True
+        article.nzf.type = "uu"
+
+        if article.lowest_partnum:
+            decoded_data.seek(0)
+            article.nzf.md5of16k = hashlib.md5(decoded_data.read(16384)).digest()
+            # Handle the filename
+            if not article.nzf.filename_checked and uu_filename:
+                article.nzf.nzo.verify_nzf_filename(article.nzf, uu_filename)
+
+        return decoded_data.getvalue()
 
 
 def search_new_server(article: Article) -> bool:

--- a/sabnzbd/decoder.py
+++ b/sabnzbd/decoder.py
@@ -363,7 +363,9 @@ def decode_uu(article: Article, raw_data: List[bytes]) -> bytes:
                     nbytes = (((ord(line[0]) - 32) & 63) * 4 + 5) / 3
                     decoded_line = binascii.a2b_uu(line[:nbytes])
                 except Exception as msg2:
-                    logging.info("Error while uu-decoding %s: %s (workaround: %s)", article.article, msg, msg2)
+                    logging.info(
+                        "Error while uu-decoding %s: %s (line: %s; workaround: %s)", article.article, msg, line, msg2
+                    )
                     raise BadData(decoded_data.getvalue())
 
             # Store the decoded data

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -1744,7 +1744,7 @@ class NzbObject(TryList):
             and not is_probably_obfuscated(yenc_filename)
             and not nzf.filename.endswith(".par2")
         ):
-            logging.info("Detected filename from yenc: %s -> %s", nzf.filename, yenc_filename)
+            logging.info("Detected filename from yenc or uu: %s -> %s", nzf.filename, yenc_filename)
             self.renamed_file(yenc_filename, nzf.filename)
             nzf.filename = yenc_filename
 

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -56,7 +56,7 @@ class TestUuDecoder:
         one is passed; all uu payload is taken from VALID_UU_{LINES, END}.
 
         Returns Article with a random id and lowest_partnum correctly set, socket-style raw
-        data, and the expected result of uu decoding for the generate message or part.
+        data, and the expected result of uu decoding for the generated message.
         """
         article_id = "test@host" + os.urandom(8).hex() + ".sab"
         article = Article(article_id, randint(4321, 54321), None)
@@ -88,14 +88,11 @@ class TestUuDecoder:
                 data.append(begin_line)
             else:
                 data.append(b"begin 644 My Favorite Open Source Movie.mkv")
+
+        if part in ("begin", "middle", "single"):
             size = randint(4, len(VALID_UU_LINES) - 1)
             data.extend(VALID_UU_LINES[:size])
             result.extend(LINES_DATA[:size])
-
-        if part == "middle":
-            size = randint(-1 * len(VALID_UU_LINES) - 1, -8)
-            data.extend(VALID_UU_LINES[size:])
-            result.extend(LINES_DATA[size:])
 
         if part in ("end", "single"):
             if insert_end:

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -153,7 +153,6 @@ class TestUuDecoder:
             b"begin 444 filename with spaces.txt",
             b"BEGIN 644 foobar",
             b"begin 0755 shell.sh",
-            None,
         ],
     )
     def test_singlepart(self, insert_empty_line, insert_excess_empty_lines, insert_headers, insert_end, begin_line):
@@ -172,7 +171,7 @@ class TestUuDecoder:
         # Generate and process a multipart msg
         decoded_data = expected_data = b""
         for part in ("begin", "middle", "middle", "end"):
-            article, data, result = self._generate_msg_part(part, insert_empty_line, False, False, True, None)
+            article, data, result = self._generate_msg_part(part, insert_empty_line, False, False, True)
             decoded_data += decoder.decode_uu(article, [data])
             expected_data += result
 

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -23,7 +23,6 @@ import os
 import pytest
 
 from random import randint
-from typing import Optional
 from unittest import mock
 
 import sabnzbd.decoder as decoder
@@ -49,11 +48,10 @@ class TestUuDecoder:
         insert_excess_empty_lines: bool = False,
         insert_headers: bool = False,
         insert_end: bool = True,
-        begin_line: Optional[bytes] = None,
+        begin_line: bytes = b"begin 644 My Favorite Open Source Movie.mkv",
     ):
         """Generate message parts. Part may be one of 'begin', 'middle', or 'end' for multipart
-        messages, or 'single' for a singlepart message. A standard uu begin line is added unless
-        one is passed; all uu payload is taken from VALID_UU_{LINES, END}.
+        messages, or 'single' for a singlepart message. All uu payload is taken from VALID_UU_*.
 
         Returns Article with a random id and lowest_partnum correctly set, socket-style raw
         data, and the expected result of uu decoding for the generated message.
@@ -84,10 +82,7 @@ class TestUuDecoder:
 
         # Insert uu data into the body
         if part in ("begin", "single"):
-            if begin_line:
-                data.append(begin_line)
-            else:
-                data.append(b"begin 644 My Favorite Open Source Movie.mkv")
+            data.append(begin_line)
 
         if part in ("begin", "middle", "single"):
             size = randint(4, len(VALID_UU_LINES) - 1)
@@ -178,8 +173,6 @@ class TestUuDecoder:
         decoded_data = expected_data = b""
         for part in ("begin", "middle", "middle", "end"):
             article, data, result = self._generate_msg_part(part, insert_empty_line, False, False, True, None)
-            print("data = %s" % data)
-            print("result = %s" % result)
             decoded_data += decoder.decode_uu(article, [data])
             expected_data += result
 

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -1,0 +1,203 @@
+#!/usr/bin/python3 -OO
+# Copyright 2007-2021 The SABnzbd-Team <team@sabnzbd.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+tests.test_decoder- Testing functions in decoder.py
+"""
+import binascii
+import os
+import pytest
+
+from random import randint
+from typing import Optional
+from unittest import mock
+
+import sabnzbd.decoder as decoder
+from sabnzbd.nzbstuff import Article
+
+
+LINES_DATA = [os.urandom(45) for _ in range(32)]
+VALID_UU_LINES = [binascii.b2a_uu(data).rstrip(b"\n") for data in LINES_DATA]
+
+END_DATA = os.urandom(randint(1, 45))
+VALID_UU_END = [
+    binascii.b2a_uu(END_DATA).rstrip(b"\n"),
+    b"`",
+    b"end",
+]
+
+
+class TestUuDecoder:
+    def _generate_msg_part(
+        self,
+        part: str,
+        insert_empty_line: bool = True,
+        insert_excess_empty_lines: bool = False,
+        insert_headers: bool = False,
+        insert_end: bool = True,
+        begin_line: Optional[bytes] = None,
+    ):
+        """Generate message parts. Part may be one of 'begin', 'middle', or 'end' for multipart
+        messages, or 'single' for a singlepart message. A standard uu begin line is added unless
+        one is passed; all uu payload is taken from VALID_UU_{LINES, END}.
+
+        Returns Article with a random id and lowest_partnum correctly set, socket-style raw
+        data, and the expected result of uu decoding for the generate message or part.
+        """
+        article_id = "test@host" + os.urandom(8).hex() + ".sab"
+        article = Article(article_id, randint(4321, 54321), None)
+        article.lowest_partnum = True if part in ("begin", "single") else False
+        # Mock an nzf so results from hashing and filename handling can be stored
+        article.nzf = mock.Mock()
+
+        # Store the message data and the expected decoding result
+        data = []
+        result = []
+
+        # Always start with the response code line
+        data.append(b"222 0 <" + bytes(article_id, encoding="ascii") + b">")
+
+        if insert_empty_line:
+            # Only insert other headers if there's an empty line
+            if insert_headers:
+                data.extend([b"x-hoop: is uitgestelde teleurstelling", b"Another-Header: Sure"])
+
+            # Insert the empty line between response code and body
+            data.append(b"")
+
+        if insert_excess_empty_lines:
+            data.extend([b"", b""])
+
+        # Insert uu data into the body
+        if part in ("begin", "single"):
+            if begin_line:
+                data.append(begin_line)
+            else:
+                data.append(b"begin 644 My Favorite Open Source Movie.mkv")
+            size = randint(4, len(VALID_UU_LINES) - 1)
+            data.extend(VALID_UU_LINES[:size])
+            result.extend(LINES_DATA[:size])
+
+        if part == "middle":
+            size = randint(-1 * len(VALID_UU_LINES) - 1, -8)
+            data.extend(VALID_UU_LINES[size:])
+            result.extend(LINES_DATA[size:])
+
+        if part in ("end", "single"):
+            if insert_end:
+                data.extend(VALID_UU_END)
+                result.append(END_DATA)
+
+        # Signal the end of the message with a dot on a line of its own
+        data.append(b".")
+
+        # Join the data with \r\n line endings, just like we get from socket reads
+        data = b"\r\n".join(data)
+        # Concatenate expected result
+        result = b"".join(result)
+
+        return article, data, result
+
+    def test_no_data(self):
+        with pytest.raises(decoder.BadUu):
+            assert decoder.decode_uu(None, None)
+
+    @pytest.mark.parametrize(
+        "raw_data",
+        [
+            [b""],
+            [b"\r\n\r\n"],
+            [b"f", b"o", b"o", b"b", b"a", b"r", b"\r\n"],  # Plenty of list items, but (too) few actual lines
+            [b"222 0 <artid@woteva>\r\nX-Too-Short: yup\r\n"],
+        ],
+    )
+    def test_short_data(self, raw_data):
+        with pytest.raises(decoder.BadUu):
+            assert decoder.decode_uu(None, raw_data)
+
+    @pytest.mark.parametrize(
+        "raw_data",
+        [
+            [b"222 0 <foo@bar>\r\n\r\n"],  # Missing altogether
+            [b"222 0 <foo@bar>\r\n\r\nbeing\r\n"],  # Typo in 'begin'
+            [b"222 0 <foo@bar>\r\n\r\nx-header: begin 644 foobar\r\n"],  # Not at start of the line
+            [b"666 0 <foo@bar>\r\nbegin\r\n"],  # No empty line + wrong response code
+            [b"OMG 0 <foo@bar>\r\nbegin\r\n"],  # No empty line + invalid response code
+            [b"222 0 <foo@bar>\r\nbegin\r\n"],  # No perms
+            [b"222 0 <foo@bar>\r\nbegin ABC DEF\r\n"],  # Permissions not octal
+            [b"222 0 <foo@bar>\r\nbegin 755\r\n"],  # No filename
+            [b"222 0 <foo@bar>\r\nbegin 644 \t \t\r\n"],  # Filename empty after stripping
+        ],
+    )
+    def test_missing_uu_begin(self, raw_data):
+        article = Article("foo@bar", 1234, None)
+        article.lowest_partnum = True
+        filler = b"Some more\r\nrandom\r\nlines\r\nso the article\r\nlong\r\nenough\r\n"
+        with pytest.raises(decoder.BadUu):
+            assert decoder.decode_uu(article, raw_data.append(filler))
+
+    @pytest.mark.parametrize("insert_empty_line", [True, False])
+    @pytest.mark.parametrize("insert_excess_empty_lines", [True, False])
+    @pytest.mark.parametrize("insert_headers", [True, False])
+    @pytest.mark.parametrize("insert_end", [True, False])
+    @pytest.mark.parametrize(
+        "begin_line",
+        [
+            b"begin 644 nospace.bin",
+            b"begin 444 filename with spaces.txt",
+            b"BEGIN 644 foobar",
+            b"begin 0755 shell.sh",
+            None,
+        ],
+    )
+    def test_singlepart(self, insert_empty_line, insert_excess_empty_lines, insert_headers, insert_end, begin_line):
+        """Test variations of a sane single part nzf with proper uu-encoded data"""
+        # Generate a singlepart message
+        article, raw_data, expected_result = self._generate_msg_part(
+            "single", insert_empty_line, insert_excess_empty_lines, insert_headers, insert_end, begin_line
+        )
+        assert decoder.decode_uu(article, [raw_data]) == expected_result
+        assert article.nzf.filename_checked
+
+    @pytest.mark.parametrize("insert_empty_line", [True, False])
+    def test_multipart(self, insert_empty_line):
+        """Test a simple multipart nzf"""
+
+        # Generate and process a multipart msg
+        decoded_data = expected_data = b""
+        for part in ("begin", "middle", "middle", "end"):
+            article, data, result = self._generate_msg_part(part, insert_empty_line, False, False, True, None)
+            print("data = %s" % data)
+            print("result = %s" % result)
+            decoded_data += decoder.decode_uu(article, [data])
+            expected_data += result
+
+        # Verify results
+        assert decoded_data == expected_data
+        assert article.nzf.filename_checked
+
+    @pytest.mark.parametrize(
+        "bad_data",
+        [
+            b"MI^+0E\"C^364:CQ':]DW++^$F0J)6FDG/!`]0\\(4;EG$UY5RI,3JMBNX\\8+06\r\n$(WAIVBC^",  # Trailing junk
+        ],
+    )
+    def test_broken_uu(self, bad_data):
+        article = Article("foo@bar", 4321, None)
+        article.lowest_partnum = False
+        with pytest.raises(decoder.BadData):
+            assert decoder.decode_uu(article, [b"222 0 <foo@bar>\r\n" + bad_data + b"\r\n"])

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -138,7 +138,7 @@ class TestUuDecoder:
     def test_missing_uu_begin(self, raw_data):
         article = Article("foo@bar", 1234, None)
         article.lowest_partnum = True
-        filler = b"Some more\r\nrandom\r\nlines\r\nso the article\r\nlong\r\nenough\r\n"
+        filler = b"\r\n" * 4
         with pytest.raises(decoder.BadUu):
             assert decoder.decode_uu(article, raw_data.append(filler))
 
@@ -183,10 +183,12 @@ class TestUuDecoder:
         "bad_data",
         [
             b"MI^+0E\"C^364:CQ':]DW++^$F0J)6FDG/!`]0\\(4;EG$UY5RI,3JMBNX\\8+06\r\n$(WAIVBC^",  # Trailing junk
+            VALID_UU_LINES[-1][:10] + bytes("ваше здоровье", encoding="utf8") + VALID_UU_LINES[-1][-10:],  # Non-ascii
         ],
     )
     def test_broken_uu(self, bad_data):
         article = Article("foo@bar", 4321, None)
         article.lowest_partnum = False
+        filler = b"\r\n".join(VALID_UU_LINES[:4]) + b"\r\n"
         with pytest.raises(decoder.BadData):
-            assert decoder.decode_uu(article, [b"222 0 <foo@bar>\r\n" + bad_data + b"\r\n"])
+            assert decoder.decode_uu(article, [b"222 0 <foo@bar>\r\n" + filler + bad_data + b"\r\n"])


### PR DESCRIPTION
Seems to work for some example jobs, both single and multipart. Not sure about the performance, as the only somewhat larger uu-encoded job would only complete on the slow freebie server of xsusenet for me.

I considered adding a "type hint" at the nzo level too (indicating what decoding to try first for the next nzf in the same job), but didn't for now in order not to complicated things.

Closes #1660