### PR TITLE
fix root dir check in make_mo

### DIFF
--- a/tools/make_mo.py
+++ b/tools/make_mo.py
@@ -28,7 +28,7 @@ import gettext
 import subprocess
 
 # Make sure it's run as "python tools/make_mo.py"
-if not os.path.exists("builder"):
+if not os.path.exists("po"):
     raise RuntimeError("Make sure to run from root directory of SABnzbd")
 
 PO_DIR = "po/main"


### PR DESCRIPTION
looking for the "builder" dir causes make_mo to fail when run from the root of the -src tarball. This change makes it look for "po" instead, which is present in releases and also the relative path make_mo actually wants.