### PR TITLE
Fix uu decode workaround

### DIFF
--- a/sabnzbd/decoder.py
+++ b/sabnzbd/decoder.py
@@ -292,7 +292,7 @@ def decode_uu(article: Article, raw_data: bytearray) -> bytes:
             except binascii.Error as msg:
                 try:
                     # Workaround for broken uuencoders by Fredrik Lundh
-                    nbytes = (((ord(line[0]) - 32) & 63) * 4 + 5) / 3
+                    nbytes = (((line[0] - 32) & 63) * 4 + 5) // 3
                     decoded_line = binascii.a2b_uu(line[:nbytes])
                 except Exception as msg2:
                     logging.info(

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -184,7 +184,6 @@ class TestUuDecoder:
     @pytest.mark.parametrize(
         "bad_data",
         [
-            b"MI^+0E\"C^364:CQ':]DW++^$F0J)6FDG/!`]0\\(4;EG$UY5RI,3JMBNX\\8+06\r\n$(WAIVBC^",  # Trailing junk
             VALID_UU_LINES[-1][:10] + bytes("ваше здоровье", encoding="utf8") + VALID_UU_LINES[-1][-10:],  # Non-ascii
         ],
     )


### PR DESCRIPTION
Replaced with line from https://github.com/python/cpython/blob/3.12/Lib/uu.py#L165

Tested with "audio fidelity", no more warnings and skipped articles.

PyCharm warns with `ord(line[0])` and `Expected type 'str | bytes', got 'int' instead ` hence exception `TypeError('ord() expected string of length 1, but int found')`