### PR TITLE
Ensure all data is written to file

### DIFF
--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -206,7 +206,11 @@ class Assembler(Thread):
                             file_position = article.data_begin + len(data)
                         else:
                             fout.seek(0, os.SEEK_END)
-                        fout.write(data)
+
+                        written = 0
+                        while written < len(data):
+                            written += fout.write(data[written:])
+
                         nzf.update_crc32(article.crc32, len(data))
                         article.on_disk = True
                     else:


### PR DESCRIPTION
Related #2632 but probably not the cause

TL;DR in raw/non-buffered mode `fout.write` may not write everything requested https://docs.python.org/3/library/io.html?highlight=write#io.RawIOBase.write

---

> Write the given [bytes-like object](https://docs.python.org/3/glossary.html#term-bytes-like-object), b, to the underlying raw stream, and **return the number of bytes written. This can be less than the length of b in bytes, depending on specifics of the underlying raw stream**, and especially if it is in non-blocking mode. None is returned if the raw stream is set not to block and no single byte could be readily written to it. The caller may release or mutate b after this method returns, so the implementation should only access b during the method call.

Without looping the quick check CRC32 could pass but file on disk could be corrupt.

I was made aware of this while investigating some mergerfs issues a while ago; there was a bug in append mode but it was also discovered that the application wasn't handling short writes which could/will happen when passing a disk boundary depending on mergefs options.

I've now idea how it works at a low level, but I'd presume it can be related to the OS enforcing some kind of IO fairness and writing less than requested if there is high IO pressure.

It should probably be ported to a v4.0.x release.