### PR TITLE
Add check XFF headers for remote ip in cookie

### DIFF
--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -263,6 +263,21 @@ def check_hostname():
 # Create a more unique ID for each instance
 COOKIE_SECRET = str(randint(1000, 100000) * os.getpid())
 
+def remote_ip_from_xff(xff_ips):
+    # Use the requst IP if no XFF headers are present
+    if not xff_ips:
+        return cherrypy.request.remote.ip
+
+    # Per MDN docs, the first non-local/non-trusted IP (rtl) is our "client"
+    # However, it's possible that all IPs are local/trusted, so we may also
+    # return the first ip in the list as it "should" be the client
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For#selecting_an_ip_address
+    for ip in reversed(xff_ips):
+        if not is_local_addr(ip) and not is_loopback_addr(ip):
+            return ip
+
+    # If no non-local/non-trusted IPs found, return the first IP in the list
+    return xff_ips[0]
 
 def set_login_cookie(remove=False, remember_me=False):
     """We try to set a cookie as unique as possible
@@ -271,7 +286,17 @@ def set_login_cookie(remove=False, remember_me=False):
     number, so cookies cannot be re-used
     """
     salt = randint(1, 1000)
-    cookie_str = utob(str(salt) + cherrypy.request.remote.ip + COOKIE_SECRET)
+
+    # If we are using XFF headers, get remote IP from XFF if possible
+    if (
+        cfg.verify_xff_header()
+        and (xff_ips := clean_comma_separated_list(cherrypy.request.headers.get("X-Forwarded-For")))
+    ):
+        remote_ip = remote_ip_from_xff(xff_ips)
+    else:
+        remote_ip = cherrypy.request.remote.ip
+
+    cookie_str = utob(str(salt) + remote_ip + COOKIE_SECRET)
     cherrypy.response.cookie["login_cookie"] = hashlib.sha1(cookie_str).hexdigest()
     cherrypy.response.cookie["login_cookie"]["path"] = "/"
     cherrypy.response.cookie["login_cookie"]["httponly"] = 1
@@ -298,7 +323,16 @@ def check_login_cookie():
     if "login_cookie" not in cherrypy.request.cookie or "login_salt" not in cherrypy.request.cookie:
         return False
 
-    cookie_str = utob(str(cherrypy.request.cookie["login_salt"].value) + cherrypy.request.remote.ip + COOKIE_SECRET)
+    # If we are using XFF headers, get remote IP from XFF if possible
+    if (
+        cfg.verify_xff_header()
+        and (xff_ips := clean_comma_separated_list(cherrypy.request.headers.get("X-Forwarded-For")))
+    ):
+        remote_ip = remote_ip_from_xff(xff_ips)
+    else:
+        remote_ip = cherrypy.request.remote.ip
+
+    cookie_str = utob(str(cherrypy.request.cookie["login_salt"].value) + remote_ip + COOKIE_SECRET)
     return cherrypy.request.cookie["login_cookie"].value == hashlib.sha1(cookie_str).hexdigest()
 
 


### PR DESCRIPTION
If verify_xff_header() then also check for the client IP in the XFF headers to
ensure the IP used for the session cookie is actually the client IP and not a
proxy IP.

### Problem/Bug

As referenced in issue #3038, the current method of generating the login cookie
involves using the remote IP address of the request. However, when SAB exists
behind a reverse proxy, the remote IP address is the address of the proxy host
instead of the client. If the client IP floats (e.g. if the cookie is stolen and
used on another machine) the cookie will still be generated using the proxy host
IP address and will be validated.

### Solution

Use the X-Forwarded-For header to find the client IP address if we know we are
behind a reverse proxy. This way, the IP address used to generate the login
cookie is more tied to the client instead of the proxy host.

### Solution Theory

When a client connects to a web server through a proxy, the X-Forwarded-For
(XFF) header is often added with the IP address of the client as the value. If
the proxied request is proxied again, another XFF header is added with the
address of the first proxy as the "client". In this way, a list is generated
with the original client on the left and each of the next proxies after it to
the right.

> X-Forwarded-For: client, proxy1, proxy2, proxy3

Unfortunately, this header is easily manipulated. Thus it is not necesarily safe
to assume that the left-most address is actually the client. Instead, the
accepted method for selecting the IP address that represents the client is by
picking the first address from right to left that is not local/trusted.
[MDN reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For#selecting_an_ip_address)

```
X-Forwaded-For: address1, address2, ourproxy1, ourproxy2
                             ^--- This is our "client"
                                  since we can't trust
                                  that address1 is correct.
```

It is possible that all of the addresses in the XFF list are local/trusted, in
which case the left-most address can be assumed to actually be the client IP.
And of course, if no XFF header is present, the request IP is the default.

### Implementation

In my implementation I created the function `remote_ip_from_xff(xff_ips)` in
interface.py. The function accepts a list of xff_ips and loops through it in
reverse order. The first address that is not `is_local_addr(ip)` and is not
`is_loopback_addr(ip)` is returned. The two pre-existing IP check functions are
defined in misc.py, and appear to accurately check if the address is defined in
`cfg.local_ranges` or exists within the same subnet as the SAB host. If the
address is not manually defined as local, and does not exist within our local
subnet, then it most definitely is not trusted/local. If no address is found,
that means all of the addresses in the list were trusted/local, and the first
(left-most) value is returned, as it should correctly identify the client.

The new function is called in two places: when the cookie is created, and when
it is checked for validity. In either case, if `cfg.verify_xff_header()` is
enabled then the list of XFF addresses is checked. If the list is empty or
`verify_xff_header()` is not enabled, the remote IP from cherrypy is used as
default.

The login cookie is generated in the same way as before, except with the
`remote_ip` returned from the new function.

### Considerations

There is no check completed to ensure the address we find is "valid". We can
assume it's likely correct because that address will have been reported by a
trusted proxy, but regardless, it should not be used elsewhere without first
confirming it is a valid address. In this particular use case, the validity is
somewhat irrelevant, as the login cookie will still be generated and should
still fail to validate if the address is changed.

I put the new function in interface.py instead of misc.py where some of the
other functions reside, because it doesn't have a use outside the scope of the
interface and creating the login cookies.
