### PR TITLE
Remove redundant if in _nzo_completed_cmp

### DIFF
--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -968,8 +968,6 @@ def _nzo_size_cmp(nzo1, nzo2):
 
 def _nzo_completed_cmp(nzo1, nzo2):
     # nzo order reversed because we have to use remaining instead of downloaded for the calculation to work
-    if not nzo1.remaining or not nzo2.remaining:
-        return 0
     return cmp(nzo2.remaining / nzo2.bytes, nzo1.remaining / nzo1.bytes)
 
 


### PR DESCRIPTION
I'm not even sure why I added it anymore so it's probably bad considering that nzo.remaining is calculated. I don't think it's necessary to optimize it further. The queue will mostly be in the correct order which means each nzo.remaining is called only once or twice.