### PR TITLE
Basic direct write implementation

### DIFF
--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -187,14 +187,22 @@ class Assembler(Thread):
                     # Could be empty in case nzo was deleted
                     if data:
                         # Seek ahead if needed
-                        if article.data_begin > file_position:
-                            fout.seek(article.data_begin, 0)
-                        file_position = article.data_begin + article.data_size
+                        if article.data_begin != file_position:
+                            fout.seek(article.data_begin)
+                        file_position = article.data_begin + len(data)
                         fout.write(data)
                         nzf.update_crc32(article.crc32, len(data))
                         article.on_disk = True
                     else:
                         logging.info("No data found when trying to write %s", article)
+                else:
+                    # If the article was not decoded but the file
+                    # is done, it is just a missing piece, so keep writing
+                    if file_done:
+                        continue
+                    else:
+                        # We reach an article that was not decoded
+                        break
 
         # Final steps
         if file_done:


### PR DESCRIPTION
I created a naive implementation of direct writing article data to their correct spot in the file and it works.
However, it does not pre-allocate files like suggested in #2169.
@animethoso will it be faster to pre-allocate files or just use this seek-ahead approach?

Still need to come up with a way to deal with jobs that were started before this commit as they lack `article.begin/end`.

@mnightingale @puzzledsab What do you think of this approach? It will make the assembler loop over every article for each write, however, the cache is kept as empty as possible. 