### PR TITLE
Check if host is valid: an IP address, or a name/FQDN that resolves

### DIFF
--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -155,11 +155,15 @@ def validate_host(value):
     # easy: plain IPv4 or IPv6 address:
     try:
         ipaddress.ip_address(value)
-        logging.debug("Valid host name")
+        # valid host, so return it
         return None, value
     except:
         pass
 
+    # not valid host, so say it, and return None
+    return T("Invalid server address."), None
+
+    """
     # we don't want a plain number
     # As socket.getaddrinfo("100", ...) allows that, we have to pre-check
     try:
@@ -180,19 +184,6 @@ def validate_host(value):
 
     # ... and if not: does it resolve to IPv6 ... ?
 
-
-
-
-
-
-
-
-
-
-
-
-
-
     try:
         socket.getaddrinfo(value, None, socket.AF_INET6)
         # all good
@@ -201,6 +192,7 @@ def validate_host(value):
     except:
         logging.debug("No valid host name")
         return None, default_ip
+    """
 
 
 def validate_script(value):

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -186,9 +186,7 @@ def validate_host(value):
 
 def validate_script(value):
     """Check if value is a valid script"""
-    if not sabnzbd.__INITIALIZED__ or (
-        value and sabnzbd.filesystem.is_valid_script(value)
-    ):
+    if not sabnzbd.__INITIALIZED__ or (value and sabnzbd.filesystem.is_valid_script(value)):
         return None, value
     elif (value and value == "None") or not value:
         return None, "None"
@@ -211,9 +209,7 @@ def validate_permissions(value: str):
     # Check if we at least have user-permissions
     if oct_value < int("700", 8):
         sabnzbd.misc.helpful_warning(
-            T(
-                "Permissions setting of %s might deny SABnzbd access to the files and folders it creates."
-            ),
+            T("Permissions setting of %s might deny SABnzbd access to the files and folders it creates."),
             value,
         )
     return None, value
@@ -221,9 +217,7 @@ def validate_permissions(value: str):
 
 def validate_safedir(root, value, default):
     """Allow only when queues are empty and no UNC"""
-    if not sabnzbd.__INITIALIZED__ or (
-        sabnzbd.PostProcessor.empty() and sabnzbd.NzbQueue.is_empty()
-    ):
+    if not sabnzbd.__INITIALIZED__ or (sabnzbd.PostProcessor.empty() and sabnzbd.NzbQueue.is_empty()):
         return validate_no_unc(root, value, default)
     else:
         return T("Error: Queue not empty, cannot change folder."), None
@@ -316,9 +310,7 @@ script_dir = OptionDir("misc", "script_dir", writable=False)
 nzb_backup_dir = OptionDir("misc", "nzb_backup_dir", DEF_NZBBACK_DIR)
 admin_dir = OptionDir("misc", "admin_dir", DEF_ADMIN_DIR, validation=validate_safedir)
 dirscan_dir = OptionDir("misc", "dirscan_dir", writable=False)
-dirscan_speed = OptionNumber(
-    "misc", "dirscan_speed", DEF_SCANRATE, minval=0, maxval=3600
-)
+dirscan_speed = OptionNumber("misc", "dirscan_speed", DEF_SCANRATE, minval=0, maxval=3600)
 password_file = OptionDir("misc", "password_file", "", create=False)
 log_dir = OptionDir("misc", "log_dir", "logs", validation=validate_notempty)
 
@@ -358,9 +350,7 @@ pause_on_post_processing = OptionBool("misc", "pause_on_post_processing", False)
 enable_all_par = OptionBool("misc", "enable_all_par", False)
 sanitize_safe = OptionBool("misc", "sanitize_safe", False)
 cleanup_list = OptionList("misc", "cleanup_list", validation=lower_case_ext)
-unwanted_extensions = OptionList(
-    "misc", "unwanted_extensions", validation=lower_case_ext
-)
+unwanted_extensions = OptionList("misc", "unwanted_extensions", validation=lower_case_ext)
 action_on_unwanted_extensions = OptionNumber("misc", "action_on_unwanted_extensions", 0)
 unwanted_extensions_mode = OptionNumber("misc", "unwanted_extensions_mode", 0)
 new_nzb_on_failure = OptionBool("misc", "new_nzb_on_failure", False)
@@ -428,15 +418,9 @@ x_frame_options = OptionBool("misc", "x_frame_options", True)
 allow_old_ssl_tls = OptionBool("misc", "allow_old_ssl_tls", False)
 
 # Text values
-rss_odd_titles = OptionList(
-    "misc", "rss_odd_titles", ["nzbindex.nl/", "nzbindex.com/", "nzbclub.com/"]
-)
-quick_check_ext_ignore = OptionList(
-    "misc", "quick_check_ext_ignore", ["nfo", "sfv", "srr"], validation=lower_case_ext
-)
-req_completion_rate = OptionNumber(
-    "misc", "req_completion_rate", 100.2, minval=100, maxval=200
-)
+rss_odd_titles = OptionList("misc", "rss_odd_titles", ["nzbindex.nl/", "nzbindex.com/", "nzbclub.com/"])
+quick_check_ext_ignore = OptionList("misc", "quick_check_ext_ignore", ["nfo", "sfv", "srr"], validation=lower_case_ext)
+req_completion_rate = OptionNumber("misc", "req_completion_rate", 100.2, minval=100, maxval=200)
 selftest_host = OptionStr("misc", "selftest_host", "self-test.sabnzbd.org")
 movie_rename_limit = OptionStr("misc", "movie_rename_limit", "100M")
 episode_rename_limit = OptionStr("misc", "episode_rename_limit", "20M")
@@ -445,22 +429,16 @@ show_sysload = OptionNumber("misc", "show_sysload", 2, minval=0, maxval=2)
 direct_unpack_threads = OptionNumber("misc", "direct_unpack_threads", 3, minval=1)
 history_limit = OptionNumber("misc", "history_limit", 10, minval=0)
 wait_ext_drive = OptionNumber("misc", "wait_ext_drive", 5, minval=1, maxval=60)
-max_foldername_length = OptionNumber(
-    "misc", "max_foldername_length", DEF_FOLDER_MAX, minval=20, maxval=65000
-)
+max_foldername_length = OptionNumber("misc", "max_foldername_length", DEF_FOLDER_MAX, minval=20, maxval=65000)
 marker_file = OptionStr("misc", "nomedia_marker")
 ipv6_servers = OptionNumber("misc", "ipv6_servers", 1, minval=0, maxval=2)
-url_base = OptionStr(
-    "misc", "url_base", "/sabnzbd", validation=validate_strip_right_slash
-)
+url_base = OptionStr("misc", "url_base", "/sabnzbd", validation=validate_strip_right_slash)
 host_whitelist = OptionList("misc", "host_whitelist", validation=all_lowercase)
 local_ranges = OptionList("misc", "local_ranges", protect=True)
 max_url_retries = OptionNumber("misc", "max_url_retries", 10, minval=1)
 downloader_sleep_time = OptionNumber("misc", "downloader_sleep_time", 10, minval=0)
 num_simd_decoders = OptionNumber("misc", "num_simd_decoders", 2, minval=1)
-ssdp_broadcast_interval = OptionNumber(
-    "misc", "ssdp_broadcast_interval", 15, minval=1, maxval=600
-)
+ssdp_broadcast_interval = OptionNumber("misc", "ssdp_broadcast_interval", 15, minval=1, maxval=600)
 ext_rename_ignore = OptionList("misc", "ext_rename_ignore", validation=lower_case_ext)
 
 
@@ -512,9 +490,7 @@ acenter_prio_queue_done = OptionBool("acenter", "acenter_prio_queue_done", True)
 acenter_prio_other = OptionBool("acenter", "acenter_prio_other", True)
 
 # [ntfosd]
-ntfosd_enable = OptionBool(
-    "ntfosd", "ntfosd_enable", not sabnzbd.WIN32 and not sabnzbd.MACOS
-)
+ntfosd_enable = OptionBool("ntfosd", "ntfosd_enable", not sabnzbd.WIN32 and not sabnzbd.MACOS)
 ntfosd_cats = OptionList("ntfosd", "ntfosd_cats", ["*"])
 ntfosd_prio_startup = OptionBool("ntfosd", "ntfosd_prio_startup", True)
 ntfosd_prio_download = OptionBool("ntfosd", "ntfosd_prio_download", False)
@@ -574,9 +550,7 @@ pushbullet_apikey = OptionStr("pushbullet", "pushbullet_apikey")
 pushbullet_device = OptionStr("pushbullet", "pushbullet_device")
 pushbullet_prio_startup = OptionBool("pushbullet", "pushbullet_prio_startup", False)
 pushbullet_prio_download = OptionBool("pushbullet", "pushbullet_prio_download", False)
-pushbullet_prio_pause_resume = OptionBool(
-    "pushbullet", "pushbullet_prio_pause_resume", False
-)
+pushbullet_prio_pause_resume = OptionBool("pushbullet", "pushbullet_prio_pause_resume", False)
 pushbullet_prio_pp = OptionBool("pushbullet", "pushbullet_prio_pp", False)
 pushbullet_prio_complete = OptionBool("pushbullet", "pushbullet_prio_complete", True)
 pushbullet_prio_failed = OptionBool("pushbullet", "pushbullet_prio_failed", True)
@@ -584,9 +558,7 @@ pushbullet_prio_disk_full = OptionBool("pushbullet", "pushbullet_prio_disk_full"
 pushbullet_prio_new_login = OptionBool("pushbullet", "pushbullet_prio_new_login", False)
 pushbullet_prio_warning = OptionBool("pushbullet", "pushbullet_prio_warning", False)
 pushbullet_prio_error = OptionBool("pushbullet", "pushbullet_prio_error", False)
-pushbullet_prio_queue_done = OptionBool(
-    "pushbullet", "pushbullet_prio_queue_done", False
-)
+pushbullet_prio_queue_done = OptionBool("pushbullet", "pushbullet_prio_queue_done", False)
 pushbullet_prio_other = OptionBool("pushbullet", "pushbullet_prio_other", True)
 
 # [nscript]

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -150,28 +150,21 @@ def validate_server(value):
 
 
 def validate_host(value):
-    """Check if host is valid: an IP address, or a name/FQDN that resolves"""
-    default_ip = "127.0.0.1"
-    # easy: plain IPv4 or IPv6 address:
+    """Check if host is valid: an IP address, or a name/FQDN that resolves to an IPv4/IPv6 address"""
+
+    # easy: value is a plain IPv4 or IPv6 address:
     try:
         ipaddress.ip_address(value)
         # valid host, so return it
-        logging.debug("SJ: valid host. Good.")
         return None, value
     except:
         pass
 
-    # not valid host, so say it, and return None
-    logging.debug("SJ: invalid host input")
-    return T("Invalid server address."), None
-
-    """
-    # we don't want a plain number
-    # As socket.getaddrinfo("100", ...) allows that, we have to pre-check
+    # we don't want a plain number. As socket.getaddrinfo("100", ...) allows that, we have to pre-check
     try:
         int(value)
-        logging.debug("No valid host name")
-        return None, default_ip
+        # plain int as input, which is not allowed
+        return T("Invalid server address."), None
     except:
         pass
 
@@ -185,7 +178,6 @@ def validate_host(value):
         pass
 
     # ... and if not: does it resolve to IPv6 ... ?
-
     try:
         socket.getaddrinfo(value, None, socket.AF_INET6)
         # all good
@@ -193,8 +185,11 @@ def validate_host(value):
         return None, value
     except:
         logging.debug("No valid host name")
-        return None, default_ip
-    """
+        pass
+
+    # if we get here, it is not valid host, so return None
+    logging.debug("SJ: invalid host input")
+    return T("Invalid server address."), None
 
 
 def validate_script(value):
@@ -222,8 +217,7 @@ def validate_permissions(value: str):
     # Check if we at least have user-permissions
     if oct_value < int("700", 8):
         sabnzbd.misc.helpful_warning(
-            T("Permissions setting of %s might deny SABnzbd access to the files and folders it creates."),
-            value,
+            T("Permissions setting of %s might deny SABnzbd access to the files and folders it creates."), value
         )
     return None, value
 
@@ -301,21 +295,11 @@ socks5_proxy_url = OptionStr("misc", "socks5_proxy_url")
 ##############################################################################
 permissions = OptionStr("misc", "permissions", validation=validate_permissions)
 download_dir = OptionDir(
-    "misc",
-    "download_dir",
-    DEF_DOWNLOAD_DIR,
-    create=False,
-    apply_permissions=True,
-    validation=validate_safedir,
+    "misc", "download_dir", DEF_DOWNLOAD_DIR, create=False, apply_permissions=True, validation=validate_safedir
 )
 download_free = OptionStr("misc", "download_free")
 complete_dir = OptionDir(
-    "misc",
-    "complete_dir",
-    DEF_COMPLETE_DIR,
-    create=False,
-    apply_permissions=True,
-    validation=validate_notempty,
+    "misc", "complete_dir", DEF_COMPLETE_DIR, create=False, apply_permissions=True, validation=validate_notempty
 )
 complete_free = OptionStr("misc", "complete_free")
 fulldisk_autoresume = OptionBool("misc", "fulldisk_autoresume", False)

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -161,13 +161,6 @@ def validate_host(value):
     except:
         pass
 
-
-
-
-
-
-
-
     # not valid host, so say it, and return None
     logging.debug("SJ: invalid host input")
     return T("Invalid server address."), None

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -151,6 +151,7 @@ def validate_server(value):
 
 def validate_host(value):
     """Check if host is valid: an IP address, or a name/FQDN that resolves"""
+    default_ip = "127.0.0.1"
     # easy: plain IPv4 or IPv6 address:
     try:
         ipaddress.ip_address(value)
@@ -162,7 +163,7 @@ def validate_host(value):
     # As socket.getaddrinfo("100", ...) allows that, we have to pre-check
     try:
         int(value)
-        return None, None
+        return None, default_ip
     except:
         pass
 
@@ -180,7 +181,7 @@ def validate_host(value):
         # all good
         return None, value
     except:
-        return None, None
+        return None, default_ip
 
 
 def validate_script(value):

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -156,11 +156,13 @@ def validate_host(value):
     try:
         ipaddress.ip_address(value)
         # valid host, so return it
+        logging.debug("SJ: valid host")
         return None, value
     except:
         pass
 
     # not valid host, so say it, and return None
+    logging.debug("SJ: invalid host input")
     return T("Invalid server address."), None
 
     """

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -180,6 +180,19 @@ def validate_host(value):
 
     # ... and if not: does it resolve to IPv6 ... ?
 
+
+
+
+
+
+
+
+
+
+
+
+
+
     try:
         socket.getaddrinfo(value, None, socket.AF_INET6)
         # all good

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -156,10 +156,17 @@ def validate_host(value):
     try:
         ipaddress.ip_address(value)
         # valid host, so return it
-        logging.debug("SJ: valid host")
+        logging.debug("SJ: valid host. Good.")
         return None, value
     except:
         pass
+
+
+
+
+
+
+
 
     # not valid host, so say it, and return None
     logging.debug("SJ: invalid host input")

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -150,7 +150,7 @@ def validate_server(value):
 
 
 def validate_host(value):
-    """Check if host is valid: an IP address, or a name/FQDN that resolves to an IPv4/IPv6 address"""
+    """Check if host is valid: an IP address, or a name/FQDN that resolves to an IP address"""
 
     # easy: value is a plain IPv4 or IPv6 address:
     try:
@@ -188,7 +188,6 @@ def validate_host(value):
         pass
 
     # if we get here, it is not valid host, so return None
-    logging.debug("SJ: invalid host input")
     return T("Invalid server address."), None
 
 

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -155,6 +155,7 @@ def validate_host(value):
     # easy: plain IPv4 or IPv6 address:
     try:
         ipaddress.ip_address(value)
+        logging.debug("Valid host name")
         return None, value
     except:
         pass
@@ -163,6 +164,7 @@ def validate_host(value):
     # As socket.getaddrinfo("100", ...) allows that, we have to pre-check
     try:
         int(value)
+        logging.debug("No valid host name")
         return None, default_ip
     except:
         pass
@@ -171,16 +173,20 @@ def validate_host(value):
     try:
         socket.getaddrinfo(value, None, socket.AF_INET)
         # all good
+        logging.debug("Valid host name")
         return None, value
     except:
         pass
 
-    # ... and if not: does it resolve to IPv6?
+    # ... and if not: does it resolve to IPv6 ... ?
+
     try:
         socket.getaddrinfo(value, None, socket.AF_INET6)
         # all good
+        logging.debug("Valid host name")
         return None, value
     except:
+        logging.debug("No valid host name")
         return None, default_ip
 
 

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -112,8 +112,8 @@ class TestValidators:
         assert cfg.validate_host("::1") == (None, "::1")
         assert cfg.validate_host("::") == (None, "::")
         assert cfg.validate_host("www.example.com")[1]
-        assert cfg.validate_host(socket.gethostname())[1]
+        assert cfg.validate_host(socket.gethostname())[1]  # resolves to something
 
-        assert cfg.validate_host("0.0.0.0.") == (None, None)  # Trailing dot
-        assert cfg.validate_host("kajkdjflkjasd") == (None, None)  # does not resolve
-        assert cfg.validate_host("100") == (None, None)  # just a number
+        assert cfg.validate_host("0.0.0.0.") != (None, "0.0.0.0.")  # Trailing dot
+        assert cfg.validate_host("kajkdjflkjasd") != (None, "kajkdjflkjasd")  # does not resolve
+        assert cfg.validate_host("100") != (None, "100")  # just a number

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -89,14 +89,8 @@ class TestValidators:
 
     def test_validate_single_tag(self):
         assert cfg.validate_single_tag(["TV", ">", "HD"]) == (None, ["TV > HD"])
-        assert cfg.validate_single_tag(["TV", ">", "HD", "Plus"]) == (
-            None,
-            ["TV", ">", "HD", "Plus"],
-        )
-        assert cfg.validate_single_tag(["alt.bin", "alt.tv"]) == (
-            None,
-            ["alt.bin", "alt.tv"],
-        )
+        assert cfg.validate_single_tag(["TV", ">", "HD", "Plus"]) == (None, ["TV", ">", "HD", "Plus"])
+        assert cfg.validate_single_tag(["alt.bin", "alt.tv"]) == (None, ["alt.bin", "alt.tv"])
         assert cfg.validate_single_tag(["alt.group"]) == (None, ["alt.group"])
 
     def test_lower_case_ext(self):
@@ -106,6 +100,8 @@ class TestValidators:
         assert cfg.lower_case_ext([".foo ", " .bar"]) == (None, ["foo", "bar"])
 
     def test_validate_host(self):
+
+        # valid input
         assert cfg.validate_host("127.0.0.1") == (None, "127.0.0.1")
         assert cfg.validate_host("0.0.0.0") == (None, "0.0.0.0")
         assert cfg.validate_host("1.1.1.1") == (None, "1.1.1.1")
@@ -114,6 +110,7 @@ class TestValidators:
         assert cfg.validate_host("www.example.com")[1]
         assert cfg.validate_host(socket.gethostname())[1]  # resolves to something
 
-        assert cfg.validate_host("0.0.0.0.") != (None, "0.0.0.0.")  # Trailing dot
-        assert cfg.validate_host("kajkdjflkjasd") != (None, "kajkdjflkjasd")  # does not resolve
-        assert cfg.validate_host("100") != (None, "100")  # just a number
+        # non-valid input. Should return None as second parameter
+        assert not cfg.validate_host("0.0.0.0.")[1]  # Trailing dot
+        assert not cfg.validate_host("kajkdjflkjasd")[1]  # does not resolve
+        assert not cfg.validate_host("100")[1]  # just a number

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -19,6 +19,7 @@
 tests.test_cfg - Testing functions in cfg.py
 """
 import sabnzbd.cfg as cfg
+import socket
 
 
 class TestValidators:
@@ -88,8 +89,14 @@ class TestValidators:
 
     def test_validate_single_tag(self):
         assert cfg.validate_single_tag(["TV", ">", "HD"]) == (None, ["TV > HD"])
-        assert cfg.validate_single_tag(["TV", ">", "HD", "Plus"]) == (None, ["TV", ">", "HD", "Plus"])
-        assert cfg.validate_single_tag(["alt.bin", "alt.tv"]) == (None, ["alt.bin", "alt.tv"])
+        assert cfg.validate_single_tag(["TV", ">", "HD", "Plus"]) == (
+            None,
+            ["TV", ">", "HD", "Plus"],
+        )
+        assert cfg.validate_single_tag(["alt.bin", "alt.tv"]) == (
+            None,
+            ["alt.bin", "alt.tv"],
+        )
         assert cfg.validate_single_tag(["alt.group"]) == (None, ["alt.group"])
 
     def test_lower_case_ext(self):
@@ -97,3 +104,18 @@ class TestValidators:
         assert cfg.lower_case_ext(".Bla") == (None, "bla")
         assert cfg.lower_case_ext([".foo", ".bar"]) == (None, ["foo", "bar"])
         assert cfg.lower_case_ext([".foo ", " .bar"]) == (None, ["foo", "bar"])
+
+    def test_validate_host(self):
+        assert cfg.validate_host("127.0.0.1") == (None, "127.0.0.1")
+        assert cfg.validate_host("0.0.0.0") == (None, "0.0.0.0")
+        assert cfg.validate_host("1.1.1.1") == (None, "1.1.1.1")
+        assert cfg.validate_host("::1") == (None, "::1")
+        assert cfg.validate_host("::") == (None, "::")
+        assert cfg.validate_host("www.example.com")[1]
+        assert cfg.validate_host(socket.gethostname())[
+            1
+        ]  # TBD: does this work on Windows?
+
+        assert cfg.validate_host("0.0.0.0.") == (None, None)  # Trailing dot
+        assert cfg.validate_host("kajkdjflkjasd") == (None, None)  # does not resolve
+        assert cfg.validate_host("100") == (None, None)  # just a number


### PR DESCRIPTION
Closes #2252

Refuses invalid input for host; should be a syntax-correct IP address, or a hostname that resolved to an IP address. Avoids a non-working on restart of SAB.
Does not check whether the IP address is on this host. So filling out 6.7.8.9 will be accepted, but still makes SAB non-working on restart
