### PR TITLE
Use 1 shared ThreadPoolExecutor instead of ThreadPool

### DIFF
--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -21,8 +21,10 @@ import datetime
 import ctypes.util
 import time
 import socket
+
 import cherrypy
 import platform
+import concurrent.futures
 import sys
 from threading import Lock, Condition
 
@@ -180,6 +182,9 @@ RESTORE_DATA = None
 
 # Condition used to handle the main loop in SABnzbd.py
 SABSTOP_CONDITION = Condition(Lock())
+
+# General threadpool
+THREAD_POOL = concurrent.futures.ThreadPoolExecutor(max_workers=2)
 
 # Performance measure for dashboard
 PYSTONE_SCORE = 0
@@ -371,6 +376,8 @@ def halt():
         sabnzbd.utils.ssdp.stop_ssdp()
 
         sabnzbd.directunpacker.abort_all()
+
+        sabnzbd.THREAD_POOL.shutdown(wait=False)
 
         logging.debug("Stopping RSSReader")
         sabnzbd.RSSReader.stop()

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -27,7 +27,6 @@ import datetime
 import time
 import json
 import getpass
-import multiprocessing
 import cherrypy
 from threading import Thread
 from typing import Tuple, Optional, List, Dict, Any
@@ -1272,10 +1271,6 @@ def handle_cat_api(kwargs):
     return name
 
 
-# Initialize pool to be re-used later
-THREAD_POOL = multiprocessing.pool.ThreadPool()
-
-
 def build_status(calculate_performance: bool = False, skip_dashboard: bool = False) -> Dict[str, Any]:
     # build up header full of basic information
     info = build_header(trans_functions=False)
@@ -1290,7 +1285,7 @@ def build_status(calculate_performance: bool = False, skip_dashboard: bool = Fal
     # Calculate performance measures, if requested
     if int_conv(calculate_performance):
         # Perform the internetspeed measure in separate thread
-        internetspeed_future = THREAD_POOL.apply_async(internetspeed)
+        internetspeed_future = sabnzbd.THREAD_POOL.submit(internetspeed)
 
         # PyStone
         sabnzbd.PYSTONE_SCORE = getpystone()
@@ -1300,7 +1295,7 @@ def build_status(calculate_performance: bool = False, skip_dashboard: bool = Fal
         sabnzbd.COMPLETE_DIR_SPEED = round(diskspeedmeasure(sabnzbd.cfg.complete_dir.get_path()), 1)
 
         # Internet bandwidth
-        sabnzbd.INTERNET_BANDWIDTH = round(internetspeed_future.get(), 1)
+        sabnzbd.INTERNET_BANDWIDTH = round(internetspeed_future.result(), 1)
 
     # Dashboard: Speed of System
     info["cpumodel"] = getcpu()

--- a/sabnzbd/getipaddress.py
+++ b/sabnzbd/getipaddress.py
@@ -33,9 +33,6 @@ import sabnzbd
 import sabnzbd.cfg
 from sabnzbd.encoding import ubtou
 
-# Initialize pool to be re-used later
-THREAD_POOL = multiprocessing.pool.ThreadPool()
-
 
 def timeout(max_timeout: float):
     """Timeout decorator, parameter in seconds."""
@@ -47,7 +44,7 @@ def timeout(max_timeout: float):
         def func_wrapper(*args, **kwargs):
             """Closure for function."""
             # Raises a TimeoutError if execution exceeds max_timeout
-            return THREAD_POOL.apply_async(item, args, kwargs).get(max_timeout)
+            return sabnzbd.THREAD_POOL.submit(item, *args, **kwargs).result(max_timeout)
 
         return func_wrapper
 


### PR DESCRIPTION
Just as a note for reference later.
It turns out that when using `multiprocessing.pool.ThreadPool` there is a problem with PyInstaller on macOS.
On startup of the application, it spawns 10+ SABnzbd sub-processes of each 50MB each, killing the system memory.
Probably something is wrong with the hook that PyInstaller has voor `multiprocess.pool` that triggers this.
Switching to `ThreadPoolExecutor` fixes that,