### PR TITLE
Fix when downloader paused only download force priority items

### DIFF
--- a/ISSUES.txt
+++ b/ISSUES.txt
@@ -48,6 +48,3 @@
   You can make SABnzbd wait for a mount of the "temporary download folder" by setting
   Config->Special->wait_for_dfolder to 1.
   SABnzbd will appear to hang until the drive is mounted.
-
-- If the queue is paused but one or more jobs have the Force priority, SABnzbd might still
-  download some data from other jobs in the queue if active servers have unused connections.

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -719,7 +719,9 @@ class NzbQueue:
         propagation_delay = float(cfg.propagation_delay() * 60)
         for nzo in self.__nzo_list:
             # Not when queue paused and not a forced item
-            if nzo.status not in (Status.PAUSED, Status.GRABBING) or nzo.priority == FORCE_PRIORITY:
+            if (
+                nzo.status not in (Status.PAUSED, Status.GRABBING) and not sabnzbd.Downloader.paused
+            ) or nzo.priority == FORCE_PRIORITY:
                 # Check if past propagation delay, or forced
                 if (
                     not propagation_delay


### PR DESCRIPTION
Fixes #2676 

A pretty simple change that seems to fix the problem.

Strangly the comment `# Not when queue paused and not a forced item` wasn't what it is doing, digging into the history a bit this is what it used to do!

It was changed in https://github.com/sabnzbd/sabnzbd/commit/6bc1c51013bc31169eba491fd57d6aeeb549280c#diff-910de0ac3edf4c8b48165397a18d3afc8b4d93dd2a09db16e92ae4963019193e - I'm not familiar with 2.x but I don't think it should have been removed, doesn't seem related to the categories to server mapping that commit was removing.

nzo.status is Status.QUEUED even though the UI shows Paused - it also checks if the downloader is paused