### PR TITLE
improve happyeyeballs tests

### DIFF
--- a/tests/test_happyeyeballs.py
+++ b/tests/test_happyeyeballs.py
@@ -26,6 +26,7 @@ import pytest
 from flaky import flaky
 
 from sabnzbd.happyeyeballs import happyeyeballs, IPV6_MAPPING
+from sabnzbd.misc import is_ipv4_addr, is_ipv6_addr
 
 
 @flaky
@@ -37,24 +38,23 @@ class TestHappyEyeballs:
 
     def test_google_http(self):
         addrinfo = happyeyeballs("www.google.com", port=80)
-        assert "." in addrinfo.ipaddress or ":" in addrinfo.ipaddress
+        assert is_ipv4_addr(addrinfo.ipaddress) or is_ipv6_addr(addrinfo.ipaddress)
         assert "google" in addrinfo.canonname
 
     def test_google_https(self):
         addrinfo = happyeyeballs("www.google.com", port=443)
-        assert "." in addrinfo.ipaddress or ":" in addrinfo.ipaddress
+        assert is_ipv4_addr(addrinfo.ipaddress) or is_ipv6_addr(addrinfo.ipaddress)
         assert "google" in addrinfo.canonname
 
     def test_google_http_want_ipv4(self):
         addrinfo = happyeyeballs("www.google.com", port=80, family=socket.AF_INET)
-        assert "." in addrinfo.ipaddress and not ":" in addrinfo.ipaddress
+        assert is_ipv4_addr(addrinfo.ipaddress) and not is_ipv6_addr(addrinfo.ipaddress)
         assert "google" in addrinfo.canonname
 
     def test_google_http_want_ipv6(self):
         # TODO: timeout needed for IPv4-only CI environment?
-        addrinfo = happyeyeballs("www.google.com", port=80, timeout=2, family=socket.AF_INET6)
-        if addrinfo:
-            assert not "." in addrinfo.ipaddress and ":" in addrinfo.ipaddress
+        if addrinfo := happyeyeballs("www.google.com", port=80, timeout=2, family=socket.AF_INET6):
+            assert not is_ipv4_addr(addrinfo.ipaddress) and is_ipv6_addr(addrinfo.ipaddress)
             assert "google" in addrinfo.canonname
 
     def test_not_resolvable(self):
@@ -62,7 +62,7 @@ class TestHappyEyeballs:
 
     def test_ipv6_only(self):
         if addrinfo := happyeyeballs("ipv6.google.com", port=443, timeout=2):
-            assert ":" in addrinfo.ipaddress
+            assert is_ipv6_addr(addrinfo.ipaddress)
             assert "google" in addrinfo.canonname
 
     def test_google_unreachable_port(self):
@@ -70,8 +70,8 @@ class TestHappyEyeballs:
 
     @pytest.mark.xfail(reason="CI sometimes blocks this")
     def test_nntp(self):
-        ip = happyeyeballs("news.newshosting.com", port=119).ipaddress
-        assert "." in ip or ":" in ip
+        if ip := happyeyeballs("news.newshosting.com", port=119).ipaddress:
+            assert is_ipv4_addr(ip) or is_ipv6_addr(ip)
 
     @pytest.mark.skipif(sys.platform.startswith("darwin"), reason="Resolves strangely on macOS CI")
     @pytest.mark.parametrize("hostname", IPV6_MAPPING.keys())


### PR DESCRIPTION
On a system without an ipv4 connection to the outside world, one of the tests for happyeyeballs would raise an error because the host it uses (news.newshosting.com) is ipv4-only:
```
test_nntp failed (1 runs remaining out of 2).
	<class 'AttributeError'>
	'NoneType' object has no attribute 'ipaddress'
```

Added a workaround for the above, and also made all tests in the same file use the `is_ipv[46]_addr` functions when verifying results.