### PR TITLE
postproc: Print last line in case of error

### DIFF
--- a/po/main/SABnzbd.pot
+++ b/po/main/SABnzbd.pot
@@ -1434,10 +1434,6 @@ msgid "Ran %s"
 msgstr ""
 
 #: sabnzbd/postproc.py
-msgid "Script exit code is %s"
-msgstr ""
-
-#: sabnzbd/postproc.py
 msgid "Exit(%s) %s"
 msgstr ""
 

--- a/po/main/SABnzbd.pot
+++ b/po/main/SABnzbd.pot
@@ -1437,6 +1437,10 @@ msgstr ""
 msgid "Script exit code is %s"
 msgstr ""
 
+#: sabnzbd/postproc.py
+msgid "Exit(%s) %s"
+msgstr ""
+
 #: sabnzbd/postproc.py, sabnzbd/skintext.py
 msgid "More"
 msgstr ""

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -556,7 +556,7 @@ def process_job(nzo: NzbObject):
                     if script_ret and cfg.script_can_fail():
                         script_error = True
                         all_ok = False
-                        nzo.fail_msg = T("Script exit code is %s") % script_ret
+                        nzo.fail_msg = T("Exit(%s) %s") % (script_ret, script_line or "")
 
         # Email the results
         if not nzb_list and cfg.email_endjob():

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -577,18 +577,18 @@ def process_job(nzo: NzbObject):
         if script_output:
             # Can do this only now, otherwise it would show up in the email
             if script_ret:
-                script_ret = "Exit(%s) " % script_ret
+                script_msg = T("Exit(%s) %s") % (script_ret, script_line)
             else:
-                script_ret = ""
+                script_msg = script_line
             if len(script_log.rstrip().split("\n")) > 1:
                 nzo.set_unpack_info(
                     "Script",
-                    '%s%s <a href="./scriptlog?name=%s">(%s)</a>' % (script_ret, script_line, script_output, T("More")),
+                    '%s <a href="./scriptlog?name=%s">(%s)</a>' % (script_msg, script_output, T("More")),
                     unique=True,
                 )
             else:
                 # No '(more)' button needed
-                nzo.set_unpack_info("Script", "%s%s " % (script_ret, script_line), unique=True)
+                nzo.set_unpack_info("Script", "%s " % script_msg, unique=True)
 
         # Cleanup again, including NZB files
         if all_ok and os.path.isdir(workdir_complete):


### PR DESCRIPTION
When a postproc fails, provide last line in addition to exit code.

before:
![image](https://github.com/sabnzbd/sabnzbd/assets/1587259/767e38d8-2ffa-4edb-844b-67acb2dc2f5e)

after:
![image](https://github.com/sabnzbd/sabnzbd/assets/1587259/448dfb56-65a9-49be-88a6-b12164425b17)
