### PR TITLE
Readd last_max_chunk_size

### DIFF
--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -58,7 +58,7 @@ _BPSMETER_UPDATE_DELAY = 0.05
 # How many articles should be prefetched when checking the next articles?
 _ARTICLE_PREFETCH = 20
 # Minimum expected size of TCP receive buffer
-_DEFAULT_CHUNK_SIZE = 65536
+_DEFAULT_CHUNK_SIZE = 32768
 
 TIMER_LOCK = RLock()
 

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -770,12 +770,16 @@ class Downloader(Thread):
 
             if self.recv_threads > 1:
                 for nw, bytes_received, done in self.recv_pool.map(self.__recv, read):
+                    if bytes_received > last_max_chunk_size:
+                        last_max_chunk_size = bytes_received
                     self.__handle_recv_result(nw, bytes_received, done)
                 if self.bandwidth_limit:
                     self.__check_speed()
             else:
                 for selected in read:
                     nw, bytes_received, done = self.__recv(selected)
+                    if bytes_received > last_max_chunk_size:
+                        last_max_chunk_size = bytes_received
                     self.__handle_recv_result(nw, bytes_received, done)
                     if self.bandwidth_limit and bytes_received:
                         self.__check_speed()


### PR DESCRIPTION
Sorry, I messed up the threadpool merge and didn't include the part that registers the size of the largest block for each loop. This means that if downloader_sleep_time is enabled it will sleep every round. It is possibly the reason why Brandoskey on Reddit got reduced speed when it was enabled. He sent me a debug log. I suspect that the VMs have a very small receive buffer because it never seemed to sleep much longer than it should but unfortunately I couldn't verify it because of this mistake. I have reduced the _DEFAULT_CHUNK_SIZE.  Now it usually shouldn't sleep at all if it's not increased because the 16 KB SSL chunk is more than 1/3 of _DEFAULT_CHUNK_SIZE.