### PR TITLE
set log level of "completed not on fat" to debug

### DIFF
--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -228,7 +228,7 @@ class PostProcessor(Thread):
                 % complete_dir
             )
         else:
-            logging.info("Completed Download Folder %s is not on FAT", complete_dir)
+            logging.debug("Completed Download Folder %s is not on FAT", complete_dir)
 
         # Start looping
         check_eoq = False


### PR DESCRIPTION
No need to log at info level that things are as expected and good to go. The current prominent logging confuses newbies into thinking not having FAT as the filesystem for the complete dir is somehow a bad thing.