### PR TITLE
Make downloader sleep test optional

### DIFF
--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -414,6 +414,7 @@ api_warnings = OptionBool("misc", "api_warnings", True, protect=True)
 no_penalties = OptionBool("misc", "no_penalties", False)
 x_frame_options = OptionBool("misc", "x_frame_options", True)
 allow_old_ssl_tls = OptionBool("misc", "allow_old_ssl_tls", False)
+downloader_sleep_test = OptionBool("misc", "downloader_sleep_test", True)
 
 # Text values
 rss_odd_titles = OptionList("misc", "rss_odd_titles", ["nzbindex.nl/", "nzbindex.com/", "nzbclub.com/"])

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -568,6 +568,8 @@ class Downloader(Thread):
         can_be_slowed: Optional[float] = None
         can_be_slowed_timer: float = 0.0
         next_stable_speed_check: float = 0.0
+        if not cfg.downloader_sleep_test():
+            can_be_slowed = 1
 
         # Check server expiration dates
         check_server_expiration()

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -868,6 +868,7 @@ SPECIAL_BOOL_LIST = (
     "api_logging",
     "x_frame_options",
     "allow_old_ssl_tls",
+    "downloader_sleep_test",
 )
 SPECIAL_VALUE_LIST = (
     "downloader_sleep_time",


### PR DESCRIPTION
Sometimes my download rate is a bit unstable so SABnzbd disables can_be_slowed. If this new switch is disabled then can_be_slowed will be set true without doing the test first. I'll add a description to the wiki if you agree.