### PR TITLE
Write first article directly

### DIFF
--- a/sabnzbd/articlecache.py
+++ b/sabnzbd/articlecache.py
@@ -92,15 +92,11 @@ class ArticleCache:
         # Register article for bookkeeping in case the job is deleted
         nzo.add_saved_article(article)
 
-        if article.lowest_partnum and not article.nzf.import_finished:
-            # If the filename is verified and there is room left then the first part
-            # will be saved to the correct file immediately, so it's kept in cache.
-            # Otherwise it will be saved temporarily to save cache space.
-            if article.nzf.filename_checked and self.space_left():
-                self.reserve_space(len(data))
-                self.__article_table[article] = data
-            else:
-                self.__flush_article_to_disk(article, data)
+        if article.lowest_partnum and not (article.nzf.import_finished or article.nzf.filename_checked):
+            # Write the first-fetched articles to temporary file unless downloading
+            # of the rest of the parts has started or filename is verified.
+            # Otherwise the cache could overflow.
+            self.__flush_article_to_disk(article, data)
             return
 
         if self.__cache_limit:

--- a/sabnzbd/articlecache.py
+++ b/sabnzbd/articlecache.py
@@ -98,7 +98,6 @@ class ArticleCache:
             if article.nzf.filename_checked and self.space_left():
                 self.reserve_space(len(data))
                 self.__article_table[article] = data
-                sabnzbd.Assembler.process(nzo, article.nzf, False)
             else:
                 self.__flush_article_to_disk(article, data)
             return

--- a/sabnzbd/articlecache.py
+++ b/sabnzbd/articlecache.py
@@ -93,8 +93,9 @@ class ArticleCache:
         nzo.add_saved_article(article)
 
         if article.lowest_partnum and not article.nzf.import_finished:
-            # Write the first-fetched articles to disk
-            # Otherwise the cache could overflow
+            # If the filename is verified and there is room left then the first part
+            # will be saved to the correct file immediately, so it's kept in cache.
+            # Otherwise it will be saved temporarily to save cache space.
             if article.nzf.filename_checked and self.space_left():
                 self.reserve_space(len(data))
                 self.__article_table[article] = data

--- a/sabnzbd/articlecache.py
+++ b/sabnzbd/articlecache.py
@@ -95,7 +95,12 @@ class ArticleCache:
         if article.lowest_partnum and not article.nzf.import_finished:
             # Write the first-fetched articles to disk
             # Otherwise the cache could overflow
-            self.__flush_article_to_disk(article, data)
+            if article.nzf.filename_checked and self.space_left():
+                self.reserve_space(len(data))
+                self.__article_table[article] = data
+                sabnzbd.Assembler.process(nzo, article.nzf, False)
+            else:
+                self.__flush_article_to_disk(article, data)
             return
 
         if self.__cache_limit:

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -757,7 +757,7 @@ class NzbQueue:
         # Skip if the file is already queued, since all available articles will then be written
         if (
             file_done
-            or (article.lowest_partnum and article.nzf.filename_checked)
+            or (article.lowest_partnum and nzf.filename_checked)
             or (
                 articles_left
                 and (articles_left % DIRECT_WRITE_TRIGGER) == 0

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -755,10 +755,14 @@ class NzbQueue:
 
         # Write data if file is done or at trigger time
         # Skip if the file is already queued, since all available articles will then be written
-        if file_done or (
-            articles_left
-            and (articles_left % DIRECT_WRITE_TRIGGER) == 0
-            and not sabnzbd.Assembler.partial_nzf_in_queue(nzf)
+        if (
+            file_done
+            or (article.lowest_partnum and article.nzf.filename_checked)
+            or (
+                articles_left
+                and (articles_left % DIRECT_WRITE_TRIGGER) == 0
+                and not sabnzbd.Assembler.partial_nzf_in_queue(nzf)
+            )
         ):
             if not nzo.precheck:
                 # Only start decoding if we have a filename and type

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -757,7 +757,7 @@ class NzbQueue:
         # Skip if the file is already queued, since all available articles will then be written
         if (
             file_done
-            or (article.lowest_partnum and nzf.filename_checked and not article.nzf.import_finished)
+            or (article.lowest_partnum and nzf.filename_checked and not nzf.import_finished)
             or (
                 articles_left
                 and (articles_left % DIRECT_WRITE_TRIGGER) == 0

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -757,7 +757,7 @@ class NzbQueue:
         # Skip if the file is already queued, since all available articles will then be written
         if (
             file_done
-            or (article.lowest_partnum and nzf.filename_checked)
+            or (article.lowest_partnum and nzf.filename_checked and not article.nzf.import_finished)
             or (
                 articles_left
                 and (articles_left % DIRECT_WRITE_TRIGGER) == 0


### PR DESCRIPTION
Yet another mini optimization. Write the first article directly to the correct file instead of temporary file if the correct filename is available. I didn't try to reserve space before checking free because it's just one article and it will usually be saved quickly. It saves a write and a read so if the cache is full then this will most likely help clear it faster because of reduced disk trashing.