### PR TITLE
Set maximum soft sleep time to 0.15 seconds

### DIFF
--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -763,7 +763,7 @@ class Downloader(Thread):
 
             # Check the Assembler queue to see if we need to delay, depending on queue size
             if (assembler_level := sabnzbd.Assembler.queue_level()) > SOFT_QUEUE_LIMIT:
-                time.sleep((assembler_level - SOFT_QUEUE_LIMIT) / 4)
+                time.sleep(min((assembler_level - SOFT_QUEUE_LIMIT) / 4, 0.15))
                 sabnzbd.BPSMeter.delayed_assembler += 1
                 logged_counter = 0
 


### PR DESCRIPTION
Another minor tweak as I saw some reports that downloads start up slower in 4.0. I suspect it's because of that other change which saves the first part to the correct file instead of a temporary file in combination with the soft sleep that would sleep 0.1 second for each item. If the user has a lot of active connections then a lot of first parts may finish in a single loop. The change to sleep less than 1/4th as long for each item probably helps a lot but there's no point in sleeping longer because it only happens if the queue is full. In that case the sleep loop kicks in if it doesn't clear during the soft sleep.