### PR TITLE
Do not apply permissions if not requested by the user, but remove xbits

### DIFF
--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1205,6 +1205,13 @@ def main():
             sabnzbd.encoding.CODEPAGE,
         )
 
+    # Verify umask, we need at least 700
+    if not sabnzbd.WIN32 and sabnzbd.ORG_UMASK > int("077", 8):
+        sabnzbd.misc.helpful_warning(
+            T("Current umask (%o) might deny SABnzbd access to the files and folders it creates."),
+            sabnzbd.ORG_UMASK,
+        )
+
     # SSL Information
     logging.info("SSL version = %s", ssl.OPENSSL_VERSION)
 

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -248,9 +248,6 @@ def initialize(pause_downloader=False, clean_up=False, repair=0):
         cfg.download_dir.set(cfg.download_dir(), create=True)
     cfg.download_dir.set_create(True)
 
-    # Set access rights for "incomplete" base folder
-    filesystem.set_permissions(cfg.download_dir.get_path(), recursive=False)
-
     # If dirscan_dir cannot be created, set a proper value anyway.
     # Maybe it's a network path that's temporarily missing.
     path = cfg.dirscan_dir.get_path()

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -140,7 +140,7 @@ nzb_key = OptionStr("misc", "nzb_key", create_api_key())
 # Config - Folders
 ##############################################################################
 permissions = OptionStr("misc", "permissions", validation=validate_permissions)
-download_dir = OptionDir("misc", "download_dir", DEF_DOWNLOAD_DIR, create=False, validation=validate_safedir)
+download_dir = OptionDir("misc", "download_dir", DEF_DOWNLOAD_DIR, create=False,  apply_permissions=True, validation=validate_safedir)
 download_free = OptionStr("misc", "download_free")
 complete_dir = OptionDir(
     "misc", "complete_dir", DEF_COMPLETE_DIR, create=False, apply_permissions=True, validation=validate_notempty

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -28,7 +28,7 @@ from sabnzbd.config import (
     OptionDir,
     OptionStr,
     OptionList,
-    validate_octal,
+    validate_permissions,
     validate_safedir,
     all_lowercase,
     create_api_key,
@@ -139,7 +139,7 @@ nzb_key = OptionStr("misc", "nzb_key", create_api_key())
 ##############################################################################
 # Config - Folders
 ##############################################################################
-permissions = OptionStr("misc", "permissions", validation=validate_octal)
+permissions = OptionStr("misc", "permissions", validation=validate_permissions)
 download_dir = OptionDir("misc", "download_dir", DEF_DOWNLOAD_DIR, create=False, validation=validate_safedir)
 download_free = OptionStr("misc", "download_free")
 complete_dir = OptionDir(

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -140,7 +140,9 @@ nzb_key = OptionStr("misc", "nzb_key", create_api_key())
 # Config - Folders
 ##############################################################################
 permissions = OptionStr("misc", "permissions", validation=validate_permissions)
-download_dir = OptionDir("misc", "download_dir", DEF_DOWNLOAD_DIR, create=False,  apply_permissions=True, validation=validate_safedir)
+download_dir = OptionDir(
+    "misc", "download_dir", DEF_DOWNLOAD_DIR, create=False, apply_permissions=True, validation=validate_safedir
+)
 download_free = OptionStr("misc", "download_free")
 complete_dir = OptionDir(
     "misc", "complete_dir", DEF_COMPLETE_DIR, create=False, apply_permissions=True, validation=validate_notempty

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -139,7 +139,7 @@ nzb_key = OptionStr("misc", "nzb_key", create_api_key())
 ##############################################################################
 # Config - Folders
 ##############################################################################
-umask = OptionStr("misc", "permissions", validation=validate_octal)
+permissions = OptionStr("misc", "permissions", validation=validate_octal)
 download_dir = OptionDir("misc", "download_dir", DEF_DOWNLOAD_DIR, create=False, validation=validate_safedir)
 download_free = OptionStr("misc", "download_free")
 complete_dir = OptionDir(

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -143,7 +143,7 @@ permissions = OptionStr("misc", "permissions", validation=validate_permissions)
 download_dir = OptionDir("misc", "download_dir", DEF_DOWNLOAD_DIR, create=False, validation=validate_safedir)
 download_free = OptionStr("misc", "download_free")
 complete_dir = OptionDir(
-    "misc", "complete_dir", DEF_COMPLETE_DIR, create=False, apply_umask=True, validation=validate_notempty
+    "misc", "complete_dir", DEF_COMPLETE_DIR, create=False, apply_permissions=True, validation=validate_notempty
 )
 complete_free = OptionStr("misc", "complete_free")
 fulldisk_autoresume = OptionBool("misc", "fulldisk_autoresume", False)

--- a/sabnzbd/config.py
+++ b/sabnzbd/config.py
@@ -220,7 +220,9 @@ class OptionDir(Option):
         if value:
             path = real_path(self.__root, value)
             if self.__create and not os.path.exists(path):
-                _, path, _ = create_real_path(self.ident()[1], self.__root, value, self.__apply_permissions, self.__writable)
+                _, path, _ = create_real_path(
+                    self.ident()[1], self.__root, value, self.__apply_permissions, self.__writable
+                )
         return path
 
     def get_clipped_path(self) -> str:
@@ -1092,14 +1094,9 @@ def all_lowercase(value):
 
 
 def validate_permissions(value: str):
-    """Check the permissions for correct input and validate the session umask"""
+    """Check the permissions for correct input"""
     # Octal verification
     if not value:
-        # Verify umask if no permissions are set, we need at least 700
-        if not sabnzbd.WIN32 and sabnzbd.ORG_UMASK > int("077", 8):
-            sabnzbd.misc.helpful_warning(
-                T("Current umask (%o) might not allow SABnzbd access the files and folders it creates."), sabnzbd.ORG_UMASK
-            )
         return None, value
     try:
         oct_value = int(value, 8)
@@ -1109,7 +1106,7 @@ def validate_permissions(value: str):
     # Check if we at least have user-permissions
     if oct_value < int("700", 8):
         sabnzbd.misc.helpful_warning(
-            T("Permissions setting of %s might not allow SABnzbd access to files and folders it creates."), value
+            T("Permissions setting of %s might deny SABnzbd access to the files and folders it creates."), value
         )
     return None, value
 

--- a/sabnzbd/config.py
+++ b/sabnzbd/config.py
@@ -1100,6 +1100,9 @@ def validate_permissions(value: str):
         return None, value
     try:
         oct_value = int(value, 8)
+        # Block setting it to 0
+        if not oct_value:
+            raise ValueError
     except ValueError:
         return T("%s is not a correct octal value") % value, None
 

--- a/sabnzbd/config.py
+++ b/sabnzbd/config.py
@@ -192,7 +192,7 @@ class OptionDir(Option):
         section: str,
         keyword: str,
         default_val: str = "",
-        apply_umask: bool = False,
+        apply_permissions: bool = False,
         create: bool = True,
         validation: Optional[Callable] = None,
         writable: bool = True,
@@ -200,7 +200,7 @@ class OptionDir(Option):
     ):
         self.__validation: Optional[Callable] = validation
         self.__root: str = ""  # Base directory for relative paths
-        self.__apply_umask: bool = apply_umask
+        self.__apply_permissions: bool = apply_permissions
         self.__create: bool = create
         self.__writable: bool = writable
         super().__init__(section, keyword, default_val, add=add)
@@ -220,7 +220,7 @@ class OptionDir(Option):
         if value:
             path = real_path(self.__root, value)
             if self.__create and not os.path.exists(path):
-                _, path, _ = create_real_path(self.ident()[1], self.__root, value, self.__apply_umask, self.__writable)
+                _, path, _ = create_real_path(self.ident()[1], self.__root, value, self.__apply_permissions, self.__writable)
         return path
 
     def get_clipped_path(self) -> str:
@@ -253,7 +253,7 @@ class OptionDir(Option):
             if not error:
                 if value and (self.__create or create):
                     res, path, error = create_real_path(
-                        self.ident()[1], self.__root, value, self.__apply_umask, self.__writable
+                        self.ident()[1], self.__root, value, self.__apply_permissions, self.__writable
                     )
             if not error:
                 super().set(value)

--- a/sabnzbd/config.py
+++ b/sabnzbd/config.py
@@ -1091,15 +1091,27 @@ def all_lowercase(value):
     return None, value.lower()
 
 
-def validate_octal(value):
-    """Check if string is valid octal number"""
+def validate_permissions(value: str):
+    """Check the permissions for correct input and validate the session umask"""
+    # Octal verification
     if not value:
+        # Verify umask if no permissions are set, we need at least 700
+        if not sabnzbd.WIN32 and sabnzbd.ORG_UMASK > int("077", 8):
+            sabnzbd.misc.helpful_warning(
+                T("Current umask (%o) might not allow SABnzbd access the files and folders it creates."), sabnzbd.ORG_UMASK
+            )
         return None, value
     try:
-        int(value, 8)
-        return None, value
-    except:
+        oct_value = int(value, 8)
+    except ValueError:
         return T("%s is not a correct octal value") % value, None
+
+    # Check if we at least have user-permissions
+    if oct_value < int("700", 8):
+        sabnzbd.misc.helpful_warning(
+            T("Permissions setting of %s might not allow SABnzbd access to files and folders it creates."), value
+        )
+    return None, value
 
 
 def validate_no_unc(root, value, default):

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -598,14 +598,14 @@ def get_admin_path(name: str, future: bool):
         return os.path.join(os.path.join(sabnzbd.cfg.download_dir.get_path(), name), JOB_ADMIN)
 
 
-def set_chmod(path: str, permissions: int, report: bool):
-    """Set 'permissions' on 'path', report any errors when 'report' is True"""
+def set_chmod(path: str, permissions: int):
+    """Set 'permissions' on 'path'"""
     try:
         logging.debug("Applying permissions %s (octal) to %s", oct(permissions), path)
         os.chmod(path, permissions)
     except:
         lpath = path.lower()
-        if report and ".appledouble" not in lpath and ".ds_store" not in lpath:
+        if ".appledouble" not in lpath and ".ds_store" not in lpath:
             logging.error(T("Cannot change permissions of %s"), clip_path(path))
             logging.info("Traceback: ", exc_info=True)
 
@@ -613,35 +613,42 @@ def set_chmod(path: str, permissions: int, report: bool):
 def set_permissions(path: str, recursive: bool = True):
     """Give folder tree and its files their proper permissions"""
     if not sabnzbd.WIN32:
-        umask = sabnzbd.cfg.umask()
-        try:
-            # Make sure that user R+W+X is on
-            umask = int(umask, 8) | int("0700", 8)
-            report = True
-        except ValueError:
-            # No or no valid permissions
-            # Use the effective permissions of the session
-            # Don't report errors (because the system might not support it)
-            umask = int("0777", 8) & (sabnzbd.ORG_UMASK ^ int("0777", 8))
-            report = False
-
-        # Remove executable and special permissions for files
-        umask_file = umask & int("0666", 8)
+        custom_permissions = sabnzbd.cfg.permissions()
+        if custom_permissions:
+            # If user set permissions, parse them
+            custom_permissions = int(custom_permissions, 8)
 
         if os.path.isdir(path):
             if recursive:
                 # Parse the dir/file tree and set permissions
-                for root, _dirs, files in os.walk(path):
-                    set_chmod(root, umask, report)
+                for root, _, files in os.walk(path):
+                    if custom_permissions:
+                        set_chmod(root, custom_permissions)
                     for name in files:
-                        set_chmod(os.path.join(root, name), umask_file, report)
-            else:
-                set_chmod(path, umask, report)
+                        removexbits(os.path.join(root, name), custom_permissions)
+            elif custom_permissions:
+                set_chmod(path, custom_permissions)
         else:
-            set_chmod(path, umask_file, report)
+            removexbits(path, custom_permissions)
 
 
-def userxbit(filename: str) -> bool:
+UNWANTED_FILE_PERMISSIONS = stat.S_ISUID | stat.S_ISGID | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+
+
+def removexbits(path: str, custom_permissions: int = None):
+    """Remove all the x-bits from files, respecting current or custom permissions"""
+    if os.path.isfile(path):
+        current_permissions = os.stat(path).st_mode
+        # Check if the file has any x-bits, no need to remove them otherwise
+        if custom_permissions or current_permissions & UNWANTED_FILE_PERMISSIONS:
+            # Use custom permissions as base
+            if custom_permissions:
+                current_permissions = custom_permissions
+            # Mask out the X-bits
+            set_chmod(path, current_permissions & ~UNWANTED_FILE_PERMISSIONS)
+
+
+def userxbit(path: str) -> bool:
     """Returns boolean if the x-bit for user is set on the given file.
     This is a workaround: os.access(filename, os.X_OK) does not work
     on certain mounted file systems. Does not work at all on Windows.
@@ -649,7 +656,7 @@ def userxbit(filename: str) -> bool:
     # rwx rwx rwx
     # 876 543 210      # we want bit 6 from the right, counting from 0
     userxbit = 1 << 6  # bit 6
-    rwxbits = os.stat(filename)[0]  # the first element of os.stat() is "mode"
+    rwxbits = os.stat(path)[0]  # the first element of os.stat() is "mode"
     # do logical AND, check if it is not 0:
     xbitset = (rwxbits & userxbit) > 0
     return xbitset
@@ -681,7 +688,7 @@ DIR_LOCK = threading.RLock()
 
 
 @synchronized(DIR_LOCK)
-def create_all_dirs(path: str, apply_umask: bool = False) -> Union[str, bool]:
+def create_all_dirs(path: str, apply_permissions: bool = False) -> Union[str, bool]:
     """Create all required path elements and set umask on all
     The umask argument is ignored on Windows
     Return path if elements could be made or exists
@@ -694,14 +701,9 @@ def create_all_dirs(path: str, apply_umask: bool = False) -> Union[str, bool]:
             if not os.path.exists(path):
                 os.makedirs(path)
         else:
-            # We need to build the directory recursively so we can
+            # We need to build the directory recursively, so we can
             # apply permissions to only the newly created folders
             # We cannot use os.makedirs() as it could ignore the mode
-            umask = sabnzbd.cfg.umask()
-            if umask:
-                umask = int(umask, 8) | int("0700", 8)
-
-            # Build path from root
             path_part_combined = "/"
             for path_part in path.split("/"):
                 if path_part:
@@ -710,8 +712,8 @@ def create_all_dirs(path: str, apply_umask: bool = False) -> Union[str, bool]:
                     if not os.path.exists(path_part_combined):
                         os.mkdir(path_part_combined)
                         # Try to set permissions if desired, ignore failures
-                        if umask and apply_umask:
-                            set_chmod(path_part_combined, umask, report=False)
+                        if apply_permissions:
+                            set_permissions(path_part_combined, recursive=False)
         return path
     except OSError:
         logging.error(T("Failed making (%s)"), clip_path(path), exc_info=True)
@@ -731,7 +733,7 @@ def get_unique_path(dirpath: str, n: int = 0, create_dir: bool = True) -> str:
 
     if not os.path.exists(path):
         if create_dir:
-            return create_all_dirs(path, apply_umask=True)
+            return create_all_dirs(path, apply_permissions=True)
         else:
             return path
     else:
@@ -792,7 +794,7 @@ def move_to_path(path: str, new_path: str) -> Tuple[bool, Optional[str]]:
             # Cannot rename, try copying
             logging.debug("File could not be renamed, trying copying: %s", path)
             try:
-                create_all_dirs(os.path.dirname(new_path), apply_umask=True)
+                create_all_dirs(os.path.dirname(new_path), apply_permissions=True)
                 shutil.copyfile(path, new_path)
                 os.remove(path)
             except:

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -638,12 +638,12 @@ UNWANTED_FILE_PERMISSIONS = stat.S_ISUID | stat.S_ISGID | stat.S_IXUSR | stat.S_
 def removexbits(path: str, custom_permissions: int = None):
     """Remove all the x-bits from files, respecting current or custom permissions"""
     if os.path.isfile(path):
-        current_permissions = os.stat(path).st_mode
+        # Use custom permissions as base
+        current_permissions = custom_permissions
+        if not custom_permissions:
+            current_permissions = os.stat(path).st_mode
         # Check if the file has any x-bits, no need to remove them otherwise
         if custom_permissions or current_permissions & UNWANTED_FILE_PERMISSIONS:
-            # Use custom permissions as base
-            if custom_permissions:
-                current_permissions = custom_permissions
             # Mask out the X-bits
             set_chmod(path, current_permissions & ~UNWANTED_FILE_PERMISSIONS)
 

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -367,7 +367,7 @@ def real_path(loc: str, path: str) -> str:
 
 
 def create_real_path(
-    name: str, loc: str, path: str, umask: bool = False, writable: bool = True
+    name: str, loc: str, path: str, apply_permissions: bool = False, writable: bool = True
 ) -> Tuple[bool, str, Optional[str]]:
     """When 'path' is relative, create join of 'loc' and 'path'
     When 'path' is absolute, create normalized path
@@ -380,7 +380,7 @@ def create_real_path(
         my_dir = real_path(loc, path)
         if not os.path.exists(my_dir):
             logging.info("%s directory: %s does not exist, try to create it", name, my_dir)
-            if not create_all_dirs(my_dir, umask):
+            if not create_all_dirs(my_dir, apply_permissions):
                 msg = T("Cannot create directory %s") % clip_path(my_dir)
                 logging.error(msg)
                 return False, my_dir, msg
@@ -689,8 +689,8 @@ DIR_LOCK = threading.RLock()
 
 @synchronized(DIR_LOCK)
 def create_all_dirs(path: str, apply_permissions: bool = False) -> Union[str, bool]:
-    """Create all required path elements and set umask on all
-    The umask argument is ignored on Windows
+    """Create all required path elements and set permissions on all
+    The apply_permissions argument is ignored on Windows
     Return path if elements could be made or exists
     """
     try:
@@ -837,7 +837,7 @@ def cleanup_empty_directories(path: str):
 def get_filepath(path: str, nzo, filename: str):
     """Create unique filepath"""
     # This procedure is only used by the Assembler thread
-    # It does no umask setting
+    # It does not apply permissions
     # It uses the dir_lock for the (rare) case that the
     # download_dir is equal to the complete_dir.
     new_dirname = dirname = nzo.work_name

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -698,7 +698,7 @@ def prepare_extraction_path(nzo: NzbObject) -> Tuple[str, str, Sorter, bool, Opt
     complete_dir = sanitize_and_trim_path(complete_dir)
 
     if one_folder:
-        workdir_complete = create_all_dirs(complete_dir, apply_umask=True)
+        workdir_complete = create_all_dirs(complete_dir, apply_permissions=True)
     else:
         workdir_complete = get_unique_path(os.path.join(complete_dir, nzo.final_name), create_dir=True)
         marker_file = set_marker(workdir_complete)

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -42,7 +42,7 @@ from threading import Thread
 from sabnzbd.misc import on_cleanup_list, is_sample, helpful_warning
 from sabnzbd.filesystem import (
     real_path,
-    get_unique_path,
+    get_unique_dir,
     move_to_path,
     make_script_path,
     long_path,
@@ -486,7 +486,7 @@ def process_job(nzo: NzbObject):
                 if not all_ok:
                     # Rename failed folders so they are easy to recognize
                     workdir_complete = tmp_workdir_complete.replace("_UNPACK_", "_FAILED_")
-                    workdir_complete = get_unique_path(workdir_complete, create_dir=False)
+                    workdir_complete = get_unique_dir(workdir_complete, create_dir=False)
 
                 try:
                     newfiles = rename_and_collapse_folder(tmp_workdir_complete, workdir_complete, newfiles)
@@ -700,7 +700,7 @@ def prepare_extraction_path(nzo: NzbObject) -> Tuple[str, str, Sorter, bool, Opt
     if one_folder:
         workdir_complete = create_all_dirs(complete_dir, apply_permissions=True)
     else:
-        workdir_complete = get_unique_path(os.path.join(complete_dir, nzo.final_name), create_dir=True)
+        workdir_complete = get_unique_dir(os.path.join(complete_dir, nzo.final_name), create_dir=True)
         marker_file = set_marker(workdir_complete)
 
     if not workdir_complete or not os.path.exists(workdir_complete):
@@ -709,7 +709,7 @@ def prepare_extraction_path(nzo: NzbObject) -> Tuple[str, str, Sorter, bool, Opt
 
     if cfg.folder_rename() and not one_folder:
         prefixed_path = prefix(workdir_complete, "_UNPACK_")
-        tmp_workdir_complete = get_unique_path(prefix(workdir_complete, "_UNPACK_"), create_dir=False)
+        tmp_workdir_complete = get_unique_dir(prefix(workdir_complete, "_UNPACK_"), create_dir=False)
 
         try:
             renamer(workdir_complete, tmp_workdir_complete)

--- a/tests/test_nzbstuff.py
+++ b/tests/test_nzbstuff.py
@@ -24,7 +24,6 @@ class TestNZO:
         nzo = nzbstuff.NzbObject("test_basic")
         assert nzo.work_name == "test_basic"
         assert not nzo.files
-        assert not nzo.created
 
         # Create NZB-file to import
         nzb_fp = create_and_read_nzb_fp("basic_rar5")


### PR DESCRIPTION
I propose to change the way we handle permissions and no longer force any if the user didn't request them.
With 1 exception: we remove any execution-related bits on files if we find them.
@jcfp What do you think?

If you approve, there is other things that still need to be done:

- [x] Check `os.umask` at start-up to see if it at least allows user read/write on created files.
- [x] Check the Incomplete Directory at startup to see if we have read/write permissions.
- [x] More tests, for example for `removexbits`.
- [ ] Documentation.