### PR TITLE
Check for errors when creating the download path

### DIFF
--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -734,7 +734,7 @@ def create_all_dirs(path: str, apply_permissions: bool = False) -> Union[str, bo
 
 
 @synchronized(DIR_LOCK)
-def get_unique_dir(path: str, n: int = 0, create_dir: bool = True) -> str:
+def get_unique_dir(path: str, n: int = 0, create_dir: bool = True) -> Union[str, bool]:
     """Determine a unique folder or filename"""
     if not check_mount(path):
         return path

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -743,7 +743,10 @@ class NzbObject(TryList):
         else:
             # Determine "incomplete" folder
             self.download_path = os.path.join(cfg.download_dir.get_path(), self.work_name)
-            self.download_path = long_path(get_unique_dir(self.download_path, create_dir=True))
+            self.download_path = get_unique_dir(self.download_path, create_dir=True)
+            if not self.download_path:
+                raise NzbEmpty
+            self.download_path = long_path(self.download_path)
             set_permissions(self.download_path)
 
         # Always create the admin-directory, just to be sure

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -741,6 +741,15 @@ class TestGetUniqueDirFilename(ffs.TestCase):
             os.chdir("/")
         assert filesystem.get_unique_dir("foo/bar", n=0, create_dir=False) == "foo/bar"
 
+    def test_nonexistent_dir_without_permission(self):
+        some_dir = "/foo/bar"
+        self.fs.create_dir(some_dir)
+
+        # Remove write permission from the directory.
+        os.chmod(some_dir, 0o500)
+
+        assert filesystem.get_unique_dir(os.path.join(some_dir, "nonexistent"), create_dir=True) is False
+
     def test_creating_dir(self):
         # First call also creates the directory for us
         assert filesystem.get_unique_dir("/foo/bar", n=0, create_dir=True) == "/foo/bar"


### PR DESCRIPTION
Fixes https://github.com/sabnzbd/sabnzbd/issues/2515.

I've checked other usages of the function with `create_dir=True` and this seems to be the only place which doesn't check the return value. Additionally, added a unit test for `get_unique_dir` to verify behaviour and prevent regressions.