### PR TITLE
Don't crash on invalid yenc footer

### DIFF
--- a/sabnzbd/decoder.py
+++ b/sabnzbd/decoder.py
@@ -205,7 +205,6 @@ class DecoderWorker(Thread):
                         # and examine the headers (for precheck) or body (for download).
                         for line in raw_data[:2000].split(b"\r\n"):
                             lline = line.lower()
-                            logging.debug("Line %s", lline)
                             if lline.startswith(b"message-id:"):
                                 article_success = True
                             # Look for DMCA clues (while skipping "X-" headers)

--- a/sabnzbd/decoder.py
+++ b/sabnzbd/decoder.py
@@ -203,17 +203,20 @@ class DecoderWorker(Thread):
                     if not article_success:
                         # Convert the initial chunks of raw socket data to article lines,
                         # and examine the headers (for precheck) or body (for download).
-                        for line in b"".join(raw_data[:2]).split(b"\r\n"):
-                            lline = line.lower()
-                            if lline.startswith(b"message-id:"):
-                                article_success = True
-                            # Look for DMCA clues (while skipping "X-" headers)
-                            if not lline.startswith(b"x-") and match_str(
-                                lline, (b"dmca", b"removed", b"cancel", b"blocked")
-                            ):
-                                article_success = False
-                                logging.info("Article removed from server (%s)", art_id)
-                                break
+                        try:
+                            for line in b"".join(raw_data[:2]).split(b"\r\n"):
+                                lline = line.lower()
+                                if lline.startswith(b"message-id:"):
+                                    article_success = True
+                                # Look for DMCA clues (while skipping "X-" headers)
+                                if not lline.startswith(b"x-") and match_str(
+                                    lline, (b"dmca", b"removed", b"cancel", b"blocked")
+                                ):
+                                    article_success = False
+                                    logging.info("Article removed from server (%s)", art_id)
+                                    break
+                        except TypeError:
+                            article_success = False
 
                 # Pre-check, proper article found so just register
                 if nzo.precheck and article_success and sabnzbd.LOG_ALL:


### PR DESCRIPTION
Fixes #2427. Aren't anyone else experiencing this with the dev branch? I've woken up to a crashed SABnzbd 3 times already. I would prefer if it was fixed by making the decoder decode what it has but either way it shouldn't crash here if the data unexpected.