### PR TITLE
Optimize highest_server

### DIFF
--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -463,12 +463,13 @@ class Downloader(Thread):
 
     def highest_server(self, me: Server):
         """Return True when this server has the highest priority of the active ones
-        0 is the highest priority
+        0 is the highest priority, servers are sorted by priority.
         """
         for server in self.servers:
-            if server is not me and server.active and server.priority < me.priority:
+            if server.priority == me.priority:
+                return True
+            if server.active:
                 return False
-        return True
 
     def maybe_block_server(self, server: Server):
         # Was it resolving problem?


### PR DESCRIPTION
Micro optimization that takes advantage of the servers being sorted by priority. Unless there is a higher priority inactive server in the top spot it will only need to check the first server before returning. It does assume that the "me" server is in the servers list but something has be seriously wrong for it not to be.