### PR TITLE
Client ip logging on first occurence, and later occurences after a minimum of an hour

### DIFF
--- a/sabnzbd/config.py
+++ b/sabnzbd/config.py
@@ -60,6 +60,7 @@ RE_PARAMFINDER = re.compile(r"""'.*?'|".*?"|[^'",\s][^,]*""")
 
 client_ip_seen_and_logged = {}
 
+
 class Option:
     """Basic option class, basic fields"""
 

--- a/sabnzbd/config.py
+++ b/sabnzbd/config.py
@@ -58,6 +58,7 @@ CFG_MODIFIED = False  # Signals a change in option dictionary
 
 RE_PARAMFINDER = re.compile(r"""'.*?'|".*?"|[^'",\s][^,]*""")
 
+client_ip_seen_and_logged = {}
 
 class Option:
     """Basic option class, basic fields"""

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -138,7 +138,6 @@ def secured_expose(
                 cherrypy.request.headers.get("User-Agent"),
             )
 
-
         if cfg.api_logging():
             # Log all requests
             logging.debug(
@@ -174,7 +173,6 @@ def secured_expose(
                     cherrypy.request.remote_label,
                     kwargs,
                 )
-
 
         # Add X-Frame-Headers headers to page-requests
         if cfg.x_frame_options():

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -164,7 +164,7 @@ def secured_expose(
                         kwargs,
                     )
             except:
-                # IP never seen/registrered, so register and log
+                # IP never seen/registered, so register and log
                 config.client_ip_seen_and_logged[clientip] = currenttime
                 logging.debug(
                     "First time IP: Request %s %s from %s %s",


### PR DESCRIPTION
I have SAB logging always on +Debug. To avoid API logging to fill out the logging, I turn off api_logging.

The result & problem is that I never see what accesses my SAB instances/

This PR logs the first occurrence from an IP address. Plus a next one from that IP address ... after at least one hour.

@Safihre feedback on:
* the global, non-class variable in config.py: OK?
* wording of the logging
* maybe put the python logging command (occurs 3 times) in a function?


