### PR TITLE
Disable password manager autofill on socks5 field

### DIFF
--- a/interfaces/Config/templates/config_general.tmpl
+++ b/interfaces/Config/templates/config_general.tmpl
@@ -181,7 +181,7 @@
                     </div>
                     <div class="field-pair advanced-settings">
                         <label class="config" for="socks5_proxy_url">$T('opt-socks5_proxy_url')</label>
-                        <input type="text" name="socks5_proxy_url" id="socks5_proxy_url" value="$socks5_proxy_url" placeholder="socks5://user:pass@hostname:port" />
+                        <input type="text" name="socks5_proxy_url" id="socks5_proxy_url" value="$socks5_proxy_url" autocomplete="off" placeholder="socks5://user:pass@hostname:port" />
                         <span class="desc">$T('explain-socks5_proxy_url') <br/>$T('readwiki')</span>
                     </div>
                     <div class="field-pair">

--- a/interfaces/Config/templates/config_general.tmpl
+++ b/interfaces/Config/templates/config_general.tmpl
@@ -181,7 +181,7 @@
                     </div>
                     <div class="field-pair advanced-settings">
                         <label class="config" for="socks5_proxy_url">$T('opt-socks5_proxy_url')</label>
-                        <input type="text" name="socks5_proxy_url" id="socks5_proxy_url" value="$socks5_proxy_url" placeholder="socks5://username:password@hostname:port" />
+                        <input type="text" name="socks5_proxy_url" id="socks5_proxy_url" value="$socks5_proxy_url" placeholder="socks5://user:pass@hostname:port" />
                         <span class="desc">$T('explain-socks5_proxy_url') <br/>$T('readwiki')</span>
                     </div>
                     <div class="field-pair">


### PR DESCRIPTION
#2053 

Bitwarden autofills the socks5 field, even when advanced settings is unchecked.
I'm guessing a lot of us use bitwarden, so I'm proposing this small compromise.

If this is not the direction we want to go, maybe we should look into getting correct input sanitization and error handling for wrong/unreachable socks5 connection strings