### PR TITLE
set per-server connection limit to 500

### DIFF
--- a/interfaces/Config/templates/config_server.tmpl
+++ b/interfaces/Config/templates/config_server.tmpl
@@ -77,7 +77,7 @@
                     </div>
                     <div class="field-pair">
                         <label class="config" for="connections">$T('srv-connections')</label>
-                        <input type="number" name="connections" id="connections" min="1" max="1000" value="8" required />
+                        <input type="number" name="connections" id="connections" min="1" max="500" value="8" required />
                     </div>
                     <div class="field-pair">
                         <label class="config" for="priority">$T('srv-priority')</label>
@@ -208,7 +208,7 @@
                         </div>
                         <div class="field-pair">
                             <label class="config" for="connections$cur">$T('srv-connections')</label>
-                            <input type="number" name="connections" id="connections$cur" value="$server['connections']" min="1" max="1000" required />
+                            <input type="number" name="connections" id="connections$cur" value="$server['connections']" min="1" max="500" required />
                         </div>
                         <div class="field-pair">
                             <label class="config" for="priority$cur">$T('srv-priority')</label>

--- a/sabnzbd/config.py
+++ b/sabnzbd/config.py
@@ -437,7 +437,7 @@ class ConfigServer:
         self.timeout = OptionNumber(name, "timeout", 60, 20, 240, add=False)
         self.username = OptionStr(name, "username", add=False)
         self.password = OptionPassword(name, "password", add=False)
-        self.connections = OptionNumber(name, "connections", 1, 0, 1000, add=False)
+        self.connections = OptionNumber(name, "connections", 1, 0, 500, add=False)
         self.ssl = OptionBool(name, "ssl", False, add=False)
         # 0=No, 1=Normal, 2=Strict (hostname verification)
         self.ssl_verify = OptionNumber(name, "ssl_verify", 2, add=False)


### PR DESCRIPTION
Python on windows is limited to 512, see https://github.com/sabnzbd/sabnzbd/issues/2667