### PR TITLE
Reduce useless debug logging

### DIFF
--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -716,14 +716,15 @@ class Downloader(Thread):
                         logging.debug("Slept %.5f seconds, sleep_time = %s", now - time_before, self.sleep_time)
                     time_slept += now - time_before
                     sleep_count += 1
-                    if sleep_count_start + 10 < now:
-                        logging.debug(
-                            "Slept %d times for an average of %.5f seconds the last %.2f seconds. sleep_time = %s",
-                            sleep_count,
-                            time_slept / sleep_count,
-                            now - sleep_count_start,
-                            self.sleep_time,
-                        )
+                    if sleep_count_start + 20 < now:
+                        if sleep_count > 21:
+                            logging.debug(
+                                "Slept %d times for an average of %.5f seconds the last %.2f seconds. sleep_time = %s",
+                                sleep_count,
+                                time_slept / sleep_count,
+                                now - sleep_count_start,
+                                self.sleep_time,
+                            )
                         sleep_count_start = now
                         sleep_count = 0
                         time_slept = 0

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -584,7 +584,8 @@ class NzbQueue:
             logging.info("Sorting by average date... (reversed: %s)", reverse)
             sort_function = lambda nzo: nzo.avg_date
         elif field == "remaining":
-            logging.debug("Sorting by percentage downloaded...")
+            if self.__nzo_list:
+                logging.debug("Sorting by percentage downloaded...")
             sort_function = lambda nzo: nzo.remaining / nzo.bytes if nzo.bytes else 1
         else:
             logging.debug("Sort: %s not recognized", field)


### PR DESCRIPTION
Now that I've run it for a while I realize that the logging is a bit excessive. Particularly when there is nothing in the queue.