### PR TITLE
Read XML from file using iterparse

### DIFF
--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -600,15 +600,15 @@ def backup_exists(filename: str) -> bool:
     return path and os.path.exists(os.path.join(path, filename + ".gz"))
 
 
-def backup_nzb(filename: str, data: AnyStr):
-    """Backup NZB file"""
+def backup_nzb(filename: str, data: AnyStr) -> Optional[str]:
+    """Backup NZB file, return path to nzb if it was saved"""
     path = cfg.nzb_backup_dir.get_path()
     if path:
         return save_compressed(path, filename, data)
 
 
-def save_compressed(folder: str, filename: str, data: AnyStr):
-    """Save compressed NZB file in folder"""
+def save_compressed(folder: str, filename: str, data: AnyStr) -> str:
+    """Save compressed NZB file in folder, return path to saved nzb file"""
     if filename.endswith(".nzb"):
         filename += ".gz"
     else:
@@ -623,7 +623,7 @@ def save_compressed(folder: str, filename: str, data: AnyStr):
             f.flush()
             f.close()
     except:
-        logging.error(T("Saving %s failed"), os.path.join(folder, filename))
+        logging.error(T("Saving %s failed"), full_nzb_path)
         logging.info("Traceback: ", exc_info=True)
 
     return full_nzb_path

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -604,7 +604,7 @@ def backup_nzb(filename: str, data: AnyStr):
     """Backup NZB file"""
     path = cfg.nzb_backup_dir.get_path()
     if path:
-        save_compressed(path, filename, data)
+        return save_compressed(path, filename, data)
 
 
 def save_compressed(folder: str, filename: str, data: AnyStr):
@@ -613,10 +613,11 @@ def save_compressed(folder: str, filename: str, data: AnyStr):
         filename += ".gz"
     else:
         filename += ".nzb.gz"
-    logging.info("Backing up %s", os.path.join(folder, filename))
+    full_nzb_path = os.path.join(folder, filename)
+    logging.info("Backing up %s", full_nzb_path)
     try:
         # Have to get around the path being put inside the tgz
-        with open(os.path.join(folder, filename), "wb") as tgz_file:
+        with open(full_nzb_path, "wb") as tgz_file:
             f = gzip.GzipFile(filename, fileobj=tgz_file, mode="wb")
             f.write(encoding.utob(data))
             f.flush()
@@ -624,6 +625,8 @@ def save_compressed(folder: str, filename: str, data: AnyStr):
     except:
         logging.error(T("Saving %s failed"), os.path.join(folder, filename))
         logging.info("Traceback: ", exc_info=True)
+
+    return full_nzb_path
 
 
 ##############################################################################

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -605,6 +605,7 @@ def backup_nzb(nzb_path: str):
     """Backup NZB file, return path to nzb if it was saved"""
     nzb_backup_dir = cfg.nzb_backup_dir.get_path()
     if nzb_backup_dir:
+        logging.debug("Saving copy of %s in %s", filesystem.get_filename(nzb_path), nzb_backup_dir)
         shutil.copy(nzb_path, nzb_backup_dir)
 
 

--- a/sabnzbd/nzbparser.py
+++ b/sabnzbd/nzbparser.py
@@ -53,6 +53,9 @@ def nzbfile_parser(full_nzb_path: str, nzo):
     with gzip.open(full_nzb_path) as nzb_fh:
         try:
             for _, element in xml.etree.ElementTree.iterparse(nzb_fh):
+                # For type-hinting
+                element: xml.etree.ElementTree.Element
+
                 # Ignore namespace
                 _, has_namespace, postfix = element.tag.partition("}")
                 if has_namespace:

--- a/sabnzbd/nzbparser.py
+++ b/sabnzbd/nzbparser.py
@@ -20,7 +20,6 @@ sabnzbd.nzbparser - Parse and import NZB files
 """
 import bz2
 import gzip
-import re
 import time
 import logging
 import hashlib
@@ -57,7 +56,7 @@ def nzbfile_parser(full_nzb_path: str, nzo):
                 # Ignore namespace
                 _, has_namespace, postfix = element.tag.partition("}")
                 if has_namespace:
-                    element.tag = postfix  # strip all namespaces
+                    element.tag = postfix
 
                 # Parse the header
                 if element.tag.lower() == "head":

--- a/sabnzbd/nzbparser.py
+++ b/sabnzbd/nzbparser.py
@@ -54,6 +54,11 @@ def nzbfile_parser(full_nzb_path: str, nzo):
     with gzip.open(full_nzb_path) as nzb_fh:
         try:
             for _, element in xml.etree.ElementTree.iterparse(nzb_fh):
+                # Ignore namespace
+                _, has_namespace, postfix = element.tag.partition("}")
+                if has_namespace:
+                    element.tag = postfix  # strip all namespaces
+
                 # Parse the header
                 if element.tag.lower() == "head":
                     for meta in element.iter("meta"):

--- a/sabnzbd/nzbparser.py
+++ b/sabnzbd/nzbparser.py
@@ -35,13 +35,9 @@ from sabnzbd.filesystem import is_archive, get_filename
 from sabnzbd.misc import name_to_cat
 
 
-def nzbfile_parser(raw_data: str, nzo):
+def nzbfile_parser(full_nzb_path: str, nzo):
     # For type-hinting
     nzo: sabnzbd.nzbstuff.NzbObject
-
-    # Load data as file-object
-    raw_data = re.sub(r"""\s(xmlns="[^"]+"|xmlns='[^']+')""", "", raw_data, count=1)
-    nzb_tree = xml.etree.ElementTree.fromstring(raw_data)
 
     # Hash for dupe-checking
     md5sum = hashlib.md5()
@@ -54,98 +50,118 @@ def nzbfile_parser(raw_data: str, nzo):
     skipped_files = 0
     valid_files = 0
 
-    # Parse the header
-    if nzb_tree.find("head"):
-        for meta in nzb_tree.find("head").iter("meta"):
-            meta_type = meta.attrib.get("type")
-            if meta_type and meta.text:
-                # Meta tags can occur multiple times
-                if meta_type not in nzo.meta:
-                    nzo.meta[meta_type] = []
-                nzo.meta[meta_type].append(meta.text)
-    logging.debug("NZB file meta-data = %s", nzo.meta)
-
-    # Parse the files
-    for file in nzb_tree.iter("file"):
-        # Get subject and date
-        file_name = ""
-        if file.attrib.get("subject"):
-            file_name = file.attrib.get("subject")
-
-        # Don't fail if no date present
+    # Use nzb.gz file from admin dir
+    with gzip.open(full_nzb_path) as nzb_fh:
         try:
-            file_date = datetime.datetime.fromtimestamp(int(file.attrib.get("date")))
-            file_timestamp = int(file.attrib.get("date"))
-        except:
-            file_date = datetime.datetime.fromtimestamp(time_now)
-            file_timestamp = time_now
+            for _, element in xml.etree.ElementTree.iterparse(nzb_fh):
+                # Parse the header
+                if element.tag.lower() == "head":
+                    for meta in element.iter("meta"):
+                        meta_type = meta.attrib.get("type")
+                        if meta_type and meta.text:
+                            # Meta tags can occur multiple times
+                            if meta_type not in nzo.meta:
+                                nzo.meta[meta_type] = []
+                            nzo.meta[meta_type].append(meta.text)
+                    element.clear()
+                    logging.debug("NZB file meta-data = %s", nzo.meta)
+                    continue
 
-        # Get group
-        for group in file.iter("group"):
-            if group.text not in nzo.groups:
-                nzo.groups.append(group.text)
+                # Parse the files
+                if element.tag.lower() == "file":
+                    # Get subject and date
+                    file_name = ""
+                    if element.attrib.get("subject"):
+                        file_name = element.attrib.get("subject")
 
-        # Get segments
-        raw_article_db = {}
-        file_bytes = 0
-        if file.find("segments"):
-            for segment in file.find("segments").iter("segment"):
-                try:
-                    article_id = segment.text
-                    segment_size = int(segment.attrib.get("bytes"))
-                    partnum = int(segment.attrib.get("number"))
+                    # Don't fail if no date present
+                    try:
+                        file_date = datetime.datetime.fromtimestamp(int(element.attrib.get("date")))
+                        file_timestamp = int(element.attrib.get("date"))
+                    except:
+                        file_date = datetime.datetime.fromtimestamp(time_now)
+                        file_timestamp = time_now
 
-                    # Update hash
-                    md5sum.update(utob(article_id))
+                    # Get group
+                    for group in element.iter("group"):
+                        if group.text not in nzo.groups:
+                            nzo.groups.append(group.text)
 
-                    # Duplicate parts?
-                    if partnum in raw_article_db:
-                        if article_id != raw_article_db[partnum][0]:
-                            logging.info(
-                                "Duplicate part %s, but different ID-s (%s // %s)",
-                                partnum,
-                                raw_article_db[partnum][0],
-                                article_id,
-                            )
-                            nzo.increase_bad_articles_counter("duplicate_articles")
-                        else:
-                            logging.info("Skipping duplicate article (%s)", article_id)
-                    elif segment_size <= 0 or segment_size >= 2 ** 23:
-                        # Perform sanity check (not negative, 0 or larger than 8MB) on article size
-                        # We use this value later to allocate memory in cache and sabyenc
-                        logging.info("Skipping article %s due to strange size (%s)", article_id, segment_size)
-                        nzo.increase_bad_articles_counter("bad_articles")
+                    # Get segments
+                    raw_article_db = {}
+                    file_bytes = 0
+                    if element.find("segments"):
+                        for segment in element.find("segments").iter("segment"):
+                            try:
+                                article_id = segment.text
+                                segment_size = int(segment.attrib.get("bytes"))
+                                partnum = int(segment.attrib.get("number"))
+
+                                # Update hash
+                                md5sum.update(utob(article_id))
+
+                                # Duplicate parts?
+                                if partnum in raw_article_db:
+                                    if article_id != raw_article_db[partnum][0]:
+                                        logging.info(
+                                            "Duplicate part %s, but different ID-s (%s // %s)",
+                                            partnum,
+                                            raw_article_db[partnum][0],
+                                            article_id,
+                                        )
+                                        nzo.increase_bad_articles_counter("duplicate_articles")
+                                    else:
+                                        logging.info("Skipping duplicate article (%s)", article_id)
+                                elif segment_size <= 0 or segment_size >= 2 ** 23:
+                                    # Perform sanity check (not negative, 0 or larger than 8MB) on article size
+                                    # We use this value later to allocate memory in cache and sabyenc
+                                    logging.info(
+                                        "Skipping article %s due to strange size (%s)", article_id, segment_size
+                                    )
+                                    nzo.increase_bad_articles_counter("bad_articles")
+                                else:
+                                    raw_article_db[partnum] = (article_id, segment_size)
+                                    file_bytes += segment_size
+                            except:
+                                # In case of missing attributes
+                                pass
+
+                    # Sort the articles by part number, compatible with Python 3.5
+                    raw_article_db_sorted = [raw_article_db[partnum] for partnum in sorted(raw_article_db)]
+
+                    # Create NZF
+                    nzf = sabnzbd.nzbstuff.NzbFile(file_date, file_name, raw_article_db_sorted, file_bytes, nzo)
+
+                    # Check if we already have this exact NZF (see custom eq-checks)
+                    if nzf in nzo.files:
+                        logging.info("File %s occured twice in NZB, skipping", nzf.filename)
+                        continue
+
+                    # Add valid NZF's
+                    if file_name and nzf.valid and nzf.nzf_id:
+                        logging.info("File %s added to queue", nzf.filename)
+                        nzo.files.append(nzf)
+                        nzo.files_table[nzf.nzf_id] = nzf
+                        nzo.bytes += nzf.bytes
+                        valid_files += 1
+                        avg_age_sum += file_timestamp
                     else:
-                        raw_article_db[partnum] = (article_id, segment_size)
-                        file_bytes += segment_size
-                except:
-                    # In case of missing attributes
-                    pass
-
-        # Sort the articles by part number, compatible with Python 3.5
-        raw_article_db_sorted = [raw_article_db[partnum] for partnum in sorted(raw_article_db)]
-
-        # Create NZF
-        nzf = sabnzbd.nzbstuff.NzbFile(file_date, file_name, raw_article_db_sorted, file_bytes, nzo)
-
-        # Check if we already have this exact NZF (see custom eq-checks)
-        if nzf in nzo.files:
-            logging.info("File %s occured twice in NZB, skipping", nzf.filename)
-            continue
-
-        # Add valid NZF's
-        if file_name and nzf.valid and nzf.nzf_id:
-            logging.info("File %s added to queue", nzf.filename)
-            nzo.files.append(nzf)
-            nzo.files_table[nzf.nzf_id] = nzf
-            nzo.bytes += nzf.bytes
-            valid_files += 1
-            avg_age_sum += file_timestamp
-        else:
-            logging.info("Error importing %s, skipping", file_name)
-            if nzf.nzf_id:
-                sabnzbd.remove_data(nzf.nzf_id, nzo.admin_path)
-            skipped_files += 1
+                        logging.info("Error importing %s, skipping", file_name)
+                        if nzf.nzf_id:
+                            sabnzbd.remove_data(nzf.nzf_id, nzo.admin_path)
+                        skipped_files += 1
+                    element.clear()
+        except:
+            # Remove all data added to the nzo
+            for nzf in nzo.files:
+                nzf.remove_admin()
+            nzo.first_articles = []
+            nzo.first_articles_count = 0
+            nzo.bytes_par2 = 0
+            nzo.files = []
+            nzo.files_table = {}
+            nzo.bytes = 0
+            raise
 
     # Final bookkeeping
     nr_files = max(1, valid_files)

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -764,7 +764,6 @@ class NzbObject(TryList):
 
         if nzb_data and "<nzb" in nzb_data:
             backup_nzb = sabnzbd.backup_nzb(filename, nzb_data)
-            nzb_data = re.sub(r"""\s(xmlns="[^"]+"|xmlns='[^']+')""", "", nzb_data, count=1)
             full_nzb_path = sabnzbd.save_compressed(admin_dir, filename, nzb_data)
             nzb_data = None
             try:

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -763,9 +763,7 @@ class NzbObject(TryList):
             remove_all(admin_dir, "SABnzbd_article_*", keep_folder=True)
 
         if nzb_data and "<nzb" in nzb_data:
-            backup_nzb = sabnzbd.backup_nzb(filename, nzb_data)
             full_nzb_path = sabnzbd.save_compressed(admin_dir, filename, nzb_data)
-            nzb_data = None
             try:
                 sabnzbd.nzbparser.nzbfile_parser(full_nzb_path, self)
             except Exception as err:
@@ -778,11 +776,6 @@ class NzbObject(TryList):
                     self.pause()
                 else:
                     self.purge_data()
-                    if backup_nzb:
-                        try:
-                            os.remove(backup_nzb)
-                        except:
-                            pass
                     raise ValueError
 
             # Check against identical checksum or series/season/episode
@@ -790,6 +783,9 @@ class NzbObject(TryList):
             # trigger the duplicate-detection based on the backup
             if not reuse and dup_check and self.priority != REPAIR_PRIORITY:
                 duplicate, series_duplicate = self.has_duplicates()
+
+            # Copy to backup
+            sabnzbd.backup_nzb(full_nzb_path)
 
         if not self.files and not reuse:
             self.purge_data()

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -779,7 +779,10 @@ class NzbObject(TryList):
                 else:
                     self.purge_data()
                     if backup_nzb:
-                        os.remove(backup_nzb)
+                        try:
+                            os.remove(backup_nzb)
+                        except:
+                            pass
                     raise ValueError
 
             # Check against identical checksum or series/season/episode


### PR DESCRIPTION
This reads the nzb file in the admin dir in increments instead of keeping the full text in RAM until it's parsed. This works much better because it doesn't have to keep as much stuff in RAM at the same time and it seems to leak a lot less.

I'm not sure why the line `re.sub(r"""\s(xmlns="[^"]+"|xmlns='[^']+')""", "", raw_data, count=1)` is there (to ignore the charset?) but it is now done before the nzb file is saved to the admin dir, but after the backup nzb is saved. The backup is deleted if the import fails. Hopefully it's not too important that the one in the admin dir is modified.

At least twice as big nzbs can be imported in the same amount of RAM and large queues use about 70% less after import. It would be an advantage if we didn't need to read the full nzb file into RAM but currently that's necessary to run `correct_unknown_encoding`.