### PR TITLE
add bash completion

### DIFF
--- a/linux/sabnzbd.bash-completion
+++ b/linux/sabnzbd.bash-completion
@@ -47,6 +47,7 @@ _sabnzbd()
         --server|-!(-*)[s])
             # suggest possible formats
             COMPREPLY=( $(compgen -W 'hostname :port hostname:port ipv4 ipv4:port [ipv6] [ipv6]:port' -- "$cur") )
+            return
             ;;
     esac
 

--- a/linux/sabnzbd.bash-completion
+++ b/linux/sabnzbd.bash-completion
@@ -1,0 +1,62 @@
+# bash completion for sabnzbd
+
+_sabnzbd()
+{
+    local cur prev words cword split
+    # list all options here
+    local all_options="-f --config-file --pidfile -t --templates --pid -l --logging -w --weblogging -d --daemon -h
+                       --help -v --version -c --clean -p --pause --repair --repair-all --no-login --log-all --console
+                       --disable-file-log --new -b --browser --ipv6_hosting --inet_exposure --https -s --server"
+    _init_completion -s || return
+
+    # handle options that take arguments
+    case $prev in
+        # 0..1
+        --browser|--ipv6_hosting|-!(-*)[b])
+            COMPREPLY=( $(compgen -W '{0..1}' -- "$cur") )
+            return
+            ;;
+        # -1..2
+        --logging|-!(-*)[l])
+            COMPREPLY=( $(compgen -W '{-1..2}' -- "$cur") )
+            return
+            ;;
+        # 0..5
+        --inet_exposure)
+            COMPREPLY=( $(compgen -W '{0..5}' -- "$cur") )
+            return
+            ;;
+        # directory path
+        --templates|--pid|-!(-*)[t])
+            compopt +o nospace
+            _filedir -d
+            return
+            ;;
+        # file path
+        --config-file|--pidfile|-!(-*)[f])
+            compopt +o nospace
+            _filedir
+            return
+            ;;
+        # port number
+        --https)
+            COMPREPLY=( $(compgen -W '{0..65535}' -- "$cur") )
+            return
+            ;;
+        # host:port
+        --server|-!(-*)[s])
+            # suggest possible formats
+            COMPREPLY=( $(compgen -W 'hostname :port hostname:port ipv4 ipv4:port [ipv6] [ipv6]:port' -- "$cur") )
+            ;;
+    esac
+
+    $split && return
+
+    if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "$all_options" -- "$cur") )
+    else
+        _filedir '@(nzb|nzb.gz|nzb.bz2|zip|rar|7z)'
+    fi
+
+} &&
+complete -F _sabnzbd SABnzbd.py sabnzbd sabnzbdplus


### PR DESCRIPTION
This change adds an autocomplete file for SABnzbd.py. It only actually does something if installed to a location where bash expects it (intended use), or when the user manually sources the file into bash; please do include in releases just like the desktop and service files.

To test, run a bash shell, source the autocomplete file, then use one of the recognized forms of the sabnzbd command and hit the TAB key one or more times:
```
source linux/sabnzbd.bash-autocomplete
SABnzbd.py <TAB>
SABnzbd.py -<TAB>
SABnzbd.py --<TAB>
```
Command-line options are automatically suggested and completed, argument values suggested, and directories and supported file types autocompleted for loading nzb files from the command line.

It deals with every option that takes arguments manually rather than parsing the program's --help output, as the latter is really slow for anything using interpreted languages (noticable lag when hitting TAB to start autocompletion).

For the --server option, only the possible argument formats are indicated rather than trying to hint actual values such as hostnames and port. The multitude of possible formats makes an autocomplete function for actual hostnames, ipv4 and ipv6 addresses and ports too complex to be worthwhile.