### PR TITLE
avoid traceback after postproc script

### DIFF
--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -588,7 +588,7 @@ def process_job(nzo: NzbObject):
                 nzo.set_unpack_info("Script", "%s%s " % (script_ret, script_line), unique=True)
 
         # Cleanup again, including NZB files
-        if all_ok:
+        if all_ok and os.path.isdir(workdir_complete):
             cleanup_list(workdir_complete, False)
 
         # Force error for empty result


### PR DESCRIPTION
Verify the directory still exists before running the final cleanup as it may have been removed by the pp script:
```
2023-03-20 17:20:01,754::INFO::[misc:1171] [sabnzbd.newsunpack.external_processing] Running external command: [...]
2023-03-20 17:20:02,757::INFO::[postproc:1086] Traceback: 
Traceback (most recent call last):
  File "/usr/share/sabnzbdplus/sabnzbd/postproc.py", line 1072, in cleanup_list
    with os.scandir(wdir) as files:
FileNotFoundError: [Errno 2] No such file or directory: '/cat/dir/job_dir'
```