### PR TITLE
Do not fail, if attribute subject ist missing

### DIFF
--- a/sabnzbd/nzbparser.py
+++ b/sabnzbd/nzbparser.py
@@ -400,12 +400,10 @@ def nzbfile_parser(full_nzb_path: str, nzo):
 
             # Parse the files
             if element.tag.lower() == "file":
-                # Get subject and date
-                file_name = ""
+                # Get subject and date, don't fail, if subject is missing
+                file_name = "No subject"
                 if element.attrib.get("subject"):
                     file_name = element.attrib.get("subject")
-                elif element.attrib.get("poster"):
-                    file_name = element.attrib.get("poster")
 
                 # Don't fail if no date present
                 try:

--- a/sabnzbd/nzbparser.py
+++ b/sabnzbd/nzbparser.py
@@ -404,6 +404,8 @@ def nzbfile_parser(full_nzb_path: str, nzo):
                 file_name = ""
                 if element.attrib.get("subject"):
                     file_name = element.attrib.get("subject")
+                elif element.attrib.get("poster"):
+                    file_name = element.attrib.get("poster")
 
                 # Don't fail if no date present
                 try:

--- a/sabnzbd/nzbparser.py
+++ b/sabnzbd/nzbparser.py
@@ -400,8 +400,9 @@ def nzbfile_parser(full_nzb_path: str, nzo):
 
             # Parse the files
             if element.tag.lower() == "file":
-                # Get subject and date, don't fail, if subject is missing
-                file_name = "No subject"
+                # Get subject and date
+                # Don't fail, if subject is missing
+                file_name = "unknown"
                 if element.attrib.get("subject"):
                     file_name = element.attrib.get("subject")
 


### PR DESCRIPTION
There are some NZBs out there, where `file` elements do not have a `subject` attribute. However, they have a `poster` attribute, which can be used instead. The attached NZB was downloaded from nzbgeek.info. [sample-from-nzbgeek.info.nzb.gz](https://github.com/sabnzbd/sabnzbd/files/8053645/sample-from-nzbgeek.info.nzb.gz)
