### PR TITLE
Print low level Windows status error on assembler IOError

### DIFF
--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -25,6 +25,7 @@ import logging
 import re
 from threading import Thread
 import hashlib
+import ctypes
 from typing import Tuple, Optional, List
 
 import sabnzbd
@@ -117,6 +118,8 @@ class Assembler(Thread):
                                 logging.error(T("Disk error on creating file %s"), clip_path(filepath))
                             # Log traceback
                             logging.info("Traceback: ", exc_info=True)
+                            if sabnzbd.WIN32:
+                                logging.info("Winerror: %s", hex(ctypes.windll.ntdll.RtlGetLastNtStatus() + 2 ** 32))
                             # Pause without saving
                             sabnzbd.Downloader.pause()
                         continue

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -957,7 +957,7 @@ def renamer(old: str, new: str, create_local_directories: bool = False) -> str:
                     time.sleep(2)
                 else:
                     raise
-        raise OSError("Failed to rename")
+        raise OSError("Failed to rename (Winerr %s)" % hex(ctypes.windll.ntdll.RtlGetLastNtStatus() + 2 ** 32))
     else:
         shutil.move(old, new)
         return new


### PR DESCRIPTION
As discussed in https://forums.sabnzbd.org/viewtopic.php?f=2&t=25261

There are some other places where it could be added but this seems like the spot that usually gives Errno 13. It would be nice to get some feedback from those who have seen the problem.