### PR TITLE
avoid pop from empty list

### DIFF
--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -363,8 +363,9 @@ class NzbFile(TryList):
 
         # Add first article to decodetable, this way we can check
         # if this is maybe a duplicate nzf
-        first_article = self.add_article(raw_article_db.pop(0))
-        first_article.lowest_partnum = True
+        if raw_article_db:
+            first_article = self.add_article(raw_article_db.pop(0))
+            first_article.lowest_partnum = True
 
         if self in nzo.files:
             logging.info("File %s occurred twice in NZB, skipping", self.filename)


### PR DESCRIPTION
NzbFile gets initialised with an empty article db in `check_existing_files` https://github.com/sabnzbd/sabnzbd/blob/a15bad6fb46b18b7e4265c1ad66bac1de7587696/sabnzbd/nzbstuff.py#L1288 and then tries to pop from that in its \_\_init\_\_: https://github.com/sabnzbd/sabnzbd/blob/a15bad6fb46b18b7e4265c1ad66bac1de7587696/sabnzbd/nzbstuff.py#L366


Found in a logfile shared on IRC for an unrelated issue:
```
2025-03-26 19:47:58,288::INFO::[postproc:459] Finished unpack_magic on _JOBNAME_
2025-03-26 19:47:58,583::INFO::[notifier:157] Sending notification: Error - Failed moving T:\incoming\nzb\temp\_JOBNAME_\Setup.exe to C:\Users\<USERNAME>\Downloads\_UNPACK__JOBNAME_\Setup.exe (type=error, job_cat=None)
2025-03-26 19:47:58,583::ERROR::[filesystem:836] Failed moving T:\incoming\nzb\temp\_JOBNAME_\Setup.exe to C:\Users\<USERNAME>\Downloads\_UNPACK__JOBNAME_\Setup.exe
2025-03-26 19:47:58,588::INFO::[filesystem:837] Traceback: 
Traceback (most recent call last):
  File "shutil.py", line 856, in move
OSError: [WinError 17] The system cannot move the file to a different disk drive: '\\\\?\\T:\\incoming\\nzb\\temp\\_JOBNAME_\\Setup.exe' -> '\\\\?\\C:\\Users\\<USERNAME>\\Downloads\\_UNPACK__JOBNAME_\\Setup.exe'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "sabnzbd\filesystem.py", line 823, in move_to_path
  File "sabnzbd\decorators.py", line 44, in call_func
  File "sabnzbd\filesystem.py", line 907, in renamer
  File "shutil.py", line 876, in move
  File "shutil.py", line 453, in copy2
OSError: [WinError 225] Operation did not complete successfully because the file contains a virus or potentially unwanted software

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "sabnzbd\filesystem.py", line 828, in move_to_path
  File "shutil.py", line 260, in copyfile
OSError: [Errno 22] Invalid argument: '\\\\?\\T:\\incoming\\nzb\\temp\\_JOBNAME_\\Setup.exe'
2025-03-26 19:47:58,590::INFO::[nzbstuff:1824] [N/A] Purging data for job _JOBNAME_ (delete_all_data=False)
2025-03-26 19:47:58,591::INFO::[notifier:157] Sending notification: Download Failed - _JOBNAME_ (type=failed, job_cat=*)
2025-03-26 19:47:58,611::INFO::[database:300] Added job _JOBNAME_ to history
2025-03-26 19:47:58,611::INFO::[database:269] Archiving completed jobs older than 60 days from history
2025-03-26 19:47:58,612::INFO::[postproc:135] Saving postproc queue
2025-03-26 19:47:58,612::INFO::[downloader:412] Post-processing finished, resuming download
2025-03-26 19:48:02,627::INFO::[nzbqueue:230] Saving queue
2025-03-26 19:48:02,630::INFO::[postproc:135] Saving postproc queue
2025-03-26 19:48:02,633::INFO::[notifier:157] Sending notification: SABnzbd - Queue finished (type=queue_done, job_cat=None)
2025-03-26 19:49:23,957::INFO::[panic:239] Launching browser with http://127.0.0.1:8085
2025-03-26 19:49:38,910::INFO::[nzbstuff:1285] Existing file Setup.exe added to _JOBNAME_
2025-03-26 19:49:38,910::INFO::[notifier:157] Sending notification: Error - Error importing _JOBNAME_ (type=error, job_cat=None)
2025-03-26 19:49:38,910::ERROR::[nzbstuff:1300] Error importing _JOBNAME_
2025-03-26 19:49:38,916::INFO::[nzbstuff:1301] Traceback: 
Traceback (most recent call last):
  File "sabnzbd\nzbstuff.py", line 1288, in check_existing_files
  File "sabnzbd\nzbstuff.py", line 366, in __init__
IndexError: pop from empty list
```