### PR TITLE
Bugfix/ciphers

### DIFF
--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -189,7 +189,7 @@ class Server:
                 logging.debug("%s: Connecting to address %s", self.host, ip)
             elif cfg.load_balancing() == 2:
                 # RFC6555 / Happy Eyeballs:
-                ip = happyeyeballs(self.host, port=self.port, use_ssl=self.ssl)
+                ip = happyeyeballs(self.host, port=self.port)
                 if ip:
                     logging.debug("%s: Connecting to address %s", self.host, ip)
                 else:

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -279,7 +279,7 @@ class NNTP:
         # Create SSL-context if it is needed and not created yet
         if self.nw.server.ssl and not self.nw.server.ssl_context:
             # Setup the SSL socket
-            self.nw.server.ssl_context = ssl.create_default_context()
+            self.nw.server.ssl_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
 
             if sabnzbd.cfg.allow_old_ssl_tls():
                 # Allow anything that the system has
@@ -299,6 +299,9 @@ class NNTP:
             if self.nw.server.ssl_ciphers:
                 # At their own risk, socket will error out in case it was invalid
                 self.nw.server.ssl_context.set_ciphers(self.nw.server.ssl_ciphers)
+            else:
+                # Support at least TLSv1.2+ ciphers, as some essential ones are removed by default in Python 3.10
+                self.nw.server.ssl_context.set_ciphers("HIGH:TLSv1.2")
 
             # Disable any verification if the setup is bad
             if not sabnzbd.CERTIFICATE_VALIDATION:

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -281,13 +281,6 @@ class NNTP:
             # Setup the SSL socket
             self.nw.server.ssl_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
 
-            if sabnzbd.cfg.allow_old_ssl_tls():
-                # Allow anything that the system has
-                self.nw.server.ssl_context.minimum_version = ssl.TLSVersion.MINIMUM_SUPPORTED
-            else:
-                # We want a modern TLS (1.2 or higher), so we disallow older protocol versions (<= TLS 1.1)
-                self.nw.server.ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
-
             # Only verify hostname when we're strict
             if self.nw.server.ssl_verify < 2:
                 self.nw.server.ssl_context.check_hostname = False
@@ -299,9 +292,18 @@ class NNTP:
             if self.nw.server.ssl_ciphers:
                 # At their own risk, socket will error out in case it was invalid
                 self.nw.server.ssl_context.set_ciphers(self.nw.server.ssl_ciphers)
+                # Python does not allow setting ciphers on TLSv1.3, so have to force TLSv1.2 as the maximum
+                self.nw.server.ssl_context.maximum_version = ssl.TLSVersion.TLSv1_2
             else:
                 # Support at least TLSv1.2+ ciphers, as some essential ones are removed by default in Python 3.10
-                self.nw.server.ssl_context.set_ciphers("HIGH:TLSv1.2")
+                self.nw.server.ssl_context.set_ciphers("HIGH")
+
+            if sabnzbd.cfg.allow_old_ssl_tls():
+                # Allow anything that the system has
+                self.nw.server.ssl_context.minimum_version = ssl.TLSVersion.MINIMUM_SUPPORTED
+            else:
+                # We want a modern TLS (1.2 or higher), so we disallow older protocol versions (<= TLS 1.1)
+                self.nw.server.ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
 
             # Disable any verification if the setup is bad
             if not sabnzbd.CERTIFICATE_VALIDATION:

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -268,7 +268,7 @@ class NNTP:
         if not self.nw.server.info:
             raise socket.error(errno.EADDRNOTAVAIL, "Address not available - Check for internet or DNS problems")
 
-        af, socktype, proto, canonname, sa = self.nw.server.info[0]
+        af, socktype, proto, _, _ = self.nw.server.info[0]
 
         # there will be a connect to host (or self.host, so let's force set 'af' to the correct value
         if is_ipv4_addr(self.host):

--- a/tests/test_newswrapper.py
+++ b/tests/test_newswrapper.py
@@ -1,0 +1,121 @@
+#!/usr/bin/python3 -OO
+# Copyright 2007-2021 The SABnzbd-Team <team@sabnzbd.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+tests.test_newswrapper - Tests of various functions in newswrapper
+"""
+import os.path
+import socket
+import tempfile
+import threading
+import ssl
+from typing import Optional
+import portend
+
+from tests.testhelper import *
+from sabnzbd import misc
+from sabnzbd import newswrapper
+
+TEST_HOST = "127.0.0.1"
+TEST_PORT = portend.find_available_local_port()
+TEST_DATA = b"connection_test"
+
+
+def socket_test_server(ssl_context: ssl.SSLContext):
+    """Support function that starts a mini-server, as
+    socket.create_server is not supported on Python 3.7"""
+    # Allow reuse of the address, because our CI is too fast for the socket closing
+    server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        server_socket.bind((TEST_HOST, TEST_PORT))
+        server_socket.listen(5)
+        server_socket.settimeout(5)
+        conn, _ = server_socket.accept()
+        with ssl_context.wrap_socket(sock=conn, server_side=True) as wrapped_socket:
+            wrapped_socket.write(TEST_DATA)
+    except:
+        # Skip SSL errors
+        pass
+    finally:
+        # Make sure to close the socket
+        server_socket.close()
+
+
+class TestNewsWrapper:
+    cert_file = os.path.join(tempfile.mkdtemp(), "test.cert")
+    key_file = os.path.join(tempfile.mkdtemp(), "test.key")
+
+    @pytest.mark.parametrize(
+        "server_tls, expected_client_tls, client_cipher, can_connect",
+        [
+            (None, "TLSv1.3", None, True),  # Default, highest
+            (ssl.TLSVersion.TLSv1_2, "TLSv1.2", None, True),  # Server with just TLSv1.2
+            (ssl.TLSVersion.SSLv3, None, None, False),  # No connection for old TLS/SSL
+            (None, None, "RC4-MD5", False),  # No connection for old cipher
+            (None, "TLSv1.2", "AES256-SHA", True),  # Forced to TLSv1.2 if ciphers set
+            (None, None, "TLS_AES_128_CCM_SHA256", False),  # Cannot force use of TLSv1.3 cipher
+        ],
+    )
+    def test_newswrapper(
+        self,
+        server_tls: Optional[ssl.TLSVersion],
+        expected_client_tls: Optional[str],
+        client_cipher: Optional[str],
+        can_connect: bool,
+    ):
+        # We need at least some certificates for the server to work
+        if not os.path.exists(self.cert_file) or not os.path.exists(self.key_file):
+            misc.create_https_certificates(self.cert_file, self.key_file)
+
+        # Create the server context
+        server_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        server_context.load_cert_chain(self.cert_file, self.key_file)
+        server_context.set_ciphers("HIGH")
+
+        # Set the options
+        if server_tls:
+            server_context.maximum_version = server_tls
+        threading.Thread(target=socket_test_server, args=(server_context,), daemon=True).start()
+
+        # Create the NNTP, mocking the required values
+        # We disable certificate validation, as we use self-signed certificates
+        nw = mock.Mock()
+        nw.blocking = True
+        nw.thrdnum = 1
+        nw.server = mock.Mock()
+        nw.server.host = TEST_HOST
+        nw.server.port = TEST_PORT
+        nw.server.info = socket.getaddrinfo(TEST_HOST, TEST_PORT, 0, socket.SOCK_STREAM)
+        nw.server.ssl = True
+        nw.server.ssl_context = None
+        nw.server.ssl_verify = 0
+        nw.server.ssl_ciphers = client_cipher
+
+        # Do we expect failure to connect?
+        if not can_connect:
+            with pytest.raises(OSError):
+                newswrapper.NNTP(nw, TEST_HOST)
+        else:
+            nntp = newswrapper.NNTP(nw, TEST_HOST)
+            assert nntp.sock.recv(len(TEST_DATA)) == TEST_DATA
+
+            # Assert SSL data
+            assert nntp.sock.version() == expected_client_tls
+
+            if client_cipher:
+                assert nntp.sock.cipher()[0] == client_cipher

--- a/tests/test_utils/test_happyeyeballs.py
+++ b/tests/test_utils/test_happyeyeballs.py
@@ -36,7 +36,7 @@ class TestHappyEyeballs:
         assert "." in ip or ":" in ip
 
     def test_google_https(self):
-        ip = happyeyeballs("www.google.com", port=443, use_ssl=True)
+        ip = happyeyeballs("www.google.com", port=443)
         assert "." in ip or ":" in ip
 
     def test_not_resolvable(self):


### PR DESCRIPTION
As described in #1982.

Because of Python 3.10 we need to force the SSL-socket to also allow TLSv1.2 ciphers if no specific one is set.
The `HIGH` one seems to cover all the TLSv1.3 ones.
I can also connect to TLSv1 servers with this setting and `allow_old_tls` (like `news.premium-news.de`), so seems it covers enough ciphers to allow even old stuff.

@jcfp @puzzledsab @sanderjo 