### PR TITLE
Intermediate script: as soon as first MBs are in, you can run an intermediate script

### DIFF
--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -81,17 +81,12 @@ class Assembler(Thread):
                         logging.debug("Decoding part of %s", filepath)
                         self.assemble(nzo, nzf, file_done)
 
-                        # code for intermediate_script in case of an XPOST, so no rar-set, but just a plain file
+                        # code for intermediate_script in case of a post with plain files, without rar-set
                         # that plain file will appear automatically, without unrar, without need for DirectUnpack
                         # that is what we handle here
 
                         # logging.debug("SJ in assembler: %s bytes done of %s total", nzo.bytes_downloaded, nzo.bytes)
-                        # is_a_rarset = any(n.endswith('.rar') for n in nzo.files_table.values())
-                        is_a_rarset = False
-                        for n in nzo.files_table.values():
-                            if ".rar, " in str(n):
-                                # rar found!!
-                                is_a_rarset = True
+                        is_a_rarset = any(n.filename.endswith(".rar") for n in nzo.files_table.values())
                         logging.debug("SJ is a rarset %s", is_a_rarset)
 
                         # TODO: first check if cfg.intermediate_script() and not nzo.intermediate_has_run

--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -81,7 +81,7 @@ class Assembler(Thread):
                         logging.debug("Decoding part of %s", filepath)
                         self.assemble(nzo, nzf, file_done)
 
-                        # code for intermediate_script in case of an xpost, so no rar-set, but just a plain file
+                        # code for intermediate_script in case of an XPOST, so no rar-set, but just a plain file
                         # that plain file will appear automatically, without unrar, without need for DirectUnpack
                         # that is what we handle here
 
@@ -93,6 +93,8 @@ class Assembler(Thread):
                             nzo.intermediate_has_run = False
 
                         # logging.debug("SJ in assembler: %s bytes done of %s total", nzo.bytes_downloaded, nzo.bytes)
+
+                        # TODO: put this into initialisation of the nzo?
                         # is_a_rarset = any(n.endswith('.rar') for n in nzo.files_table.values())
                         is_a_rarset = False
                         for n in nzo.files_table.values():
@@ -100,9 +102,20 @@ class Assembler(Thread):
                                 # rar found!!
                                 is_a_rarset = True
                         logging.debug("SJ is a rarset %s", is_a_rarset)
+
+                        # TODO: first check if cfg.intermediate_script() and not nzo.intermediate_has_run
+
+                        if nzo.bytes_downloaded > 500_000_000:
+                            logging.debug("SJ 500 MB downloaded!")
+                            # if DirectUnpack is True, and has done some work, and
+                            # if we only knew the <complete_dir> and actual _UNPACK_ sub directory here,
+                            # ... we could handle it here
+
                         if is_a_rarset:
                             # here we do not do anything with rar-sets. Leave it to DirectUnpack.
                             logging.debug("SJ rarset, so DirectUnpack will kick in")
+                            # ... but maybe, if DirectUnpack is doing the unpacking of the rar-st elsewhere, we can do the intermediate_script here?
+
                         else:
                             # no .rar (probably an "xpost"), so DirectUnpack will not kick in, and the plain appears here
                             logging.debug("SJ Alert: no rarset, so no Directunpack. Run intermediate script from here")

--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -81,15 +81,18 @@ class Assembler(Thread):
                         logging.debug("Decoding part of %s", filepath)
                         self.assemble(nzo, nzf, file_done)
 
-                        # TODO: remove this ugly stuff
+                        # code for intermediate_script in case of an xpost, so no rar-set, but just a plain file
+                        # that plain file will appear automatically, without unrar, without need for DirectUnpack
+                        # that is what we handle here
 
-                        nzo.blabla = 1
+                        # TODO: put this somehwere in initialisation of the nzo ?
                         try:
+                            # does it exist already?
                             nzo.intermediate_has_run
                         except:
                             nzo.intermediate_has_run = False
 
-                        logging.debug("SJ in assembler: %s bytes done of %s total", nzo.bytes_downloaded, nzo.bytes)
+                        # logging.debug("SJ in assembler: %s bytes done of %s total", nzo.bytes_downloaded, nzo.bytes)
                         # is_a_rarset = any(n.endswith('.rar') for n in nzo.files_table.values())
                         is_a_rarset = False
                         for n in nzo.files_table.values():
@@ -98,12 +101,13 @@ class Assembler(Thread):
                                 is_a_rarset = True
                         logging.debug("SJ is a rarset %s", is_a_rarset)
                         if is_a_rarset:
+                            # here we do not do anything with rar-sets. Leave it to DirectUnpack.
                             logging.debug("SJ rarset, so DirectUnpack will kick in")
                         else:
-                            # no .rar (probably an "xpost"), so DirectUnpack will not kick in.
-                            logging.debug("SJ Alert: no rarset, so no Directunpack. Run intermediate script from there")
-                            if nzo.bytes_downloaded > 500_000_000 and not nzo.intermediate_has_run:
-                                # 500 MB needed before output is there?
+                            # no .rar (probably an "xpost"), so DirectUnpack will not kick in, and the plain appears here
+                            logging.debug("SJ Alert: no rarset, so no Directunpack. Run intermediate script from here")
+                            if nzo.bytes_downloaded > 200_000_000 and not nzo.intermediate_has_run:
+                                # 200 MB needed before output is there?
                                 # run intermediate_script
                                 if cfg.intermediate_script():
                                     logging.debug(

--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -85,16 +85,7 @@ class Assembler(Thread):
                         # that plain file will appear automatically, without unrar, without need for DirectUnpack
                         # that is what we handle here
 
-                        # TODO: put this somehwere in initialisation of the nzo ?
-                        try:
-                            # does it exist already?
-                            nzo.intermediate_has_run
-                        except:
-                            nzo.intermediate_has_run = False
-
                         # logging.debug("SJ in assembler: %s bytes done of %s total", nzo.bytes_downloaded, nzo.bytes)
-
-                        # TODO: put this into initialisation of the nzo?
                         # is_a_rarset = any(n.endswith('.rar') for n in nzo.files_table.values())
                         is_a_rarset = False
                         for n in nzo.files_table.values():

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -379,6 +379,7 @@ fail_hopeless_jobs = OptionBool("misc", "fail_hopeless_jobs", True)
 fast_fail = OptionBool("misc", "fast_fail", True)
 autodisconnect = OptionBool("misc", "auto_disconnect", True)
 pre_script = OptionStr("misc", "pre_script", "None", validation=validate_script)
+intermediate_script = OptionStr("misc", "intermediate_script", "None", validation=validate_script)
 end_queue_script = OptionStr("misc", "end_queue_script", "None", validation=validate_script)
 no_dupes = OptionNumber("misc", "no_dupes", 0)
 no_series_dupes = OptionNumber("misc", "no_series_dupes", 0)  # Kept for converting to no_smart_dupes

--- a/sabnzbd/directunpacker.py
+++ b/sabnzbd/directunpacker.py
@@ -332,8 +332,11 @@ class DirectUnpacker(threading.Thread):
                             # run intermediate_script
                             logging.debug("SJ1 yes yes")
                             if cfg.intermediate_script():
-                                logging.debug("SJ: running intermediate script %s on %s", cfg.intermediate_script(),
-                                              extraction_path)
+                                logging.debug(
+                                    "SJ: running intermediate script %s on %s",
+                                    cfg.intermediate_script(),
+                                    extraction_path,
+                                )
 
                     # If lines did not change and we don't have the next volume, this download is missing files!
                     # In rare occasions we can get stuck forever with repeating lines

--- a/sabnzbd/directunpacker.py
+++ b/sabnzbd/directunpacker.py
@@ -326,6 +326,14 @@ class DirectUnpacker(threading.Thread):
                         self.cur_volume += 1
                         self.nzo.set_action_line(T("Direct Unpack"), self.get_formatted_stats(include_time_left=True))
                         logging.info("DirectUnpacked volume %s for %s", self.cur_volume, self.cur_setname)
+                        logging.debug("SJ1 intermediate_script() %s", cfg.intermediate_script())
+                        logging.debug("SJ1 cur_volume %s", self.cur_volume)
+                        if self.cur_volume == 1:
+                            # run intermediate_script
+                            logging.debug("SJ1 yes yes")
+                            if cfg.intermediate_script():
+                                logging.debug("SJ: running intermediate script %s on %s", cfg.intermediate_script(),
+                                              extraction_path)
 
                     # If lines did not change and we don't have the next volume, this download is missing files!
                     # In rare occasions we can get stuck forever with repeating lines
@@ -462,6 +470,13 @@ class DirectUnpacker(threading.Thread):
 
         # Doing the first
         logging.info("DirectUnpacked volume %s for %s", self.cur_volume, self.cur_setname)
+        logging.debug("SJ2 intermediate_script() %s", cfg.intermediate_script())
+        logging.debug("SJ2 cur_volume %s", self.cur_volume)
+        if self.cur_volume == 1:
+            # run intermediate_script
+            if cfg.intermediate_script():
+                logging.debug("SJ: running pre stage")
+                logging.debug("SJ: running intermediate script %s on %s", cfg.intermediate_script(), extraction_path)
 
     @synchronized(START_STOP_LOCK)
     def abort(self):

--- a/sabnzbd/directunpacker.py
+++ b/sabnzbd/directunpacker.py
@@ -326,7 +326,8 @@ class DirectUnpacker(threading.Thread):
                         self.cur_volume += 1
                         self.nzo.set_action_line(T("Direct Unpack"), self.get_formatted_stats(include_time_left=True))
                         logging.info("DirectUnpacked volume %s for %s", self.cur_volume, self.cur_setname)
-                        # TODO: never intermediate_script needed here, because cur_volume > 1
+
+                        # TODO Note: never intermediate_script needed here, because cur_volume > 1
 
                     # If lines did not change and we don't have the next volume, this download is missing files!
                     # In rare occasions we can get stuck forever with repeating lines
@@ -464,6 +465,8 @@ class DirectUnpacker(threading.Thread):
         # Doing the first
         logging.info("DirectUnpacked volume %s for %s", self.cur_volume, self.cur_setname)
 
+        # code for intermediate_script. We get here if 1) traditional post with rar-set AND 2) directunpack is on
+        # (so not with xpost)
         # NB we only get if DirectUnpacker gets kicked in: with rar files in post (not with xpost post)
         logging.debug("SJ2 intermediate_script() %s", cfg.intermediate_script())
         logging.debug("SJ2 cur_volume %s", self.cur_volume)
@@ -481,7 +484,7 @@ class DirectUnpacker(threading.Thread):
 
                 output = p.stdout.read()
                 ret = p.wait()
-                logging.info("Intermediate script returned %s and output=\n%s", ret, output)
+                logging.debug("Intermediate script returned %s and output=\n%s", ret, output)
                 if ret == 0:
                     split_output = output.splitlines()
                     decision = int(split_output[0])

--- a/sabnzbd/directunpacker.py
+++ b/sabnzbd/directunpacker.py
@@ -466,8 +466,7 @@ class DirectUnpacker(threading.Thread):
         logging.info("DirectUnpacked volume %s for %s", self.cur_volume, self.cur_setname)
 
         # code for intermediate_script. We get here if 1) traditional post with rar-set AND 2) directunpack is on
-        # (so not with xpost)
-        # NB we only get if DirectUnpacker gets kicked in: with rar files in post (not with xpost post)
+        # (so not with xpost, or with directunpack False)
         logging.debug("SJ2 intermediate_script() %s", cfg.intermediate_script())
         logging.debug("SJ2 cur_volume %s", self.cur_volume)
         if self.cur_volume == 1:  # always True at this location, so remove? #TODO

--- a/sabnzbd/directunpacker.py
+++ b/sabnzbd/directunpacker.py
@@ -463,9 +463,11 @@ class DirectUnpacker(threading.Thread):
 
         # Doing the first
         logging.info("DirectUnpacked volume %s for %s", self.cur_volume, self.cur_setname)
+
+        # NB we only get if DirectUnpacker gets kicked in: with rar files in post (not with xpost post)
         logging.debug("SJ2 intermediate_script() %s", cfg.intermediate_script())
         logging.debug("SJ2 cur_volume %s", self.cur_volume)
-        if self.cur_volume == 1:
+        if self.cur_volume == 1:  # always True at this location, so remove? #TODO
             # run intermediate_script
             if cfg.intermediate_script():
                 logging.debug("SJ: running intermediate script %s on %s", cfg.intermediate_script(), extraction_path)
@@ -482,15 +484,13 @@ class DirectUnpacker(threading.Thread):
                 logging.info("Intermediate script returned %s and output=\n%s", ret, output)
                 if ret == 0:
                     split_output = output.splitlines()
-                    for index, line in enumerate(split_output):
-                        if index == 0:
-                            decision = int_conv(line, 0)
-                            if decision != 0:
-                                # there was a decision!
-                                logging.debug("SJ decision %s", decision)
-                                logging.debug("SJ prio was %s", self.nzo.priority)
-                                self.nzo.priority = decision
-                                logging.debug("SJ prio is %s", self.nzo.priority)
+                    decision = int(split_output[0])
+                    if decision != 0:
+                        # there was a decision, so use it!
+                        logging.debug("SJ decision %s", decision)
+                        logging.debug("SJ prio was %s", self.nzo.priority)
+                        self.nzo.priority = decision
+                        logging.debug("SJ prio is %s", self.nzo.priority)
 
     @synchronized(START_STOP_LOCK)
     def abort(self):

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -578,6 +578,7 @@ NzbObjectSaver = (
     "servercount",
     "unwanted_ext",
     "renames",
+    "intermediate_has_run",
 )
 
 NzoAttributeSaver = ("cat", "pp", "script", "priority", "final_name", "password", "url")
@@ -725,6 +726,7 @@ class NzbObject(TryList):
         self.url_tries = 0
         self.pp_active = False
         self.md5sum: Optional[str] = None
+        self.intermediate_has_run = False
 
         # Path is empty in case of a future NZB
         self.download_path = ""

--- a/sabnzbd/utils/intermediate_script.py
+++ b/sabnzbd/utils/intermediate_script.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python3
+
+"""
+Handling of running an intermediate_script on a given directory
+
+If that directory contains .rar files, those rar files are first unrarred
+
+The given directory might contain partial files.
+
+The intermediate_script itself should return the same parameters as a pre-queue script, with in position 6:
+
+-100 = Default
+-2 = Paused
+-1 = Low
+0 = Normal
+1 = High
+2 = Force
+
+"""
+
+import os
+import logging
+
+from sabnzbd.misc import build_and_run_command
+
+
+def intermediate_script(script, directory):
+    # run script on directory
+    # returns the decision (=prio).
+    # returns None if no decision
+
+    # check if directory contains  *.rar files
+    files = os.listdir(directory)
+    rar_files = [file for file in files if file.endswith(".rar")]
+    if rar_files:
+        pass  # TODO fill out below
+        # unpack rar files into a temp directory
+        # create tempdir
+        # unpack wild-card style *rar (?)
+        directory = tempdir
+
+    # OK, let's run the script on the given directory
+    command = [script, directory]
+    try:
+        p = build_and_run_command(command)
+    except:
+        logging.debug("Failed script %s, Traceback: ", script_path, exc_info=True)
+        return None  # TODO remove this line, and handle exception correctly
+
+    output = p.stdout.read()
+    ret = p.wait()
+    logging.info("Intermediate script returned %s and output=\n%s", ret, output)
+    if ret == 0:
+        split_output = output.splitlines()
+        # line #6 is the decision, so [5] in python speak
+        decision = int(split_output[5])
+        if decision != 0:
+            # there was a decision, so use it!
+            logging.debug("SJ decision %s", decision)
+            return decision
+
+    return None


### PR DESCRIPTION
Handy to avoid downloads you don't want after all.

For example: as soon as the first MBs of a MKV are in, you can check for certain characteristics (like audio and subtitles) in the MKV.  Method: with this PR, SABnzbd will call your user defined intermediate_script, with the "working" directory as parameter, and your intermediate_script should the 0, 1, or -1 (or other SABnzbd known prio, like Pause, Forced, etc)

This works for

- traditional rar-set, with DirectUnpack on (aka True)
- no rar-set, with final file(s) in plain sight. Often: an xpost

Example intermediate script (hacked together!): 
https://github.com/sanderjo/anything_everything/blob/main/SABnzbd_post_pre_intermediate_scripts/mkv_checker.py

Result: a download automatically upvoted, one down voted, very early in the download phase.

![image](https://github.com/sabnzbd/sabnzbd/assets/1273502/6a7aece0-1222-420e-87a2-d681d5aa40d1)
