### PR TITLE
add per-category extension cleanup list

### DIFF
--- a/interfaces/Config/templates/config_cat.tmpl
+++ b/interfaces/Config/templates/config_cat.tmpl
@@ -19,6 +19,7 @@
                             <th>$T('mode')</th>
                             <th>$T('script')</th>
                             <th>$T('catFolderPath')</th>
+                            <th>$T('Cleanup List')</th>
                             <th colspan="2">$T('catTags')</th>
                         </tr>
                         <!--#end if#-->
@@ -75,10 +76,13 @@
                                 <!--#end if#-->
                             </td>
                             <td class="nowrap">
-                                <input type="text" name="dir" class="fileBrowserSmall" value="$slot.dir" size="20" data-initialdir="$defdir" data-title="$T('catFolderPath')" title="$T('explain-catTags2')" />
+                                <input type="text" name="dir" class="fileBrowserSmall" value="$slot.dir" size="12" data-initialdir="$defdir" data-title="$T('catFolderPath')" title="$T('explain-catTags2')" />
                             </td>
                             <td>
-                                <input type="text" name="newzbin" value="$slot.newzbin" size="20" />
+                                <input type="text" name="cleanup" value="$slot.cleanup" size="12" />
+                            </td>
+                            <td>
+                                <input type="text" name="newzbin" value="$slot.newzbin" size="12" />
                             </td>
                             <td class="nowrap">
                                 <button class="btn btn-default">

--- a/interfaces/Config/templates/staticcfg/css/style.css
+++ b/interfaces/Config/templates/staticcfg/css/style.css
@@ -891,11 +891,11 @@ input[type="checkbox"] {
 .Scheduling select,
 .Categories select,
 .RSS select {
-    min-width: 120px;
+    min-width: 100px;
 }
 
 .Categories select {
-    max-width: 150px;
+    max-width: 125px;
 }
 
 .Categories #content input {

--- a/sabnzbd/config.py
+++ b/sabnzbd/config.py
@@ -519,13 +519,14 @@ class ConfigCat:
         self.dir = OptionDir(name, "dir", add=False, create=False)
         self.newzbin = OptionList(name, "newzbin", add=False, validation=sabnzbd.cfg.validate_single_tag)
         self.priority = OptionNumber(name, "priority", DEFAULT_PRIORITY, add=False)
+        self.cleanup = OptionList(name, "cleanup", add=False, validation=sabnzbd.cfg.lower_case_ext)
 
         self.set_dict(values)
         add_to_database("categories", self.__name, self)
 
     def set_dict(self, values: Dict[str, Any]):
         """Set one or more fields, passed as dictionary"""
-        for kw in ("order", "pp", "script", "dir", "newzbin", "priority"):
+        for kw in ("order", "pp", "script", "dir", "newzbin", "priority", "cleanup"):
             try:
                 value = values[kw]
                 getattr(self, kw).set(value)
@@ -542,6 +543,7 @@ class ConfigCat:
         output_dict["dir"] = self.dir()
         output_dict["newzbin"] = self.newzbin.get_string()
         output_dict["priority"] = self.priority()
+        output_dict["cleanup"] = self.cleanup.get_string()
         return output_dict
 
     def delete(self):

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -1787,6 +1787,7 @@ class ConfigCats:
             "dir": "",
             "newzbin": "",
             "priority": DEFAULT_PRIORITY,
+            "cleanup": "",
         }
         categories.insert(1, empty)
         conf["slotinfo"] = categories

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -702,20 +702,6 @@ def get_macos_memory():
     return float(system_output.split()[1])
 
 
-def on_cleanup_list(filename: str, skip_nzb: bool = False) -> bool:
-    """Return True if a filename matches the clean-up list"""
-    cleanup_list = cfg.cleanup_list()
-    if cleanup_list:
-        name, ext = os.path.splitext(filename)
-        ext = ext.strip().lower()
-        name = name.strip()
-        for cleanup_ext in cleanup_list:
-            cleanup_ext = "." + cleanup_ext
-            if (cleanup_ext == ext or (ext == "" and cleanup_ext == name)) and not (skip_nzb and cleanup_ext == ".nzb"):
-                return True
-    return False
-
-
 def memory_usage():
     try:
         # Probably only works on Linux because it uses /proc/<pid>/statm

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -1067,11 +1067,7 @@ def cleanup_list(wdir: str, cat: str, skip_nzb: bool):
     """Remove all files whose extension matches the cleanup list,
     optionally ignoring the nzb extension
     """
-    # Get the list of extensions to be removed
-    if not (cleanup_exts := config.get_category(cat).cleanup()):
-        cleanup_exts = cfg.cleanup_list()
-
-    if cleanup_exts:
+    if cleanup_exts := config.get_category(cat).cleanup() or cfg.cleanup_list():
         try:
             with os.scandir(wdir) as files:
                 for entry in files:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -163,16 +163,6 @@ class TestMisc:
         assert ("[::1]", 1234) == misc.split_host("[::1]:1234")
         assert ("[2001:db8::8080]", None) == misc.split_host("[2001:db8::8080]")
 
-    @set_config({"cleanup_list": [".exe", ".nzb"]})
-    def test_on_cleanup_list(self):
-        assert misc.on_cleanup_list("test.exe")
-        assert misc.on_cleanup_list("TEST.EXE")
-        assert misc.on_cleanup_list("longExeFIlanam.EXe")
-        assert not misc.on_cleanup_list("testexe")
-        assert misc.on_cleanup_list("test.nzb")
-        assert not misc.on_cleanup_list("test.nzb", skip_nzb=True)
-        assert not misc.on_cleanup_list("test.exe.lnk")
-
     def test_format_time_string(self):
         assert "0 seconds" == misc.format_time_string(None)
         assert "0 seconds" == misc.format_time_string("Test")


### PR DESCRIPTION
This change adds a per-category extension cleanup list (comma separated, empty by default), allowing for more fine-grained control of unwanted extensions.

If a cleanup list is defined for a given category, it overrules the global cleanup list for jobs in that category. In case no cleanup list is defined at category level, the global extension cleanup list is applied. Existing configurations should thus continue to work as-is and no settings conversion is needed either.