### PR TITLE
Refresh and expand the appstream metadata

### DIFF
--- a/linux/org.sabnzbd.sabnzbd.appdata.xml
+++ b/linux/org.sabnzbd.sabnzbd.appdata.xml
@@ -23,16 +23,26 @@
   </categories>
   <url type="homepage">https://sabnzbd.org</url>
   <url type="bugtracker">https://github.com/sabnzbd/sabnzbd/issues</url>
+  <url type="vcs-browser">https://github.com/sabnzbd/sabnzbd</url>
   <url type="translate">https://sabnzbd.org/wiki/translate</url>
   <url type="donation">https://sabnzbd.org/donate</url>
   <url type="help">https://sabnzbd.org/wiki/</url>
   <url type="faq">https://sabnzbd.org/wiki/faq</url>
-  <url type="contact">https://forums.sabnzbd.org</url>
+  <url type="contact">https://sabnzbd.org/live-chat.html</url>
   <launchable type="desktop-id">sabnzbd.desktop</launchable>
   <provides>
     <mediatype>application/x-nzb</mediatype>
     <mediatype>application/x-compressed-nzb</mediatype>
   </provides>
+  <supports>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+  </supports>
+  <recommends>
+    <display_length compare="ge">small</display_length>
+    <internet>always</internet>
+  </recommends>
   <project_license>GPL-2.0-or-later</project_license>
   <developer_name>The SABnzbd-team</developer_name>
   <screenshots>


### PR DESCRIPTION
Add supported control methods [1] as well as recommended screen sizes [2] and internet availability. Most of these properties are already in active use by appdata clients such a Gnome's "Software" program. The display size basically says "all but extra-small", where the extra extra-small category is used for tiny devices such a wearables and watches, and is kept as a recommend to not block installs on headless systems.

Also set a vcs-browser URL, and update the contact URL to point to the more generic live-chat page rather than directly to the forums.

[1] https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-relations-control
[2] https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-relations-display_length