### PR TITLE
Replace article_queue list with a deque

### DIFF
--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -23,7 +23,8 @@ import os
 import logging
 import time
 import cherrypy._cpreqbody
-from typing import List, Dict, Union, Tuple, Optional
+import collections
+from typing import List, Dict, Union, Tuple, Optional, Deque
 
 import sabnzbd
 from sabnzbd.nzbstuff import NzbObject, Article
@@ -711,7 +712,7 @@ class NzbQueue:
                 return False
         return False
 
-    def get_articles(self, server: Server, servers: List[Server], fetch_limit: int) -> List[Article]:
+    def get_articles(self, server: Server, servers: List[Server], fetch_limit: int) -> Deque[Article]:
         """Get next article for jobs in the queue
         Not locked for performance, since it only reads the queue
         """
@@ -732,8 +733,8 @@ class NzbQueue:
                             return articles
                     # Stop after first job that wasn't paused/propagating/etc
                     if self.__top_only:
-                        return []
-        return []
+                        return collections.deque()
+        return collections.deque()
 
     def register_article(self, article: Article, success: bool = True):
         """Register the articles we tried

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -18,6 +18,7 @@
 """
 sabnzbd.nzbstuff - misc
 """
+
 import os
 import time
 import re
@@ -26,7 +27,8 @@ import datetime
 import threading
 import functools
 import difflib
-from typing import List, Dict, Any, Tuple, Optional, Union, BinaryIO
+import collections
+from typing import List, Dict, Any, Tuple, Optional, Union, BinaryIO, Deque
 
 # SABnzbd modules
 import sabnzbd
@@ -403,9 +405,9 @@ class NzbFile(TryList):
         else:
             self.crc32 = sabctools.crc32_combine(self.crc32, crc32, length)
 
-    def get_articles(self, server: Server, servers: List[Server], fetch_limit: int) -> List[Article]:
+    def get_articles(self, server: Server, servers: List[Server], fetch_limit: int) -> Deque[Article]:
         """Get next articles to be downloaded"""
-        articles = []
+        articles = collections.deque()
         for article in self.articles:
             article = article.get_article(server, servers)
             if article:
@@ -1596,8 +1598,8 @@ class NzbObject(TryList):
         self.nzo_info[bad_article_type] += 1
         self.bad_articles += 1
 
-    def get_articles(self, server: Server, servers: List[Server], fetch_limit: int) -> List[Article]:
-        articles = []
+    def get_articles(self, server: Server, servers: List[Server], fetch_limit: int) -> Deque[Article]:
+        articles = collections.deque()
         nzf_remove_list = []
 
         # Did we go through all first-articles?


### PR DESCRIPTION
# Why

Almost all operations on the article_queue which is a list are `pop(0)` and the one that isn't probably should be.

Popping the first item on a list has complexity O(n) - it has to shift every following item along.

It's a pretty minor issue but its a lot more CPU operations than are necessary.

# How

Replaced with `collections.deque` which is O(1) at either end and still O(1) to append.

https://wiki.python.org/moin/TimeComplexity

# Extra

I wanted to keep this PR simple, but what do we think about reusing the same deque?

This PR currently leaves it as `self.article_queue = collections.deque()`

So `reset_article_queue` could do:

```py
def reset_article_queue(self):
    logging.debug("Resetting article queue for %s", self)
    while self.article_queue:
        article = self.article_queue.popleft()
        sabnzbd.NzbQueue.reset_try_lists(article, remove_fetcher_from_trylist=False)
```

Or to stay like it is currently:

```py
def reset_article_queue(self):
    logging.debug("Resetting article queue for %s", self)
    for article in self.article_queue:
        sabnzbd.NzbQueue.reset_try_lists(article, remove_fetcher_from_trylist=False)
    self.article_queue.clear()
```

`sabnzbd.NzbQueue.get_articles` could be a generator which we loop over to append to the existing deque.

# Future

I could do with seeing if similar happens anywhere else that is worth changing, `NzbFile.articles` seems a possible candidate, `remove_article` does an x in s O(n) but it'll be near the beginning so not too bad, then it does the actual remove which is O(n) and near worst case since it'll be near the beginning. 
Perhaps a dict would be more appropriate for the types of calls it's used for.