### PR TITLE
Use broken article data if no valid data exists and let the assembler continue if an article is missing

### DIFF
--- a/sabnzbd/decoder.py
+++ b/sabnzbd/decoder.py
@@ -167,9 +167,6 @@ class DecoderWorker(Thread):
             except BadData as error:
                 # Continue to the next one if we found new server
                 if search_new_server(article):
-                    if error.data and not article.decoded:
-                        article.decoded = True
-                        sabnzbd.ArticleCache.save_article(article, error.data)
                     continue
 
                 # Store data, maybe par2 can still fix it
@@ -232,14 +229,6 @@ class DecoderWorker(Thread):
                 if search_new_server(article):
                     continue
 
-            if article.decoded:
-                if decoded_data:
-                    # Clear old cache data
-                    sabnzbd.ArticleCache.load_article(article)
-                else:
-                    # Load broken data from a higher priority server
-                    decoded_data = sabnzbd.ArticleCache.load_article(article)
-
             if decoded_data:
                 # If the data needs to be written to disk due to full cache, this will be slow
                 # Causing the decoder-queue to fill up and delay the downloader
@@ -248,6 +237,7 @@ class DecoderWorker(Thread):
             elif not nzo.precheck:
                 # Nothing to save
                 article.on_disk = True
+
             sabnzbd.NzbQueue.register_article(article, article_success)
 
 

--- a/sabnzbd/decoder.py
+++ b/sabnzbd/decoder.py
@@ -233,7 +233,9 @@ class DecoderWorker(Thread):
                 # If the data needs to be written to disk due to full cache, this will be slow
                 # Causing the decoder-queue to fill up and delay the downloader
                 sabnzbd.ArticleCache.save_article(article, decoded_data)
-
+            elif not nzo.precheck:
+                # Nothing to save
+                article.on_disk = True
             sabnzbd.NzbQueue.register_article(article, article_success)
 
 

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -227,7 +227,7 @@ class Article(TryList):
                     sabnzbd.NzbQueue.reset_try_lists(self, remove_fetcher_from_trylist=False)
                     return True
 
-        logging.info("Article %s unavailable on all servers, discarding", self.article)
+        logging.info("Article %s unavailable or broken on all servers", self.article)
         return False
 
     def __getstate__(self):

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -227,7 +227,7 @@ class Article(TryList):
                     sabnzbd.NzbQueue.reset_try_lists(self, remove_fetcher_from_trylist=False)
                     return True
 
-        logging.info("Article %s unavailable or broken on all servers", self.article)
+        logging.info("Article %s unavailable on all servers, discarding", self.article)
         return False
 
     def __getstate__(self):


### PR DESCRIPTION
I tested it by making a single article nzb and putting a wrong CRC in mnightingale's server, with some real servers on a lower priority. It seems to work and saved the 800 000 byte file. The dev version saves a 0 byte file. The bad_article count stayed at 0, though. I don't understand why.