### PR TITLE
sanitize email related fields from json

### DIFF
--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -652,7 +652,7 @@ def _api_warnings(name: str, kwargs: Dict[str, Union[str, List[str]]]) -> bytes:
     return report(keyword="warnings", data=sabnzbd.GUIHANDLER.content())
 
 
-LOG_JSON_RE = re.compile(rb"'(apikey|api|username|password)': '(.*?)'", re.I)
+LOG_JSON_RE = re.compile(rb"'(apikey|api|username|password|email_(server|to|from|account|pwd))': '(.*?)'", re.I)
 LOG_INI_HIDE_RE = re.compile(
     rb"(apikey|api|user|username|password|email_pwd|email_account|email_to|email_from|pushover_token|pushover_userkey"
     rb"|apprise_(target_[a-z_]+|urls)|pushbullet_apikey|prowl_apikey|growl_password|growl_server|IPv[4|6] address|Public address IPv[4|6]-only|Local IPv6 address)\s?=.*",


### PR DESCRIPTION
this fixes https://github.com/sabnzbd/sabnzbd/issues/3020

before/after change:
```diff
-2025-01-14 17:20:28,268::DEBUG::[interface:144] Request GET /api from 192.168.0.2 [Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:134.0) Gecko/20100101 Firefox/134.0] {'mode': 'test_email', 'REMOVED': '<REMOVED>', 'output': 'json', 'email_full': '1', 'email_rss': '1', 'email_server': 'smtp-mail.localhost.com:587', 'email_to': 'dummy_to@outlook.com', 'email_from': 'dummy_from@outlook.com', 'email_account': 'dummy_acc@outlook.com', 'email_pwd': 'dummy_pw', 'email_cats': '*', 'email_endjob': '0'}
+2025-01-14 17:29:29,796::DEBUG::[interface:144] Request GET /api from 192.168.0.2 [Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:134.0) Gecko/20100101 Firefox/134.0] {'mode': 'test_email', 'REMOVED': '<REMOVED>', 'output': 'json', 'email_full': '1', 'email_rss': '1', 'REMOVED': '<REMOVED>', 'REMOVED': '<REMOVED>', 'REMOVED': '<REMOVED>', 'REMOVED': '<REMOVED>', 'REMOVED': '<REMOVED>', 'email_cats': '*', 'email_endjob': '0'}
```

note that we arent sanitizing other notification agents in the json like we do in the ini... focused on just smtp since this ends up being a larger security risk as people are sharing their gmail/outlook/etc pw publicly...