### PR TITLE
check default posix acl before setting permissions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,9 @@ pywin32>=227; sys_platform == 'win32'
 # macOS system calls
 pyobjc; sys_platform == 'darwin'
 
+# Optional detection of default posix ACLs; requires libacl1 headers
+pylibacl; sys_platform != 'win32'
+
 # Optional support for *nix tray icon.
 # Note that pygobject depends on pycairo, which requires pkg-config and cairo headers.
 # See https://pycairo.readthedocs.io/en/latest/getting_started.html


### PR DESCRIPTION
Change `filesystem.set_permissions` to not act if the given path is subject to a default posix access control list. In that case, it leaves things alone and assumes whoever set the ACL knows best.

I'm aware the CI trips over the acl dev header, but E_NOTIME right now.