### PR TITLE
Run assemble loop at most once per second for each file

### DIFF
--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -170,11 +170,6 @@ class Assembler(Thread):
         1) Partial write: write what we have
         2) Nothing written before: write all
         """
-        # Run at most once per second unless the file is finished.
-        if nzf.next_assemble_time > time.time() and not file_done:
-            return
-        nzf.next_assemble_time = time.time() + 1
-
         # We write large article-sized chunks, so we can safely skip the buffering of Python
         with open(nzf.filepath, "ab", buffering=0) as fout:
             for article in nzf.decodetable:

--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -23,6 +23,7 @@ import os
 import queue
 import logging
 import re
+import time
 from threading import Thread
 import ctypes
 from typing import Tuple, Optional, List
@@ -169,6 +170,10 @@ class Assembler(Thread):
         1) Partial write: write what we have
         2) Nothing written before: write all
         """
+        # Run at most once per second unless the file is finished.
+        if nzf.next_assemble_time > time.time() and not file_done:
+            return
+        nzf.next_assemble_time = time.time() + 1
 
         # We write large article-sized chunks, so we can safely skip the buffering of Python
         with open(nzf.filepath, "ab", buffering=0) as fout:

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -758,12 +758,14 @@ class NzbQueue:
         if file_done or (
             articles_left
             and (articles_left % DIRECT_WRITE_TRIGGER) == 0
+            and nzf.next_assemble_time < time.time()
             and not sabnzbd.Assembler.partial_nzf_in_queue(nzf)
         ):
             if not nzo.precheck:
                 # Only start decoding if we have a filename and type
                 # The type is only set if sabctools could decode the article
                 if nzf.filename and nzf.type:
+                    nzf.next_assemble_time = time.time() + 1
                     sabnzbd.Assembler.process(nzo, nzf, file_done)
                 elif nzf.filename.lower().endswith(".par2"):
                     # Broken par2 file, try to get another one

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -300,7 +300,7 @@ class NzbFile(TryList):
     """Representation of one file consisting of multiple articles"""
 
     # Pre-define attributes to save memory
-    __slots__ = NzbFileSaver
+    __slots__ = NzbFileSaver + ("next_assemble_time",)
 
     def __init__(self, date, subject, raw_article_db, file_bytes, nzo):
         """Setup object"""
@@ -333,6 +333,7 @@ class NzbFile(TryList):
         self.crc32: Optional[int] = 0
         self.assembled: bool = False
         self.md5of16k: Optional[bytes] = None
+        self.next_assemble_time: float = 0
 
         self.valid: bool = bool(raw_article_db)
 
@@ -460,6 +461,7 @@ class NzbFile(TryList):
                 # Handle new attributes
                 setattr(self, item, None)
         super().__setstate__(dict_.get("try_list", []))
+        setattr(self, "next_assemble_time", 0)
 
         # Convert 2.x.x jobs
         if isinstance(self.decodetable, dict):


### PR DESCRIPTION
As talked about previously. Not sure if maybe the limits should be changed a bit. LIMIT_DECODE_QUEUE = 100 seems very high because the decoding speed will generally be very smooth. MAX_ASSEMBLER_QUEUE is only 5, but the speed will vary a lot. Sometimes it will do nothing and sometimes it may have to write a full file before it returns and starts clearing the queue again.

I have added a variation that starts sleeping 0.01 second during decoding if one of the queues is half full in the threadpool PR. I'm hoping it will help the decoder and assembler to keep up with minimal impact on the download speed.