### PR TITLE
Fix quick check of sets with duplicate files

### DIFF
--- a/sabnzbd/par2file.py
+++ b/sabnzbd/par2file.py
@@ -243,4 +243,7 @@ def parse_par2_file(fname: str, md5of16k: Dict[bytes, str]) -> Tuple[str, Dict[s
             old_name = md5of16k.pop(hash16k)
             logging.debug("Par2-16k signature of %s not unique, discarding", old_name)
 
+    # Sort table by filename
+    table = {filename: table[filename] for filename in sorted(table.keys())}
+
     return set_id, table


### PR DESCRIPTION
Fixes #2640

This is the simplest fix I can think of.

Changes:
- parse_par2_file return a dictionary sorted by filename
- quick_check_set won't rename to the same path as an ready found/verified path

Hopefully the list comprehension stuff is not too magic 🙈 