### PR TITLE
make WIN64 also true if on ARM64

### DIFF
--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -37,7 +37,7 @@ KERNEL32 = LIBC = MACOSLIBC = None
 
 if os.name == "nt":
     WIN32 = True
-    WIN64 = platform.uname().machine == "AMD64"
+    WIN64 = platform.uname().machine in ["AMD64", "ARM64"]  # includes emulation of X86_64 on Windows ARM64
     from sabnzbd.utils.apireg import del_connection_info
 
     try:


### PR DESCRIPTION
closes https://github.com/sabnzbd/sabnzbd/issues/2892

Note: this is for the x86_64 version of SABnzbd.exe with x86_64 python/unrar/par2/sactools emulated on Windows on ARM aka Snapdragon Elite X