### PR TITLE
include https config files in backup

### DIFF
--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -77,6 +77,7 @@ from sabnzbd.constants import (
     DEF_LOG_FILE,
     DEF_STD_CONFIG,
     DEF_LOG_CHERRY,
+    CONFIG_BACKUP_HTTPS,
 )
 import sabnzbd.newsunpack
 from sabnzbd.misc import (
@@ -1445,6 +1446,12 @@ def main():
         # start-up errors. This try/except only catches very few errors, the rest is only shown in the console.
         logging.error(T("Failed to start web-interface: "), exc_info=True)
         abort_and_show_error(browserhost, cherryport)
+
+    # Create a record of the active cert/key/chain files, for use with config.create_config_backup()
+    if enable_https:
+        for setting in CONFIG_BACKUP_HTTPS.values():
+            if full_path := getattr(sabnzbd.cfg, setting).get_path():
+                sabnzbd.CONFIG_BACKUP_HTTPS_OK.append(full_path)
 
     if sabnzbd.WIN32:
         if enable_https:

--- a/interfaces/Config/templates/config_general.tmpl
+++ b/interfaces/Config/templates/config_general.tmpl
@@ -375,7 +375,7 @@
     })
 
     // Only allow re-generate if default certs
-    if(\$('#https_cert').val() != 'server.cert') {
+    if(\$('#https_cert').val() != '$def_https_cert_file') {
         \$('.generate_cert').attr('disabled', 'disabled')
     }
 

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -190,6 +190,9 @@ DOWNLOAD_DIR_SPEED = 0
 COMPLETE_DIR_SPEED = 0
 INTERNET_BANDWIDTH = 0
 
+# Record of HTTPS config files at startup
+CONFIG_BACKUP_HTTPS_OK = []
+
 # Rendering of original command line arguments in Config
 CMDLINE = " ".join(['"%s"' % arg for arg in sys.argv])
 

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -47,6 +47,8 @@ from sabnzbd.constants import (
     DEF_COMPLETE_DIR,
     DEF_FOLDER_MAX,
     DEF_STD_WEB_COLOR,
+    DEF_HTTPS_CERT_FILE,
+    DEF_HTTPS_KEY_FILE,
 )
 
 
@@ -279,8 +281,8 @@ bandwidth_max = OptionStr("misc", "bandwidth_max")
 cache_limit = OptionStr("misc", "cache_limit")
 web_dir = OptionStr("misc", "web_dir", DEF_STD_WEB_DIR)
 web_color = OptionStr("misc", "web_color", DEF_STD_WEB_COLOR)
-https_cert = OptionDir("misc", "https_cert", "server.cert", create=False)
-https_key = OptionDir("misc", "https_key", "server.key", create=False)
+https_cert = OptionDir("misc", "https_cert", DEF_HTTPS_CERT_FILE, create=False)
+https_key = OptionDir("misc", "https_key", DEF_HTTPS_KEY_FILE, create=False)
 https_chain = OptionDir("misc", "https_chain", create=False)
 enable_https = OptionBool("misc", "enable_https", False)
 # 0=local-only, 1=nzb, 2=api, 3=full_api, 4=webui, 5=webui with login for external

--- a/sabnzbd/constants.py
+++ b/sabnzbd/constants.py
@@ -59,6 +59,11 @@ CONFIG_BACKUP_FILES = [
     RSS_FILE_NAME,
     DB_HISTORY_NAME,
 ]
+CONFIG_BACKUP_HTTPS = {  # "basename": "associated setting"
+    "server.cert": "https_cert",
+    "server.key": "https_key",
+    "server.chain": "https_chain",
+}
 
 DEF_DOWNLOAD_DIR = os.path.normpath("Downloads/incomplete")
 DEF_COMPLETE_DIR = os.path.normpath("Downloads/complete")

--- a/sabnzbd/constants.py
+++ b/sabnzbd/constants.py
@@ -54,17 +54,6 @@ SABCTOOLS_VERSION_REQUIRED = "6.0.0"
 DB_HISTORY_VERSION = 1
 DB_HISTORY_NAME = "history%s.db" % DB_HISTORY_VERSION
 
-CONFIG_BACKUP_FILES = [
-    BYTES_FILE_NAME,
-    RSS_FILE_NAME,
-    DB_HISTORY_NAME,
-]
-CONFIG_BACKUP_HTTPS = {  # "basename": "associated setting"
-    "server.cert": "https_cert",
-    "server.key": "https_key",
-    "server.chain": "https_chain",
-}
-
 DEF_DOWNLOAD_DIR = os.path.normpath("Downloads/incomplete")
 DEF_COMPLETE_DIR = os.path.normpath("Downloads/complete")
 DEF_ADMIN_DIR = "admin"
@@ -87,8 +76,21 @@ DEF_ARTICLE_CACHE_DEFAULT = "500M"
 DEF_ARTICLE_CACHE_MAX = "1G"
 DEF_TIMEOUT = 60
 DEF_SCANRATE = 5
+DEF_HTTPS_CERT_FILE = "server.cert"
+DEF_HTTPS_KEY_FILE = "server.key"
 MAX_WARNINGS = 20
 MAX_BAD_ARTICLES = 5
+
+CONFIG_BACKUP_FILES = [
+    BYTES_FILE_NAME,
+    RSS_FILE_NAME,
+    DB_HISTORY_NAME,
+]
+CONFIG_BACKUP_HTTPS = {  # "basename": "associated setting"
+    DEF_HTTPS_CERT_FILE: "https_cert",
+    DEF_HTTPS_KEY_FILE: "https_key",
+    "server.chain": "https_chain",
+}
 
 # Constants affecting download performance
 MIN_DECODE_QUEUE = 10

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -70,7 +70,13 @@ import sabnzbd.newsunpack
 from sabnzbd.utils.servertests import test_nntp_server_dict
 from sabnzbd.utils.getperformance import getcpu
 import sabnzbd.utils.ssdp
-from sabnzbd.constants import DEF_STD_CONFIG, DEFAULT_PRIORITY, CHEETAH_DIRECTIVES, EXCLUDED_GUESSIT_PROPERTIES
+from sabnzbd.constants import (
+    DEF_STD_CONFIG,
+    DEFAULT_PRIORITY,
+    CHEETAH_DIRECTIVES,
+    EXCLUDED_GUESSIT_PROPERTIES,
+    DEF_HTTPS_CERT_FILE,
+)
 from sabnzbd.lang import list_languages
 from sabnzbd.api import (
     list_scripts,
@@ -979,6 +985,7 @@ class ConfigGeneral:
 
         conf["language"] = cfg.language()
         conf["lang_list"] = list_languages()
+        conf["def_https_cert_file"] = DEF_HTTPS_CERT_FILE
 
         for kw in GENERAL_LIST:
             conf[kw] = config.get_config("misc", kw)()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -185,8 +185,8 @@ class TestConfig:
         assert os.path.exists(key_file)
 
         # Copy cert and key to create a second set of https config files outside the admin dir
-        other_cert_file = os.path.join(SAB_CACHE_DIR, "foobar.ใบรับรอง")
-        other_key_file = os.path.join(SAB_CACHE_DIR, "foobar.สำคัญ")
+        other_cert_file = os.path.join(SAB_CACHE_DIR, "foobar.mycert")
+        other_key_file = os.path.join(SAB_CACHE_DIR, "foobar.mykey")
         shutil.copyfile(cert_file, other_key_file)
         shutil.copyfile(key_file, other_cert_file)
         assert os.path.exists(other_cert_file)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,11 +22,21 @@ from tests.testhelper import *
 import shutil
 import zipfile
 import os
+from typing import List
 
 import sabnzbd.cfg
-from sabnzbd.constants import DEF_INI_FILE
+from sabnzbd.constants import (
+    DEF_INI_FILE,
+    DEF_HTTPS_CERT_FILE,
+    DEF_HTTPS_KEY_FILE,
+    CONFIG_BACKUP_HTTPS,
+    CONFIG_BACKUP_FILES,
+)
 from sabnzbd import config
 from sabnzbd import filesystem
+
+
+DEF_CHAIN_FILE = "server.chain"
 
 
 @pytest.mark.usefixtures("clean_cache_dir")
@@ -38,34 +48,213 @@ class TestConfig:
                 zip_ref.writestr(filename, "foobar")
             return zip_buffer.getvalue()
 
-    @set_config({"admin_dir": os.path.join(SAB_CACHE_DIR, "test_config"), "complete_dir": SAB_COMPLETE_DIR})
-    def test_config(self):
-        full_ini_path = os.path.join(sabnzbd.cfg.admin_dir.get_path(), DEF_INI_FILE)
-        shutil.copyfile(os.path.join(SAB_DATA_DIR, "sabnzbd.basic.ini"), full_ini_path)
-        assert os.path.exists(full_ini_path)
-        config.read_config(full_ini_path)
-
-        # Make sure the Complete folder exists
-        filesystem.create_all_dirs(sabnzbd.cfg.complete_dir())
-
-        # Check actual backup data
+    @staticmethod
+    def create_and_verify_backup(admin_dir: str, must_haves: List[str]):
+        # Create the backup
         config_backup_path = config.create_config_backup()
         assert os.path.exists(config_backup_path)
         assert sabnzbd.__version__ in config_backup_path
         assert time.strftime("%Y.%m.%d_%H") in config_backup_path
 
+        # Verify the zipfile has the expected content
+        with open(config_backup_path, "rb") as fp:
+            # Do basic backup validation
+            assert config.validate_config_backup(fp.read())
+            # Reset the file pointer
+            fp.seek(0)
+            with zipfile.ZipFile(fp, "r") as zip:
+                for basename in must_haves:
+                    assert zip.getinfo(basename)
+                # Make sure there's nothing else in the zip
+                assert (zip_len := len(zip.filelist)) == len(must_haves)
+
+        # Move the current admin dir out of the way
+        stowed_admin = os.path.join(SAB_CACHE_DIR, "stowed_admin")
+        if os.path.isdir(stowed_admin):
+            filesystem.remove_all(stowed_admin)
+            assert not os.path.exists(stowed_admin)
+        os.rename(admin_dir, stowed_admin)
+        assert os.path.exists(stowed_admin)
+        assert filesystem.globber(stowed_admin) != []
+        assert not os.path.exists(admin_dir)
+        filesystem.create_all_dirs(admin_dir)
+        assert os.path.exists(admin_dir)
+        assert filesystem.globber(admin_dir) == []
+
+        # Store current test settings, as these may change when restoring a backup
+        restore_me = {setting: getattr(sabnzbd.cfg, setting)() for setting in CONFIG_BACKUP_HTTPS.values()}
+
+        # Restore the backup
         with open(config_backup_path, "rb") as config_backup_fp:
-            config_backup_data = config_backup_fp.read()
+            config.restore_config_backup(config_backup_fp.read())
 
-        assert config.validate_config_backup(config_backup_data)
+        # Check settings results
+        restore_changed_settings = False
+        for filename, setting in CONFIG_BACKUP_HTTPS.items():
+            if filename in must_haves:
+                restore_changed_settings = True
+                value = getattr(sabnzbd.cfg, setting)()
+                if setting != "https_chain":
+                    # All https settings should point to the default basenames of the restored files...
+                    assert value == getattr(sabnzbd.cfg, setting).default
+                else:
+                    # ...except the one that doesn't have a default and uses a hardcoded filename instead
+                    assert value == DEF_CHAIN_FILE
+        # Check filename results
+        for basename in must_haves:
+            # Verify all files in the backup were restored into the admin dir...
+            assert os.path.exists(os.path.join(admin_dir, basename))
+            # ...and nothing else
+            if not restore_changed_settings:
+                assert zip_len == len(filesystem.globber(admin_dir))
+            else:
+                # Account for sabnzbd.ini.bak in case settings were changed as part of the restore
+                assert zip_len + 1 == len(filesystem.globber(admin_dir))
 
-        # Validate basic dummy data
+        # Restore the test settings
+        for setting, value in restore_me.items():
+            getattr(sabnzbd.cfg, setting).set(value)
+        sabnzbd.config.save_config(True)
+
+        # Purge the backup file to prevent collisions
+        os.unlink(config_backup_path)
+        assert not os.path.exists(config_backup_path)
+
+        # Call the original admin dir back into active duty
+        filesystem.remove_all(admin_dir)
+        assert not os.path.exists(admin_dir)
+        os.rename(stowed_admin, admin_dir)
+        assert os.path.exists(admin_dir)
+        assert filesystem.globber(admin_dir) != []
+        assert not os.path.exists(stowed_admin)
+
+    def test_validate_config_backup(self):
+        """Validate basic dummy data"""
         assert not config.validate_config_backup(b"invalid")
         assert not config.validate_config_backup(self.create_dummy_zip("dummyfile"))
         assert config.validate_config_backup(self.create_dummy_zip(DEF_INI_FILE))
 
-        # Check restore
-        os.remove(full_ini_path)
-        assert not os.path.exists(full_ini_path)
-        config.restore_config_backup(config_backup_data)
-        assert os.path.isfile(full_ini_path)
+    @set_config(
+        {
+            "admin_dir": os.path.join(SAB_CACHE_DIR, "test_config_backup"),
+            "complete_dir": os.path.join(SAB_COMPLETE_DIR, "test_config_backup"),
+        }
+    )
+    def test_config_backup(self):
+        """Combined tests for the config.{create,validate,restore}_config_backup functions"""
+        # Prepare the basics
+        admin_dir = sabnzbd.cfg.admin_dir.get_path()
+        sabnzbd.cfg.set_root_folders2()
+        ini_path = os.path.join(admin_dir, DEF_INI_FILE)
+        shutil.copyfile(os.path.join(SAB_DATA_DIR, "sabnzbd.basic.ini"), ini_path)
+        assert os.path.exists(ini_path)
+        config.read_config(ini_path)
+        filesystem.create_all_dirs(sabnzbd.cfg.complete_dir())
+        assert os.path.exists(sabnzbd.cfg.complete_dir())
+
+        # Create a backup and verify it has the expected files (ini only, as there are no admin and https config files)
+        self.create_and_verify_backup(admin_dir, [DEF_INI_FILE])
+
+        # Add other admin files that qualify for inclusion in backups
+        for basename in CONFIG_BACKUP_FILES:
+            with open(admin_file := os.path.join(admin_dir, basename), "wb") as fp:
+                fp.write(os.urandom(128))
+            assert os.path.exists(admin_file)
+        self.create_and_verify_backup(admin_dir, [DEF_INI_FILE] + CONFIG_BACKUP_FILES)
+
+        # Add some useless files in the admin_dir
+        for basename in ["totals3.sab", "Best.Movie.Ever.1951.240p.avi", "Rating.sab"]:
+            with open(useless_file := os.path.join(admin_dir, basename), "wb") as fp:
+                fp.write(os.urandom(256))
+            assert os.path.exists(useless_file)
+        # None of these should appear in the backup
+        self.create_and_verify_backup(admin_dir, [DEF_INI_FILE] + CONFIG_BACKUP_FILES)
+
+        # Remove the extra admin files, but keep the useless ones around
+        for basename in CONFIG_BACKUP_FILES:
+            os.unlink(admin_file := os.path.join(admin_dir, basename))
+            assert not os.path.exists(admin_file)
+
+        # Generate fake HTTPS certificate and key files
+        cert_file = os.path.join(admin_dir, DEF_HTTPS_CERT_FILE)
+        key_file = os.path.join(admin_dir, DEF_HTTPS_KEY_FILE)
+        for filepath in (cert_file, key_file):
+            with open(filepath, "wb") as fp:
+                fp.write(os.urandom(512))
+        assert os.path.exists(cert_file)
+        assert os.path.exists(key_file)
+
+        # Copy cert and key to create a second set of https config files outside the admin dir
+        other_cert_file = os.path.join(SAB_CACHE_DIR, "foobar.ใบรับรอง")
+        other_key_file = os.path.join(SAB_CACHE_DIR, "foobar.สำคัญ")
+        shutil.copyfile(cert_file, other_key_file)
+        shutil.copyfile(key_file, other_cert_file)
+        assert os.path.exists(other_cert_file)
+        assert os.path.exists(other_key_file)
+
+        # Imitate a mainstream https setup (cert and key present, but no chain file)
+        sabnzbd.cfg.enable_https.set(True)
+        sabnzbd.cfg.https_cert.set(DEF_HTTPS_CERT_FILE)
+        sabnzbd.cfg.https_key.set(DEF_HTTPS_KEY_FILE)
+        sabnzbd.config.save_config(True)
+        assert not sabnzbd.cfg.https_chain()
+        assert sabnzbd.CONFIG_BACKUP_HTTPS_OK == []
+
+        # Results should remain the same, as we didn't fake the results of a startup with https enabled yet
+        self.create_and_verify_backup(admin_dir, [DEF_INI_FILE])
+
+        # Results should still remain the same, the startup data lists only bogus files
+        sabnzbd.CONFIG_BACKUP_HTTPS_OK = ["/tmp/no.cert", "/lib/fuldstændig_falsk.nøgle", "/etc/存在しないファイル"]
+        self.create_and_verify_backup(admin_dir, [DEF_INI_FILE])
+
+        # Now pretend the program started with this config (note: full paths must be used for _OK)
+        sabnzbd.CONFIG_BACKUP_HTTPS_OK = [cert_file, key_file]
+        self.create_and_verify_backup(admin_dir, [DEF_INI_FILE, DEF_HTTPS_CERT_FILE, DEF_HTTPS_KEY_FILE])
+
+        # Pretend some other files were loaded on startup instead
+        sabnzbd.CONFIG_BACKUP_HTTPS_OK = [other_cert_file, other_key_file]
+        # Files in the settings no longer match those in _OK; no https config should be in the backup
+        self.create_and_verify_backup(admin_dir, [DEF_INI_FILE])
+
+        # Set the full path to a key and cert file outside the admin dir
+        sabnzbd.cfg.https_cert.set(other_cert_file)
+        sabnzbd.cfg.https_key.set(other_key_file)
+        sabnzbd.config.save_config(True)
+        # Now the files should be included, albeit under the default names
+        self.create_and_verify_backup(admin_dir, [DEF_INI_FILE, DEF_HTTPS_CERT_FILE, DEF_HTTPS_KEY_FILE])
+
+        # Repeat with the "others" removed, so there's nothing (but the ini) left to include in the first place
+        for f in (other_cert_file, other_key_file):
+            os.unlink(f)
+        assert not os.path.exists(other_cert_file)
+        assert not os.path.exists(other_key_file)
+        self.create_and_verify_backup(admin_dir, [DEF_INI_FILE])
+
+        # Make up a chain file
+        chain_file = os.path.join(admin_dir, "ssl-chain.txt")
+        shutil.copyfile(cert_file, chain_file)
+        assert os.path.exists(chain_file)
+        # Update the config and the startup record (mostly)
+        sabnzbd.cfg.https_cert.set(cert_file)
+        sabnzbd.cfg.https_key.set(key_file)
+        sabnzbd.cfg.https_chain.set(chain_file)
+        sabnzbd.config.save_config(True)
+        sabnzbd.CONFIG_BACKUP_HTTPS_OK = [cert_file, key_file]
+
+        # There may be a chain file now, but as long as it's not listed in _OK it should be excluded from the backup
+        self.create_and_verify_backup(admin_dir, [DEF_INI_FILE, DEF_HTTPS_CERT_FILE, DEF_HTTPS_KEY_FILE])
+
+        # Now it should be included
+        sabnzbd.CONFIG_BACKUP_HTTPS_OK.append(chain_file)
+        self.create_and_verify_backup(
+            admin_dir, [DEF_INI_FILE, DEF_HTTPS_CERT_FILE, DEF_HTTPS_KEY_FILE, DEF_CHAIN_FILE]
+        )
+
+        # Same same but more lonely
+        sabnzbd.CONFIG_BACKUP_HTTPS_OK = [chain_file, "/tmp/foobar.exe"]
+        self.create_and_verify_backup(admin_dir, [DEF_INI_FILE, DEF_CHAIN_FILE])
+
+        # Disabling https shouldn't make any difference as long as the evidence shows it was active on startup
+        sabnzbd.cfg.enable_https.set(False)
+        sabnzbd.config.save_config(True)
+        self.create_and_verify_backup(admin_dir, [DEF_INI_FILE, DEF_CHAIN_FILE])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,6 +18,7 @@
 """
 tests.test_config - Tests of config methods
 """
+from sabnzbd.filesystem import long_path
 from tests.testhelper import *
 import shutil
 import zipfile
@@ -185,8 +186,8 @@ class TestConfig:
         assert os.path.exists(key_file)
 
         # Copy cert and key to create a second set of https config files outside the admin dir
-        other_cert_file = os.path.join(SAB_CACHE_DIR, "foobar.mycert")
-        other_key_file = os.path.join(SAB_CACHE_DIR, "foobar.mykey")
+        other_cert_file = long_path(os.path.join(SAB_CACHE_DIR, "foobar.mycert"))
+        other_key_file = long_path(os.path.join(SAB_CACHE_DIR, "foobar.mykey"))
         shutil.copyfile(cert_file, other_key_file)
         shutil.copyfile(key_file, other_cert_file)
         assert os.path.exists(other_cert_file)


### PR DESCRIPTION
Files are included in the backup zipfile under their default basename (with "server.chain" used for the one that doesn't have a usable default value). On restore, all files are placed in the admin dir, the affected setting(s) modified to point to the restored file(s) and the config saved.

To prevent backing up a https config broken by some last-minute change as well as the inclusion of arbitrary (possibly large or sensitive) files into the backup by manipulating the settings just prior to creating a backup, the cert/key/chain files are only included if https was enabled at startup and files with a matching full path successfully loaded at that time.

Closes #2338