### PR TITLE
switch test_cert_gen check to utc

### DIFF
--- a/tests/test_utils/test_cert_gen.py
+++ b/tests/test_utils/test_cert_gen.py
@@ -64,4 +64,4 @@ class TestCertGen:
             cert = x509.load_pem_x509_certificate(cert_content, default_backend())
 
             # Validate that the timestamp at which the certificate stops being valid (expiration date) is in future
-            assert datetime.datetime.now() < cert.not_valid_after
+            assert datetime.datetime.now(datetime.timezone.utc) < cert.not_valid_after_utc


### PR DESCRIPTION
Came across this deprecation warning in the CI logs while investigting an unrelated issue:
```
tests/test_utils/test_cert_gen.py::TestCertGen::test_generate_local_cert
   /tmp/autopkgtest-lxc.jwrwyq1a/downtmp/autopkgtest_tmp/tests/test_utils/test_cert_gen.py:67: CryptographyDeprecationWarning: Properties that return a naïve datetime object have been deprecated. Please switch to not_valid_after_utc.
      assert datetime.datetime.now() < cert.not_valid_after
```