### PR TITLE
avoid exceeding winsock limits when calling select

### DIFF
--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -30,6 +30,7 @@ import ssl
 from typing import List, Dict, Optional, Union, Set
 import concurrent
 from concurrent.futures import ThreadPoolExecutor, Future
+from random import sample
 
 import sabnzbd
 from sabnzbd.decorators import synchronized, NzbQueueLocker, DOWNLOADER_CV
@@ -688,6 +689,9 @@ class Downloader(Thread):
 
                 # Use select to find sockets ready for reading/writing
                 if readkeys := self.read_fds.keys():
+                    if sabnzbd.WIN32 and len(readkeys) > 512:
+                        # Avoid exceeding winsock's FD_SETSIZE when calling select, see issue #2667
+                        readkeys = sample(readkeys, 512)
                     read, _, _ = select.select(readkeys, (), (), 1.0)
                 else:
                     read = []


### PR DESCRIPTION
On windows, the number of sockets one can pass into `select()` is determined by a winsock limit, set to 512 at compile time for the Python executable. That limit is below most if not all other operating systems and cannot easily be modified. Users with multiple providers setting the number of connections to the maximum permitted on every server could hit this limit, esp. if backup/block accounts come into play, (repeatedly) triggering a downloader crash.

This code change avoids that getting a random selection of read_fds in case their number exceeds 512. The limit is hardcoded because this info isn't exposed by Python at runtime.

On other platforms, no action is taken as `select()` appears to be limited by the operating system setting for the total number of open files per process. Typical defaults for that are north of 1000, with the option of setting even higher values if needed.