### PR TITLE
Feature/addnzbfile enums and keep empty

### DIFF
--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -29,8 +29,6 @@ import cherrypy
 from threading import Thread
 from typing import Tuple, Optional, List, Dict, Any
 
-from sabnzbd.nzbparser import AddNzbFileResult
-
 # For json.dumps, orjson is magnitudes faster than ujson, but it is harder to
 # compile due to Rust dependency. Since the output is the same, we support all modules.
 try:
@@ -52,6 +50,7 @@ from sabnzbd.constants import (
     KIBI,
     MEBI,
     GIGI,
+    AddNzbFileResult,
 )
 import sabnzbd.config as config
 import sabnzbd.cfg as cfg

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -29,6 +29,8 @@ import cherrypy
 from threading import Thread
 from typing import Tuple, Optional, List, Dict, Any
 
+from sabnzbd.nzbparser import AddNzbFileResult
+
 # For json.dumps, orjson is magnitudes faster than ujson, but it is harder to
 # compile due to Rust dependency. Since the output is the same, we support all modules.
 try:
@@ -305,7 +307,7 @@ def _api_addfile(name, kwargs):
             nzbname=kwargs.get("nzbname"),
             password=kwargs.get("password"),
         )
-        return report(keyword="", data={"status": res == 0, "nzo_ids": nzo_ids})
+        return report(keyword="", data={"status": res is AddNzbFileResult.OK, "nzo_ids": nzo_ids})
     else:
         return report(_MSG_NO_VALUE)
 
@@ -350,7 +352,7 @@ def _api_addlocalfile(name, kwargs):
                     nzbname=kwargs.get("nzbname"),
                     password=kwargs.get("password"),
                 )
-                return report(keyword="", data={"status": res == 0, "nzo_ids": nzo_ids})
+                return report(keyword="", data={"status": res is AddNzbFileResult.OK, "nzo_ids": nzo_ids})
             else:
                 logging.info('API-call addlocalfile: "%s" is not a supported file', name)
                 return report(_MSG_NO_FILE)

--- a/sabnzbd/constants.py
+++ b/sabnzbd/constants.py
@@ -162,3 +162,10 @@ class Status:
     VERIFYING = "Verifying"  # PP: Job is being verified (by par2)
     DELETED = "Deleted"  # Q:  Job has been deleted (and is almost gone)
     PROP = "Propagating"  # Q:  Delayed download
+
+
+class AddNzbFileResult:
+    RETRY = "Retry"  # File could not be read
+    ERROR = "Error"  # Rejected as duplicate, by pre-queue script or other failure to process file
+    OK = "OK"  # Added to queue
+    NO_FILES_FOUND = "No files found"  # Malformed or might not be an NZB file

--- a/sabnzbd/dirscanner.py
+++ b/sabnzbd/dirscanner.py
@@ -26,11 +26,10 @@ import threading
 from typing import Generator, Set, Optional, Tuple
 
 import sabnzbd
-from sabnzbd.constants import SCAN_FILE_NAME, VALID_ARCHIVES, VALID_NZB_FILES
+from sabnzbd.constants import SCAN_FILE_NAME, VALID_ARCHIVES, VALID_NZB_FILES, AddNzbFileResult
 import sabnzbd.filesystem as filesystem
 import sabnzbd.config as config
 import sabnzbd.cfg as cfg
-from sabnzbd.nzbparser import AddNzbFileResult
 
 DIR_SCANNER_LOCK = threading.RLock()
 VALID_EXTENSIONS = set(VALID_NZB_FILES + VALID_ARCHIVES)

--- a/sabnzbd/dirscanner.py
+++ b/sabnzbd/dirscanner.py
@@ -30,6 +30,7 @@ from sabnzbd.constants import SCAN_FILE_NAME, VALID_ARCHIVES, VALID_NZB_FILES
 import sabnzbd.filesystem as filesystem
 import sabnzbd.config as config
 import sabnzbd.cfg as cfg
+from sabnzbd.nzbparser import AddNzbFileResult
 
 DIR_SCANNER_LOCK = threading.RLock()
 VALID_EXTENSIONS = set(VALID_NZB_FILES + VALID_ARCHIVES)
@@ -205,10 +206,10 @@ class DirScanner(threading.Thread):
 
         # Add the NZB's
         res, _ = sabnzbd.nzbparser.add_nzbfile(path, catdir=catdir, keep=False)
-        if res < 0:
+        if res is AddNzbFileResult.RETRY or res is AddNzbFileResult.ERROR:
             # Retry later, for example when we can't read the file
             self.suspected[path] = stat_tuple
-        elif res == 0:
+        elif res is AddNzbFileResult.OK:
             self.error_reported = False
         else:
             self.ignored[path] = 1

--- a/sabnzbd/nzbparser.py
+++ b/sabnzbd/nzbparser.py
@@ -28,7 +28,6 @@ import xml.etree.ElementTree
 import datetime
 import zipfile
 import tempfile
-from enum import Enum, auto
 
 import cherrypy._cpreqbody
 from typing import Optional, Dict, Any, Union, List, Tuple
@@ -45,15 +44,8 @@ from sabnzbd.filesystem import (
     remove_data,
 )
 from sabnzbd.misc import name_to_cat
-from sabnzbd.constants import DEFAULT_PRIORITY, VALID_ARCHIVES
+from sabnzbd.constants import DEFAULT_PRIORITY, VALID_ARCHIVES, AddNzbFileResult
 from sabnzbd.utils import rarfile
-
-
-class AddNzbFileResult(Enum):
-    RETRY = auto()
-    ERROR = auto()
-    OK = auto()
-    NO_FILES_FOUND = auto()
 
 
 def add_nzbfile(

--- a/sabnzbd/nzbparser.py
+++ b/sabnzbd/nzbparser.py
@@ -28,6 +28,8 @@ import xml.etree.ElementTree
 import datetime
 import zipfile
 import tempfile
+from enum import Enum, auto
+
 import cherrypy._cpreqbody
 from typing import Optional, Dict, Any, Union, List, Tuple
 
@@ -45,6 +47,13 @@ from sabnzbd.filesystem import (
 from sabnzbd.misc import name_to_cat
 from sabnzbd.constants import DEFAULT_PRIORITY, VALID_ARCHIVES
 from sabnzbd.utils import rarfile
+
+
+class AddNzbFileResult(Enum):
+    RETRY = auto()
+    ERROR = auto()
+    OK = auto()
+    NO_FILES_FOUND = auto()
 
 
 def add_nzbfile(
@@ -158,11 +167,9 @@ def process_nzb_archive_file(
     url: Optional[str] = None,
     password: Optional[str] = None,
     nzo_id: Optional[str] = None,
-) -> Tuple[int, List[str]]:
+) -> Tuple[AddNzbFileResult, List[str]]:
     """Analyse archive and create job(s).
     Accepts archive files with ONLY nzb/nfo/folder files in it.
-    returns (status, nzo_ids)
-        status: -2==Error/retry, -1==Error, 0==OK, 1==No files found
     """
     nzo_ids = []
     if catdir is None:
@@ -178,21 +185,21 @@ def process_nzb_archive_file(
             zf = sabnzbd.newsunpack.SevenZip(path)
         else:
             logging.info("File %s is not a supported archive!", filename)
-            return -1, []
+            return AddNzbFileResult.ERROR, []
     except:
         logging.info(T("Cannot read %s"), path, exc_info=True)
-        return -2, []
+        return AddNzbFileResult.RETRY, []
 
-    status = 1
+    status: AddNzbFileResult = AddNzbFileResult.NO_FILES_FOUND
     names = zf.namelist()
     nzbcount = 0
     for name in names:
         name = name.lower()
         if name.endswith(".nzb"):
-            status = 0
+            status = AddNzbFileResult.OK
             nzbcount += 1
 
-    if status == 0:
+    if status == AddNzbFileResult.OK:
         if nzbcount != 1:
             nzbname = None
         for name in names:
@@ -202,7 +209,7 @@ def process_nzb_archive_file(
                 except OSError:
                     logging.error(T("Cannot read %s"), name, exc_info=True)
                     zf.close()
-                    return -1, []
+                    return AddNzbFileResult.ERROR, []
                 name = get_filename(name)
                 if datap:
                     nzo = None
@@ -254,7 +261,7 @@ def process_nzb_archive_file(
 
     # If all were rejected/empty/etc, update status
     if not nzo_ids:
-        status = 1
+        status = AddNzbFileResult.NO_FILES_FOUND
 
     return status, nzo_ids
 
@@ -275,11 +282,9 @@ def process_single_nzb(
     url: Optional[str] = None,
     password: Optional[str] = None,
     nzo_id: Optional[str] = None,
-) -> Tuple[int, List[str]]:
+) -> Tuple[AddNzbFileResult, List[str]]:
     """Analyze file and create a job from it
     Supports NZB, NZB.BZ2, NZB.GZ and GZ.NZB-in-disguise
-    returns (status, nzo_ids)
-        status: -2==Error/retry, -1==Error, 0==OK
     """
     if catdir is None:
         catdir = cat
@@ -302,7 +307,7 @@ def process_single_nzb(
     except OSError:
         logging.warning(T("Cannot read %s"), clip_path(path))
         logging.info("Traceback: ", exc_info=True)
-        return -2, []
+        return AddNzbFileResult.RETRY, []
 
     if filename:
         filename, cat = name_to_cat(filename, catdir)
@@ -312,7 +317,7 @@ def process_single_nzb(
             nzbname = get_filename(filename)
 
     # Parse the data
-    result = 0
+    result: AddNzbFileResult = AddNzbFileResult.OK
     nzo = None
     nzo_ids = []
     try:
@@ -334,7 +339,7 @@ def process_single_nzb(
             nzo.password = password
     except (sabnzbd.nzbstuff.NzbEmpty, sabnzbd.nzbstuff.NzbRejected):
         # Empty or fully rejected
-        result = -1
+        result = AddNzbFileResult.ERROR
         pass
     except sabnzbd.nzbstuff.NzbRejectedToHistory as err:
         # Duplicate or unwanted extension that was failed to history
@@ -342,7 +347,7 @@ def process_single_nzb(
     except:
         # Something else is wrong, show error
         logging.error(T("Error while adding %s, removing"), filename, exc_info=True)
-        result = -1
+        result = AddNzbFileResult.ERROR
     finally:
         nzb_fp.close()
 

--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -40,6 +40,7 @@ import sabnzbd.cfg as cfg
 import sabnzbd.emailer as emailer
 import sabnzbd.notifier as notifier
 from sabnzbd.encoding import ubtou, utob
+from sabnzbd.nzbparser import AddNzbFileResult
 from sabnzbd.nzbstuff import NzbObject
 
 
@@ -255,14 +256,13 @@ class URLGrabber(Thread):
                         password=future_nzo.password,
                         nzo_id=future_nzo.nzo_id,
                     )
-                    # -2==Error/retry, -1==Error, 0==OK, 1==Empty
-                    if res == -2:
+                    if res is AddNzbFileResult.RETRY:
                         logging.info("Incomplete NZB, retry after 5 min %s", url)
                         self.add(url, future_nzo, when=300)
-                    elif res == -1:
+                    elif res is AddNzbFileResult.ERROR:
                         # Error already thrown
                         self.fail_to_history(future_nzo, url)
-                    elif res == 1:
+                    elif res is AddNzbFileResult.NO_FILES_FOUND:
                         # No NZB-files inside archive
                         self.fail_to_history(future_nzo, url, T("Empty NZB file %s") % filename)
                 else:

--- a/tests/test_dirscanner.py
+++ b/tests/test_dirscanner.py
@@ -21,7 +21,7 @@ tests.test_dirscanner - Testing functions in dirscanner.py
 
 import pyfakefs.fake_filesystem_unittest as ffs
 
-from sabnzbd.nzbparser import AddNzbFileResult
+from sabnzbd.constants import AddNzbFileResult
 from tests.testhelper import *
 
 # Set the global uid for fake filesystems to a non-root user;

--- a/tests/test_dirscanner.py
+++ b/tests/test_dirscanner.py
@@ -21,6 +21,7 @@ tests.test_dirscanner - Testing functions in dirscanner.py
 
 import pyfakefs.fake_filesystem_unittest as ffs
 
+from sabnzbd.nzbparser import AddNzbFileResult
 from tests.testhelper import *
 
 # Set the global uid for fake filesystems to a non-root user;
@@ -70,7 +71,7 @@ class TestDirScanner:
         ],
     )
     async def test_adds_valid_nzbs(self, mock_sleep, fs, mocker, path, catdir):
-        mocker.patch("sabnzbd.nzbparser.add_nzbfile", return_value=(-1, []))
+        mocker.patch("sabnzbd.nzbparser.add_nzbfile", return_value=(AddNzbFileResult.ERROR, []))
         mocker.patch("sabnzbd.config.save_config", return_value=True)
 
         fs.create_file(os.path.join(sabnzbd.cfg.dirscan_dir.get_path(), catdir or "", path), contents="FAKEFILE")
@@ -97,7 +98,7 @@ class TestDirScanner:
         ],
     )
     async def test_ignores_empty_files(self, mock_sleep, fs, mocker, path):
-        mocker.patch("sabnzbd.nzbparser.add_nzbfile", return_value=(-1, []))
+        mocker.patch("sabnzbd.nzbparser.add_nzbfile", return_value=(AddNzbFileResult.ERROR, []))
         mocker.patch("sabnzbd.config.save_config", return_value=True)
 
         fs.create_file(os.path.join(sabnzbd.cfg.dirscan_dir.get_path(), path))
@@ -118,7 +119,7 @@ class TestDirScanner:
         ],
     )
     async def test_ignores_non_nzbs(self, mock_sleep, fs, mocker, path):
-        mocker.patch("sabnzbd.nzbparser.add_nzbfile", return_value=(-1, []))
+        mocker.patch("sabnzbd.nzbparser.add_nzbfile", return_value=(AddNzbFileResult.ERROR, []))
         mocker.patch("sabnzbd.config.save_config", return_value=True)
 
         fs.create_file(os.path.join(sabnzbd.cfg.dirscan_dir.get_path(), path), contents="FAKEFILE")


### PR DESCRIPTION
Closes #2550

I suggest looking at the commits separately.

# Replace `add_nzbfile` result int with an enum

This is really just to make the logic a little easier to follow.
If an IntEnum was used dirscanner could have carried on using `if res < AddNzbFileResult.OK` but it seemed a bit magic to me so I replace it with explicitly checking for enums.
I intentionally chose not to use the old ints as the enum values, it doesn't really make any difference either way as you can't compare the enum to the int value directly anyway, IntEnum could but it's defeating the purpose of using enums.

# Watched folder keep empty/invalid files

As #2550 describes this is mainly for `.gz` files, they might not be `.nzb` files so we shouldn't delete them if the decoding resulted in an empty file.
It'll still try and add the file and report errors, but it shouldn't delete the file.
Files rejected by pre-queue script should still be deleted.

---

Ideally we'd also check the extensions so the watcher matches `.nzb.gz` and `.nzb.bz2` but that gets a bit complicated.
VALID_NZB_FILES is used in combination with `sabnzbd.filesystem.get_ext` in several places but that isn't going to work.
If we did want that behaviour I think we'd need a `is_nzbfile` method to regex check the path or another solution.
I could change this but I'd need to change everywhere which uses get_ext - thoughts?
