### PR TITLE
Fix typos

### DIFF
--- a/interfaces/Config/templates/config_server.tmpl
+++ b/interfaces/Config/templates/config_server.tmpl
@@ -628,7 +628,7 @@
                             })
                         }
                         if(event.data === 'hide_server') {
-                            // Hide and don't load anymore untill the next release
+                            // Hide and don't load anymore until the next release
                             jQuery('.Servers .server-frame').hide()
                             localStorage.setItem("server-frame-hide-$version", "hide")
                         }

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -258,7 +258,7 @@ def validate_download_vs_complete_dir(root: str, value: str, default: str):
 
 def validate_scriptdir_not_appdir(root: str, value: str, default: str) -> Tuple[None, str]:
     """Warn users to not use the Program Files folder for their scripts"""
-    # Need to add seperator so /mnt/sabnzbd and /mnt/sabnzbd-data are not detected as equal
+    # Need to add separator so /mnt/sabnzbd and /mnt/sabnzbd-data are not detected as equal
     if value and same_directory(sabnzbd.DIR_PROG, os.path.join(root, value)):
         # Warn, but do not block
         sabnzbd.misc.helpful_warning(

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -418,7 +418,7 @@ def same_directory(a: str, b: str) -> int:
     a = os.path.normpath(os.path.abspath(a))
     b = os.path.normpath(os.path.abspath(b))
 
-    # Need to add seperator so /mnt/sabnzbd and /mnt/sabnzbd-data are not detected as equal
+    # Need to add separator so /mnt/sabnzbd and /mnt/sabnzbd-data are not detected as equal
     # But only if it doesn't already end in a slash, for example C:\
     if not a.endswith(os.sep):
         a = a + os.sep

--- a/sabnzbd/happyeyeballs.py
+++ b/sabnzbd/happyeyeballs.py
@@ -39,7 +39,7 @@ from sabnzbd.decorators import cache_maintainer
 
 # How long to delay between connection attempts? The RFC suggests 250ms, but this is
 # quite long and might give us a slow host that just happened to be on top of the list.
-# The absolute minium specified in RFC 8305 is 10ms, so we use that.
+# The absolute minimum specified in RFC 8305 is 10ms, so we use that.
 CONNECTION_ATTEMPT_DELAY = 0.01
 
 # While providers are afraid to add IPv6 to their standard hostnames

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -494,7 +494,7 @@ class NzbQueue:
             # to determine whether to change the priority
             nzo3 = self.__nzo_table[item_id_3]
             nzo3_priority = nzo3.priority
-            # if id1 is surrounded by items of a different priority then change it's pririty to match
+            # if id1 is surrounded by items of a different priority then change its priority to match
             if nzo2_priority != nzo1_priority and nzo3_priority != nzo1_priority or nzo2_priority > nzo1_priority:
                 nzo1.priority = nzo2_priority
         except:

--- a/sabnzbd/par2file.py
+++ b/sabnzbd/par2file.py
@@ -222,7 +222,7 @@ def parse_par2_file(fname: str, md5of16k: Dict[bytes, str]) -> Tuple[str, Dict[s
                     )
                 par2info.filehash = crc32
 
-                # We found hash data, add it to final tabel
+                # We found hash data, add it to final table
                 table[par2info.filename] = par2info
 
                 # Check for md5of16k duplicates

--- a/sabnzbd/utils/rarfile.py
+++ b/sabnzbd/utils/rarfile.py
@@ -105,7 +105,7 @@ except ImportError:
             return self._DST
 
 
-# only needed for encryped headers
+# only needed for encrypted headers
 try:
     try:
         from cryptography.hazmat.primitives.ciphers import algorithms, modes, Cipher
@@ -2136,7 +2136,7 @@ class RarExtFile(RawIOBase):
 
         On uncompressed files, the seeking works by actual
         seeks so it's fast.  On compresses files its slow
-        - forward seeking happends by reading ahead,
+        - forward seeking happens by reading ahead,
         backwards by re-opening and decompressing from the start.
         """
 

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -31,7 +31,7 @@ class TestNotifier(TestCase):
     @classmethod
     def setUpClass(self):
         # hack since test_misc uses @set_config decorator eliminating all of the default configuration
-        # We wnat to test with the default configuration in place; This safely resets all fields and
+        # We want to test with the default configuration in place; This safely resets all fields and
         # replaces them correctly in memory
         reload(cfg)
 


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.po,*.pot,*.min.js" -L allo,collet,fo,parm,ciph,datas,parms,reenabled,re-use,re-used,re-using,sav,tage`