### PR TITLE
Improve sample detection using filesize and extension

### DIFF
--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -736,9 +736,9 @@ def parring(nzo: NzbObject):
 
     if nzo.extrapars:
         # Need to make a copy because it can change during iteration
-        for setname in list(nzo.extrapars):
+        for setname, setfiles in dict(nzo.extrapars).items():
             # We do not care about repairing samples
-            if cfg.ignore_samples() and is_sample(setname.lower()):
+            if cfg.ignore_samples() and is_sample(setname.lower(), sum(nzf.bytes for nzf in setfiles)):
                 logging.info("Skipping verification and repair of %s because it looks like a sample", setname)
                 continue
 
@@ -1163,8 +1163,9 @@ def remove_samples(path):
     for root, _dirs, files in os.walk(path):
         for file_to_match in files:
             nr_files += 1
-            if is_sample(file_to_match):
-                files_to_delete.append(os.path.join(root, file_to_match))
+            path = os.path.join(root, file_to_match)
+            if is_sample(file_to_match, os.path.getsize(path)):
+                files_to_delete.append(path)
 
     # Make sure we skip false-positives
     if len(files_to_delete) < nr_files:

--- a/sabnzbd/sorting.py
+++ b/sabnzbd/sorting.py
@@ -456,7 +456,8 @@ class MovieSorter(BaseSorter):
         def filter_files(f, current_path):
             filepath = os.path.normpath(f) if is_full_path(f) else os.path.normpath(os.path.join(current_path, f))
             if os.path.exists(filepath):
-                if os.stat(filepath).st_size >= min_size and not is_sample(f) and get_ext(f) not in EXCLUDED_FILE_EXTS:
+                size = os.path.getsize(filepath)
+                if size >= min_size and not is_sample(f, size) and get_ext(f) not in EXCLUDED_FILE_EXTS:
                     return True
             return False
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -29,7 +29,7 @@ from sabnzbd import lang
 from sabnzbd import misc
 from sabnzbd import newsunpack
 from sabnzbd.config import ConfigCat
-from sabnzbd.constants import HIGH_PRIORITY, FORCE_PRIORITY, DEFAULT_PRIORITY, NORMAL_PRIORITY
+from sabnzbd.constants import HIGH_PRIORITY, FORCE_PRIORITY, DEFAULT_PRIORITY, NORMAL_PRIORITY, MEBI, GIGI
 from tests.testhelper import *
 
 
@@ -241,42 +241,33 @@ class TestMisc:
         os.unlink("test.key")
 
     @pytest.mark.parametrize(
-        "name, result",
+        "name, size, result",
         [
-            ("Free.Open.Source.Movie.2001.1080p.WEB-DL.DD5.1.H264-FOSS", False),  # Not samples
-            ("Setup.exe", False),
-            ("23.123.hdtv-rofl", False),
-            ("Something.1080p.WEB-DL.DD5.1.H264-EMRG-sample", True),  # Samples
-            ("Something.1080p.WEB-DL.DD5.1.H264-EMRG-sample.ogg", True),
-            ("Sumtin_Else_1080p_WEB-DL_DD5.1_H264_proof-EMRG", True),
-            ("Wot.Eva.540i.WEB-DL.aac.H264-Groupie sample.mp4", True),
-            ("file-sample.mkv", True),
-            ("PROOF.JPG", True),
-            ("Bla.s01e02.title.1080p.aac-sample proof.mkv", True),
-            ("Bla.s01e02.title.1080p.aac-proof.mkv", True),
-            ("Bla.s01e02.title.1080p.aac sample proof.mkv", True),
-            ("Bla.s01e02.title.1080p.aac proof.mkv", True),
-            ("Lwtn.s08e26.1080p.web.h264-glhf-sample.par2", True),
-            ("Lwtn.s08e26.1080p.web.h264-glhf-sample.vol001-002.par2", True),
-            ("Look at That 2011 540i WEB-DL.H265-NoSample", False),
+            ("Free.Open.Source.Movie.2001.1080p.WEB-DL.DD5.1.H264-FOSS", 5 * GIGI, False),  # Not samples
+            ("Setup.exe", 10 * MEBI, False),
+            ("23.123.hdtv-rofl", 500 * MEBI, False),
+            ("Not Death Proof (2022) 1080p x264 (DD5.1) BE Subs.mkv", 2 * GIGI, False),
+            ("Proof.of.Everything.(2042).4320p.x266-4U.mkv", 3 * GIGI, False),
+            ("Crime_Scene_S01E13_Free_Sample_For_Sale_480p-OhDear.mkv", 4 * GIGI, False),
+            ("Sample That 2011 480p WEB-DL.H265-aMiGo.mkv", 5 * GIGI, False),
+            ("NOT A SAMPLE.JPG", 6 * GIGI, False),
+            ("Look at That 2011 540i WEB-DL.H265-NoSample.mp4", 200 * MEBI, False),
+            ("Something.1080p.WEB-DL.DD5.1.H264-EMRG-sample.mkv", 10 * MEBI, True),  # Samples
+            ("Something.1080p.WEB-DL.DD5.1.H264-EMRG-sample.ogg", 2 * MEBI, True),
+            ("Sumtin_Else_1080p_WEB-DL_DD5.1_H264_proof-EMRG.mkv", 49 * MEBI, True),
+            ("Wot.Eva.540i.WEB-DL.aac.H264-Groupie sample.mp4", 5 * MEBI, True),
+            ("file-sample.mkv", 15 * MEBI, True),
+            ("PROOF.JPG", 524288, True),
+            ("Bla.s01e02.title.1080p.aac-sample proof.mkv", 2 * MEBI, True),
+            ("Bla.s01e02.title.1080p.aac-proof.mkv", 3 * MEBI, True),
+            ("Bla.s01e02.title.1080p.aac sample proof.mkv", 4 * MEBI, True),
+            ("Bla.s01e02.title.1080p.aac proof.mkv", 5 * MEBI, True),
+            ("Lwtn.s08e26.1080p.web.h264-glhf-sample.par2", 6 * MEBI, True),
+            ("Lwtn.s08e26.1080p.web.h264-glhf-sample.vol001-002.par2", 7 * MEBI, True),
         ],
     )
-    def test_is_sample(self, name, result):
-        assert misc.is_sample(name) == result
-
-    @pytest.mark.parametrize(
-        "name, result",
-        [
-            ("Not Death Proof (2022) 1080p x264 (DD5.1) BE Subs", False),  # Try to trigger some false positives
-            ("Proof.of.Everything.(2042).4320p.x266-4U", False),
-            ("Crime_Scene_S01E13_Free_Sample_For_Sale_480p-OhDear", False),
-            ("Sample That 2011 480p WEB-DL.H265-aMiGo", False),
-            ("NOT A SAMPLE.JPG", False),
-        ],
-    )
-    def test_is_sample_known_false_positives(self, name, result):
-        """We know these fail, but don't have a better solution for them at the moment."""
-        assert misc.is_sample(name) != result
+    def test_is_sample(self, name, size, result):
+        assert misc.is_sample(name, size) == result
 
     @pytest.mark.parametrize(
         "test_input, expected_output",


### PR DESCRIPTION
Fixes #2083 (mostly)

I've taken inspiration from a script I've used in NZBGet for many years [DeleteSamples.py](https://github.com/clinton-hall/GetScripts/blob/master/DeleteSamples.py)

Before the current filename check I first check against a size cut off (100 MB - reduced from inspiration because files are getting smaller) and limit it to known sample extensions - some of these were based on the existing tests, I probably wouldn't have bothered with if not for them.

I removed `test_is_sample_known_false_positives` and moved them into test_is_sample but I think the tests should be simplified to testing the bounds of each condition (size, extension and name) - which I can do but I'd rather know if this is likely to be accepted.

I think there are probably still possibilities for false positive, but this will reduce the chance of them.

Perhaps I should include the suggested check if NameOfTheDownload contains sample|proof always return False?