### PR TITLE
remove pyfakefs umask workarounds

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,7 +3,7 @@ pytest==7.4.4
 setuptools
 selenium
 requests
-pyfakefs>=5.4.0
+pyfakefs>=5.6.0
 werkzeug<2.1.0 # Breaks httpbin in newer versions
 pytest-httpbin
 pytest-httpserver


### PR DESCRIPTION
Remove the temporary umask workarounds introduced in #2905, and put pyfakefs' new apply_umask parameter to good use.