### PR TITLE
only save series_info in the history db for job type "tv"

### DIFF
--- a/sabnzbd/database.py
+++ b/sabnzbd/database.py
@@ -474,8 +474,8 @@ def build_history_info(nzo, workdir_complete="", postproc_time=0, script_output=
 
     # Analyze series info only when job is finished
     series = ""
-    if series_info:
-        seriesname, season, episode = sabnzbd.newsunpack.analyse_show(nzo.final_name)[:3]
+    if series_info and (show_analysis := sabnzbd.newsunpack.analyse_show(nzo.final_name))[10] == "tv":
+        seriesname, season, episode = show_analysis[:3]
         if seriesname and season and episode:
             series = "%s/%s/%s" % (seriesname.lower(), season, episode)
 

--- a/sabnzbd/database.py
+++ b/sabnzbd/database.py
@@ -474,8 +474,8 @@ def build_history_info(nzo, workdir_complete="", postproc_time=0, script_output=
 
     # Analyze series info only when job is finished
     series = ""
-    if series_info and (show_analysis := sabnzbd.newsunpack.analyse_show(nzo.final_name))[10] == "tv":
-        seriesname, season, episode = show_analysis[:3]
+    if series_info and (show_analysis := sabnzbd.newsunpack.analyse_show(nzo.final_name))["job_type"] == "tv":
+        seriesname, season, episode = (show_analysis[key] for key in ("title", "season", "episode"))
         if seriesname and season and episode:
             series = "%s/%s/%s" % (seriesname.lower(), season, episode)
 

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -2249,7 +2249,7 @@ def add_time_left(perc: float, start_time: Optional[float] = None, time_used: Op
     return ""
 
 
-def analyse_show(name: str) -> Tuple[str, str, str, str, bool, str, str, str, str, str, str, str, str, str]:
+def analyse_show(name: str) -> Dict[str, str]:
     """Use the Sorter to collect some basic info on series"""
     job = Sorter(
         None,
@@ -2269,19 +2269,19 @@ def analyse_show(name: str) -> Tuple[str, str, str, str, bool, str, str, str, st
         },
     )
     job.get_values()
-    return (
-        job.info.get("title", ""),
-        job.info.get("season_num", ""),
-        job.info.get("episode_num", ""),
-        job.info.get("ep_name", ""),
-        str(job.is_proper()),
-        job.info.get("resolution", ""),
-        job.info.get("decade", ""),
-        job.info.get("year", ""),
-        job.info.get("month", ""),
-        job.info.get("day", ""),
-        job.type,
-    )
+    return {
+        "title": job.info.get("title", ""),
+        "season": job.info.get("season_num", ""),
+        "episode": job.info.get("episode_num", ""),
+        "episode_name": job.info.get("ep_name", ""),
+        "is_proper": str(job.is_proper()),
+        "resolution": job.info.get("resolution", ""),
+        "decade": job.info.get("decade", ""),
+        "year": job.info.get("year", ""),
+        "month": job.info.get("month", ""),
+        "day": job.info.get("day", ""),
+        "job_type": job.type,
+    }
 
 
 def pre_queue(nzo: NzbObject, pp, cat):
@@ -2309,7 +2309,7 @@ def pre_queue(nzo: NzbObject, pp, cat):
             str(nzo.bytes),
             " ".join(nzo.groups),
         ]
-        command.extend(analyse_show(nzo.final_name_with_password))
+        command.extend(list(analyse_show(nzo.final_name_with_password).values()))
         command = [fix(arg) for arg in command]
 
         # Fields not in the NZO directly

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -1940,7 +1940,10 @@ class NzbObject(TryList):
 
             # Dupe check off nzb filename
             if not res and no_series_dupes:
-                series, season, episode, _, is_proper = sabnzbd.newsunpack.analyse_show(self.final_name)[:5]
+                show_analysis = sabnzbd.newsunpack.analyse_show(self.final_name)
+                series, season, episode, is_proper = (
+                    show_analysis[key] for key in ("title", "season", "episode", "is_proper")
+                )
                 if is_proper and series_propercheck:
                     logging.debug("Dupe checking series+season+ep in history aborted due to PROPER/REAL/REPACK found")
                 else:

--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -308,7 +308,8 @@ class RSSReader:
                     myPrio = defPrio
                     n = 0
                     if ("F" in reTypes or "S" in reTypes) and (not season or not episode):
-                        season, episode = sabnzbd.newsunpack.analyse_show(title)[1:3]
+                        show_analysis = sabnzbd.newsunpack.analyse_show(title)
+                        season, episode = show_analysis["season"], show_analysis["episode"]
 
                     # Match against all filters until an positive or negative match
                     logging.debug("Size %s", size)


### PR DESCRIPTION
This restores previous behaviour, when analyse_show called the series sorter directly. The series info in the db is only used to detect series dupes based on name/season/episode, so storing it for other job types serves no purpose.