### PR TITLE
Translate ascii control chars below value 32 to _

### DIFF
--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -186,8 +186,8 @@ def has_win_device(filename: str) -> bool:
 
 CH_ILLEGAL = "/"
 CH_LEGAL = "+"
-CH_ILLEGAL_WIN = '\\/<>?*|"\t:'
-CH_LEGAL_WIN = "++{}!@#'+-"
+CH_ILLEGAL_WIN = '\\/<>?*|":'
+CH_LEGAL_WIN = "++{}!@#'-"
 for i in range(2, 32):
     CH_ILLEGAL_WIN += chr(i)
     CH_LEGAL_WIN += "_"

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -186,11 +186,11 @@ def has_win_device(filename: str) -> bool:
 
 CH_ILLEGAL = "/"
 CH_LEGAL = "+"
+CH_ILLEGAL_WIN = '\\/<>?*|"\t:'
+CH_LEGAL_WIN = "++{}!@#'+-"
 for i in range(2, 32):
-    CH_ILLEGAL += chr(i)
-    CH_LEGAL += "_"
-CH_ILLEGAL_WIN = CH_ILLEGAL + '\\<>?*|"\t:'
-CH_LEGAL_WIN = CH_LEGAL + "+{}!@#'+-"
+    CH_ILLEGAL_WIN += chr(i)
+    CH_LEGAL_WIN += "_"
 
 
 def sanitize_filename(name: str) -> str:
@@ -205,8 +205,8 @@ def sanitize_filename(name: str) -> str:
 
     if sabnzbd.WIN32 or sabnzbd.cfg.sanitize_safe():
         # Remove all bad Windows chars too
-        illegal = CH_ILLEGAL_WIN
-        legal = CH_LEGAL_WIN
+        illegal += CH_ILLEGAL_WIN
+        legal += CH_LEGAL_WIN
 
     if ":" in name and sabnzbd.MACOS:
         # Compensate for the foolish way par2 on macOS handles a colon character

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -186,6 +186,9 @@ def has_win_device(filename: str) -> bool:
 
 CH_ILLEGAL = "/"
 CH_LEGAL = "+"
+for i in range(2, 32):
+    CH_ILLEGAL += chr(i)
+    CH_LEGAL += "_"
 CH_ILLEGAL_WIN = '\\/<>?*|"\t:'
 CH_LEGAL_WIN = "++{}!@#'+-"
 

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -189,8 +189,8 @@ CH_LEGAL = "+"
 for i in range(2, 32):
     CH_ILLEGAL += chr(i)
     CH_LEGAL += "_"
-CH_ILLEGAL_WIN = '\\/<>?*|"\t:'
-CH_LEGAL_WIN = "++{}!@#'+-"
+CH_ILLEGAL_WIN = CH_ILLEGAL + '\\/<>?*|"\t:'
+CH_LEGAL_WIN = CH_LEGAL + "++{}!@#'+-"
 
 
 def sanitize_filename(name: str) -> str:
@@ -205,8 +205,8 @@ def sanitize_filename(name: str) -> str:
 
     if sabnzbd.WIN32 or sabnzbd.cfg.sanitize_safe():
         # Remove all bad Windows chars too
-        illegal += CH_ILLEGAL_WIN
-        legal += CH_LEGAL_WIN
+        illegal = CH_ILLEGAL_WIN
+        legal = CH_LEGAL_WIN
 
     if ":" in name and sabnzbd.MACOS:
         # Compensate for the foolish way par2 on macOS handles a colon character

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -188,7 +188,7 @@ CH_ILLEGAL = "/"
 CH_LEGAL = "+"
 CH_ILLEGAL_WIN = '\\/<>?*|":'
 CH_LEGAL_WIN = "++{}!@#'-"
-for i in range(2, 32):
+for i in range(0, 32):
     CH_ILLEGAL_WIN += chr(i)
     CH_LEGAL_WIN += "_"
 

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -189,8 +189,8 @@ CH_LEGAL = "+"
 for i in range(2, 32):
     CH_ILLEGAL += chr(i)
     CH_LEGAL += "_"
-CH_ILLEGAL_WIN = CH_ILLEGAL + '\\/<>?*|"\t:'
-CH_LEGAL_WIN = CH_LEGAL + "++{}!@#'+-"
+CH_ILLEGAL_WIN = CH_ILLEGAL + '\\<>?*|"\t:'
+CH_LEGAL_WIN = CH_LEGAL + "+{}!@#'+-"
 
 
 def sanitize_filename(name: str) -> str:

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -184,11 +184,11 @@ def has_win_device(filename: str) -> bool:
     return False
 
 
-CH_ILLEGAL = "/"
-CH_LEGAL = "+"
+CH_ILLEGAL = "\0/"
+CH_LEGAL = "_+"
 CH_ILLEGAL_WIN = '\\/<>?*|":'
 CH_LEGAL_WIN = "++{}!@#'-"
-for i in range(0, 32):
+for i in range(1, 32):
     CH_ILLEGAL_WIN += chr(i)
     CH_LEGAL_WIN += "_"
 

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -113,8 +113,6 @@ class TestFileFolderNameSanitizer:
     @set_platform("linux")
     def test_legal_chars_linux(self):
         # Illegal on Windows but not on Linux, unless sanitize_safe is active.
-        # Don't bother with '/' which is illegal in filenames on all platforms.
-        char_ill = filesystem.CH_ILLEGAL_WIN.replace("/", "")
         assert filesystem.sanitize_filename("test" + char_ill + "aftertest") == ("test" + char_ill + "aftertest")
         for char in char_ill:
             # Try at start, middle, and end of a filename.

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -89,6 +89,12 @@ class TestFileFolderNameSanitizer:
         assert filesystem.sanitize_filename("$mft") == "$mft"
         assert filesystem.sanitize_filename("a$mft") == "a$mft"
 
+    @set_platform("win32")
+    def test_file_illegal_chars_win32(self):
+        assert filesystem.sanitize_filename("test" + filesystem.CH_ILLEGAL_WIN + "aftertest") == (
+            "test" + filesystem.CH_LEGAL_WIN + "aftertest"
+        )
+
     @set_platform("linux")
     def test_file_illegal_chars_linux(self):
         assert filesystem.sanitize_filename("test/aftertest") == "test+aftertest"

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -113,6 +113,7 @@ class TestFileFolderNameSanitizer:
     @set_platform("linux")
     def test_legal_chars_linux(self):
         # Illegal on Windows but not on Linux, unless sanitize_safe is active.
+        char_ill = filesystem.CH_ILLEGAL_WIN
         assert filesystem.sanitize_filename("test" + char_ill + "aftertest") == ("test" + char_ill + "aftertest")
         for char in char_ill:
             # Try at start, middle, and end of a filename.

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -113,7 +113,8 @@ class TestFileFolderNameSanitizer:
     @set_platform("linux")
     def test_legal_chars_linux(self):
         # Illegal on Windows but not on Linux, unless sanitize_safe is active.
-        char_ill = filesystem.CH_ILLEGAL_WIN
+        # Don't bother with '/' which is illegal in filenames on all platforms.
+        char_ill = filesystem.CH_ILLEGAL_WIN.replace("/", "")
         assert filesystem.sanitize_filename("test" + char_ill + "aftertest") == ("test" + char_ill + "aftertest")
         for char in char_ill:
             # Try at start, middle, and end of a filename.

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -94,6 +94,17 @@ class TestFileFolderNameSanitizer:
         assert filesystem.sanitize_filename("test" + filesystem.CH_ILLEGAL_WIN + "aftertest") == (
             "test" + filesystem.CH_LEGAL_WIN + "aftertest"
         )
+        assert (
+            filesystem.sanitize_filename("test" + chr(0) + chr(1) + chr(15) + chr(31) + "aftertest")
+            == "test____aftertest"
+        )
+
+    @set_platform("win32")
+    def test_folder_illegal_chars_win32(self):
+        assert (
+            filesystem.sanitize_foldername("test" + chr(0) + chr(9) + chr(13) + chr(31) + "aftertest")
+            == "test____aftertest"
+        )
 
     @set_platform("linux")
     def test_file_illegal_chars_linux(self):


### PR DESCRIPTION
Fixes #2462

I did it for all platforms because I don't think they are valid filename values on any. Adding 0 or 1 seems to break the string so I skipped them.