### PR TITLE
Better analysis & better user info if newsserver connection fails

### DIFF
--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1355,14 +1355,18 @@ def test_nntp_server_dict(kwargs: Dict[str, Union[str, List[str]]]) -> Tuple[boo
                 "possibly an indexer, not a usenet server. You have to fill a usenet server."
             ) % (host, port, host)
         elif port563working and port not in [119, 563]:
-            # it's a newsserver (good), but the user has specified a weird port
-            return False, T("Could not connect to %s on port %s. Use the default usenet settings, with SSL") % (
+            # it's a newsserver (good), on port 563, but the user has specified a weird port
+            return False, T(
+                "Could not connect to %s on port %s. Use the default usenet settings: port 563 and SSL turned on"
+            ) % (
                 host,
                 port,
             )
         elif port119working and not port563working and port not in [119, 563]:
-            # it's a newsserver (good), but the user has specified a weird port
-            return False, T("Could not connect to %s on port %s. Use the default usenet settings, without SSL") % (
+            # it's a newsserver (good), only on port 119, but the user has specified a weird port
+            return False, T(
+                "Could not connect to %s on port %s. Use the default usenet settings: port 119 and SSL turned off"
+            ) % (
                 host,
                 port,
             )

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1392,7 +1392,7 @@ def test_nntp_server_dict(kwargs: Dict[str, Union[str, List[str]]]) -> Tuple[boo
     if nw.status_code:
         if nw.status_code == 480:
             return_status = (False, T("Server requires username and password."))
-        elif nw.status_code < 300 or nw.staBtus_code in (411, 423, 430):
+        elif nw.status_code < 300 or nw.status_code in (411, 423, 430):
             # If no username/password set and we requested fake-article, it will return 430 Not Found
             return_status = (True, T("Connection Successful!"))
         elif nw.status_code == 502 or sabnzbd.downloader.clues_login(nw.nntp_msg):

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1324,17 +1324,29 @@ def test_nntp_server_dict(kwargs: Dict[str, Union[str, List[str]]]) -> Tuple[boo
 
         test_server.timeout = DEF_NETWORKING_TEST_TIMEOUT  # force a short timeout
         # let's try well-known ports: HTTP and NTTP(S)
-        test_server.port = 80
-        test_server.request_addrinfo_blocking()
-        port80working = bool(test_server.addrinfo)
+        if port == 80:
+            # already tried, and not working
+            port80working = False
+        else:
+            test_server.port = 80
+            test_server.request_addrinfo_blocking()
+            port80working = bool(test_server.addrinfo)
 
-        test_server.port = 119  # NNTP
-        test_server.request_addrinfo_blocking()
-        port119working = bool(test_server.addrinfo)
+        if port == 119:
+            # already tried, and not working
+            port119working = False
+        else:
+            test_server.port = 119  # NNTP
+            test_server.request_addrinfo_blocking()
+            port119working = bool(test_server.addrinfo)
 
-        test_server.port = 563  # NNTPS
-        test_server.request_addrinfo_blocking()
-        port563working = bool(test_server.addrinfo)
+        if port == 563:
+            # already tried, and not working
+            port563working = False
+        else:
+            test_server.port = 563  # NNTPS
+            test_server.request_addrinfo_blocking()
+            port563working = bool(test_server.addrinfo)
 
         if (not port119working) and (not port563working) and port80working:
             # That's a webserver, not a newsserver!
@@ -1342,9 +1354,15 @@ def test_nntp_server_dict(kwargs: Dict[str, Union[str, List[str]]]) -> Tuple[boo
                 "Could not connect to %s on port %s. It appears that %s operates as a web server (port 80), "
                 "possibly an indexer, not a usenet server. You have to fill a usenet server."
             ) % (host, port, host)
-        elif (port119working or port563working) and port not in [119, 563]:
+        elif port563working and port not in [119, 563]:
             # it's a newsserver (good), but the user has specified a weird port
-            return False, T("Could not connect to %s on port %s. Use the default ports 119 (NNTP) or 563 (NNTPS) ") % (
+            return False, T("Could not connect to %s on port %s. Use the default usenet settings, with SSL") % (
+                host,
+                port,
+            )
+        elif port119working and not port563working and port not in [119, 563]:
+            # it's a newsserver (good), but the user has specified a weird port
+            return False, T("Could not connect to %s on port %s. Use the default usenet settings, without SSL") % (
                 host,
                 port,
             )

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1340,6 +1340,7 @@ def test_nntp_server_dict(kwargs: Dict[str, Union[str, List[str]]]) -> Tuple[boo
         # - generic network problem (?)
 
         test_server.timeout = DEF_NETWORKING_TEST_TIMEOUT  # force a short timeout
+
         # let's try well-known ports: HTTP and NTTP(S)
         test_server.port = 80
         test_server.request_addrinfo_blocking()

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -78,9 +78,23 @@ from sabnzbd.misc import (
     match_str,
     bool_conv,
 )
-from sabnzbd.filesystem import diskspace, get_ext, clip_path, remove_all, list_scripts, purge_log_files, pathbrowser
+from sabnzbd.filesystem import (
+    diskspace,
+    get_ext,
+    clip_path,
+    remove_all,
+    list_scripts,
+    purge_log_files,
+    pathbrowser,
+)
 from sabnzbd.encoding import xml_name, utob
-from sabnzbd.getipaddress import local_ipv4, public_ipv4, public_ipv6, dnslookup, active_socks5_proxy
+from sabnzbd.getipaddress import (
+    local_ipv4,
+    public_ipv4,
+    public_ipv6,
+    dnslookup,
+    active_socks5_proxy,
+)
 from sabnzbd.database import HistoryDB
 from sabnzbd.lang import is_rtl
 from sabnzbd.nzbstuff import NzbObject
@@ -360,7 +374,10 @@ def _api_addlocalfile(name: str, kwargs: Dict[str, Union[str, List[str]]]) -> by
                     nzbname=kwargs.get("nzbname"),
                     password=kwargs.get("password"),
                 )
-                return report(keyword="", data={"status": res is AddNzbFileResult.OK, "nzo_ids": nzo_ids})
+                return report(
+                    keyword="",
+                    data={"status": res is AddNzbFileResult.OK, "nzo_ids": nzo_ids},
+                )
             else:
                 logging.info('API-call addlocalfile: "%s" is not a supported file', name)
                 return report(_MSG_NO_FILE)
@@ -1317,22 +1334,22 @@ def test_nntp_server_dict(kwargs: Dict[str, Union[str, List[str]]]) -> Tuple[boo
     # All exceptions are caught internally
     test_server.request_addrinfo_blocking()
     if not test_server.addrinfo:
-        # so NNTP connection tried, but did not succeed. Possible causes:
+        # so NNTP connection was tried, but did not succeed: no addrinfo. Possible causes:
         # - user has filled out an indexer as newsserver. Not good.
         # - user has filled out a weird port on which there is no newsserver
         # - generic network problem (?)
 
-        test_server.timeout = DEF_NETWORKING_TEST_TIMEOUT # force a short timeout
-        # let's try well-known ports
+        test_server.timeout = DEF_NETWORKING_TEST_TIMEOUT  # force a short timeout
+        # let's try well-known ports: HTTP and NTTP(S)
         test_server.port = 80
         test_server.request_addrinfo_blocking()
         port80working = bool(test_server.addrinfo)
 
-        test_server.port = 119 # NNTP
+        test_server.port = 119  # NNTP
         test_server.request_addrinfo_blocking()
         port119working = bool(test_server.addrinfo)
 
-        test_server.port = 563 #NNTPS
+        test_server.port = 563  # NNTPS
         test_server.request_addrinfo_blocking()
         port563working = bool(test_server.addrinfo)
 
@@ -1344,9 +1361,10 @@ def test_nntp_server_dict(kwargs: Dict[str, Union[str, List[str]]]) -> Tuple[boo
             ) % (host, port, host)
         elif (port119working or port563working) and port not in [119, 563]:
             # it's a newsserver (good), but the user has specified a weird port
-            return False, T(
-                "Could not connect to %s on port %s. Use the default ports 119 (NNTP) or 563 (NNTPS) "
-            ) % (host, port)
+            return False, T("Could not connect to %s on port %s. Use the default ports 119 (NNTP) or 563 (NNTPS) ") % (
+                host,
+                port,
+            )
 
         # Sorry, no clever analysis:
         return False, T('Server address "%s:%s" is not valid.') % (host, port)
@@ -1395,13 +1413,22 @@ def test_nntp_server_dict(kwargs: Dict[str, Union[str, List[str]]]) -> Tuple[boo
             # If no username/password set and we requested fake-article, it will return 430 Not Found
             return_status = (True, T("Connection Successful!"))
         elif nw.status_code == 502 or sabnzbd.downloader.clues_login(nw.nntp_msg):
-            return_status = (False, T("Authentication failed, check username/password."))
+            return_status = (
+                False,
+                T("Authentication failed, check username/password."),
+            )
         elif sabnzbd.downloader.clues_too_many(nw.nntp_msg):
-            return_status = (False, T("Too many connections, please pause downloading or try again later"))
+            return_status = (
+                False,
+                T("Too many connections, please pause downloading or try again later"),
+            )
 
     # Fallback in case no data was received or unknown status
     if not return_status:
-        return_status = (False, T("Could not determine connection result (%s)") % nw.nntp_msg)
+        return_status = (
+            False,
+            T("Could not determine connection result (%s)") % nw.nntp_msg,
+        )
 
     # Close the connection and return result
     nw.hard_reset()
@@ -1579,7 +1606,11 @@ def build_queue(
         slot["mbmissing"] = "%.2f" % (nzo.bytes_missing / MEBI)
         slot["direct_unpack"] = nzo.direct_unpack_progress
 
-        if not sabnzbd.Downloader.paused and nzo.status not in (Status.PAUSED, Status.FETCHING, Status.GRABBING):
+        if not sabnzbd.Downloader.paused and nzo.status not in (
+            Status.PAUSED,
+            Status.FETCHING,
+            Status.GRABBING,
+        ):
             if nzo.propagation_delay_left:
                 slot["status"] = Status.PROPAGATING
             elif nzo.status == Status.CHECKING:

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -78,23 +78,9 @@ from sabnzbd.misc import (
     match_str,
     bool_conv,
 )
-from sabnzbd.filesystem import (
-    diskspace,
-    get_ext,
-    clip_path,
-    remove_all,
-    list_scripts,
-    purge_log_files,
-    pathbrowser,
-)
+from sabnzbd.filesystem import diskspace, get_ext, clip_path, remove_all, list_scripts, purge_log_files, pathbrowser
 from sabnzbd.encoding import xml_name, utob
-from sabnzbd.getipaddress import (
-    local_ipv4,
-    public_ipv4,
-    public_ipv6,
-    dnslookup,
-    active_socks5_proxy,
-)
+from sabnzbd.getipaddress import local_ipv4, public_ipv4, public_ipv6, dnslookup, active_socks5_proxy
 from sabnzbd.database import HistoryDB
 from sabnzbd.lang import is_rtl
 from sabnzbd.nzbstuff import NzbObject
@@ -374,10 +360,7 @@ def _api_addlocalfile(name: str, kwargs: Dict[str, Union[str, List[str]]]) -> by
                     nzbname=kwargs.get("nzbname"),
                     password=kwargs.get("password"),
                 )
-                return report(
-                    keyword="",
-                    data={"status": res is AddNzbFileResult.OK, "nzo_ids": nzo_ids},
-                )
+                return report(keyword="", data={"status": res is AddNzbFileResult.OK, "nzo_ids": nzo_ids})
             else:
                 logging.info('API-call addlocalfile: "%s" is not a supported file', name)
                 return report(_MSG_NO_FILE)
@@ -1414,22 +1397,13 @@ def test_nntp_server_dict(kwargs: Dict[str, Union[str, List[str]]]) -> Tuple[boo
             # If no username/password set and we requested fake-article, it will return 430 Not Found
             return_status = (True, T("Connection Successful!"))
         elif nw.status_code == 502 or sabnzbd.downloader.clues_login(nw.nntp_msg):
-            return_status = (
-                False,
-                T("Authentication failed, check username/password."),
-            )
+            return_status = (False, T("Authentication failed, check username/password."))
         elif sabnzbd.downloader.clues_too_many(nw.nntp_msg):
-            return_status = (
-                False,
-                T("Too many connections, please pause downloading or try again later"),
-            )
+            return_status = (False, T("Too many connections, please pause downloading or try again later"))
 
     # Fallback in case no data was received or unknown status
     if not return_status:
-        return_status = (
-            False,
-            T("Could not determine connection result (%s)") % nw.nntp_msg,
-        )
+        return_status = (False, T("Could not determine connection result (%s)") % nw.nntp_msg)
 
     # Close the connection and return result
     nw.hard_reset()
@@ -1607,11 +1581,7 @@ def build_queue(
         slot["mbmissing"] = "%.2f" % (nzo.bytes_missing / MEBI)
         slot["direct_unpack"] = nzo.direct_unpack_progress
 
-        if not sabnzbd.Downloader.paused and nzo.status not in (
-            Status.PAUSED,
-            Status.FETCHING,
-            Status.GRABBING,
-        ):
+        if not sabnzbd.Downloader.paused and nzo.status not in (Status.PAUSED, Status.FETCHING, Status.GRABBING):
             if nzo.propagation_delay_left:
                 slot["status"] = Status.PROPAGATING
             elif nzo.status == Status.CHECKING:

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1323,7 +1323,6 @@ def test_nntp_server_dict(kwargs: Dict[str, Union[str, List[str]]]) -> Tuple[boo
         # - generic network problem (?)
 
         test_server.timeout = DEF_NETWORKING_TEST_TIMEOUT  # force a short timeout
-
         # let's try well-known ports: HTTP and NTTP(S)
         test_server.port = 80
         test_server.request_addrinfo_blocking()


### PR DESCRIPTION
If a user fills out a weird port for a correct newsserver (which happens to speak on port 80 too), SABnzbd does say 
![image](https://github.com/user-attachments/assets/a85720f2-4b35-4a89-aa68-81530a4836c7)
... which is confusing.

So improved that message to
![image](https://github.com/user-attachments/assets/2010bee7-168c-485c-9d56-ff647646b36c)

I rewrote the python code to make the logic more clear.

Feedback wanted, for example `port119working` ... is that the correct variable naming? Maybe better: port_OK_119 ?
