### PR TITLE
fix filesystem permission tests for pyfakefs 5.4.0+

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,7 +3,7 @@ pytest==7.4.4
 setuptools
 selenium
 requests
-pyfakefs<5.4.0
+pyfakefs>=5.4.0
 werkzeug<2.1.0 # Breaks httpbin in newer versions
 pytest-httpbin
 pytest-httpserver

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -748,7 +748,6 @@ class TestSortingSorter:
     @pytest.mark.parametrize("extension", [".mkv", ".data", ".mkv", ".vob"])
     @pytest.mark.parametrize("number_of_files", [0, 1, 2, 4])
     @pytest.mark.parametrize("generate_sequential_filenames", [True, False])
-    @pytest.mark.xfail(reason="Waiting for #2883")
     def test_sorter_rename(
         self,
         s_class,


### PR DESCRIPTION
Most of the failures were triggered by upstream changes in umask handling, worked around for now by setting an all-permissive umask on the fake filesystem or by taking the new behaviour into account when checking/asserting permissions. The failures that weren't umask-related relied on an implementation detail (permissions in the fake filesystem not getting enforced) and got their expected outcomes adjusted to match recent pyfakefs releases.

The required version of pyfakefs was bumped to >=5.4.0, the minimum needed for both the changes in this PR as well as the `shutil` fixes for the (re-enabled) sorting tests.

Closes #2883

PS: we should probably ask pyfakefs upstream to add a boolean parameter to ignore the umask in `create_dir()`, similar to the existing one for `create_file()`, so we can get rid of the workarounds.