### PR TITLE
Fix typos

### DIFF
--- a/builder/package.py
+++ b/builder/package.py
@@ -64,7 +64,7 @@ extra_folders = [
 
 # Support functions
 def safe_remove(path):
-    """Remove file without erros if the file doesn't exist
+    """Remove file without errors if the file doesn't exist
     Can also handle folders
     """
     if os.path.exists(path):

--- a/builder/win/NSIS_Installer.nsi
+++ b/builder/win/NSIS_Installer.nsi
@@ -56,7 +56,7 @@ Unicode true
   CRCCheck on ; (can be off)
   AutoCloseWindow false ; (can be true for the window go away automatically at end)
   ShowInstDetails hide ; (can be show to have them shown, or nevershow to disable)
-  SetDateSave off ; (can be on to have files restored to their orginal date)
+  SetDateSave off ; (can be on to have files restored to their original date)
   WindowIcon on
   SpaceTexts none
 
@@ -185,7 +185,7 @@ Section "SABnzbd" SecDummy
   liteFirewallW::AddRule "$INSTDIR\SABnzbd-console.exe" "SABnzbd-console"
 
   ;------------------------------------------------------------------
-  ; Add to registery
+  ; Add to registry
   WriteRegStr HKEY_LOCAL_MACHINE "SOFTWARE\SABnzbd" "" "$INSTDIR"
   WriteRegStr HKEY_LOCAL_MACHINE "SOFTWARE\SABnzbd" "Installer Language" "$(MsgLangCode)"
   WriteRegStr HKEY_LOCAL_MACHINE "Software\Microsoft\Windows\CurrentVersion\Uninstall\SABnzbd" "DisplayName" "SABnzbd ${SAB_VERSION}"
@@ -328,7 +328,7 @@ FunctionEnd
 UninstallText $(MsgUninstall)
 
 Section "un.$(MsgDelProgram)" Uninstall
-;make sure sabnzbd.exe isnt running..if so shut it down
+;make sure sabnzbd.exe isn't running..if so shut it down
   ${nsProcess::KillProcess} "SABnzbd.exe" $R0
   ${nsProcess::Unload}
   DetailPrint "Process Killed"

--- a/licenses/License-kronos.txt
+++ b/licenses/License-kronos.txt
@@ -1,5 +1,5 @@
 Kronos.py is written by Irmen de Jong.
-Retreived from:
+Retrieved from:
 http://www.razorvine.net/download/kronos.py
 
 Quote from the module:

--- a/sabnzbd/deobfuscate_filenames.py
+++ b/sabnzbd/deobfuscate_filenames.py
@@ -46,7 +46,7 @@ MIN_FILE_SIZE = 10 * 1024 * 1024
 
 
 def decode_par2(parfile: str) -> List[str]:
-    """Parse a par2 file and rename files listed in the par2 to their real name. Resturn list of generated files"""
+    """Parse a par2 file and rename files listed in the par2 to their real name. Return list of generated files"""
     # Check if really a par2 file
     if not is_parfile(parfile):
         logging.info("Par2 file %s was not really a par2 file")


### PR DESCRIPTION
Found via `codespell -S po,interfaces -L
ciph,fo,ro,nd,parm,parms,readd,reenabled,msdos,sav,tage,datas`