### PR TITLE
Use threadpool for recv_chunk()

### DIFF
--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -55,8 +55,12 @@ class Assembler(Thread):
     def process(self, nzo: NzbObject, nzf: Optional[NzbFile] = None, file_done: Optional[bool] = None):
         self.queue.put((nzo, nzf, file_done))
 
-    def queue_full(self):
-        return self.queue.qsize() >= MAX_ASSEMBLER_QUEUE
+    def queue_level(self) -> float:
+        size = self.queue.qsize()
+        if size:
+            return size / MAX_ASSEMBLER_QUEUE
+        else:
+            return 0
 
     def partial_nzf_in_queue(self, nzf: NzbFile):
         return (nzf.nzo, nzf, False) in self.queue.queue

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -37,6 +37,7 @@ import sabnzbd.config as config
 import sabnzbd.cfg as cfg
 from sabnzbd.misc import from_units, get_server_addrinfo, helpful_warning, int_conv
 from sabnzbd.utils.happyeyeballs import happyeyeballs
+from multiprocessing.pool import ThreadPool
 
 
 # Timeout penalty in minutes for each cause
@@ -581,6 +582,9 @@ class Downloader(Thread):
         if config.get_servers() and not self.servers:
             logging.warning(T("There are no active servers!"))
 
+        dl_threads = 2
+        dl_pool = ThreadPool(dl_threads)
+
         # Kick BPS-Meter to check quota
         BPSMeter = sabnzbd.BPSMeter
         BPSMeter.update()
@@ -751,90 +755,105 @@ class Downloader(Thread):
             if not read:
                 continue
 
-            for selected in read:
-                nw = self.read_fds[selected]
-                article = nw.article
-                server = nw.server
+            if dl_threads > 1:
+                for i in range(0, len(read), dl_threads):
+                    for nw, bytes_received, done in dl_pool.map(
+                        self.__recv, read[i : min(len(read), i + dl_threads - 1)]
+                    ):
+                        if nw:
+                            self.__handle_recv_result(nw, bytes_received, done)
+            else:
+                for selected in read:
+                    nw, bytes_received, done = self.__recv(selected)
+                    if nw:
+                        self.__handle_recv_result(nw, bytes_received, done)
 
-                try:
-                    bytes_received, done = nw.recv_chunk()
-                except ssl.SSLWantReadError:
-                    continue
-                except:
-                    self.__reset_nw(nw, "server closed connection", wait=False)
-                    continue
+    def __recv(self, selected) -> List:
+        nw = self.read_fds[selected]
+        try:
+            bytes_received, done = nw.recv_chunk()
+            return nw, bytes_received, done
+        except ssl.SSLWantReadError:
+            return None, None, None
+        except:
+            self.__reset_nw(nw, "server closed connection", wait=False)
+            return None, None, None
 
-                BPSMeter.update(server.id, bytes_received)
-                if self.bandwidth_limit and BPSMeter.bps + BPSMeter.sum_cached_amount > self.bandwidth_limit:
-                    BPSMeter.update()
-                    while BPSMeter.bps > self.bandwidth_limit:
-                        time.sleep(0.01)
-                        BPSMeter.update()
+    def __handle_recv_result(self, nw: NewsWrapper, bytes_received: int = 0, done: bool = False) -> List:
+        article = nw.article
+        server = nw.server
+        BPSMeter = sabnzbd.BPSMeter
+        BPSMeter.update(server.id, bytes_received)
+        if self.bandwidth_limit and BPSMeter.bps + BPSMeter.sum_cached_amount > self.bandwidth_limit:
+            BPSMeter.update()
+            while BPSMeter.bps > self.bandwidth_limit:
+                time.sleep(0.01)
+                BPSMeter.update()
 
-                if nw.status_code != 222 and not done:
-                    if not nw.connected or nw.status_code == 480:
-                        if not self.__finish_connect_nw(nw):
-                            continue
-                        if nw.connected:
-                            logging.info("Connecting %s@%s finished", nw.thrdnum, nw.server.host)
-                            self.__request_article(nw)
+        if nw.status_code != 222 and not done:
+            if not nw.connected or nw.status_code == 480:
+                if not self.__finish_connect_nw(nw):
+                    return
+                if nw.connected:
+                    logging.info("Connecting %s@%s finished", nw.thrdnum, nw.server.host)
+                    self.__request_article(nw)
 
-                    elif nw.status_code == 223:
-                        done = True
-                        logging.debug("Article <%s> is present", article.article)
+            elif nw.status_code == 223:
+                done = True
+                logging.debug("Article <%s> is present", article.article)
 
-                    elif nw.status_code == 211:
-                        logging.debug("group command ok -> %s", nw.nntp_msg)
-                        nw.group = nw.article.nzf.nzo.group
-                        nw.reset_data_buffer()
-                        self.__request_article(nw)
+            elif nw.status_code == 211:
+                logging.debug("group command ok -> %s", nw.nntp_msg)
+                nw.group = nw.article.nzf.nzo.group
+                nw.reset_data_buffer()
+                self.__request_article(nw)
 
-                    elif nw.status_code in (411, 423, 430):
-                        done = True
-                        logging.debug(
-                            "Thread %s@%s: Article %s missing (error=%s)",
-                            nw.thrdnum,
-                            nw.server.host,
-                            article.article,
-                            nw.status_code,
-                        )
-                        nw.reset_data_buffer()
+            elif nw.status_code in (411, 423, 430):
+                done = True
+                logging.debug(
+                    "Thread %s@%s: Article %s missing (error=%s)",
+                    nw.thrdnum,
+                    nw.server.host,
+                    article.article,
+                    nw.status_code,
+                )
+                nw.reset_data_buffer()
 
-                    elif nw.status_code == 500:
-                        if article.nzf.nzo.precheck:
-                            # Assume "STAT" command is not supported
-                            server.have_stat = False
-                            logging.debug("Server %s does not support STAT", server.host)
-                        else:
-                            # Assume "BODY" command is not supported
-                            server.have_body = False
-                            logging.debug("Server %s does not support BODY", server.host)
-                        nw.reset_data_buffer()
-                        self.__request_article(nw)
+            elif nw.status_code == 500:
+                if article.nzf.nzo.precheck:
+                    # Assume "STAT" command is not supported
+                    server.have_stat = False
+                    logging.debug("Server %s does not support STAT", server.host)
+                else:
+                    # Assume "BODY" command is not supported
+                    server.have_body = False
+                    logging.debug("Server %s does not support BODY", server.host)
+                nw.reset_data_buffer()
+                self.__request_article(nw)
 
-                if done:
-                    # Successful data, clear "bad" counter
-                    server.bad_cons = 0
-                    server.errormsg = server.warning = ""
+        if done:
+            # Successful data, clear "bad" counter
+            server.bad_cons = 0
+            server.errormsg = server.warning = ""
 
-                    # Update statistics and decode
-                    article.nzf.nzo.update_download_stats(BPSMeter.bps, server.id, nw.data_position)
-                    self.decode(article, nw.get_data_buffer(), nw.data_position)
+            # Update statistics and decode
+            article.nzf.nzo.update_download_stats(BPSMeter.bps, server.id, nw.data_position)
+            self.decode(article, nw.get_data_buffer(), nw.data_position)
 
-                    if sabnzbd.LOG_ALL:
-                        logging.debug("Thread %s@%s: %s done", nw.thrdnum, server.host, article.article)
+            if sabnzbd.LOG_ALL:
+                logging.debug("Thread %s@%s: %s done", nw.thrdnum, server.host, article.article)
 
-                    # Reset connection for new activity
-                    nw.soft_reset()
-                    # Request a new article immediately if possible
-                    if nw.connected:
-                        nw.article = server.get_article()
-                        if nw.article:
-                            self.__request_article(nw)
-                            continue
-                    server.busy_threads.remove(nw)
-                    server.idle_threads.append(nw)
-                    self.remove_socket(nw)
+            # Reset connection for new activity
+            nw.soft_reset()
+            # Request a new article immediately if possible
+            if nw.connected:
+                nw.article = server.get_article()
+                if nw.article:
+                    self.__request_article(nw)
+                    return
+            server.busy_threads.remove(nw)
+            server.idle_threads.append(nw)
+            self.remove_socket(nw)
 
     def __finish_connect_nw(self, nw: NewsWrapper) -> bool:
         server = nw.server

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -852,11 +852,7 @@ class Downloader(Thread):
             # Reset connection for new activity
             nw.soft_reset()
             # Request a new article immediately if possible
-            if (
-                nw.connected
-                and server.active
-                and not (self.paused or self.shutdown or self.paused_for_postproc)
-            ):
+            if nw.connected and server.active and not (self.paused or self.shutdown or self.paused_for_postproc):
                 nw.article = server.get_article()
                 if nw.article:
                     self.__request_article(nw)

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -756,12 +756,9 @@ class Downloader(Thread):
                 continue
 
             if dl_threads > 1:
-                for i in range(0, len(read), dl_threads):
-                    for nw, bytes_received, done in dl_pool.map(
-                        self.__recv, read[i : min(len(read), i + dl_threads - 1)]
-                    ):
-                        if nw:
-                            self.__handle_recv_result(nw, bytes_received, done)
+                for nw, bytes_received, done in dl_pool.imap_unordered(self.__recv, read):
+                    if nw:
+                        self.__handle_recv_result(nw, bytes_received, done)
             else:
                 for selected in read:
                     nw, bytes_received, done = self.__recv(selected)


### PR DESCRIPTION
Inspired by the Reddit thread about SABnzbd being slow on Rpi 4, I tried calling recv_chunk using threadpool. I think it might help on Rpi 4 because it doesn't have hardware AES decoding so SSL downloading uses a lot of CPU. The current version is hard coded to 2 threads because it's just a test.

The changes needed are very small. The diff only looks big because I put the old code into two new methods to avoid duplication for the single and multithreaded variations. However, there is a lot of CPU overhead when using threadpool compared fixed threads and queues (like the decoder). Does anyone know if there are any tricks to reduce the overhead without big code changes? If so, I think it could be very helpful for some users.

One issue I did notice while testing it on an Rpi 3 was that the decoder was unable to keep up and it saved cached parts to disk. I'm not sure why, I assumed the downloader thread would start sleeping before this happened. Maybe the `decoder_cache_article_limit` should be reduced. It may also help to increase `num_simd_decoders` to let decoding get enough CPU time to keep up, but it wasn't enough to increase it to 4 in my Rpi 3 test.

@mnightingale: You talked about using threadpool in your testing, do you have any input?