### PR TITLE
Use "all users" locations for shortcuts on Windows

### DIFF
--- a/builder/win/NSIS_Installer.nsi
+++ b/builder/win/NSIS_Installer.nsi
@@ -66,6 +66,9 @@ Unicode true
   RequestExecutionLevel admin
   FileErrorText "If you have no admin rights, try to install into a user directory."
 
+;------------------------------------------------------------------
+; Makes sure shell folders (e.g. $SMPROGRAMS and $DESKTOP) use the "all users" location
+  SetShellVarContext all
 
 ;------------------------------------------------------------------
 ;Variables


### PR DESCRIPTION
Fixes https://github.com/sabnzbd/sabnzbd/issues/2675

See [$SMPROGRAMS](https://github.com/NSIS-Dev/Documentation/blob/main/docs/Variables/SMPROGRAMS.md) documentation, which refers to [SetShellVarContext](https://github.com/NSIS-Dev/Documentation/blob/main/docs/Commands/SetShellVarContext.md).

Disclaimer: I haven't actually tested this