### PR TITLE
fix: extracted file permissions on Synology

### DIFF
--- a/sabnzbd/directunpacker.py
+++ b/sabnzbd/directunpacker.py
@@ -414,7 +414,6 @@ class DirectUnpacker(threading.Thread):
                 "%s\\" % long_path(extraction_path),
             ]
         else:
-            # Don't use "-ai" (not needed for non-Windows)
             # The -scf forces the output to be UTF8
             command = [
                 sabnzbd.newsunpack.RAR_COMMAND,
@@ -423,6 +422,7 @@ class DirectUnpacker(threading.Thread):
                 "-idp",
                 "-scf",
                 "-o+",
+                "-ai",
                 password_command,
                 rarfile_path,
                 "%s/" % extraction_path,

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -624,13 +624,16 @@ def set_permissions(path: str, recursive: bool = True):
                 # If custom permissions are absent, set them when doing recursion
                 if not custom_permissions:
                     logging.debug("Setting permission bits of files based on parent folder")
-                    custom_permissions = int(os.stat(path).st_mode)
+                    root_permissions = int(os.stat(path).st_mode)
                 # Parse the dir/file tree and set permissions
                 for root, _, files in os.walk(path):
                     if custom_permissions:
                         set_chmod(root, custom_permissions)
                     for name in files:
-                        removexbits(os.path.join(root, name), custom_permissions)
+                        if custom_permissions:
+                            removexbits(os.path.join(root, name), custom_permissions)
+                        else:
+                            removexbits(os.path.join(root, name), root_permissions)
             elif custom_permissions:
                 set_chmod(path, custom_permissions)
         else:

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -621,10 +621,6 @@ def set_permissions(path: str, recursive: bool = True):
 
         if os.path.isdir(path):
             if recursive:
-                # If custom permissions are absent, set them when doing recursion
-                if not custom_permissions:
-                    logging.debug("Setting permission bits of files based on parent folder")
-                    custom_permissions = int(os.stat(path).st_mode)
                 # Parse the dir/file tree and set permissions
                 for root, _, files in os.walk(path):
                     if custom_permissions:

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -621,6 +621,10 @@ def set_permissions(path: str, recursive: bool = True):
 
         if os.path.isdir(path):
             if recursive:
+                # If custom permissions are absent, set them when doing recursion
+                if not custom_permissions:
+                    logging.debug("Setting permission bits of files based on parent folder")
+                    custom_permissions = int(os.stat(path).st_mode)
                 # Parse the dir/file tree and set permissions
                 for root, _, files in os.walk(path):
                     if custom_permissions:

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -624,16 +624,13 @@ def set_permissions(path: str, recursive: bool = True):
                 # If custom permissions are absent, set them when doing recursion
                 if not custom_permissions:
                     logging.debug("Setting permission bits of files based on parent folder")
-                    root_permissions = int(os.stat(path).st_mode)
+                    custom_permissions = int(os.stat(path).st_mode)
                 # Parse the dir/file tree and set permissions
                 for root, _, files in os.walk(path):
                     if custom_permissions:
                         set_chmod(root, custom_permissions)
                     for name in files:
-                        if custom_permissions:
-                            removexbits(os.path.join(root, name), custom_permissions)
-                        else:
-                            removexbits(os.path.join(root, name), root_permissions)
+                        removexbits(os.path.join(root, name), custom_permissions)
             elif custom_permissions:
                 set_chmod(path, custom_permissions)
         else:

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -701,7 +701,6 @@ def rar_extract_core(
             "%s/" % extraction_path,
         ]
     else:
-        # Don't use "-ai" (not needed for non-Windows)
         # The -scf forces the output to be UTF8
         command = [
             RAR_COMMAND,
@@ -710,6 +709,7 @@ def rar_extract_core(
             "-scf",
             overwrite,
             rename,
+            "-ai",
             password_command,
             rarfile_path,
             "%s/" % extraction_path,


### PR DESCRIPTION
For archives extracted under non-Windows platforms the "-ai" switch was excluded with the logic that it was not needed. It is proposed that the switch is still required as it allows the extracted files to ignore the file attributes stored in the archive.

This is important for archives which may have no group attributes set as these extract with permissions only set for the user. This results in problems post-processing the files with other packages on Synology platforms running DSM 7 as demonstrated in the following example:

```
Sample archive contents:
Archive: ./rar_files/Rihanna - Loud.part1.rar
Details: RAR 4, volume, lock

 Attributes      Size    Packed Ratio    Date    Time   Checksum  Name
----------- ---------  -------- ----- ---------- -----  --------  ----
    ..A....      1907       686  35%  2014-03-16 18:10  C4966751  00._Rihanna_-_Loud.nfo
    ..A....   9800349   9308923  94%  2010-11-14 18:29  0F544CC5  01 S&M.mp3
[---snip---]
```

When this is extracted using the standard switches, the files look like this:

```
$ sudo -u sc-sabnzbd /var/packages/sabnzbd/target/bin/unrar x -vp -idp -scf -o+ -p- ./rar_files/Rihanna\ -\ Loud.part1.rar ./test4

UNRAR 6.12 freeware      Copyright (c) 1993-2022 Alexander Roshal

Extracting from ./rar_files/Rihanna - Loud.part1.rar
[---snip---]
Extracting  ./test4/00._Rihanna_-_Loud.nfo                            OK 
Extracting  ./test4/01 S&M.mp3                                        OK 
[---snip---]
Extracting  ./test4/Rihanna - Loud - Front.bmp                        OK 
All OK
```
```
$ ls -all test4
total 129220
drwxrwxrwx+ 1 sc-sabnzbd synocommunity      750 Jan  3 12:38  .
drwxrwxrwx+ 1 sc-sabnzbd synocommunity      122 Jan  3 12:37  ..
-rw-------  1 sc-sabnzbd synocommunity     1907 Mar 16  2014  00._Rihanna_-_Loud.nfo
-rw-------  1 sc-sabnzbd synocommunity  9800349 Nov 14  2010 '01 S&M.mp3'
[---snip---]
```

For the extracted files they have the attributes 'rw' for the owner and no attributes otherwise. This is different than the attributes which are set when we include the "-ai" switch in the following example:

```
$ sudo -u sc-sabnzbd /var/packages/sabnzbd/target/bin/unrar x -vp -idp -scf -o+ -ai -p- ./rar_files/Rihanna\ -\ Loud.part1.rar ./test3

UNRAR 6.12 freeware      Copyright (c) 1993-2022 Alexander Roshal

Extracting from ./rar_files/Rihanna - Loud.part1.rar
[---snip---]
Extracting  ./test3/00._Rihanna_-_Loud.nfo                            OK 
Extracting  ./test3/01 S&M.mp3                                        OK 
[---snip---]
Extracting  ./test3/Rihanna - Loud - Front.bmp                        OK 
All OK
```
```
$ ls -all test3/
total 129220
drwxrwxrwx+ 1 sc-sabnzbd synocommunity      750 Jan  3 12:17  .
drwxrwxrwx+ 1 sc-sabnzbd synocommunity      140 Jan  3 12:16  ..
-rwxrwxrwx+ 1 sc-sabnzbd synocommunity     1907 Mar 16  2014  00._Rihanna_-_Loud.nfo
-rwxrwxrwx+ 1 sc-sabnzbd synocommunity  9800349 Nov 14  2010 '01 S&M.mp3'
[---snip---]
```

In this case, the files have attributes assigned by the operating system for newly created files. Now this would include executable permissions but the built-in set_permissions script would clean this up where files contain 'xbits'.

This was proven by applying these modifications to a Virtual DSM unit running DSM 7.1.1. The debug logs are included below:
*	[sabnzbd.log (without "-ai")](https://pastebin.com/dbB346NT)
*	[sabnzbd.log (with "-ai")](https://pastebin.com/mUgxejzG)

This fix should be simple enough to address the permissions issue on Synology as noted in: https://github.com/SynoCommunity/spksrc/issues/4940.