### PR TITLE
set min-width so modern browsers are more aligned

### DIFF
--- a/interfaces/Config/templates/staticcfg/css/style.css
+++ b/interfaces/Config/templates/staticcfg/css/style.css
@@ -831,6 +831,7 @@ select {
     vertical-align:middle;
     max-width: 100%;
     min-height: 34px;
+    min-width: 55px;
     font-size: 13px;
     background-color: white;
 }


### PR DESCRIPTION
Set min-width to make macos chrome behave like others

closes #2502 