### PR TITLE
disable randomisation of directory listings in pyfakefs

### DIFF
--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -257,6 +257,8 @@ class TestSanitizeFiles(ffs.TestCase):
         self.setUpPyfakefs()
         self.fs.path_separator = "\\"
         self.fs.is_windows_fs = True
+        # Disable randomisation of directory listings
+        self.fs.shuffle_listdir_results = False
 
     def test_sanitize_files_input(self):
         assert [] == filesystem.sanitize_files(folder=None)


### PR DESCRIPTION
Prevents the tests from breaking again when this setting comes enabled by default in some future release of pyfakefs.

Re: https://github.com/jmcgeheeiv/pyfakefs/issues/647