### PR TITLE
Corrected msgids -  msgid "Pause * prioirty jobs" spelling error

### DIFF
--- a/po/main/SABnzbd.pot
+++ b/po/main/SABnzbd.pot
@@ -1746,32 +1746,32 @@ msgstr ""
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause low prioirty jobs"
+msgid "Pause low priority jobs"
 msgstr ""
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause normal prioirty jobs"
+msgid "Pause normal priority jobs"
 msgstr ""
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause high prioirty jobs"
+msgid "Pause high priority jobs"
 msgstr ""
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume low prioirty jobs"
+msgid "Resume low priority jobs"
 msgstr ""
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume normal prioirty jobs"
+msgid "Resume normal priority jobs"
 msgstr ""
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume high prioirty jobs"
+msgid "Resume high priority jobs"
 msgstr ""
 
 #. Config->Scheduler

--- a/po/main/cs.po
+++ b/po/main/cs.po
@@ -1820,32 +1820,32 @@ msgstr "Odstranit dokončené úkoly"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause low prioirty jobs"
+msgid "Pause low priority jobs"
 msgstr "Pozastavit úkoly s nízkou prioritou"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause normal prioirty jobs"
+msgid "Pause normal priority jobs"
 msgstr "Pozastavit úkoly s normální prioritou"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause high prioirty jobs"
+msgid "Pause high priority jobs"
 msgstr "Pozastavit úkoly s vysokou prioritou"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume low prioirty jobs"
+msgid "Resume low priority jobs"
 msgstr ""
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume normal prioirty jobs"
+msgid "Resume normal priority jobs"
 msgstr ""
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume high prioirty jobs"
+msgid "Resume high priority jobs"
 msgstr "Obnovit úkoly s vysokou prioritou"
 
 #. Config->Scheduler

--- a/po/main/da.po
+++ b/po/main/da.po
@@ -1851,32 +1851,32 @@ msgstr "Fjern fuldførte job"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause low prioirty jobs"
+msgid "Pause low priority jobs"
 msgstr "Pause lav prioritets jobs"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause normal prioirty jobs"
+msgid "Pause normal priority jobs"
 msgstr "Pause normal prioritets jobs"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause high prioirty jobs"
+msgid "Pause high priority jobs"
 msgstr "Pause høj prioritets jobs"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume low prioirty jobs"
+msgid "Resume low priority jobs"
 msgstr "Genoptag lav prioritets jobs"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume normal prioirty jobs"
+msgid "Resume normal priority jobs"
 msgstr "Genoptag normal prioritets jobs"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume high prioirty jobs"
+msgid "Resume high priority jobs"
 msgstr "Genoptag høj prioritets jobs"
 
 #. Config->Scheduler

--- a/po/main/de.po
+++ b/po/main/de.po
@@ -1915,32 +1915,32 @@ msgstr "Abgeschlossene Aufträge entfernen"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause low prioirty jobs"
+msgid "Pause low priority jobs"
 msgstr "Aufträge mit niedriger Priorität pausieren"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause normal prioirty jobs"
+msgid "Pause normal priority jobs"
 msgstr "Aufträge mit normaler Priorität pausieren"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause high prioirty jobs"
+msgid "Pause high priority jobs"
 msgstr "Aufträge mit hoher Priorität pausieren"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume low prioirty jobs"
+msgid "Resume low priority jobs"
 msgstr "Aufträge mit niedriger Priorität fortsetzen"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume normal prioirty jobs"
+msgid "Resume normal priority jobs"
 msgstr "Aufträge mit normaler Priorität fortsetzen"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume high prioirty jobs"
+msgid "Resume high priority jobs"
 msgstr "Aufträge mit hoher Priorität fortsetzen"
 
 #. Config->Scheduler

--- a/po/main/en.po
+++ b/po/main/en.po
@@ -15,22 +15,22 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-msgid "Pause low prioirty jobs"
+msgid "Pause low priority jobs"
 msgstr "Pause low priority jobs"
 
-msgid "Pause normal prioirty jobs"
+msgid "Pause normal priority jobs"
 msgstr "Pause normal priority jobs"
 
-msgid "Pause high prioirty jobs"
+msgid "Pause high priority jobs"
 msgstr "Pause high priority jobs"
 
-msgid "Resume low prioirty jobs"
+msgid "Resume low priority jobs"
 msgstr "Resume low priority jobs"
 
-msgid "Resume normal prioirty jobs"
+msgid "Resume normal priority jobs"
 msgstr "Resume normal priority jobs"
 
-msgid "Resume high prioirty jobs"
+msgid "Resume high priority jobs"
 msgstr "Resume high priority jobs"
 
 msgid ""

--- a/po/main/en.po
+++ b/po/main/en.po
@@ -15,22 +15,22 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-msgid "Pause low priority jobs"
+msgid "Pause low prioirty jobs"
 msgstr "Pause low priority jobs"
 
-msgid "Pause normal priority jobs"
+msgid "Pause normal prioirty jobs"
 msgstr "Pause normal priority jobs"
 
-msgid "Pause high priority jobs"
+msgid "Pause high prioirty jobs"
 msgstr "Pause high priority jobs"
 
-msgid "Resume low priority jobs"
+msgid "Resume low prioirty jobs"
 msgstr "Resume low priority jobs"
 
-msgid "Resume normal priority jobs"
+msgid "Resume normal prioirty jobs"
 msgstr "Resume normal priority jobs"
 
-msgid "Resume high priority jobs"
+msgid "Resume high prioirty jobs"
 msgstr "Resume high priority jobs"
 
 msgid ""

--- a/po/main/es.po
+++ b/po/main/es.po
@@ -1907,27 +1907,27 @@ msgstr "Eliminar trabajos completados"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause low prioirty jobs"
+msgid "Pause low priority jobs"
 msgstr "Pausar trabajos de prioridad baja"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause normal prioirty jobs"
+msgid "Pause normal priority jobs"
 msgstr "Pausar trabajos de prioridad normal"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause high prioirty jobs"
+msgid "Pause high priority jobs"
 msgstr "Pausar trabajos de prioridad alta"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume low prioirty jobs"
+msgid "Resume low priority jobs"
 msgstr "Reanudar trabajos de prioridad baja"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume normal prioirty jobs"
+msgid "Resume normal priority jobs"
 msgstr "Reanudar trabajos de prioridad normal"
 
 #. Config->Scheduler

--- a/po/main/fi.po
+++ b/po/main/fi.po
@@ -1845,32 +1845,32 @@ msgstr "Poista valmistuneet lataukset"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause low prioirty jobs"
+msgid "Pause low priority jobs"
 msgstr "Keskeytä alhaisen prioriteetin lataukset"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause normal prioirty jobs"
+msgid "Pause normal priority jobs"
 msgstr "Keskeytä normaalin prioriteetin lataukset"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause high prioirty jobs"
+msgid "Pause high priority jobs"
 msgstr "Keskeytä korkean prioriteetin lataukset"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume low prioirty jobs"
+msgid "Resume low priority jobs"
 msgstr "Jatka alhaisen prioriteetin lataukset"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume normal prioirty jobs"
+msgid "Resume normal priority jobs"
 msgstr "Jatka normaalin prioriteetin lataukset"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume high prioirty jobs"
+msgid "Resume high priority jobs"
 msgstr "Jatka korkean prioriteetin lataukset"
 
 #. Config->Scheduler

--- a/po/main/fr.po
+++ b/po/main/fr.po
@@ -1910,32 +1910,32 @@ msgstr "Effacer les tâches terminées"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause low prioirty jobs"
+msgid "Pause low priority jobs"
 msgstr "Mettre en pause les tâches de priorité faible"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause normal prioirty jobs"
+msgid "Pause normal priority jobs"
 msgstr "Mettre en pause les tâches de priorité normale"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause high prioirty jobs"
+msgid "Pause high priority jobs"
 msgstr "Mettre en pause les tâches de priorité haute"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume low prioirty jobs"
+msgid "Resume low priority jobs"
 msgstr "Reprendre les tâches de priorité faible"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume normal prioirty jobs"
+msgid "Resume normal priority jobs"
 msgstr "Reprendre les tâches de priorité normale"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume high prioirty jobs"
+msgid "Resume high priority jobs"
 msgstr "Reprendre les tâches de priorité haute"
 
 #. Config->Scheduler

--- a/po/main/he.po
+++ b/po/main/he.po
@@ -1852,32 +1852,32 @@ msgstr "הסר עבודות נשלמות"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause low prioirty jobs"
+msgid "Pause low priority jobs"
 msgstr "השהה עבודות עם עדיפות נמוכה"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause normal prioirty jobs"
+msgid "Pause normal priority jobs"
 msgstr "השהה עבודות עם עדיפות רגילה"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause high prioirty jobs"
+msgid "Pause high priority jobs"
 msgstr "השהה עבודות עם עדיפות גבוהה"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume low prioirty jobs"
+msgid "Resume low priority jobs"
 msgstr "המשך עבודות עם עדיפות נמוכה"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume normal prioirty jobs"
+msgid "Resume normal priority jobs"
 msgstr "המשך עבודות עם עדיפות רגילה"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume high prioirty jobs"
+msgid "Resume high priority jobs"
 msgstr "המשך עבודות עם עדיפות גבוהה"
 
 #. Config->Scheduler

--- a/po/main/nb.po
+++ b/po/main/nb.po
@@ -1841,32 +1841,32 @@ msgstr "Fjern ferdige jobber"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause low prioirty jobs"
+msgid "Pause low priority jobs"
 msgstr "Pause jobber med lav prioritet"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause normal prioirty jobs"
+msgid "Pause normal priority jobs"
 msgstr "Pause jobber med normal prioritet"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause high prioirty jobs"
+msgid "Pause high priority jobs"
 msgstr "Pause jobber med høy prioritet"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume low prioirty jobs"
+msgid "Resume low priority jobs"
 msgstr "Gjenoppta jobber med lav prioritet"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume normal prioirty jobs"
+msgid "Resume normal priority jobs"
 msgstr "Gjenoppta jobber med normal prioritet"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume high prioirty jobs"
+msgid "Resume high priority jobs"
 msgstr "Gjenoppta jobber med høy prioritet"
 
 #. Config->Scheduler

--- a/po/main/nl.po
+++ b/po/main/nl.po
@@ -1891,32 +1891,32 @@ msgstr "Verwijder voltooide downloads"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause low prioirty jobs"
+msgid "Pause low priority jobs"
 msgstr "Pauzeer downloads met prioriteit \"Laag\""
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause normal prioirty jobs"
+msgid "Pause normal priority jobs"
 msgstr "Pauzeer downloads met prioriteit \"Normaal\""
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause high prioirty jobs"
+msgid "Pause high priority jobs"
 msgstr "Pauzeer downloads met prioriteit \"Hoog\""
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume low prioirty jobs"
+msgid "Resume low priority jobs"
 msgstr "Hervat downloads met prioriteit \"Laag\""
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume normal prioirty jobs"
+msgid "Resume normal priority jobs"
 msgstr "Hervat downloads met prioriteit \"Normaal\""
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume high prioirty jobs"
+msgid "Resume high priority jobs"
 msgstr "Hervat downloads met prioriteit \"Hoog\""
 
 #. Config->Scheduler

--- a/po/main/pl.po
+++ b/po/main/pl.po
@@ -1847,32 +1847,32 @@ msgstr "Usuń ukończone zadania"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause low prioirty jobs"
+msgid "Pause low priority jobs"
 msgstr "Wstrzymaj zadania o niskim priorytecie"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause normal prioirty jobs"
+msgid "Pause normal priority jobs"
 msgstr "Wstrzymaj zadania o normalnym priorytecie"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause high prioirty jobs"
+msgid "Pause high priority jobs"
 msgstr "Wstrzymaj zadania o wysokim priorytecie"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume low prioirty jobs"
+msgid "Resume low priority jobs"
 msgstr "Wznów zadania o niskim priorytecie"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume normal prioirty jobs"
+msgid "Resume normal priority jobs"
 msgstr "Wznów zadania o normalnym priorytecie"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume high prioirty jobs"
+msgid "Resume high priority jobs"
 msgstr "Wznów zadania o wysokim priorytecie"
 
 #. Config->Scheduler

--- a/po/main/pt_BR.po
+++ b/po/main/pt_BR.po
@@ -1850,32 +1850,32 @@ msgstr "Remover trabalhos encerrados"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause low prioirty jobs"
+msgid "Pause low priority jobs"
 msgstr "Pausa tarefas de baixa prioridade"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause normal prioirty jobs"
+msgid "Pause normal priority jobs"
 msgstr "Pausa tarefas de prioridade normal"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause high prioirty jobs"
+msgid "Pause high priority jobs"
 msgstr "Pausa tarefas de alta prioridade"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume low prioirty jobs"
+msgid "Resume low priority jobs"
 msgstr "Continua tarefas de baixa prioridade"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume normal prioirty jobs"
+msgid "Resume normal priority jobs"
 msgstr "Continua tarefas de prioridade normal"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume high prioirty jobs"
+msgid "Resume high priority jobs"
 msgstr "Continua tarefas de alta prioridade"
 
 #. Config->Scheduler

--- a/po/main/ro.po
+++ b/po/main/ro.po
@@ -1877,32 +1877,32 @@ msgstr "Elimină sarcinile finalizate"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause low prioirty jobs"
+msgid "Pause low priority jobs"
 msgstr "Întrerupte sarcinile cu prioritate redusă"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause normal prioirty jobs"
+msgid "Pause normal priority jobs"
 msgstr "Întrerupe sarcinile cu prioritate normală"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause high prioirty jobs"
+msgid "Pause high priority jobs"
 msgstr "Întrerupe sarcinile cu prioritate ridicată"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume low prioirty jobs"
+msgid "Resume low priority jobs"
 msgstr "Reia sarcinile cu prioritate redusă"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume normal prioirty jobs"
+msgid "Resume normal priority jobs"
 msgstr "Reia sarcinile cu prioritate normală"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume high prioirty jobs"
+msgid "Resume high priority jobs"
 msgstr "Reia sarcinile cu prioritate ridicată"
 
 #. Config->Scheduler

--- a/po/main/ru.po
+++ b/po/main/ru.po
@@ -1846,32 +1846,32 @@ msgstr ""
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause low prioirty jobs"
+msgid "Pause low priority jobs"
 msgstr ""
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause normal prioirty jobs"
+msgid "Pause normal priority jobs"
 msgstr ""
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause high prioirty jobs"
+msgid "Pause high priority jobs"
 msgstr ""
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume low prioirty jobs"
+msgid "Resume low priority jobs"
 msgstr ""
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume normal prioirty jobs"
+msgid "Resume normal priority jobs"
 msgstr ""
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume high prioirty jobs"
+msgid "Resume high priority jobs"
 msgstr ""
 
 #. Config->Scheduler

--- a/po/main/sr.po
+++ b/po/main/sr.po
@@ -1838,32 +1838,32 @@ msgstr "Ukloni završene poslove"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause low prioirty jobs"
+msgid "Pause low priority jobs"
 msgstr "Pauziraj poslove sa niskim prioritetom"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause normal prioirty jobs"
+msgid "Pause normal priority jobs"
 msgstr "Pauziraj poslove sa normalnim prioritetom"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause high prioirty jobs"
+msgid "Pause high priority jobs"
 msgstr "Pauziraj poslove sa visokim prioritetom"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume low prioirty jobs"
+msgid "Resume low priority jobs"
 msgstr "Настави радови са ниским приоритетом"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume normal prioirty jobs"
+msgid "Resume normal priority jobs"
 msgstr "Настави радови са нормалним приоритетом"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume high prioirty jobs"
+msgid "Resume high priority jobs"
 msgstr "Настави радови са високим приоритетом"
 
 #. Config->Scheduler

--- a/po/main/sv.po
+++ b/po/main/sv.po
@@ -1844,32 +1844,32 @@ msgstr "Ta bort färdiga jobb"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause low prioirty jobs"
+msgid "Pause low priority jobs"
 msgstr "Pausa lågprioriterade jobb"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause normal prioirty jobs"
+msgid "Pause normal priority jobs"
 msgstr "Pausa normalprioriterade jobb"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause high prioirty jobs"
+msgid "Pause high priority jobs"
 msgstr "Pausa högprioriterade jobb"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume low prioirty jobs"
+msgid "Resume low priority jobs"
 msgstr "Återuppta lågprioriterade jobb"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume normal prioirty jobs"
+msgid "Resume normal priority jobs"
 msgstr "Återuppta normalprioriterade jobb"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume high prioirty jobs"
+msgid "Resume high priority jobs"
 msgstr "Återuppta högprioriterade jobb"
 
 #. Config->Scheduler

--- a/po/main/zh_CN.po
+++ b/po/main/zh_CN.po
@@ -1831,32 +1831,32 @@ msgstr "移除已完成任务"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause low prioirty jobs"
+msgid "Pause low priority jobs"
 msgstr "暂停低优先级任务"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause normal prioirty jobs"
+msgid "Pause normal priority jobs"
 msgstr "暂停常规优先级任务"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Pause high prioirty jobs"
+msgid "Pause high priority jobs"
 msgstr "暂停高优先级任务"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume low prioirty jobs"
+msgid "Resume low priority jobs"
 msgstr "继续低优先级任务"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume normal prioirty jobs"
+msgid "Resume normal priority jobs"
 msgstr "继续常规优先级任务"
 
 #. Config->Scheduler
 #: sabnzbd/skintext.py
-msgid "Resume high prioirty jobs"
+msgid "Resume high priority jobs"
 msgstr "继续高优先级任务"
 
 #. Config->Scheduler

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -52,12 +52,12 @@ SKIN_TEXT = {
     "sch-rss_scan": TT("Read RSS feeds"),  #:  #: Config->Scheduler
     "sch-remove_failed": TT("Remove failed jobs"),  #: Config->Scheduler
     "sch-remove_completed": TT("Remove completed jobs"),  #: Config->Scheduler
-    "sch-pause_all_low": TT("Pause low prioirty jobs"),  #: Config->Scheduler
-    "sch-pause_all_normal": TT("Pause normal prioirty jobs"),  #: Config->Scheduler
-    "sch-pause_all_high": TT("Pause high prioirty jobs"),  #: Config->Scheduler
-    "sch-resume_all_low": TT("Resume low prioirty jobs"),  #: Config->Scheduler
-    "sch-resume_all_normal": TT("Resume normal prioirty jobs"),  #: Config->Scheduler
-    "sch-resume_all_high": TT("Resume high prioirty jobs"),  #: Config->Scheduler
+    "sch-pause_all_low": TT("Pause low priority jobs"),  #: Config->Scheduler
+    "sch-pause_all_normal": TT("Pause normal priority jobs"),  #: Config->Scheduler
+    "sch-pause_all_high": TT("Pause high priority jobs"),  #: Config->Scheduler
+    "sch-resume_all_low": TT("Resume low priority jobs"),  #: Config->Scheduler
+    "sch-resume_all_normal": TT("Resume normal priority jobs"),  #: Config->Scheduler
+    "sch-resume_all_high": TT("Resume high priority jobs"),  #: Config->Scheduler
     "sch-enable_quota": TT("Enable quota management"),  #: Config->Scheduler
     "sch-disable_quota": TT("Disable quota management"),  #: Config->Scheduler
     "sch-pause_cat": TT("Pause jobs with category"),  #: Config->Scheduler


### PR DESCRIPTION
Corrected spelling errors in “Prioirty” msgid definitions. This pull request should update all definition language definitions and calls to them.