### PR TITLE
Increase threshold for logging excessive sleep time

### DIFF
--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -717,7 +717,7 @@ class Downloader(Thread):
                     time.sleep(self.sleep_time)
                     now = time.time()
                     # Debugging code for v4 test release
-                    if now - time_before > self.sleep_time + 0.01:
+                    if now - time_before > self.sleep_time + 0.05:
                         logging.debug("Slept %.5f seconds, sleep_time = %s", now - time_before, self.sleep_time)
                     time_slept += now - time_before
                     sleep_count += 1


### PR DESCRIPTION
It seems your system sleeps much longer than `downloader_sleep_time` requests much more frequently than mine. That's one of the things I wanted to know. I only rarely get those messages. Before you switch to this code, could you try setting
```
import sys
sys.setswitchinterval(0.001)
```
in `SABnzbd.py` and see if it helps? Is there a lot of other load on your system?

The new code increases it from 0.01 to 0.05 seconds longer than `downloader_sleep_time`. If it sleeps longer then that frequently then it will seriously impact the performance.