### PR TITLE
Call getsize in try and use CRC32 from sabyenc

### DIFF
--- a/sabnzbd/decoder.py
+++ b/sabnzbd/decoder.py
@@ -270,7 +270,7 @@ def decode_yenc(article: Article, raw_data: List[bytes]) -> bytes:
         logging.info("CRC Error in %s", article.article)
         raise BadData(decoded_data)
 
-    article.crc32 = crc32(decoded_data)
+    article.crc32 = crc_correct
     # Determine part size and precalculate crc_2pow
     if article.lowest_partnum and len(decoded_data) > nzf.nzo.article_size:
         nzf.nzo.article_size = len(decoded_data)

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -121,6 +121,14 @@ def is_writable(path: str) -> bool:
         return True
 
 
+def is_size(filepath: str, size: int) -> bool:
+    """Return True if filepath exists and is specified size"""
+    try:
+        return os.path.getsize(filepath) == size
+    except:
+        return False
+
+
 _DEVICES = (
     "con",
     "prn",

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -1998,11 +1998,7 @@ def quick_check_set(setname: str, nzo: NzbObject) -> bool:
             # Do a simple filename based check
             if file == nzf.filename:
                 found = True
-                if (
-                    (nzf.crc32sum is not None)
-                    and nzf.crc32sum == par2info.filehash
-                    and is_size(nzf.filepath, par2info.filesize)
-                ):
+                if nzf.crc32sum > 0 and nzf.crc32sum == par2info.filehash and is_size(nzf.filepath, par2info.filesize):
                     logging.debug("Quick-check of file %s OK", file)
                     result &= True
                 elif file_to_ignore:

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -61,6 +61,7 @@ from sabnzbd.filesystem import (
     build_filelists,
     get_filename,
     SEVENMULTI_RE,
+    is_size,
 )
 from sabnzbd.nzbstuff import NzbObject
 from sabnzbd.sorting import SeriesSorter
@@ -2000,7 +2001,7 @@ def quick_check_set(setname: str, nzo: NzbObject) -> bool:
                 if (
                     (nzf.crc32sum is not None)
                     and nzf.crc32sum == par2info.filehash
-                    and os.path.getsize(nzf.filepath) == par2info.filesize
+                    and is_size(nzf.filepath, par2info.filesize)
                 ):
                     logging.debug("Quick-check of file %s OK", file)
                     result &= True
@@ -2014,7 +2015,7 @@ def quick_check_set(setname: str, nzo: NzbObject) -> bool:
                 break
 
             # Now let's do obfuscation check
-            if nzf.crc32sum == par2info.filehash and os.path.getsize(nzf.filepath) == par2info.filesize:
+            if nzf.crc32sum == par2info.filehash and is_size(nzf.filepath, par2info.filesize):
                 try:
                     logging.debug("Quick-check will rename %s to %s", nzf.filename, file)
 


### PR DESCRIPTION
I think it should be done after this commit. If you like I can remove article.decoded and use article.crc32 to signal status instead (None = not decoded, some value = decoded).

I looked into getting actual size on sparse files but I didn't find a good solution that works on all platforms. I guess we'll have to burn that bridge when we get there.