### PR TITLE
Do a more thorough check when a bad try_list is detected

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -84,9 +84,6 @@ jobs:
     runs-on: macos-11
     timeout-minutes: 30
     env:
-      SIGNING_AUTH: ${{ secrets.SIGNING_AUTH }}
-      NOTARIZATION_USER: ${{ secrets.NOTARIZATION_USER }}
-      NOTARIZATION_PASS: ${{ secrets.NOTARIZATION_PASS }}
       # We need the official Python, because the GA ones only support newer macOS versions
       # The deployment target is picked up by the Python build tools automatically
       # If updated, make sure to also set LSMinimumSystemVersion in SABnzbd.spec
@@ -142,11 +139,19 @@ jobs:
         
         PYINSTALLER_COMPILE_BOOTLOADER=1 pip3 install --upgrade -r builder/requirements.txt --no-binary pyinstaller
     - name: Import macOS codesign certificates
-      uses: apple-actions/import-codesign-certs@v1
-      if: env.SIGNING_AUTH
-      with:
-        p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
-        p12-password: ${{ secrets.CERTIFICATES_P12_PASSWORD }}
+      # Taken from https://github.com/Apple-Actions/import-codesign-certs/pull/27 (comments)
+      env:
+        CERTIFICATES_P12: ${{ secrets.CERTIFICATES_P12 }}
+        CERTIFICATES_P12_PASSWORD: ${{ secrets.CERTIFICATES_P12_PASSWORD }}
+        MACOS_KEYCHAIN_TEMP_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_TEMP_PASSWORD }}
+      run: |
+        echo $CERTIFICATES_P12 | base64 --decode > certificate.p12
+        security create-keychain -p "$MACOS_KEYCHAIN_TEMP_PASSWORD" build.keychain 
+        security default-keychain -s build.keychain 
+        security unlock-keychain -p "$MACOS_KEYCHAIN_TEMP_PASSWORD" build.keychain
+        security set-keychain-settings -lut 21600 build.keychain
+        security import certificate.p12 -k build.keychain -P "$CERTIFICATES_P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/productsign -T /usr/bin/xcrun
+        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_KEYCHAIN_TEMP_PASSWORD" build.keychain
     - name: Build source distribution
       # Run this on macOS so the line endings are correct by default
       run: python builder/package.py source
@@ -156,6 +161,10 @@ jobs:
         path: "*-src.tar.gz"
         name: Source distribution
     - name: Build macOS binary
+      env:
+        SIGNING_AUTH: ${{ secrets.SIGNING_AUTH }}
+        NOTARIZATION_USER: ${{ secrets.NOTARIZATION_USER }}
+        NOTARIZATION_PASS: ${{ secrets.NOTARIZATION_PASS }}
       run: |
         python3 builder/package.py app
         python3 builder/make_dmg.py

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -230,6 +230,7 @@ class Server:
         self.info = get_server_addrinfo(self.host, self.port)
         if not self.info:
             self.bad_cons += self.threads
+            self.info = False
         else:
             self.bad_cons = 0
         self.request = False

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -903,18 +903,16 @@ class NzbQueue:
                 for nzf in nzo.files:
                     if nzo.removed_from_queue:
                         break
-                    if len(nzf.try_list) >= nr_servers:
-                        logging.info("Resetting bad trylist for file %s in job %s", nzf.filename, nzo.final_name)
-                        nzf.reset_try_list()
 
+                    if len(nzf.try_list) >= nr_servers:
                         # Check for articles where all active servers have already been tried
-                        for article in nzf.articles:
-                            if nzf.deleted or nzo.removed_from_queue:
-                                break
+                        for article in nzf.articles[:]:
                             if article.all_servers_in_try_list(active_servers):
                                 sabnzbd.NzbQueue.register_article(article, success=False)
                                 nzo.increase_bad_articles_counter("missing_articles")
-                                nzf.has_bad_articles = True
+
+                        logging.info("Resetting bad trylist for file %s in job %s", nzf.filename, nzo.final_name)
+                        nzf.reset_try_list()
 
                 # Reset main trylist, minimal performance impact
                 logging.info("Resetting bad trylist for job %s", nzo.final_name)

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -134,6 +134,13 @@ class TryList:
         with TRYLIST_LOCK:
             self.try_list = []
 
+    def cleanup_try_list(self, servers: List[Server]):
+        """Remove invalid servers from try_list"""
+        with TRYLIST_LOCK:
+            for server in self.try_list:
+                if not server in servers:
+                    self.try_list.remove(server)
+
     def __getstate__(self):
         """Save the servers"""
         return [server.id for server in self.try_list]

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -112,10 +112,18 @@ class TryList:
     def __init__(self):
         self.try_list: List[Server] = []
 
-    def server_in_try_list(self, server: Server):
+    def server_in_try_list(self, server: Server) -> bool:
         """Return whether specified server has been tried"""
         with TRYLIST_LOCK:
             return server in self.try_list
+
+    def all_servers_in_try_list(self, servers: List[Server]) -> bool:
+        """Check if all servers have been tried"""
+        with TRYLIST_LOCK:
+            for server in servers:
+                if not server in self.try_list:
+                    return False
+        return True
 
     def add_to_try_list(self, server: Server):
         """Register server as having been tried already"""
@@ -133,13 +141,6 @@ class TryList:
         """Clean the list"""
         with TRYLIST_LOCK:
             self.try_list = []
-
-    def cleanup_try_list(self, servers: List[Server]):
-        """Remove invalid servers from try_list"""
-        with TRYLIST_LOCK:
-            for server in self.try_list:
-                if not server in servers:
-                    self.try_list.remove(server)
 
     def __getstate__(self):
         """Save the servers"""


### PR DESCRIPTION
First part of #2320.

If the last server in the priority list is deactivated and it was the only missing server in the article try_list then none of the active servers will check the article. This means that the article, file and nzb may never be registered as finished because that is only done after checking an article.

The bad try_list check will notice this because if there are 3 active servers and the last is deactivated then there will be 2 servers in the try_list and 2 active servers. If this is still the case after checking that all the servers in the try_list are currently active then the article will be marked as failed.