### PR TITLE
don't call get_unique_filename in Sorter.rename

### DIFF
--- a/sabnzbd/sorting.py
+++ b/sabnzbd/sorting.py
@@ -558,11 +558,9 @@ class Sorter:
         # Rename it
         f_name, f_ext = os.path.splitext(largest_file.get("name"))
         filepath = self._to_filepath(largest_file.get("name"), base_path)
-        new_filepath = get_unique_filename(
-            os.path.join(
-                base_path,
-                to_lowercase(path_subst(self.filename_set, [("%fn", f_name), ("%ext", f_ext.lstrip("."))]) + f_ext),
-            )
+        new_filepath = os.path.join(
+            base_path,
+            to_lowercase(path_subst(self.filename_set, [("%fn", f_name), ("%ext", f_ext.lstrip("."))]) + f_ext),
         )
         if not os.path.exists(new_filepath):
             renamed_files = []


### PR DESCRIPTION
Remove leftover call to get_unique_filename that IIRC was only added for debugging purposes.

Fixes #2619