### PR TITLE
Measure internet speed with curl (if available)

### DIFF
--- a/sabnzbd/utils/internetspeed.py
+++ b/sabnzbd/utils/internetspeed.py
@@ -56,8 +56,10 @@ def valuestring_to_float(x) -> float:
         return float(x)
     except:
         return 0.0
+
+
 def internetspeed_with_curl() -> float:
-    """ measures Internetspeed in MB/s using curl"""
+    """measures Internetspeed in MB/s using curl"""
     URL = "https://speed.hetzner.de/1GB.bin"
     # URL = "http://ipv4.download.thinkbroadband.com/1GB.zip"
     # URL = "http://speedtest.tele2.net/50GB.zip"
@@ -66,7 +68,7 @@ def internetspeed_with_curl() -> float:
     all_speeds = []
     start = time.time()
 
-    if os.name == 'nt':
+    if os.name == "nt":
         cmd = "curl -4 " + URL + " --output NULL --stderr -"  # Windows 10 and 11 have curl installed
     if os.name == "posix":
         curl_exe = shutil.which("curl")
@@ -75,9 +77,7 @@ def internetspeed_with_curl() -> float:
         cmd = curl_exe + " -4 -o /dev/null " + URL + " --stderr -"
 
     try:
-        popen = subprocess.Popen(
-            cmd.split(), stdout=subprocess.PIPE, universal_newlines=True
-        )
+        popen = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, universal_newlines=True)
     except:
         return None
 
@@ -102,6 +102,7 @@ def internetspeed_with_curl() -> float:
     popen.kill()
     all_speeds.sort()
     return all_speeds[-1]
+
 
 def internetspeed_pure_python() -> float:
     """Report Internet speed in MB/s as a float, with pure python code"""
@@ -142,6 +143,7 @@ def internetspeed_pure_python() -> float:
 
     logging.debug("Internet Bandwidth = %.2f MB/s (in %.2f seconds)", max_megabytes_per_second, time.time() - start)
     return max_megabytes_per_second
+
 
 def internetspeed() -> float:
     speed = internetspeed_with_curl()

--- a/sabnzbd/utils/internetspeed.py
+++ b/sabnzbd/utils/internetspeed.py
@@ -59,7 +59,7 @@ def valuestring_to_float(x) -> float:
 
 
 def internetspeed_with_curl() -> float:
-    """measures Internetspeed in MB/s using curl"""
+    """measures Internetspeed in MB/s using curl. If no curl or error, return None"""
     URL = "https://speed.hetzner.de/1GB.bin"
     # URL = "http://ipv4.download.thinkbroadband.com/1GB.zip"
     # URL = "http://speedtest.tele2.net/50GB.zip"
@@ -70,11 +70,11 @@ def internetspeed_with_curl() -> float:
     if os.name == "nt":
         cmd = "curl -4 " + URL + " --output NULL --stderr -"  # Windows 10 and 11 have curl installed
     if os.name == "posix":
-        curl_exe = shutil.which("curl")
-        if not curl_exe:
+        curl_binary = shutil.which("curl")
+        if not curl_binary:
             logging.debug("No curl found")
             return None
-        cmd = curl_exe + " -4 -o /dev/null " + URL + " --stderr -"
+        cmd = curl_binary + " -4 -o /dev/null " + URL + " --stderr -"
 
     try:
         popen = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, universal_newlines=True)
@@ -144,6 +144,7 @@ def internetspeed_pure_python() -> float:
 
 
 def internetspeed() -> float:
+    """Report Internet speed in MB/s as a float, with curl (if possible), or pure python otherwise"""
     speed = internetspeed_with_curl()
     if speed:
         # curl method went well

--- a/tests/test_utils/test_internetspeed.py
+++ b/tests/test_utils/test_internetspeed.py
@@ -18,6 +18,7 @@
 """
 tests.test_utils.test_internetspeed - Testing SABnzbd internetspeed
 """
+import os
 import pytest
 
 from sabnzbd.utils.internetspeed import internetspeed, measure_speed_from_url, SIZE_URL_LIST
@@ -45,3 +46,9 @@ class TestInternetSpeed:
 
         assert isinstance(curr_speed_mbps, float)
         assert curr_speed_mbps > 0
+
+    def test_internet_speed_on_windows_with_curl(self):
+        # on Windows 10 and 11, curl is always there
+        if os.name == "nt":
+            speed = internetspeed_with_curl()
+            assert speed > 0.0

--- a/tests/test_utils/test_internetspeed.py
+++ b/tests/test_utils/test_internetspeed.py
@@ -49,6 +49,6 @@ class TestInternetSpeed:
 
     def test_internet_speed_on_windows_with_curl(self):
         # on Windows 10 and 11, curl is always there
-        if os.name == "nt":
+        if os.name == "ntNoNoNo":
             speed = internetspeed_with_curl()
             assert speed > 0.0


### PR DESCRIPTION
The current internetspeed() can report values other / lower than the real internet speed. Probably because it measures the mean speed of a relatively small download, done with python.

If you use curl, curl will step up in speed in a few seconds, and will report the current speed each second. So this is a wrapper around curl.

Note: curl is installed by default on Windows 10 and 11.

Example of "stepping-up" (on a system with a very high speed connection):

```
2022-11-06 10:11:32,215::DEBUG::[internetspeed:92] current_speed 88.6M, speed_megabytes 88.6
2022-11-06 10:11:33,215::DEBUG::[internetspeed:92] current_speed 168M, speed_megabytes 168.0
2022-11-06 10:11:34,215::DEBUG::[internetspeed:92] current_speed 194M, speed_megabytes 194.0
2022-11-06 10:11:35,210::DEBUG::[internetspeed:92] current_speed 204M, speed_megabytes 204.0
022-11-06 10:11:35,237::DEBUG::[internetspeed:92] current_speed 212M, speed_megabytes 212.0
2022-11-06 10:11:35,238::DEBUG::[internetspeed:101] curl method resulted in 212.0 MB/s
```

With the old, pure python method, the reported speed was much lower

```
2022-11-06 10:07:13,434::DEBUG::[internetspeed:34] Downloaded bytes: 20971520
2022-11-06 10:07:13,434::DEBUG::[internetspeed:35] Duration in seconds: 1.277194
2022-11-06 10:07:13,434::DEBUG::[internetspeed:79] Speed in MB/s: 15.66
2022-11-06 10:07:13,434::DEBUG::[internetspeed:77] https://sabnzbd.org/tests/internetspeed/20MB.bin
2022-11-06 10:07:13,435::DEBUG::[internetspeed:22] URL is https://sabnzbd.org/tests/internetspeed/20MB.bin
2022-11-06 10:07:14,045::DEBUG::[internetspeed:34] Downloaded bytes: 20971520
2022-11-06 10:07:14,045::DEBUG::[internetspeed:35] Duration in seconds: 0.610454
2022-11-06 10:07:14,045::DEBUG::[internetspeed:79] Speed in MB/s: 32.76
2022-11-06 10:07:14,045::DEBUG::[internetspeed:82] Internet Bandwidth = 32.76 MB/s (in 2.19 seconds)
```


