### PR TITLE
add m4b file extension

### DIFF
--- a/sabnzbd/utils/file_extension.py
+++ b/sabnzbd/utils/file_extension.py
@@ -214,6 +214,7 @@ DOWNLOAD_EXT = (
     "m2ts",
     "m3u",
     "m4a",
+    "m4b",
     "mkv",
     "mp3",
     "mp4",


### PR DESCRIPTION
add m4b file extension to prevent m4b files getting renamed to .m4b.mp4