### PR TITLE
add optional xff header verification to check_access

### DIFF
--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -430,6 +430,7 @@ no_penalties = OptionBool("misc", "no_penalties", False)
 x_frame_options = OptionBool("misc", "x_frame_options", True)
 allow_old_ssl_tls = OptionBool("misc", "allow_old_ssl_tls", False)
 enable_season_sorting = OptionBool("misc", "enable_season_sorting", True)
+verify_xff_header = OptionBool("misc", "verify_xff_header", False)
 
 # Text values
 rss_odd_titles = OptionList("misc", "rss_odd_titles", ["nzbindex.nl/", "nzbindex.com/", "nzbclub.com/"])

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -213,7 +213,8 @@ def check_access(access_type: int = 4, warn_user: bool = False) -> bool:
     # Never check the XFF header unless access would have been granted based on the remote IP alone!
     if is_allowed and cfg.verify_xff_header() and (xff_header := cherrypy.request.headers.get("X-Forwarded-For")):
         xff_ips = [ip.strip() for ip in xff_header.split(",")]
-        if not (is_allowed := all(is_local_addr(ip) or is_loopback_addr(ip) for ip in xff_ips)):
+        is_allowed = all(is_local_addr(ip) or is_loopback_addr(ip) for ip in xff_ips)
+        if not is_allowed:
             logging.debug("Denying access based on X-Forwarded-For header '%s'", xff_header)
 
     if not is_allowed and warn_user:

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -983,6 +983,15 @@ def is_lan_addr(ip: str) -> bool:
         return False
 
 
+def is_local_addr(ip: str) -> bool:
+    """Determine if an IP address is to be considered local, i.e. it's part of a subnet in
+    local_ranges, if defined, or in private address space reserved for local area networks."""
+    if local_ranges := cfg.local_ranges():
+        return any(ip_in_subnet(ip, local_range) for local_range in local_ranges)
+    else:
+        return is_lan_addr(ip)
+
+
 def ip_extract() -> List[str]:
     """Return list of IP addresses of this system"""
     ips = []

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,0 +1,165 @@
+#!/usr/bin/python3 -OO
+# Copyright 2007-2023 The SABnzbd-Team <team@sabnzbd.org>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+tests.test_interface - Testing functions in interface.py
+"""
+import cherrypy
+
+from sabnzbd import interface
+from sabnzbd.misc import is_local_addr, is_loopback_addr
+
+from tests.testhelper import *
+
+
+class TestInterfaceFunctions:
+    @pytest.mark.parametrize(
+        "remote_ip, local_ranges, xff_header, result_with_xff",
+        [
+            ("10.11.12.13", None, None, True),
+            ("10.11.12.13", None, "127.0.0.1", True),
+            ("10.11.12.13", None, "127.1.2.3", True),
+            ("10.11.12.13", None, "127.0.0.1:8080", False),  # Port number in XFF
+            ("10.11.12.13", None, "::1", True),
+            ("10.11.12.13", None, "[::1]", True),
+            ("10.11.12.13", None, "[::1]:8080", False),  # Port number in XFF
+            ("10.11.12.13", None, "localhost", False),  # Hostname in XFF
+            ("10.11.12.13", None, "example.org", False),  # Hostname in XFF
+            ("10.11.12.13", None, "192.168.1.1", True),
+            ("10.11.12.13", None, "10.11.12.99", True),
+            ("10.11.12.13", None, "8.7.6.5", False),  # XFF IP isn't local
+            ("10.11.12.13", None, "192.168.1.1, 10.11.12.13", True),
+            ("10.11.12.13", None, "192.168.1.1, 10.11.12.13, 9.8.7.6", False),  # Last XFF IP isn't local
+            ("10.11.12.13", None, "192.168.1.1, 10.11.12.13, ::1", True),
+            ("10.11.12.13", None, "192.168.1.1, 10.11.12.13, sabrules.example.org", False),  # Hostname in XFF
+            ("10.11.12.13", "192.168.1.0/24", None, False),  # Remote IP not part of local ranges
+            ("10.11.12.13", "192.168.1.0/24", "192.168.1.23", False),
+            ("10.11.12.13", "192.168.1.0/24", "192.168.1.23, 10.11.12.1", False),
+            ("10.11.12.13", "192.168.1.0/24, 10.0.0.0/8", "192.168.1.23", True),
+            ("10.11.12.13", "192.168.2.0/24, 10.0.0.0/8", "192.168.1.23", False),
+            ("10.11.12.13", "192.168.1.0/24, 10.0.0.0/24", "192.168.1.23", False),
+            ("10.11.12.13", "10.11.12.0/24", "192.168.1.23", False),
+            ("10.11.12.13", "2001:ffff::/64", None, False),
+            ("10.11.12.13", "2001:ffff::/64, 192.168.1.0/24", None, False),
+            ("13.12.11.10", None, None, False),  # Public remote IP doesn't have access, XFF ignored altogether
+            ("13.12.11.10", None, "127.0.0.1", False),
+            ("13.12.11.10", None, "127.1.2.3", False),
+            ("13.12.11.10", None, "::1", False),
+            ("13.12.11.10", None, "[::1]", False),
+            ("13.12.11.10", None, "localhost", False),
+            ("13.12.11.10", None, "192.168.1.1", False),
+            ("13.12.11.10", None, "192.168.1.1, 13.12.11.10", False),
+            ("13.12.11.10", None, "192.168.1.1, 13.12.11.10, ::1", False),
+            ("13.12.11.10", None, "2001::/16", False),
+            ("13.12.11.10", None, "2001::/16, 13.12.11.10", False),
+            ("13.12.11.10", None, "2001::/16, 13.0.0.0/9", False),
+            ("13.12.11.10", "13.12.11.10", None, True),  # Local ranges include a public IP
+            ("13.12.11.10", "13.12.11.10, 192.168.255.0/24", None, True),
+            ("13.12.11.10", "13.12.11.10", "192.168.1.1", False),  # XFF not in local ranges
+            ("13.12.11.10", "13.12.11.10, 192.168.255.0/24", "192.168.1.1", False),
+            ("13.12.11.10", "13.12.11.10", "192.168.1.1, 9.8.7.6", False),
+            ("13.12.11.10", "13.12.11.10, 192.168.255.0/24", "192.168.1.1, 9.8.7.6", False),
+            ("13.12.11.10", "13.0.0.0/12", None, True),
+            ("13.12.11.10", "13.0.0.0/12, 192.168.255.0/24", None, True),
+            ("13.12.11.10", "13.0.0.0/12", "192.168.1.1", False),  # XFF not in local ranges
+            ("13.12.11.10", "13.0.0.0/12, 192.168.255.0/24", "192.168.1.1", False),
+            ("13.12.11.10", "13.0.0.0/12", "192.168.1.1, 9.8.7.6", False),
+            ("13.12.11.10", "13.0.0.0/12, 192.168.255.0/24", "192.168.1.1, 9.8.7.6", False),
+            ("127.6.6.6", None, None, True),
+            ("127.6.6.6", None, "127.0.0.1", True),
+            ("127.6.6.6", None, "127.1.2.3", True),
+            ("127.6.6.6", None, "127.0.0.1:8080", False),  # Port number in XFF
+            ("127.6.6.6", None, "::1", True),
+            ("127.6.6.6", None, "[::1]", True),
+            ("127.6.6.6", None, "[::1]:8080", False),  # Port number in XFF
+            ("127.6.6.6", None, "localhost", False),  # Hostname in XFF
+            ("127.6.6.6", None, "example.org", False),  # Hostname in XFF
+            ("127.6.6.6", None, "192.168.1.1", True),
+            ("127.6.6.6", None, "10.11.12.99", True),
+            ("127.6.6.6", None, "8.7.6.5", False),  # XFF IP isn't local
+            ("127.6.6.6", None, "192.168.1.1, 127.6.6.6", True),
+            ("127.6.6.6", None, "192.168.1.1, 127.6.6.6, 9.8.7.6", False),  # Last XFF IP isn't local
+            ("127.6.6.6", None, "192.168.1.1, 127.6.6.6, ::1", True),
+            ("127.6.6.6", None, "192.168.1.1, 127.6.6.6, sabrules.example.org", False),  # Hostname in XFF
+            ("127.6.6.6", "192.168.1.0/24", None, True),  # Remote IP is loopback, local ranges be damned
+            ("127.6.6.6", "192.168.1.0/24", "192.168.1.23", True),
+            ("127.6.6.6", "192.168.1.0/24", "192.168.1.23, 127.0.0.1", True),
+            ("127.6.6.6", "192.168.1.0/24, 127.0.0.0/8", "192.168.1.23", True),
+            ("127.6.6.6", "192.168.2.0/24, 127.0.0.0/8", "192.168.1.23", False),  # Access denied by XFF
+            ("127.6.6.6", "192.168.2.0/24, 127.0.0.0/8", "5.6.7.8", False),  # Idem
+            ("127.6.6.6", "192.168.1.0/24, 127.0.0.0/8", "192.168.1.23, 5.6.7.8", False),  # Idem
+            ("127.6.6.6", "192.168.1.0/24, 10.0.0.0/24", "::1", True),
+            ("127.6.6.6", "127.6.6.0/24", "192.168.1.23", False),  # Access denied by XFF
+            ("127.6.6.6", "2001:ffff::/32", None, True),
+            ("127.6.6.6", "2001:ffff::/32, 192.168.1.0/24", None, True),
+            ("127.6.6.6", "2001:ffff::/32", "2001:ffff:a:b:c:d:e:f", True),
+            ("127.6.6.6", "2001:ffff::/32, 192.168.1.0/24", "2001:ffff:a:b:c:d:e:f, 192.168.1.1", True),
+            ("127.6.6.6", "2001:ffff::/32", "666:ffff:a:b:c:d:e:f", False),  # Access denied by XFF
+            ("127.6.6.6", "2001:ffff::/32, 192.168.1.0/24", "666:ffff:a:b:c:d:e:f, 192.168.1.1", False),  # Idem
+            ("DEAD:BEEF:2023:007::1", None, None, False),  # Back to ignoring XFF altogether
+            ("DEAD:BEEF:2023:007::1", None, "127.0.0.1", False),  # XFF is loopback
+            ("DEAD:BEEF:2023:007::1", None, "127.1.2.3", False),
+            ("DEAD:BEEF:2023:007::1", None, "::1", False),
+            ("DEAD:BEEF:2023:007::1", None, "[::1]", False),
+            ("DEAD:BEEF:2023:007::1", None, "localhost", False),  # Hostname in XFF
+            ("DEAD:BEEF:2023:007::1", None, "192.168.1.1", False),
+            ("DEAD:BEEF:2023:007::1", None, "192.168.1.1, DEAD:BEEF:2023:0007::1", False),
+            ("DEAD:BEEF:2023:007::1", None, "192.168.1.1, DEAD:BEEF:2023:0007::1, ::1", False),
+            ("DEAD:BEEF:2023:007::1", None, "2001::/16", False),
+            ("DEAD:BEEF:2023:007::1", "dead:beef::/32", None, True),  # Local ranges include a public IPv6
+            ("DEAD:BEEF:2023:007::1", "dead:beef::/32", "127.0.0.1", True),  # XFF is loopback
+            ("DEAD:BEEF:2023:007::1", "dead:beef::/32", "127.1.2.3", True),
+            ("DEAD:BEEF:2023:007::1", "dead:beef::/32", "::1", True),
+            ("DEAD:BEEF:2023:007::1", "dead:beef::/32", "[::1]", True),
+            ("DEAD:BEEF:2023:007::1", "dead:beef::/32", "localhost", False),  # Hostname in XFF
+            ("DEAD:BEEF:2023:007::1", "dead:beef::/32", "192.168.1.1", False),
+            ("DEAD:BEEF:2023:007::1", "dead:beef::/32", "192.168.1.1, DEAD:BEEF:2023:0007::1", False),
+            ("DEAD:BEEF:2023:007::1", "dead:beef::/32", "192.168.1.1, DEAD:BEEF:2023:0007::1, ::1", False),
+            ("DEAD:BEEF:2023:007::1", "dead:beef::/32", "DEAD::/16", False),  # Netmask in XFF
+            ("DEAD:BEEF:2023:007::1", "dead:beef::/32", "DEAD:BEEF:2023:7::42", True),  # XFF in local ranges
+        ],
+    )
+    @pytest.mark.parametrize("access_type", [1, 2, 3, 4, 5, 6])
+    @pytest.mark.parametrize("inet_exposure", [0, 1, 2, 3, 4, 5])
+    @pytest.mark.parametrize("verify_xff_header", [False, True])
+    def test_check_access(
+        self, access_type, inet_exposure, local_ranges, remote_ip, xff_header, verify_xff_header, result_with_xff
+    ):
+        @set_config(
+            {
+                "local_ranges": local_ranges,
+                "inet_exposure": inet_exposure,
+                "verify_xff_header": verify_xff_header,
+            }
+        )
+        def _func():
+            # Insert fake request data
+            cherrypy.request.remote.ip = remote_ip
+            cherrypy.request.headers.update({"X-Forwarded-For": xff_header})
+
+            if verify_xff_header:
+                result = result_with_xff
+            else:
+                # Without XFF, only the remote IP and the local ranges setting matter
+                result = is_loopback_addr(remote_ip) or is_local_addr(remote_ip)
+
+            if access_type <= inet_exposure:
+                assert interface.check_access(access_type) is True
+            else:
+                assert interface.check_access(access_type) is result
+
+        _func()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -470,6 +470,70 @@ class TestMisc:
         assert misc.is_lan_addr(value) is result
 
     @pytest.mark.parametrize(
+        "value, local_ranges, result",
+        [
+            ("10.11.12.13", None, True),
+            ("172.16.2.81", None, True),
+            ("192.168.255.255", None, True),
+            ("169.254.42.42", None, True),  # Link-local
+            ("fd00::ffff", None, True),  # Part of fc00::/7, IPv6 "Unique Local Addresses"
+            ("fe80::a1", None, True),  # IPv6 Link-local
+            ("::1", None, False),
+            ("localhost", None, False),
+            ("127.0.0.1", None, False),
+            ("2001:1337:babe::", None, False),
+            ("172.32.32.32", None, False),  # Near but not part of 172.16.0.0/12
+            ("100.64.0.1", None, False),  # Test net
+            ("[2001::1]", None, False),
+            ("::", None, False),
+            ("::a:b:c", None, False),
+            ("1.2.3.4", None, False),
+            ("255.255.255.255", None, False),
+            ("0.0.0.0", None, False),
+            ("127.0.0.1", None, False),
+            ("400.500.600.700", None, False),
+            ("blabla", None, False),
+            (-666, None, False),
+            ("example.org", None, False),
+            (None, None, False),
+            ("", None, False),
+            ("[1.2.3.4]", None, False),
+            ("2001:1", None, False),
+            ("2001::[2001::1]", None, False),
+            ("::ffff:192.168.1.100", None, True),
+            ("::ffff:1.1.1.1", None, False),
+            ("::ffff:127.0.0.1", None, False),
+            ("10.11.12.13", "10.0.0.0/8", True),
+            ("10.11.12.13", "12.34.56.78, 10.0.0.0/8", True),
+            ("10.11.12.13", "10.0.0.0/24", False),
+            ("172.16.2.81", "10.0.0.0/24", False),
+            ("192.168.255.255", "2001::/64", False),
+            ("2001:1337:babe::42", "2001:1337:babe::/48", True),
+            ("2001:1337:babe::11", "1002:1337:babe::/48", False),
+            ("2001:1337:babe::", "2001:1337:babe::/16", False),  # Invalid local range
+            ("2001:1337:babe::", "1002:1337:babe::/8", False),  # Idem
+            ("2001::1", "2001::/2", False),
+            ("::", "1.2.3.0/26, 9.8.7.6", False),
+            ("::a:b:c", "1.2.3.0/26, 9.8.7.6", False),
+            ("1.2.3.4", "1.2.3.0/24, 9.8.7.6", True),
+            ("1.2.3.4", "1.2.3.4/32, 9.8.7.6", True),
+            ("1.2.3.4", "9.8.7.6, 1.2.3.4/32", True),
+            ("1.2.3.4", "ffff:1234::/128, 1.2.3.4/32, 9.8.7.6", True),
+            ("ffff:1234::0", "ffff:1234::/128, 1.2.3.4/32, 9.8.7.6", True),
+            ("EEEE::ccc", "ffff:1234::/128, 1.2.3.4/32, 9.8.7.6", False),
+            ("FFFFFFFF:1234::0", "ffff:1234::/128, 1.2.3.4/32, 9.8.7.6", False),
+            ("1.2.3.4", "1.2.3.3/32, 9.8.7.6", False),
+            ("1.2.3.4", "1.2.3.5/32, 9.8.7.6", False),
+        ],
+    )
+    def test_is_local_addr(self, value, local_ranges, result):
+        @set_config({"local_ranges": local_ranges})
+        def _func():
+            assert misc.is_local_addr(value) is result
+
+        _func()
+
+    @pytest.mark.parametrize(
         "ip, subnet, result",
         [
             ("2001:c0f:fee::1", "2001:c0f:fee", True),  # Old-style range setting


### PR DESCRIPTION
As the "X-" at the start of the name suggests, no formal specification exists for the X-Forwarded-For header. Consensus seems to be that it's supposed to provide one or more IP addresses (with multiple entries comma-separated, spacing optional). A legitimate reverse proxy setup would typically rewrite the header though, so there will often only be a single IP address present even for connections that passed through a chain of proxies. Cherrypy seems to only pass on a single header even if multiple xff headers were sent with the request.

This changeset adds optional verification of the address(es) in the header. Verification is off by default, in which case access is determined solely on the basis of the remote IP - same as before - so existing setups relying on this behaviour continue to work.

With verification turned on, every IP address in the XFF header is checked **in addition to** the remote IP, and access only granted if all checks pass. If the header contains multiple addresses, they must all qualify for access to be granted. Invalid entries (hostnames, IP addresses with port numbers attached, random junk, etc.) aren't filtered out and may lead to access being denied.

Thus, for a typical connection coming in through a reverse proxy (remote IP 127.0.0.1 with XFF IP 12.34.56.78, as seen from the perspective of sabnzbd):
- allowed with verification off, as the remote IP is a loopback address (same as before);
- denied with verification on (fixing the reported issue), unless 12.34.56.78 is in a subnet listed in local_ranges.

For a connection made by "evil1337" to a sabnzbd instance directly accessible from the interwebs (not behind a reverse proxy; remote IP 12.34.56.78 with or without a fake XFF header):
- always denied regardless of XFF verification setting and header content, based solely on the remote IP, unless 12.34.56.78 is in a subnet listed in local_ranges (same as before).

Closes: #1307