### PR TITLE
Tweak assembler queue variables for smoother download

### DIFF
--- a/sabnzbd/constants.py
+++ b/sabnzbd/constants.py
@@ -94,8 +94,8 @@ CONFIG_BACKUP_HTTPS = {  # "basename": "associated setting"
 }
 
 # Constants affecting download performance
-MAX_ASSEMBLER_QUEUE = 10
-SOFT_QUEUE_LIMIT = 0.6
+MAX_ASSEMBLER_QUEUE = 12
+SOFT_QUEUE_LIMIT = 0.5
 # Percentage of cache to use before adding file to assembler
 ASSEMBLER_WRITE_THRESHOLD = 5
 NNTP_BUFFER_SIZE = int(800 * KIBI)

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -770,7 +770,7 @@ class Downloader(Thread):
 
             # Check the Assembler queue to see if we need to delay, depending on queue size
             if (assembler_level := sabnzbd.Assembler.queue_level()) > SOFT_QUEUE_LIMIT:
-                time.sleep(assembler_level - SOFT_QUEUE_LIMIT)
+                time.sleep((assembler_level - SOFT_QUEUE_LIMIT) / 4)
                 sabnzbd.BPSMeter.delayed_assembler += 1
                 logged_counter = 0
 


### PR DESCRIPTION
Related to the discussion in #2474. I realized that commit https://github.com/sabnzbd/sabnzbd/commit/70aea9ac0c5ab69156202c1c8d1a19e2f5f95c92 removed the /2 from the time to sleep calculation so it would sleep twice as long as I intended. Currently it sleeps a minimum of 0.1 second, which is probably too much. It also only sleeps once per full loop instead of each time a part has been completed. The effects of that change probably depends on the number of threads and connections.

This commit reduces the minimum sleep time to 1/4 of the current but it starts earlier (50% full instead of 60%). I also increased the queue to 12 so that there are 6 levels instead of 4 which causes soft sleeping.