### PR TITLE
add appstream metadata, sample desktop and mimeinfo files

### DIFF
--- a/linux/org.sabnzbd.sabnzbd.appdata.xml
+++ b/linux/org.sabnzbd.sabnzbd.appdata.xml
@@ -7,7 +7,7 @@
   <summary>Free and easy binary newsreader</summary>
   <description>
     <p>
-      SABnzbd+ is a free and Open Source web-based binary newsreader,
+      SABnzbd is a free and Open Source web-based binary newsreader,
       with support for the popular nzb file format. It greatly simplifies
       the process of downloading from Usenet, thanks to a friendly
       web-based user interface and advanced built-in post-processing

--- a/linux/org.sabnzbd.sabnzbd.appdata.xml
+++ b/linux/org.sabnzbd.sabnzbd.appdata.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2022 The SABnzbd-Team <team@sabnzbd.org> -->
+<component type="desktop-application">
+  <id>org.sabnzbd.sabnzbd</id>
+  <metadata_license>MIT</metadata_license>
+  <name>SABnzbd</name>
+  <summary>Free and easy binary newsreader</summary>
+  <description>
+    <p>
+      SABnzbd+ is a free and Open Source web-based binary newsreader,
+      with support for the popular nzb file format. It greatly simplifies
+      the process of downloading from Usenet, thanks to a friendly
+      web-based user interface and advanced built-in post-processing
+      options including the ability to automatically verify, repair,
+      extract and clean up downloaded posts. It runs anywhere, comes in
+      over a dozen languages, and integrates with a host of tools, apps
+      and services that help automate the download process.
+    </p>
+  </description>
+  <categories>
+    <category>Network</category>
+    <category>FileTransfer</category>
+  </categories>
+  <url type="homepage">https://sabnzbd.org</url>
+  <url type="bugtracker">https://github.com/sabnzbd/sabnzbd/issues</url>
+  <url type="translate">https://sabnzbd.org/wiki/translate</url>
+  <url type="donation">https://sabnzbd.org/donate</url>
+  <url type="help">https://sabnzbd.org/wiki/</url>
+  <url type="faq">https://sabnzbd.org/wiki/faq</url>
+  <url type="contact">https://forums.sabnzbd.org</url>
+  <launchable type="desktop-id">sabnzbd.desktop</launchable>
+  <provides>
+    <mediatype>application/x-nzb</mediatype>
+    <mediatype>application/x-compressed-nzb</mediatype>
+  </provides>
+  <project_license>GPL-2.0-or-later</project_license>
+  <developer_name>The SABnzbd-team</developer_name>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://sabnzbd.org/images/landing/screenshots/interface.png</image>
+      <caption>Web interface</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://sabnzbd.org/images/landing/screenshots/night-mode.png</image>
+      <caption>Night mode</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://sabnzbd.org/images/landing/screenshots/config.png</image>
+      <caption>Easy configuration</caption>
+    </screenshot>
+  </screenshots>
+  <content_rating type="oars-1.1"/>
+</component>

--- a/linux/org.sabnzbd.sabnzbd.sharedmimeinfo
+++ b/linux/org.sabnzbd.sabnzbd.sharedmimeinfo
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="application/x-compressed-nzb">
+    <sub-class-of type="application/x-nzb"/>
+    <comment>NewzBin Usenet index (compressed)</comment>
+    <glob pattern="*.nzb.gz"/>
+    <glob pattern="*.nzb.bz2"/>
+  </mime-type>
+</mime-info>

--- a/linux/sabnzbd.desktop
+++ b/linux/sabnzbd.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=SABnzbd
+GenericName=Binary newsreader
+Comment=Download from Usenet
+Exec=/opt/sabnzbd/SABnzbd.py --browser 1 %F
+Icon=sabnzbd
+Terminal=false
+Type=Application
+Categories=Network;FileTransfer;
+Keywords=usenet;binaries;download;nzb;nntp;newsreader;
+MimeType=application/x-nzb;application/x-compressed-nzb;


### PR DESCRIPTION
This change adds [appstream](https://www.freedesktop.org/software/appstream/docs/) metadata, desktop and mimeinfo files. Various app stores and package managers increasingly rely on such files, which means providing known-good versions with a number of optional fields filled in can benefit the project vs. someone else (distro packagers, etc.) writing a minimal/skeleton version from scratch (with possibly incorrect info).

Note:
- File locations match those in the existing systemd example.
- The appdata file can be verified using: `appstreamcli validate linux/org.sabnzbd.sabnzbd.appdata.xml` (from the `appstream` package on ubuntu).
- The metadata license in the appdata file is set to MIT in line with the considerations at [freedesktop.org](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-metadata_license).
- It's possible to list releases too, see [spec](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-releases).
- The sharedmimeinfo file defines a compressed nzb file format, extending the regular nzb filetype. Properly installed alongside the desktop file, this allows for setting sabnzbd as the default program in file managers and desktop environments for `nzb`, `nzb.gz`, and `nzb.bz2`. Regular archive formats such as zip, rar, 7z - while supported by the program - aren't listed to prevent sabnzbd from ending up as a suggested or default application for those.