### PR TITLE
fix: set stage_log to empty array on missing database content

### DIFF
--- a/sabnzbd/database.py
+++ b/sabnzbd/database.py
@@ -543,6 +543,8 @@ def unpack_history_info(item: Union[Dict, sqlite3.Row]):
         # Sort it so it is more logical
         parsed_stage_log.sort(key=lambda stage_log: STAGES.get(stage_log["name"], 100))
         item["stage_log"] = parsed_stage_log
+    else:
+        item["stage_log"] = []
 
     if item["script_log"]:
         item["script_log"] = ""


### PR DESCRIPTION
This should solve #2363 as [`stage_log` will be an empty string](https://github.com/sabnzbd/sabnzbd/blob/develop/sabnzbd/database.py#L467-L470) if `nzo.unpack_info` is an empty dictionary. This later will [fail the implicit booleanness check](https://github.com/sabnzbd/sabnzbd/blob/develop/sabnzbd/database.py#L519-L520) and an empty string will remain as the `stage_log`.

This causes `stage_log` to be an empty array instead on any false nullish value (including an empty string), keeping in-line with the expected data type for `stage_log` (an array of stage result dicts).

This keeps the response type true to the expected response type and should not impact any consuming applications or services of the API. The unpack information is only empty/null in very rare scenarios so this does not happen frequently but is problematic for type-safe languages.