### PR TITLE
solve traceback and failing GUI when unknown langauge setting sabnzbd.ini

### DIFF
--- a/sabnzbd/lang.py
+++ b/sabnzbd/lang.py
@@ -93,7 +93,11 @@ def list_languages():
 
 
 def is_rtl(lang):
-    return LanguageTable.get(lang, "en")[3]
+    """returns True if given lang is a right-to-left language. Default: False."""
+    try:
+        return LanguageTable.get(lang, "en")[3]
+    except:
+        return False
 
 
 # English name, native name, code page, right-to-left

--- a/tests/test_lang.py
+++ b/tests/test_lang.py
@@ -26,6 +26,6 @@ def test_is_rtl():
     assert not is_rtl("en")
     assert is_rtl("he")
 
+    # edge cases
     assert not is_rtl("blabla")
     assert not is_rtl(None)
-

--- a/tests/test_lang.py
+++ b/tests/test_lang.py
@@ -21,6 +21,7 @@ tests.test_lang - Test stuff in sabnzbd/lang.py
 
 from sabnzbd.lang import *
 
+
 def test_is_rtl():
     # Test if a language is right-to-left
     assert not is_rtl("en")

--- a/tests/test_lang.py
+++ b/tests/test_lang.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python3 -OO
+# Copyright 2007-2022 The SABnzbd-Team <team@sabnzbd.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+tests.test_lang - Test stuff in sabnzbd/lang.py
+"""
+
+from sabnzbd.lang import *
+
+def test_is_rtl():
+    # Test if a language is right-to-left
+    assert not is_rtl("en")
+    assert is_rtl("he")
+
+    assert not is_rtl("blabla")
+    assert not is_rtl(None)
+


### PR DESCRIPTION
Solves traceback below, as reported on https://www.reddit.com/r/SABnzbd/comments/u28hpy/new_error_trying_to_access_my_docker_install_of/ 

Does not change/correct incorrect "langauge = " setting in sabnzbd.ini. It must be a niche case, because the language is only settable via a dropdown menu, so it should be correct.


```
500 Internal Server Error
The server encountered an unexpected condition which prevented it from fulfilling the request.

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/cherrypy/_cprequest.py", line 638, in respond
    self._do_respond(path_info)
  File "/usr/lib/python3/dist-packages/cherrypy/_cprequest.py", line 697, in _do_respond
    response.body = self.handler()
  File "/usr/lib/python3/dist-packages/cherrypy/lib/encoding.py", line 223, in __call__
    self.body = self.oldhandler(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/cherrypy/_cpdispatch.py", line 54, in __call__
    return self.callable(*self.args, **self.kwargs)
  File "/usr/share/sabnzbdplus/sabnzbd/interface.py", line 171, in internal_wrap
    return wrap_func(*args, **kwargs)
  File "/usr/share/sabnzbdplus/sabnzbd/interface.py", line 424, in index
    info = build_header()
  File "/usr/share/sabnzbdplus/sabnzbd/api.py", line 1663, in build_header
    header["rtl"] = is_rtl(header["active_lang"])
  File "/usr/share/sabnzbdplus/sabnzbd/lang.py", line 96, in is_rtl
    return LanguageTable.get(lang, "en")[3]
IndexError: string index out of range 
Powered by [CherryPy 18.6.1](http://www.cherrypy.org/)
```