### PR TITLE
Limited refactoring of recv_chunk

### DIFF
--- a/sabnzbd/utils/servertests.py
+++ b/sabnzbd/utils/servertests.py
@@ -90,7 +90,9 @@ def test_nntp_server_dict(kwargs):
         nw.init_connect()
         while not nw.connected:
             nw.clear_data()
-            nw.recv_chunk(block=True)
+            nw.nntp.sock.setblocking(True)
+            nw.recv_chunk()
+            nw.nntp.sock.setblocking(nw.blocking)
             nw.finish_connect(nw.status_code)
 
     except socket.timeout:
@@ -124,7 +126,9 @@ def test_nntp_server_dict(kwargs):
         nw.nntp.sock.sendall(b"ARTICLE <test@home>\r\n")
         try:
             nw.clear_data()
-            nw.recv_chunk(block=True)
+            nw.nntp.sock.setblocking(True)
+            nw.recv_chunk()
+            nw.nntp.sock.setblocking(nw.blocking)
         except:
             # Some internal error, not always safe to close connection
             return False, str(sys.exc_info()[1])


### PR DESCRIPTION
I've currently given up on trying to read more than one chunk for each call. It seems like it's more important to read each connection frequently. Anyway, I've looked at this code for so long now that I figured I'd make a PR of some possible improvements I noticed.

- `block` parameter is removed because setting blocking mode makes sure data is read and `ssl.SSLWantReadError` isn't triggered. Instead blocking mode is set explicitly before calling `recv_chunk`. It removes the need for the `while 1` and the `if` in the `except ssl.SSLWantReadError` part.
- I changed the order of `try` and `if self.nntp.nw.server.ssl` because try is only needed for ssl.
- I moved setting `self.timeout` below reading the data. This makes more sense to me because then it will only be updated if data has been read (at least for ssl).