### PR TITLE
Add all passwords to list every time

### DIFF
--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -752,16 +752,15 @@ def create_https_certificates(ssl_cert, ssl_key):
 
 
 def get_all_passwords(nzo) -> List[str]:
-    """Get all passwords, from the NZB, meta and password file. In case the correct password is
-    already known, only that password is returned."""
+    """Get all passwords, from the NZB, meta and password file. In case a working password is
+    already known, try it first."""
+    passwords = []
     if nzo.correct_password:
-        return [nzo.correct_password]
+        passwords.append(nzo.correct_password)
 
     if nzo.password:
         logging.info("Found a password that was set by the user: %s", nzo.password)
-        passwords = [nzo.password.strip()]
-    else:
-        passwords = []
+        passwords.append(nzo.password.strip())
 
     meta_passwords = nzo.meta.get("password", [])
     pw = nzo.nzo_info.get("password")


### PR DESCRIPTION
Fixes #1979

The support was already pretty much there. I considered @jcfp's suggestion about moving the last working password to the end of the list, but then it gets really slow if that password is used for several or all the archives. I figure this will be used so rarely that it doesn't matter.