### PR TITLE
update appstream xml

### DIFF
--- a/linux/org.sabnzbd.sabnzbd.appdata.xml
+++ b/linux/org.sabnzbd.sabnzbd.appdata.xml
@@ -51,11 +51,13 @@
     <control>touch</control>
   </supports>
   <recommends>
-    <display_length compare="ge">small</display_length>
+    <display_length compare="ge">640</display_length>
     <internet>always</internet>
   </recommends>
   <project_license>GPL-2.0-or-later</project_license>
-  <developer_name>The SABnzbd-Team</developer_name>
+  <developer id="org.sabnzbd">
+    <name>The SABnzbd-Team</name>
+  </developer>
   <screenshots>
     <screenshot type="default">
       <image>https://sabnzbd.org/images/landing/screenshots/interface.png</image>


### PR DESCRIPTION
Set an integer value for the display_length, and replace the deprecated developer_name variable.

We could also add validation of this file (e.g. as part of building the release), all it takes is installing _appstream_ and running this cmd:
`appstreamcli validate --no-color --no-net --strict --pedantic --explain org.sabnzbd.sabnzbd.appdata.xml`

closes #2827