### PR TITLE
Add support for finding updated 7-Zip versions on Linux

### DIFF
--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -139,10 +139,26 @@ def find_programs(curdir: str):
             )
         sabnzbd.newsunpack.NICE_COMMAND = find_on_path("nice")
         sabnzbd.newsunpack.IONICE_COMMAND = find_on_path("ionice")
+
+        # p7zip is the old Linux port of 7-Zip, now unmaintained.
+        # Therefore the official filenames are different for Linux:
+        #
+        # 7zz  (7-Zip) - full version of 7-Zip that supports all formats.
+        # 7zzs (7-Zip) - full version of 7-Zip that supports all formats (static linked).
+        #
+        # 7z   (p7zip) - older linux port that requires 7z.so shared library, supports all formats via 7z.so.
+        # 7za  (p7zip) - older linux port that supports some main formats:
+        #                  7z, xz, lzma, zip, bzip2, gzip, tar, cab, ppmd and split.
+
         if not sabnzbd.newsunpack.SEVENZIP_COMMAND:
-            sabnzbd.newsunpack.SEVENZIP_COMMAND = find_on_path("7za")  # 7za = 7z stand-alone executable
-        if not sabnzbd.newsunpack.SEVENZIP_COMMAND:
-            sabnzbd.newsunpack.SEVENZIP_COMMAND = find_on_path("7z")
+            sabnzbd.newsunpack.SEVENZIP_COMMAND = find_on_path(
+                (
+                    "7zz",
+                    "7zzs",
+                    "7za",
+                    "7z",
+                )
+            )
 
     if not (sabnzbd.WIN32 or sabnzbd.MACOS):
         # Run check on rar version


### PR DESCRIPTION
The old linux port of 7-Zip named p7zip has not been maintained since 2016, and a few updates has come out for 7zip since.
In 2022, 7-Zip released its own linux port, but uses different commands for its port to avoid colliding with p7zip.

This PR adds support for detecting the `7zz` and ` 7zzs` commands.

A lot has happened since 16.01, ref: https://www.7-zip.org/history.txt
For example, a new `ARM64` filter has been introduced for LZMA, I am guessing archives compressed using this will fail to unpack using older versions.


My own benchmarks on x86_64:

p7zip 16.01:
```
# 7za b
7-Zip (a) [64] 16.02 : Copyright (c) 1999-2016 Igor Pavlov : 2016-05-21
p7zip Version 16.02 (locale=en_US.UTF-8,Utf16=on,HugeFiles=on,64 bits,8 CPUs Intel(R) Xeon(R) CPU E3-1245 v6 @ 3.70GHz (906E9),ASM,AES-NI)

Intel(R) Xeon(R) CPU E3-1245 v6 @ 3.70GHz (906E9)
CPU Freq: - - - - - - - - -

RAM size:   64206 MB,  # CPU hardware threads:   8
RAM usage:   1765 MB,  # Benchmark threads:      8

                       Compressing  |                  Decompressing
Dict     Speed Usage    R/U Rating  |      Speed Usage    R/U Rating
         KiB/s     %   MIPS   MIPS  |      KiB/s     %   MIPS   MIPS

22:      24370   652   3638  23708  |     262333   798   2803  22376
```

7-Zip 23.01:
```
# 7zz b
7-Zip (z) 23.01 (x64) : Copyright (c) 1999-2023 Igor Pavlov : 2023-06-20
 64-bit locale=en_US.UTF-8 Threads:8 OPEN_MAX:1024, ASM

Compiler: 9.4.0 GCC 9.4.0: SSE2
Linux : 6.1.27-1.el9.x86_64 : #1 SMP Fri May  5 12:31:25 CEST 2023 : x86_64
PageSize:4KB THP:madvise hwcap:2 hwcap2:2
Intel(R) Xeon(R) CPU E3-1245 v6 @ 3.70GHz (906E9)

1T CPU Freq (MHz):  4042  4069  4050  4047  4065  4051  4060
4T CPU Freq (MHz): 399% 3895   398% 3897

RAM size:   64206 MB,  # CPU hardware threads:   8
RAM usage:   1779 MB,  # Benchmark threads:      8

                       Compressing  |                  Decompressing
Dict     Speed Usage    R/U Rating  |      Speed Usage    R/U Rating
         KiB/s     %   MIPS   MIPS  |      KiB/s     %   MIPS   MIPS

22:      29936   629   4629  29122  |     410380   797   4391  34994
```

Decompression of LZMA went from 262MB/s to 410MB/s, a whopping 56% speedup.
According to changelist, ARM should have an even bigger speedup.