### PR TITLE
Fix displayTabbed observable default value

### DIFF
--- a/interfaces/Glitter/templates/static/javascripts/glitter.main.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.main.js
@@ -13,7 +13,7 @@ function ViewModel() {
     self.useGlobalOptions = ko.observable(true).extend({ persist: 'useGlobalOptions' });
     self.refreshRate = ko.observable(1).extend({ persist: 'pageRefreshRate' });
     self.dateFormat = ko.observable('fromNow').extend({ persist: 'pageDateFormat' });
-    self.displayTabbed = ko.observable().extend({ persist: 'displayTabbed' });
+    self.displayTabbed = ko.observable(false).extend({ persist: 'displayTabbed' });
     self.displayCompact = ko.observable(false).extend({ persist: 'displayCompact' });
     self.displayFullWidth = ko.observable(false).extend({ persist: 'displayFullWidth' });
     self.confirmDeleteQueue = ko.observable(true).extend({ persist: 'confirmDeleteQueue' });


### PR DESCRIPTION
Fixes #2981

Similar to that report I noticed this behaviour.

I think it's related to interface_settings having `"displayTabbed":false` it wasn't present in my config until I started having problems.

Steps to reproduce before this PR:

1. Ensure `"displayTabbed":false` is not set in the config and clear localStorage (at least the displayTabbed) - working as expected no tabs and localStorage displayTabbed is not set on load
2. From web interface settings enable 'Tabbed layout' - this sets "displayTabbed":true in the config and localStorage
3. From web interface settings disable 'Tabbed layout' - this sets "displayTabbed":false in the config and localStorage
4. Open SAB in a private window, or clear localStorage and refresh

Result is tabbed layout shown and "displayTabbed":false gets set in localStorage.
Instead of a new private window you can just clear localStorage for displayTabbed.

---

Poking around the only difference I can see is ko.observable() instead of ko.observable(false) like the others and it seems to be the cause. I'm not totally sure what the meaning is seems like a default value or tells it to parse the string value as a bool?

https://github.com/sabnzbd/sabnzbd/blob/a5239808ebd94f0870ea0022e955f63dbe31e666/interfaces/Glitter/templates/static/javascripts/glitter.main.js#L16-L20