### PR TITLE
Set on_disk = True on unavailable articles

### DIFF
--- a/sabnzbd/decoder.py
+++ b/sabnzbd/decoder.py
@@ -233,7 +233,9 @@ class DecoderWorker(Thread):
                 # If the data needs to be written to disk due to full cache, this will be slow
                 # Causing the decoder-queue to fill up and delay the downloader
                 sabnzbd.ArticleCache.save_article(article, decoded_data)
-
+            elif not nzo.precheck:
+                # Nothing to save
+                article.on_disk = True
             sabnzbd.NzbQueue.register_article(article, article_success)
 
 


### PR DESCRIPTION
To avoid them stopping the assembler and the cache filling up. Do you know if this can break anything?