### PR TITLE
Stop using 0 as failed and use new crc32 value in SFV check

### DIFF
--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -203,7 +203,10 @@ class Assembler(Thread):
         # Final steps
         if file_done:
             set_permissions(nzf.filepath)
-            nzf.crc32sum = nzf.crc32
+            if nzf.crc32 is None:
+                nzf.crc32sum = -1
+            else:
+                nzf.crc32sum = nzf.crc32
 
     @staticmethod
     def check_encrypted_and_unwanted(nzo: NzbObject, nzf: NzbFile):

--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -203,10 +203,7 @@ class Assembler(Thread):
         # Final steps
         if file_done:
             set_permissions(nzf.filepath)
-            if nzf.crc32 is None:
-                nzf.crc32sum = -1
-            else:
-                nzf.crc32sum = nzf.crc32
+            nzf.assembled = True
 
     @staticmethod
     def check_encrypted_and_unwanted(nzo: NzbObject, nzf: NzbFile):

--- a/sabnzbd/directunpacker.py
+++ b/sabnzbd/directunpacker.py
@@ -344,13 +344,13 @@ class DirectUnpacker(threading.Thread):
     def have_next_volume(self):
         """Check if next volume of set is available, start
         from the end of the list where latest completed files are
-        Make sure that files are 100% written to disk by checking crc32sum
+        Make sure that files are 100% written to disk by checking nzf.assembled
         """
         for nzf_search in reversed(self.nzo.finished_files):
             if (
                 nzf_search.setname == self.cur_setname
                 and nzf_search.vol == (self.cur_volume + 1)
-                and nzf_search.crc32sum is not None
+                and nzf_search.assembled
             ):
                 return nzf_search
         return False

--- a/sabnzbd/directunpacker.py
+++ b/sabnzbd/directunpacker.py
@@ -350,7 +350,7 @@ class DirectUnpacker(threading.Thread):
             if (
                 nzf_search.setname == self.cur_setname
                 and nzf_search.vol == (self.cur_volume + 1)
-                and nzf_search.crc32sum
+                and nzf_search.crc32sum is not None
             ):
                 return nzf_search
         return False

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -1976,7 +1976,7 @@ def rar_sort(a: str, b: str) -> int:
 
 
 def quick_check_set(setname: str, nzo: NzbObject) -> bool:
-    """Check all on-the-fly crc32sums of a set"""
+    """Check all on-the-fly crc32s of a set"""
     par2pack = nzo.par2packs.get(setname)
     if par2pack is None:
         return False
@@ -1999,8 +1999,8 @@ def quick_check_set(setname: str, nzo: NzbObject) -> bool:
             if file == nzf.filename:
                 found = True
                 if (
-                    nzf.crc32sum is not None
-                    and nzf.crc32sum == par2info.filehash
+                    nzf.crc32 is not None
+                    and nzf.crc32 == par2info.filehash
                     and is_size(nzf.filepath, par2info.filesize)
                 ):
                     logging.debug("Quick-check of file %s OK", file)
@@ -2015,7 +2015,7 @@ def quick_check_set(setname: str, nzo: NzbObject) -> bool:
                 break
 
             # Now let's do obfuscation check
-            if nzf.crc32sum == par2info.filehash and is_size(nzf.filepath, par2info.filesize):
+            if nzf.crc32 is not None and nzf.crc32 == par2info.filehash and is_size(nzf.filepath, par2info.filesize):
                 try:
                     logging.debug("Quick-check will rename %s to %s", nzf.filename, file)
 
@@ -2160,9 +2160,10 @@ def sfv_check(sfvs: List[str], nzo: NzbObject) -> bool:
     verifytotal = len(nzo.finished_files)
     verifynum = 0
     for nzf in nzf_list:
-        verifynum += 1
-        nzo.set_action_line(T("Verifying"), "%02d/%02d" % (verifynum, verifytotal))
-        calculated_crc32[nzf.filename] = b"%08x" % (nzf.crc32sum & 0xFFFFFFFF)
+        if nzf.crc32 is not None:
+            verifynum += 1
+            nzo.set_action_line(T("Verifying"), "%02d/%02d" % (verifynum, verifytotal))
+            calculated_crc32[nzf.filename] = b"%08x" % (nzf.crc32 & 0xFFFFFFFF)
 
     sfv_parse_results = {}
     nzo.set_action_line(T("Trying SFV verification"), "...")

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -330,8 +330,8 @@ class NzbFile(TryList):
         self.deleted = False
         self.import_finished = False
 
-        self.crc32: int = 0
-        self.crc32sum: Optional[bytes] = None
+        self.crc32: Optional[int] = 0
+        self.crc32sum: Optional[int] = None
         self.md5of16k: Optional[bytes] = None
 
         self.valid: bool = bool(raw_article_db)
@@ -397,11 +397,14 @@ class NzbFile(TryList):
         self.vol = vol
         self.blocks = int_conv(blocks)
 
-    def update_crc32(self, crc32: int, length: int) -> None:
-        if length == self.nzo.article_size:
-            self.crc32 = crc_multiply(self.crc32, self.nzo.crc32_coeff) ^ crc32
+    def update_crc32(self, crc32: Optional[int], length: int) -> None:
+        if self.crc32 is None or crc32 is None:
+            self.crc32 = None
         else:
-            self.crc32 = crc_concat(self.crc32, crc32, length)
+            if length == self.nzo.article_size:
+                self.crc32 = crc_multiply(self.crc32, self.nzo.crc32_coeff) ^ crc32
+            else:
+                self.crc32 = crc_concat(self.crc32, crc32, length)
 
     def get_articles(self, server: Server, servers: List[Server], fetch_limit: int) -> List[Article]:
         """Get next articles to be downloaded"""

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -291,7 +291,7 @@ NzbFileSaver = (
     "valid",
     "import_finished",
     "crc32",
-    "crc32sum",
+    "assembled",
     "md5of16k",
 )
 
@@ -331,7 +331,7 @@ class NzbFile(TryList):
         self.import_finished = False
 
         self.crc32: Optional[int] = 0
-        self.crc32sum: Optional[int] = None
+        self.assembled: bool = False
         self.md5of16k: Optional[bytes] = None
 
         self.valid: bool = bool(raw_article_db)


### PR DESCRIPTION
And fix declaration `self.crc32sum: Optional[int]`. I'm now setting nzf.crc32sum to -1 on invalid CRC because None means not finished writing (for direct unpack). It's a bit hackish so I'm open for other suggestions. I didn't want to set a value that could theoretically be correct if the decoder detects bad CRCs. If there are other ways of forcing a par2 check then maybe we should use that.

I tested the SFV update with an nzb which contained an sfv. When I removed the par2 files it correctly identified the files with the same CRC32 string.