### PR TITLE
add additional colors for server priorities

### DIFF
--- a/interfaces/Config/templates/config_server.tmpl
+++ b/interfaces/Config/templates/config_server.tmpl
@@ -142,7 +142,7 @@
         </div>
     </div>
 
-    <!--#set $prio_colors = ["#59cc33", "#3366cc","#7f33cc", "#cc33a6", "#cc3333"] #-->
+    <!--#set $prio_colors = ["#59cc33", "#26a69a", "#3366cc", "#7f33cc", "#cc33a6", "#f39c12", "#cc3333", "#8d6e63"] #-->
     <!--#set $cur_prio_color = -1 #-->
     <!--#set $last_prio = -1 #-->
     <!--#for $cur, $server in enumerate($servers) #-->


### PR DESCRIPTION
5 colors before, 8 colors now. added teal, orange, brown
![firefox_2024-09-17_12-16-09](https://github.com/user-attachments/assets/e63ff17d-b55a-43c9-9825-2e2ddb37039b) ![sab-servers](https://zoggy.net/firefox_2024-09-17_12-35-02.png)