### PR TITLE
also disable argparse's auto-added help in the (io)nice parameters check

### DIFF
--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -73,7 +73,7 @@ class ErrorCatchingArgumentParser(argparse.ArgumentParser):
 def clean_nice_ionice_parameters(value: str) -> ValidateResult:
     """Verify that the passed parameters are not exploits"""
     if value:
-        parser = ErrorCatchingArgumentParser()
+        parser = ErrorCatchingArgumentParser(add_help=False)
 
         # Nice parameters
         parser.add_argument("-n", "--adjustment", type=int)

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -88,6 +88,10 @@ class TestValidators:
         assert_blocked("echo 'how;now;brown;cow'")
         assert_blocked("-c'echo'")
         assert_blocked("--classdata=;/bin/echo")
+        assert_blocked("-h")
+        assert_blocked("--help")
+        assert_blocked("-h -c1")
+        assert_blocked("-c1 --help")
 
     @pytest.mark.parametrize(
         "setting, is_correct_win, is_correct_unix",


### PR DESCRIPTION
As noted in #3047, argparser's auto-added help makes the parser accept `-h/--help` by default which isn't an argument we want to accept for `nice` or `ionice` in sabnzbd. This changeset stops the clean_nice_ionice_parameters function from accepting `-h/--help`.

As a free bonus, this also avoids a bug in argparse that can trigger a SystemExit despite using the error-catching ArgumentParser or passing `exit_on_error=False` to the ArgumentParser (>=3.9 only). For an example, see [this log](https://paste.debian.net/hidden/b78b66ae/) of a test run with the _test_cfg.py_ from this changeset but the `add_help=False` at line 76 of _cfg.py_ removed.