### PR TITLE
Add doctype

### DIFF
--- a/interfaces/Config/templates/login/main.tmpl
+++ b/interfaces/Config/templates/login/main.tmpl
@@ -1,3 +1,4 @@
+<!DOCTYPE HTML>
 <html lang="$active_lang">
 <head>
     <title>SABnzbd - $T('login')</title>


### PR DESCRIPTION
The login page is missing a doctype, which causes Chrome and Firefox to render it in quirks mode:

![image](https://github.com/user-attachments/assets/b3d8792d-cf6e-49d2-88c8-70fe2c3dca43)

https://developer.mozilla.org/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode