### PR TITLE
fix UnboundLocalError in testhelper

### DIFF
--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -269,11 +269,12 @@ class SABnzbdBaseTest:
             try:
                 return func(*args)
             except WebDriverException as e:
+                prior_exception = e
                 # Try again in 2 seconds!
                 time.sleep(2)
                 pass
         else:
-            raise e
+            raise prior_exception
 
 
 class DownloadFlowBasics(SABnzbdBaseTest):


### PR DESCRIPTION
```
[...]
tests/test_functional_config.py:137: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

func = <bound method WebDriver.find_element of <selenium.webdriver.chrome.webdriver.WebDriver (session="bd74c1db141e8e6583f8df1b533f9c6a")>>
args = ('css selector', "input[data-hide='username']"), _ = 2

    @staticmethod
    def selenium_wrapper(func, *args):
        """Wrapper with retries for more stable Selenium"""
        for _ in range(3):
            try:
                return func(*args)
            except WebDriverException as e:
                # Try again in 2 seconds!
                time.sleep(2)
                pass
        else:
>           raise e
E           UnboundLocalError: cannot access local variable 'e' where it is not associated with a value

tests/testhelper.py:276: UnboundLocalError
```