### PR TITLE
ensure sufficient available blocks remain if add_parfile fails

### DIFF
--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -1140,21 +1140,21 @@ class NzbObject(TryList):
                     block_list.append(nzf)
                     avail_blocks += nzf.blocks
 
-        # Sort by smallest blocks last, to be popped first
-        block_list.sort(key=lambda x: x.blocks, reverse=True)
+        # Sort the smallest blocks first
+        block_list.sort(key=lambda x: x.blocks, reverse=False)
         logging.info("%s blocks available", avail_blocks)
 
         # Enough?
         if avail_blocks >= needed_blocks:
             added_blocks = 0
-            while added_blocks < needed_blocks:
-                new_nzf = block_list.pop()
+            for new_nzf in block_list:
                 if self.add_parfile(new_nzf):
                     added_blocks += new_nzf.blocks
-                else:
-                    avail_blocks -= new_nzf.blocks
-                    if avail_blocks < needed_blocks:
-                        return 0
+                    if added_blocks >= needed_blocks:
+                        break
+            else:
+                # End of block_list reached with insufficient blocks added
+                return 0
 
             logging.info("Added %s blocks to %s", added_blocks, self.final_name)
             return added_blocks

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -1151,6 +1151,10 @@ class NzbObject(TryList):
                 new_nzf = block_list.pop()
                 if self.add_parfile(new_nzf):
                     added_blocks += new_nzf.blocks
+                else:
+                    avail_blocks -= new_nzf.blocks
+                    if avail_blocks < needed_blocks:
+                        return 0
 
             logging.info("Added %s blocks to %s", added_blocks, self.final_name)
             return added_blocks


### PR DESCRIPTION
The logic is off if `add_parfile` in [sabnzbd/nzbstuff.py#L1152](https://github.com/sabnzbd/sabnzbd/blob/879af8744dbfafcb9d9bb6b0cac40e3f1b0f4ff0/sabnzbd/nzbstuff.py#L1152) fails, which may reduce the number of available blocks below the minimum needed.

From a bug reported on irc:
```
2022-03-15 10:10:51,822::INFO::[nzbstuff:1118] Need 2 more blocks, checking blocks
2022-03-15 10:10:51,822::INFO::[nzbstuff:1135] 20 blocks available
2022-03-15 10:10:51,823::INFO::[notifier:123] Sending notification: Error - Error pop from empty list while running par2_repair on set [My NZB] My NZB) [C2099B69] (type=error, job_cat=None)
2022-03-15 10:10:51,823::ERROR::[newsunpack:1156] Error pop from empty list while running par2_repair on set[My NZB] My NZB) [C2099B69]
2022-03-15 10:10:51,823::INFO::[newsunpack:1157] Traceback: 
Traceback (most recent call last):
  File "sabnzbd\newsunpack.py", line 1143, in par2_repair
  File "sabnzbd\newsunpack.py", line 1735, in multipar_verify
  File "sabnzbd\nzbstuff.py", line 1141, in get_extra_blocks
IndexError: pop from empty list
2022-03-15 10:10:51,831::DEBUG::[postproc:804] Verified sets: {'[My NZB] My NZB': False}
```