### PR TITLE
use local ipv6 if routable

### DIFF
--- a/sabnzbd/getipaddress.py
+++ b/sabnzbd/getipaddress.py
@@ -168,8 +168,8 @@ def local_ipv6():
 
 
 def public_ipv6():
-    if ipv6_address := local_ipv6():
-        if sabnzbd.misc.is_lan_addr(ipv6_address):
-            return public_ip(family=socket.AF_INET6)
-        else:
-            return ipv6_address
+    if local_address := local_ipv6():
+        if public_address := public_ip(family=socket.AF_INET6):
+            return public_address
+        elif not sabnzbd.misc.is_lan_addr(local_address):
+            return local_address

--- a/sabnzbd/getipaddress.py
+++ b/sabnzbd/getipaddress.py
@@ -168,5 +168,8 @@ def local_ipv6():
 
 
 def public_ipv6():
-    if local_ipv6():
-        return public_ip(family=socket.AF_INET6)
+    if ipv6_address := local_ipv6():
+        if sabnzbd.misc.is_lan_addr(ipv6_address):
+            return public_ip(family=socket.AF_INET6)
+        else:
+            return ipv6_address


### PR DESCRIPTION
Only connect to the remote test host to discover the systems ipv6 address if there's reason to believe it will be different from the local address, i.e. if the latter is in an address range such as fc00::/7 (ipv6 "unique local addresses") or fe80::/10 (ipv6 "link-local").

Saves the time and effort of doing a remote request, and allows for displaying the ipv6 address in the status and interface options dialog even if remote lookups are disabled and/or the test host removed in config->special.