### PR TITLE
Improve dirscanner performance and reduce system calls

### DIFF
--- a/sabnzbd/dirscanner.py
+++ b/sabnzbd/dirscanner.py
@@ -235,7 +235,6 @@ class DirScanner(threading.Thread):
                 files.add(path)
 
                 if path in self.ignored or path in self.suspected:
-                    await asyncio.sleep(0)
                     continue
 
                 if stat_tuple.st_size > 0:

--- a/sabnzbd/dirscanner.py
+++ b/sabnzbd/dirscanner.py
@@ -179,6 +179,7 @@ class DirScanner(threading.Thread):
         except:
             if not self.error_reported and not catdir:
                 logging.error(T("Cannot read Watched Folder %s"), filesystem.clip_path(folder))
+                logging.info("Traceback: ", exc_info=True)
                 self.error_reported = True
 
     async def when_stable_add_nzbfile(self, path: str, catdir: Optional[str], stat_tuple: os.stat_result):

--- a/sabnzbd/dirscanner.py
+++ b/sabnzbd/dirscanner.py
@@ -176,7 +176,7 @@ class DirScanner(threading.Thread):
                             del self.suspected[path]
 
                     yield path, catdir, stat_tuple
-        except OSError:
+        except:
             if not self.error_reported and not catdir:
                 logging.error(T("Cannot read Watched Folder %s"), filesystem.clip_path(folder))
                 self.error_reported = True
@@ -254,10 +254,7 @@ class DirScanner(threading.Thread):
             if not (dirscan_dir := self.dirscan_dir):
                 break
 
-            try:
-                await self.scan_async(dirscan_dir)
-            except:
-                pass
+            await self.scan_async(dirscan_dir)
 
             await asyncio.sleep(dirscan_speed)
 

--- a/sabnzbd/dirscanner.py
+++ b/sabnzbd/dirscanner.py
@@ -235,6 +235,7 @@ class DirScanner(threading.Thread):
                 files.add(path)
 
                 if path in self.ignored or path in self.suspected:
+                    await asyncio.sleep(0)
                     continue
 
                 if stat_tuple.st_size > 0:

--- a/sabnzbd/dirscanner.py
+++ b/sabnzbd/dirscanner.py
@@ -269,7 +269,8 @@ class DirScanner(threading.Thread):
         tasks = filter(lambda task: task is not asyncio.current_task(), asyncio.all_tasks())
 
         # Cancel them all
-        [task.cancel() for task in tasks]
+        for task in tasks:
+            task.cancel()
 
         # Wait for the tasks to be done
         await asyncio.gather(*tasks, return_exceptions=True)

--- a/sabnzbd/dirscanner.py
+++ b/sabnzbd/dirscanner.py
@@ -122,7 +122,10 @@ class DirScanner(threading.Thread):
     def __listfiles(self, folder, catdir=None):
         """Generator listing possible paths to NZB files"""
 
-        cats = config.get_categories() if catdir is None else {}
+        if catdir is None:
+            cats = config.get_categories()
+        else:
+            cats = {}
 
         try:
             with os.scandir(os.path.join(folder, catdir or "")) as it:
@@ -149,7 +152,10 @@ class DirScanner(threading.Thread):
                             # https://docs.python.org/3/library/os.html#os.DirEntry.stat
                             # On Windows, the st_ino, st_dev and st_nlink attributes of the stat_result are always set
                             # to zero. Call os.stat() to get these attributes.
-                            stat_tuple = os.stat(path) if sabnzbd.WIN32 else entry.stat()
+                            if sabnzbd.WIN32:
+                                stat_tuple = os.stat(path)
+                            else:
+                                stat_tuple = entry.stat()
                         except OSError:
                             continue
                     else:

--- a/sabnzbd/dirscanner.py
+++ b/sabnzbd/dirscanner.py
@@ -121,7 +121,7 @@ class DirScanner(threading.Thread):
 
     def get_suspected_files(
         self, folder: str, catdir: Optional[str] = None
-    ) -> Generator[Tuple[str, Optional[str], os.stat_result], None, None]:
+    ) -> Generator[Tuple[str, Optional[str], Optional[os.stat_result]], None, None]:
         """Generator listing possible paths to NZB files"""
 
         if catdir is None:

--- a/sabnzbd/dirscanner.py
+++ b/sabnzbd/dirscanner.py
@@ -145,8 +145,7 @@ class DirScanner(threading.Thread):
                     # If the entry is a catdir then recursion
                     if entry.is_dir():
                         if not catdir and entry.name.lower() in cats:
-                            for result in self.__listfiles(folder, entry.name):
-                                yield result
+                            yield from self.get_suspected_files(folder, entry.name)
                         continue
 
                     if filesystem.get_ext(path) in VALID_EXTENSIONS:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -14,3 +14,4 @@ tavalidate
 importlib_metadata
 lxml
 black
+pytest-mock

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -15,3 +15,4 @@ importlib_metadata
 lxml
 black
 pytest-mock
+pytest-asyncio

--- a/tests/test_dirscanner.py
+++ b/tests/test_dirscanner.py
@@ -1,0 +1,129 @@
+#!/usr/bin/python3 -OO
+# Copyright 2007-2023 The SABnzbd-Team <team@sabnzbd.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+tests.test_dirscanner - Testing functions in dirscanner.py
+"""
+import threading
+import time
+
+import pyfakefs.fake_filesystem_unittest as ffs
+from pyfakefs.fake_filesystem import OSType
+
+from tests.testhelper import *
+
+# Set the global uid for fake filesystems to a non-root user;
+# by default this depends on the user running pytest.
+global_uid = 1000
+ffs.set_uid(global_uid)
+
+
+class WrappedDirScanner(sabnzbd.dirscanner.DirScanner):
+    def __init__(self):
+        self.finished_startup_scan = threading.Event()
+
+        super().__init__()
+
+    def scan(self):
+        super().scan()
+
+        self.finished_startup_scan.set()
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, *args):
+        self.stop()
+        self.join()
+
+
+@pytest.fixture
+def dirscanner():
+    scanner = WrappedDirScanner()
+    with scanner:
+        yield scanner
+
+
+def wait_for(condition, timeout: float = 30):
+    timeout = time.time() + timeout
+    while time.time() < timeout:
+        if condition():
+            break
+        time.sleep(0.01)
+
+
+class TestDirScanner:
+    @set_config({"dirscan_dir": os.path.join(SAB_CACHE_DIR, "watched")})
+    def test_adds_valid_nzbs_on_startup(self, fs, mocker, dirscanner):
+        mocker.patch("sabnzbd.nzbparser.add_nzbfile", return_value=(-1, []))
+        mocker.patch("sabnzbd.config.save_config", return_value=True)
+
+        filenames = [
+            "file.zip",
+            "file.rar",
+            "file.7z",
+            "file.nzb",
+            "file.gz",
+            "file.bz2",
+        ]
+
+        for filename in filenames:
+            fs.create_file(os.path.join(sabnzbd.cfg.dirscan_dir.get_path(), filename), contents="FAKEFILE")
+
+        # This could be in __enter__ instead
+        dirscanner.start()
+
+        wait_for(lambda: sabnzbd.nzbparser.add_nzbfile.call_count == len(filenames))
+
+        for filename in filenames:
+            sabnzbd.nzbparser.add_nzbfile.assert_any_call(
+                os.path.join(sabnzbd.cfg.dirscan_dir.get_path(), filename), catdir=None, keep=False
+            )
+
+    @set_config({"dirscan_dir": os.path.join(SAB_CACHE_DIR, "watched")})
+    def test_detects_nzbs(self, fs, mocker, dirscanner):
+        mocker.patch("sabnzbd.nzbparser.add_nzbfile", return_value=(-1, []))
+        mocker.patch("sabnzbd.config.save_config", return_value=True)
+
+        dirscanner.start()
+
+        dirscanner.finished_startup_scan.wait()
+
+        fs.create_file(os.path.join(sabnzbd.cfg.dirscan_dir.get_path(), "file.nzb"), contents="FAKEFILE")
+
+        wait_for(lambda: sabnzbd.nzbparser.add_nzbfile.called)
+
+        sabnzbd.nzbparser.add_nzbfile.assert_called_once_with(
+            os.path.join(sabnzbd.cfg.dirscan_dir.get_path(), "file.nzb"), catdir=None, keep=False
+        )
+
+    @set_config({"dirscan_dir": os.path.join(SAB_CACHE_DIR, "watched")})
+    def test_detects_catdir_nzbs(self, fs, mocker, dirscanner):
+        mocker.patch("sabnzbd.nzbparser.add_nzbfile", return_value=(-1, []))
+        mocker.patch("sabnzbd.config.save_config", return_value=True)
+
+        dirscanner.start()
+
+        dirscanner.finished_startup_scan.wait()
+
+        fs.create_file(os.path.join(sabnzbd.cfg.dirscan_dir.get_path(), "movies", "file.nzb"), contents="FAKEFILE")
+
+        wait_for(lambda: sabnzbd.nzbparser.add_nzbfile.called)
+
+        sabnzbd.nzbparser.add_nzbfile.assert_called_once_with(
+            os.path.join(sabnzbd.cfg.dirscan_dir.get_path(), "movies", "file.nzb"), catdir="movies", keep=False
+        )

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -35,6 +35,7 @@ from string import ascii_lowercase, digits
 from unittest import mock
 from urllib3.exceptions import ProtocolError
 import xmltodict
+from functools import wraps
 
 import sabnzbd
 import sabnzbd.cfg as cfg
@@ -71,6 +72,7 @@ def set_config(settings_dict):
     """Change config-values on the fly, per test"""
 
     def set_config_decorator(func):
+        @wraps(func)
         def wrapper_func(*args, **kwargs):
             # Setting up as requested
             for item, val in settings_dict.items():

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -35,7 +35,7 @@ from string import ascii_lowercase, digits
 from unittest import mock
 from urllib3.exceptions import ProtocolError
 import xmltodict
-from functools import wraps
+import functools
 
 import sabnzbd
 import sabnzbd.cfg as cfg
@@ -72,7 +72,7 @@ def set_config(settings_dict):
     """Change config-values on the fly, per test"""
 
     def set_config_decorator(func):
-        @wraps(func)
+        @functools.wraps(func)
         def wrapper_func(*args, **kwargs):
             # Setting up as requested
             for item, val in settings_dict.items():


### PR DESCRIPTION
This is related to the discussion on #2425 where it was identified that even if filesystem events could be used there is probably still a requirement for some users to use polling such as if their watched directory is on a remote network share.
Additionally a poll/scan would still be required on startup or whenever the directory changes.

Therefore to start off with I've looked at optimising the over 13 year old code to take advantage of some Python 3 features, reduce system calls and improve import speed.

Changes include:
- Added a few tests 🥳
  - This required a minor change to testhelper so I could inject pytest fixtures when using the set_config decorator
  - I'm not sure what you'll make of how I setup the tests, I wanted to black box test it because its internals will change a bit once I add events, so I have a bit of an odd thread wrapper so I can test files already being in the watched folder at start and those added after the startup scan cycle.
  - I've mocked a few things because I just wanted to know if add_nzbfile was being called correctly, some were necessary mocks because I'm not loading all of SAB.
- On to the fun stuff, I've replaced `os.listdir` with `os.scandir`, this won't have existed 13 years ago but it has a few advantages; it uses an iterator of `os.DirEntry` so reduced memory usage and populates `is_dir` and `is_file` usually without an additional system call. Windows doesn't populate `st_ino` in `entry.stat()` so it has to use `os.stat`.
- Since it's an iterator this change is what makes the majority of the other logic changes necessary and why I've split the code into a couple of functions and use recursion for the `catdirs` - fewer system calls.
- Previously for each possible path the code would sleep for at least one second before calling `os.stat` and comparing to the previous result, this is to ensure that we don't try and add files that are changing such as those still downloading or copying. This has the consequence that a watched directory with 60 items takes a minimum of 60 seconds to import! 
  - Therefore I've stuck a ThreadPoolExecutor in there so we can sleep for several of them at once, I've left it as the default max_workers (cpu_count + 4) which I think is probably fine, if anything it could probably be larger since the method basically just sleeps for up to 3 seconds - maybe asyncio would be better fit but I'm not familiar with it or how to use it in an existing non asyncio app
  - I've also used `loop_condition` with a wait of 1 second instead of `time.sleep` so it can return quicker on shutdown
- Minor change to `clean_file_list` to be more efficient using the sets difference method
- I wasn't sure why there are nested functions, I added a couple of new ones but didn't nest them and prefixed with `__` - not sure if there is a different style which would be preferred
