### PR TITLE
Make downloader use used buffer size to determine if it's ok to sleep

### DIFF
--- a/sabnzbd/bpsmeter.py
+++ b/sabnzbd/bpsmeter.py
@@ -434,40 +434,6 @@ class BPSMeter:
         # We record every second, but display at the user's refresh-rate
         return self.bps_list[::refresh_rate]
 
-    def get_stable_speed(self, timespan: int = 10) -> Optional[int]:
-        """See if there is a stable speed the last <timespan> seconds
-        None: indicates it can't determine yet
-        0: the speed was not stable during <timespan>
-        Positive float: the speed was stable
-        """
-        if len(self.bps_list) < timespan:
-            return None
-
-        # Check if speed fell by more than 15%
-        try:
-            if self.bps_list[-1] / self.bps_list[-timespan] < 0.85:
-                return 0
-        except:
-            pass
-
-        # Calculate the variance in the speed
-        avg = sum(self.bps_list[-timespan:]) / timespan
-        vari = 0
-        for bps in self.bps_list[-timespan:]:
-            vari += abs(bps - avg)
-        vari = vari / timespan
-
-        try:
-            # See if the variance is less than 5%
-            if (vari / (self.bps / KIBI)) < 0.05:
-                return avg
-            else:
-                return 0
-        except:
-            # Probably one of the values was 0
-            pass
-        return None
-
     def reset_quota(self, force: bool = False):
         """Check if it's time to reset the quota, optionally resuming
         Return True, when still paused or should be paused

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -55,6 +55,8 @@ _SERVER_CHECK_DELAY = 0.5
 _BPSMETER_UPDATE_DELAY = 0.05
 # How many articles should be prefetched when checking the next articles?
 _ARTICLE_PREFETCH = 20
+# Minimum expected size of TCP receive buffer
+_DEFAULT_CHUNK_SIZE = 65536
 
 TIMER_LOCK = RLock()
 
@@ -564,10 +566,9 @@ class Downloader(Thread):
         BPSMeter.update()
         next_bpsmeter_update = 0
 
-        # can_be_slowed variables
-        can_be_slowed: Optional[float] = None
-        can_be_slowed_timer: float = 0.0
-        next_stable_speed_check: float = 0.0
+        # Sleep check variables
+        last_max_chunk_size: int = 0
+        max_chunk_size: int = _DEFAULT_CHUNK_SIZE
 
         # Check server expiration dates
         check_server_expiration()
@@ -695,43 +696,24 @@ class Downloader(Thread):
                     logging.info("Shutting down")
                     break
 
+            # If less data than possible was received then it should be ok to sleep a bit
+            if self.sleep_time:
+                if last_max_chunk_size > max_chunk_size:
+                    logging.debug("New max_chunk_size %d -> %d", max_chunk_size, last_max_chunk_size)
+                    max_chunk_size = last_max_chunk_size
+                elif last_max_chunk_size < max_chunk_size / 3:
+                    time.sleep(self.sleep_time)
+                last_max_chunk_size = 0
+
             # Use select to find sockets ready for reading/writing
             readkeys = self.read_fds.keys()
             if readkeys:
                 read, _, _ = select.select(readkeys, (), (), 1.0)
-
-                # Add a sleep if there are too few results compared to the number of active connections
-                if self.sleep_time:
-                    if can_be_slowed and len(read) < 1 + len(readkeys) / 10:
-                        time.sleep(self.sleep_time)
-
-                    # Initialize by waiting for stable speed and then enable sleep
-                    if can_be_slowed is None or can_be_slowed_timer:
-                        # Wait for stable speed to start testing
-
-                        if not can_be_slowed_timer and now > next_stable_speed_check:
-                            if BPSMeter.get_stable_speed(timespan=10):
-                                can_be_slowed_timer = now + 8
-                                can_be_slowed = 1
-                            else:
-                                next_stable_speed_check = now + _BPSMETER_UPDATE_DELAY
-
-                        # Check 10 seconds after enabling slowdown
-                        if can_be_slowed_timer and now > can_be_slowed_timer:
-                            # Now let's check if it was stable in the last 10 seconds
-                            can_be_slowed = BPSMeter.get_stable_speed(timespan=10)
-                            can_be_slowed_timer = 0
-                            if not can_be_slowed:
-                                self.sleep_time = 0
-                            logging.debug("Downloader-slowdown: %r", can_be_slowed)
-
             else:
                 read = []
-
                 BPSMeter.reset()
-
                 time.sleep(1.0)
-
+                max_chunk_size = _DEFAULT_CHUNK_SIZE
                 with DOWNLOADER_CV:
                     while (
                         (sabnzbd.NzbQueue.is_empty() or self.no_active_jobs() or self.paused_for_postproc)
@@ -755,6 +737,8 @@ class Downloader(Thread):
 
                 try:
                     bytes_received, done = nw.recv_chunk()
+                    if bytes_received > last_max_chunk_size:
+                        last_max_chunk_size = bytes_received
                 except ssl.SSLWantReadError:
                     continue
                 except:

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -709,6 +709,8 @@ class Downloader(Thread):
                     now = time.time()
                     time.sleep(self.sleep_time)
                     # Debugging code for v4 test release
+                    if time.time() - now > self.sleep_time * 3:
+                        logging.debug("Slept %.5f seconds, sleep_time = %s", time.time() - now, self.sleep_time)
                     time_slept += time.time() - now
                     sleep_count += 1
                     if sleep_count_start + 10 < now:

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -569,6 +569,10 @@ class Downloader(Thread):
         # Sleep check variables
         last_max_chunk_size: int = 0
         max_chunk_size: int = _DEFAULT_CHUNK_SIZE
+        # Debugging code for v4 test release
+        sleep_count_start: float = time.time()
+        sleep_count: int = 0
+        time_slept: float = 0
 
         # Check server expiration dates
         check_server_expiration()
@@ -702,7 +706,23 @@ class Downloader(Thread):
                     logging.debug("New max_chunk_size %d -> %d", max_chunk_size, last_max_chunk_size)
                     max_chunk_size = last_max_chunk_size
                 elif last_max_chunk_size < max_chunk_size / 3:
+                    now = time.time()
                     time.sleep(self.sleep_time)
+                    # Debugging code for v4 test release
+                    time_slept += time.time() - now
+                    sleep_count += 1
+                    if sleep_count_start + 10 < now:
+                        logging.debug(
+                            "Slept %d times for an average of %.5f seconds the last %.2f seconds. sleep_time = %s",
+                            sleep_count,
+                            time_slept / sleep_count,
+                            time.time() - sleep_count_start,
+                            self.sleep_time,
+                        )
+                        sleep_count_start = now
+                        sleep_count = 0
+                        time_slept = 0
+
                 last_max_chunk_size = 0
 
             # Use select to find sockets ready for reading/writing

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -706,19 +706,20 @@ class Downloader(Thread):
                     logging.debug("New max_chunk_size %d -> %d", max_chunk_size, last_max_chunk_size)
                     max_chunk_size = last_max_chunk_size
                 elif last_max_chunk_size < max_chunk_size / 3:
-                    now = time.time()
+                    time_before = time.time()
                     time.sleep(self.sleep_time)
+                    now = time.time()
                     # Debugging code for v4 test release
-                    if time.time() - now > self.sleep_time * 3:
-                        logging.debug("Slept %.5f seconds, sleep_time = %s", time.time() - now, self.sleep_time)
-                    time_slept += time.time() - now
+                    if now - time_before > self.sleep_time + 0.01:
+                        logging.debug("Slept %.5f seconds, sleep_time = %s", now - time_before, self.sleep_time)
+                    time_slept += now - time_before
                     sleep_count += 1
                     if sleep_count_start + 10 < now:
                         logging.debug(
                             "Slept %d times for an average of %.5f seconds the last %.2f seconds. sleep_time = %s",
                             sleep_count,
                             time_slept / sleep_count,
-                            time.time() - sleep_count_start,
+                            now - sleep_count_start,
                             self.sleep_time,
                         )
                         sleep_count_start = now


### PR DESCRIPTION
I believe this method is easier to understand and has the potential to be more reliable than the current `can_be_slowed`. Basically, keep track of what the biggest chunk received so far is and sleep in the following rounds if no connection received more than 1/3 of that number. The idea being that there should be plenty room left in the connection buffer if that is true.

The starting value of 64 KiB is a bit arbitrary but it seems very unlikely that any OSes uses a smaller number than this. 1/3 is also arbitrary but feels conservative enough. `max_chunk_size` is reset when the downloader is idle (and connections are reset) because the receive buffer starts small and grows on demand. It might be a bit safer to have an upper limit but I didn't want to complicate things more than necessary.

It can still be turned off completely by setting `downloader_sleep_time` to 0.