### PR TITLE
Fix uu decoding for lines starting with a doubled period

### DIFF
--- a/sabnzbd/decoder.py
+++ b/sabnzbd/decoder.py
@@ -287,6 +287,10 @@ def decode_uu(article: Article, raw_data: bytearray) -> bytes:
             if line in (b"`", b"end", b"."):
                 break
 
+            # Remove dot stuffing
+            if line.startswith(b".."):
+                line = line[1:]
+
             try:
                 decoded_line = binascii.a2b_uu(line)
             except binascii.Error as msg:


### PR DESCRIPTION
Closes #2599

Raw lines of length 14 will start with a period[^1], NNTP spec requires such lines are prefixed with an additional period. Therefore we need to handle lines starting with a double period when decoding.

For the tests I added a `uu` helper and used it for all cases, it's only necessary for lines of length 14 such as `END_DATA = os.urandom(randint(1, 45))` or `insert_dot_stuffing_line` but it is a bit clearer to always use it.

The test is not totally representative or uuencoded data since all data lines except the last should be 45 characters (unencoded) but if `insert_dot_stuffing_line` and `insert_end` are set they may both be less than 45.
I don't think it matters, they are still correctly encoded lines and I ensured `insert_end` is still always at the end.

[^1]: https://en.wikipedia.org/wiki/Uuencoding#Encoded_format