### PR TITLE
Only allocate disk speed random data when required

### DIFF
--- a/sabnzbd/utils/diskspeed.py
+++ b/sabnzbd/utils/diskspeed.py
@@ -9,7 +9,6 @@ import logging
 import time
 
 _DUMP_DATA_SIZE = 10 * 1024 * 1024
-_DUMP_DATA = os.urandom(_DUMP_DATA_SIZE)
 
 
 def diskspeedmeasure(dirname: str) -> float:
@@ -18,6 +17,7 @@ def diskspeedmeasure(dirname: str) -> float:
     Then divide bytes written by time passed
     In case of problems (ie non-writable dir or file), return 0.0
     """
+    dump_data = os.urandom(_DUMP_DATA_SIZE)
     start = time.time()
     maxtime = 0.5  # sec
     total_written = 0
@@ -34,7 +34,7 @@ def diskspeedmeasure(dirname: str) -> float:
         total_time = 0.0
         while total_time < maxtime:
             start = time.time()
-            os.write(fp_testfile, _DUMP_DATA)
+            os.write(fp_testfile, dump_data)
             os.fsync(fp_testfile)
             total_time += time.time() - start
             total_written += _DUMP_DATA_SIZE


### PR DESCRIPTION
I was having a play with https://github.com/bloomberg/memray and noticed 10MB of random data is allocated at startup and kept around forever to be used for testing disk speed.

Better to just allocate it when required.

## Before
![before](https://user-images.githubusercontent.com/9887246/219497608-9ece137a-1d0d-4fb4-8fec-6decd55e536f.png)

## After:
![after](https://user-images.githubusercontent.com/9887246/219497628-cc8dadca-ed2b-4b35-838a-7e54b17bdbfe.png)
