### PR TITLE
relabel UI button to show "Hidden" instead of "System"

### DIFF
--- a/interfaces/Config/templates/_inc_footer_uc.tmpl
+++ b/interfaces/Config/templates/_inc_footer_uc.tmpl
@@ -15,7 +15,7 @@
                         <!--#if not $windows#-->
                         <div class="checkbox">
                             <label>
-                                <input type="checkbox" id="show_hidden_folders"> <span>$T('systemFolders')</span>
+                                <input type="checkbox" id="show_hidden_folders"> <span>$T('hiddenFolders')</span>
                             </label>
                         </div>
                         <!--#end if#-->

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -389,6 +389,7 @@ SKIN_TEXT = {
     "opt-password_file": TT("Password file"),
     "explain-password_file": TT("File containing all passwords to be tried on encrypted RAR files."),
     "systemFolders": TT("System Folders"),
+    "hiddenFolders": TT("Hidden Folders"),
     "opt-admin_dir": TT("Administrative Folder"),
     "explain-admin_dir1": TT(
         "Location for queue admin and history database.<br /><i>Can only be changed when queue is empty.</i>"


### PR DESCRIPTION
- as per: https://forums.sabnzbd.org/viewtopic.php?t=26089

I created a new TT label for this as `systemFolders` is also used to label the config page category (on the left side of the UI, under `Folders`). 