### PR TITLE
refactor: display more accurate uptime

### DIFF
--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -134,7 +134,7 @@ def format_time_left(totalseconds: int, short_format: bool = False) -> str:
 
 def calc_age(date: datetime.datetime, trans: bool = False) -> str:
     """Calculate the age difference between now and date.
-    Value is returned as a formatted string of days, hours and minutes
+    Value is returned as a formatted string of days, hours and minutes.
     When 'trans' is True, time symbols will be translated.
     """
     if trans:

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -134,7 +134,7 @@ def format_time_left(totalseconds: int, short_format: bool = False) -> str:
 
 def calc_age(date: datetime.datetime, trans: bool = False) -> str:
     """Calculate the age difference between now and date.
-    Value is returned as either days, hours, or minutes.
+    Value is returned as a formatted string of days, hours and minutes
     When 'trans' is True, time symbols will be translated.
     """
     if trans:
@@ -149,12 +149,9 @@ def calc_age(date: datetime.datetime, trans: bool = False) -> str:
     try:
         # Return time difference in human-readable format
         date_diff = datetime.datetime.now() - date
-        if date_diff.days:
-            return "%d%s" % (date_diff.days, d)
-        elif int(date_diff.seconds / 3600):
-            return "%d%s" % (date_diff.seconds / 3600, h)
-        else:
-            return "%d%s" % (date_diff.seconds / 60, m)
+        days, hours = divmod(date_diff.days, 24)
+        hours, minutes = divmod(hours, 60)
+        return f"{days}{d} {hours}{h} {minutes}{m}"
     except:
         return "-"
 

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -149,8 +149,9 @@ def calc_age(date: datetime.datetime, trans: bool = False) -> str:
     try:
         # Return time difference in human-readable format
         date_diff = datetime.datetime.now() - date
-        days, hours = divmod(date_diff.days, 24)
-        hours, minutes = divmod(hours, 60)
+        days = date_diff.days
+        hours, rem = divmod(date_diff.seconds, 3600)
+        minutes, seconds = divmod(rem, 60)
         return f"{days}{d} {hours}{h} {minutes}{m}"
     except:
         return "-"

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -54,9 +54,11 @@ class TestMisc:
         m = date - datetime.timedelta(minutes=1)
         h = date - datetime.timedelta(hours=1)
         d = date - datetime.timedelta(days=1)
-        self.assertTime("1m", m)
-        self.assertTime("1h", h)
-        self.assertTime("1d", d)
+        dhm = date - datetime.timedelta(days=1, hours=1, minutes=1)
+        self.assertTime("0d 0h 1m", m)
+        self.assertTime("0d 1h 0m", h)
+        self.assertTime("1d 0h 0m", d)
+        self.assertTime("1d 1h 1m", dhm)
 
     def test_safe_lower(self):
         assert "all caps" == misc.safe_lower("ALL CAPS")


### PR DESCRIPTION
I have seen that the uptime only gets shown as `1d` if you are past 24 hours and thought this is pretty inaccurate and I do not really like it.

There is well more than enough space to show "0d 0h 0m" for the uptime and that would be way more accurate for not much of an overhead in terms of performance cost or whatever you might think off.

