### PR TITLE
Let the assembler write trigger scale with the size of the cache

### DIFF
--- a/sabnzbd/articlecache.py
+++ b/sabnzbd/articlecache.py
@@ -26,7 +26,7 @@ from typing import Dict, List
 
 import sabnzbd
 from sabnzbd.decorators import synchronized
-from sabnzbd.constants import GIGI, ANFO, MEBI, LIMIT_DECODE_QUEUE, MIN_DECODE_QUEUE
+from sabnzbd.constants import GIGI, ANFO, MEBI, LIMIT_DECODE_QUEUE, MIN_DECODE_QUEUE, ASSEMBLER_WRITE_THRESHOLD
 from sabnzbd.nzbstuff import Article
 
 # Operations on the article table are handled via try/except.
@@ -44,6 +44,8 @@ class ArticleCache:
         # Limit for the decoder is based on the total available cache
         # so it can be larger on memory-rich systems
         self.decoder_cache_article_limit = 0
+
+        self.assembler_write_trigger: int = 1
 
         # On 32 bit we only allow the user to set 1GB
         # For 64 bit we allow up to 4GB, in case somebody wants that
@@ -67,6 +69,10 @@ class ArticleCache:
         decoder_cache_limit = int(min(self.__cache_limit / 3 / MEBI, LIMIT_DECODE_QUEUE))
         # The cache should also not be too small
         self.decoder_cache_article_limit = max(decoder_cache_limit, MIN_DECODE_QUEUE)
+
+        # Set assembler_write_trigger to be the equivalent of ASSEMBLER_WRITE_THRESHOLD %
+        # of the total cache, assuming an article size of 750 000 bytes
+        self.assembler_write_trigger = int(self.__cache_limit * ASSEMBLER_WRITE_THRESHOLD / 100 / 750_000) + 1
 
     @synchronized(ARTICLE_COUNTER_LOCK)
     def reserve_space(self, data_size: int):

--- a/sabnzbd/constants.py
+++ b/sabnzbd/constants.py
@@ -88,8 +88,9 @@ MAX_BAD_ARTICLES = 5
 # Constants affecting download performance
 MIN_DECODE_QUEUE = 10
 LIMIT_DECODE_QUEUE = 100
-DIRECT_WRITE_TRIGGER = 35
 MAX_ASSEMBLER_QUEUE = 5
+# Percentage of cache to use before adding file to assembler
+ASSEMBLER_WRITE_THRESHOLD = 5
 NNTP_BUFFER_SIZE = int(800 * KIBI)
 
 REPAIR_PRIORITY = 3

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -47,7 +47,6 @@ from sabnzbd.constants import (
     VERIFIED_FILE,
     Status,
     IGNORED_FILES_AND_FOLDERS,
-    DIRECT_WRITE_TRIGGER,
 )
 
 import sabnzbd.cfg as cfg
@@ -757,7 +756,7 @@ class NzbQueue:
         # Skip if the file is already queued, since all available articles will then be written
         if file_done or (
             articles_left
-            and (articles_left % DIRECT_WRITE_TRIGGER) == 0
+            and (articles_left % sabnzbd.ArticleCache.assembler_write_trigger) == 0
             and not sabnzbd.Assembler.partial_nzf_in_queue(nzf)
         ):
             if not nzo.precheck:


### PR DESCRIPTION
The +1 is not a hack to avoid division by zero. Setting it to 1 results in no caching (every article is added), 2 will cache one article before writing and so on.