### PR TITLE
Fix Platform Detection on Linux

### DIFF
--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -818,11 +818,9 @@ def get_platform_description() -> str:
         else:
             # Check for other forms of virtualization
             try:
-                # Check if the command exists by searching in the PATH
-                if run_command(["which", "systemd-detect-virt"]).strip():
-                    if virt := run_command(["systemd-detect-virt"]).strip():
-                        if virt != "none":
-                            platform_tags.append(virt)
+                if virt := run_command(["systemd-detect-virt"], stderr=subprocess.DEVNULL).strip():
+                    if virt != "none":
+                        platform_tags.append(virt)
             except:
                 pass
 

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -818,9 +818,11 @@ def get_platform_description() -> str:
         else:
             # Check for other forms of virtualization
             try:
-                if virt := run_command(["systemd-detect-virt"]).strip():
-                    if virt != "none":
-                        platform_tags.append(virt)
+                # Check if the command exists by searching in the PATH
+                if run_command(["which", "systemd-detect-virt"]).strip():
+                    if virt := run_command(["systemd-detect-virt"]).strip():
+                        if virt != "none":
+                            platform_tags.append(virt)
             except:
                 pass
 


### PR DESCRIPTION
**Description:**

This patch improves platform detection on Linux by directly attempting to run `systemd-detect-virt` while suppressing error output. This approach enhances robustness by avoiding unnecessary checks and handling potential errors gracefully.

**Changes:**

- Directly executes `systemd-detect-virt` with error suppression using `stderr=subprocess.DEVNULL`.
- Ensures compatibility with environments where the command might not be present.
