### PR TITLE
set basic systemd hardening options

### DIFF
--- a/linux/sabnzbd@.service
+++ b/linux/sabnzbd@.service
@@ -22,6 +22,11 @@ ExecStart=/opt/sabnzbd/SABnzbd.py --disable-file-log --logging 1 --browser 0
 User=%I
 Type=simple
 Restart=on-failure
+ProtectSystem=full
+DeviceAllow=/dev/null rw
+DeviceAllow=/dev/urandom r
+DevicePolicy=strict
+NoNewPrivileges=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Set a bunch of hardening options in the systemd service file that are unlikely to get in any legitimate user's way. Most are rather self-descriptive; `ProtectSystem=full` prevents modifications to critical parts of the filesystem (`/boot` `/efi` `/etc` and `/usr`).