### PR TITLE
stop catching BaseException

### DIFF
--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -311,7 +311,7 @@ def identify_web_template(key, defweb, wdir):
     if wdir is None:
         try:
             wdir = fix_webname(key())
-        except:
+        except Exception:
             wdir = ""
     if not wdir:
         wdir = defweb
@@ -383,13 +383,13 @@ def get_user_profile_paths():
             path = shell.SHGetFolderPath(0, shellcon.CSIDL_LOCAL_APPDATA, None, 0)
             sabnzbd.DIR_LCLDATA = os.path.join(path, DEF_WORKDIR)
             sabnzbd.DIR_HOME = os.environ["USERPROFILE"]
-        except:
+        except Exception:
             try:
                 root = os.environ["AppData"]
                 user = os.environ["USERPROFILE"]
                 sabnzbd.DIR_LCLDATA = "%s\\%s" % (root.replace("\\Roaming", "\\Local"), DEF_WORKDIR)
                 sabnzbd.DIR_HOME = user
-            except:
+            except Exception:
                 pass
 
         # Long-path everything
@@ -675,7 +675,7 @@ def is_sabnzbd_running(url):
         ver = get_from_url(url)
         set_https_verification(prev)
         return ver and (re.search(r"\d+\.\d+\.", ver) or ver.strip() == sabnzbd.__version__)
-    except:
+    except Exception:
         return False
 
 
@@ -686,7 +686,7 @@ def find_free_port(host, currentport):
         try:
             portend.free(host, currentport, timeout=0.025)
             return currentport
-        except:
+        except Exception:
             currentport += 5
             n += 1
     return 0
@@ -888,7 +888,7 @@ def main():
         elif opt in ("-l", "--logging"):
             try:
                 logging_level = int(arg)
-            except:
+            except Exception:
                 logging_level = -2
             if logging_level < -1 or logging_level > 2:
                 print_help()
@@ -1007,13 +1007,13 @@ def main():
                 portend.free(web_host, https_port, timeout=0.05)
             except IOError:
                 abort_and_show_error(browserhost, web_port)
-            except:
+            except Exception:
                 abort_and_show_error(browserhost, web_port, "49")
         try:
             portend.free(web_host, web_port, timeout=0.05)
         except IOError:
             abort_and_show_error(browserhost, web_port)
-        except:
+        except Exception:
             abort_and_show_error(browserhost, web_port, "49")
 
     # Windows instance is reachable through registry
@@ -1049,7 +1049,7 @@ def main():
                             # In case HTTPS == HTTP port
                             web_port = newport
                             sabnzbd.cfg.web_port.set(newport)
-        except:
+        except Exception:
             # Something else wrong, probably badly specified host
             abort_and_show_error(browserhost, web_port, "49")
 
@@ -1072,7 +1072,7 @@ def main():
                     if port > 0:
                         sabnzbd.cfg.web_port.set(port)
                         web_port = port
-        except:
+        except Exception:
             # Something else wrong, probably badly specified host
             abort_and_show_error(browserhost, web_port, "49")
 
@@ -1090,7 +1090,7 @@ def main():
             if RSS_FILE_NAME not in x:
                 try:
                     os.remove(x)
-                except:
+                except Exception:
                     pass
 
     # Prevent the logger from raising exceptions
@@ -1146,7 +1146,7 @@ def main():
             os.environ["SSL_CERT_FILE"] = certifi.where()
             logging.info("Certifi version = %s", certifi.__version__)
             logging.info("Loaded additional certificates from %s", os.environ["SSL_CERT_FILE"])
-        except:
+        except Exception:
             # Sometimes the certificate file is blocked
             logging.warning(T("Could not load additional certificates from certifi package"))
             logging.info("Traceback: ", exc_info=True)
@@ -1181,7 +1181,7 @@ def main():
                 import sabnzbd.sabtraylinux
 
                 sabnzbd.sabtraylinux.StatusIcon()
-            except:
+            except Exception:
                 logging.info("python3-gi not found, no SysTray.")
 
     # Find external programs
@@ -1210,7 +1210,7 @@ def main():
         try:
             trialcontext.load_cert_chain(https_cert, https_key)
             logging.info("HTTPS keys are OK")
-        except:
+        except Exception:
             logging.warning(T("Disabled HTTPS because of invalid CERT and KEY files"))
             logging.info("Traceback: ", exc_info=True)
             enable_https = False
@@ -1351,7 +1351,7 @@ def main():
 
     try:
         cherrypy.engine.start()
-    except:
+    except Exception:
         # Since the webserver is started by cherrypy in a separate thread, we can't really catch any
         # start-up errors. This try/except only catches very few errors, the rest is only shown in the console.
         logging.error(T("Failed to start web-interface: "), exc_info=True)
@@ -1387,7 +1387,7 @@ def main():
     logging.info("Starting %s-%s", sabnzbd.MY_NAME, sabnzbd.__version__)
     try:
         sabnzbd.start()
-    except:
+    except Exception:
         logging.exception("Failed to start %s-%s", sabnzbd.MY_NAME, sabnzbd.__version__)
         sabnzbd.halt()
 
@@ -1493,7 +1493,7 @@ def main():
     if hasattr(sys, "frozen") and sabnzbd.MACOS:
         try:
             AppHelper.stopEventLoop()
-        except:
+        except Exception:
             # Failing AppHelper library!
             os._exit(0)
     elif sabnzbd.WIN_SERVICE:

--- a/builder/make_dmg.py
+++ b/builder/make_dmg.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     # Check for DMGBuild
     try:
         import dmgbuild
-    except:
+    except Exception:
         print("Requires dmgbuild-module, use pip install dmgbuild")
         exit()
 

--- a/builder/package.py
+++ b/builder/package.py
@@ -125,7 +125,7 @@ def test_sab_binary(binary_path: str):
             try:
                 urllib.request.urlopen(base_url, timeout=1).read()
                 break
-            except:
+            except Exception:
                 time.sleep(1)
         else:
             # Print console output and give some time to print

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -46,7 +46,7 @@ if os.name == "nt":
 
     try:
         KERNEL32 = ctypes.windll.LoadLibrary("Kernel32.dll")
-    except:
+    except Exception:
         pass
 elif os.name == "posix":
     ORG_UMASK = os.umask(18)
@@ -56,7 +56,7 @@ elif os.name == "posix":
     try:
         LIBC = ctypes.CDLL("libc.so.6")
         LIBC.malloc_trim(0)  # try the malloc_trim() call, which is a GNU extension
-    except:
+    except Exception:
         # No malloc_trim(), probably because no glibc
         LIBC = None
         pass
@@ -71,7 +71,7 @@ elif os.name == "posix":
             import sabnzbd.utils.sleepless as sleepless
 
             FOUNDATION = True
-        except:
+        except Exception:
             pass
 
 
@@ -358,41 +358,41 @@ def halt():
         sabnzbd.URLGrabber.stop()
         try:
             sabnzbd.URLGrabber.join(timeout=3)
-        except:
+        except Exception:
             pass
 
         logging.debug("Stopping dirscanner")
         sabnzbd.DirScanner.stop()
         try:
             sabnzbd.DirScanner.join(timeout=3)
-        except:
+        except Exception:
             pass
 
         logging.debug("Stopping downloader")
         sabnzbd.Downloader.stop()
         try:
             sabnzbd.Downloader.join(timeout=3)
-        except:
+        except Exception:
             pass
 
         logging.debug("Stopping assembler")
         sabnzbd.Assembler.stop()
         try:
             sabnzbd.Assembler.join(timeout=3)
-        except:
+        except Exception:
             pass
 
         logging.debug("Stopping postprocessor")
         sabnzbd.PostProcessor.stop()
         try:
             sabnzbd.PostProcessor.join(timeout=3)
-        except:
+        except Exception:
             pass
 
         # Save State
         try:
             save_state()
-        except:
+        except Exception:
             logging.error(T("Fatal error at saving state"), exc_info=True)
 
         # The Scheduler cannot be stopped when the stop was scheduled.
@@ -454,7 +454,7 @@ def delayed_startup_actions():
             sabnzbd.__baseline__ = sabnzbd.misc.run_command(
                 ["git", "rev-parse", "--short", "HEAD"], cwd=sabnzbd.DIR_PROG
             ).strip()
-        except:
+        except Exception:
             pass
 
     logging.info("Commit = %s", sabnzbd.__baseline__)
@@ -607,5 +607,5 @@ def pid_file(pid_path=None, pid_file=None, port=0):
                     f.write("%d\n" % os.getpid())
             else:
                 filesystem.remove_file(sabnzbd.DIR_PID)
-        except:
+        except Exception:
             logging.warning(T("Cannot access PID file %s"), sabnzbd.DIR_PID)

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -246,12 +246,12 @@ def _api_queue_priority(value: str, kwargs: Dict[str, Union[str, List[str]]]) ->
         try:
             try:
                 priority = int(priority)
-            except:
+            except Exception:
                 return report(_MSG_INT_VALUE)
             pos = sabnzbd.NzbQueue.set_priority(nzo_ids, priority)
             # Returns the position in the queue, -1 is incorrect job-id
             return report(keyword="position", data=pos)
-        except:
+        except Exception:
             return report(_MSG_NO_VALUE2)
     else:
         return report(_MSG_NO_VALUE2)
@@ -682,7 +682,7 @@ def _api_showlog(name: str, kwargs: Dict[str, Union[str, List[str]]]) -> bytes:
     try:
         if cur_user := getpass.getuser():
             log_data = log_data.replace(utob(cur_user), b"<USERNAME>")
-    except:
+    except Exception:
         pass
 
     # Set headers
@@ -1311,7 +1311,7 @@ def test_nntp_server_dict(kwargs: Dict[str, Union[str, List[str]]]) -> Tuple[boo
             username=username,
             password=password,
         )
-    except:
+    except Exception:
         return False, T("Invalid server details")
 
     # All exceptions are caught internally
@@ -1852,7 +1852,7 @@ def build_history(
     try:
         history_db = sabnzbd.get_db_connection()
         close_db = False
-    except:
+    except Exception:
         # Required for repairs at startup because Cherrypy isn't active yet
         history_db = HistoryDB()
         close_db = True

--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -118,7 +118,7 @@ class Assembler(Thread):
                             sabnzbd.Downloader.pause()
                         else:
                             logging.debug("Ignoring error %s for %s, already finished or in post-proc", err, filepath)
-                    except:
+                    except Exception:
                         logging.error(T("Fatal error in Assembler"), exc_info=True)
                         break
             else:
@@ -342,7 +342,7 @@ def check_encrypted_and_unwanted_files(nzo: NzbObject, filepath: str) -> Tuple[b
                                         break
                                     # This one didn't work
                                     pass
-                                except:
+                                except Exception:
                                     # All the other errors we skip, they might be fixable in post-proc.
                                     # For example starting from the wrong volume, or damaged files
                                     # This will cause the check to be performed again for the next rar, might

--- a/sabnzbd/bpsmeter.py
+++ b/sabnzbd/bpsmeter.py
@@ -237,7 +237,7 @@ class BPSMeter:
             if abs(quota - self.quota) > 0.5:
                 self.change_quota()
             res = self.reset_quota()
-        except:
+        except Exception:
             self.defaults()
         return res
 

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -185,7 +185,7 @@ def validate_host(value: str) -> ValidateResult:
         ipaddress.ip_address(value)
         # valid host, so return it
         return None, value
-    except:
+    except Exception:
         pass
 
     # we don't want a plain number. As socket.getaddrinfo("100", ...) allows that, we have to pre-check
@@ -193,7 +193,7 @@ def validate_host(value: str) -> ValidateResult:
         int(value)
         # plain int as input, which is not allowed
         return T("Invalid server address."), None
-    except:
+    except Exception:
         pass
 
     # not a plain IPv4 nor IPv6 address, so let's check if it's a name that resolves to IPv4
@@ -202,7 +202,7 @@ def validate_host(value: str) -> ValidateResult:
         # all good
         logging.debug("Valid host name")
         return None, value
-    except:
+    except Exception:
         pass
 
     # ... and if not: does it resolve to IPv6 ... ?
@@ -211,7 +211,7 @@ def validate_host(value: str) -> ValidateResult:
         # all good
         logging.debug("Valid host name")
         return None, value
-    except:
+    except Exception:
         logging.debug("No valid host name")
         pass
 

--- a/sabnzbd/config.py
+++ b/sabnzbd/config.py
@@ -988,7 +988,7 @@ def save_config(force=False):
     try:
         shutil.copyfile(filename, bakname)
         shutil.copymode(filename, bakname)
-    except:
+    except Exception:
         # Something wrong with the backup,
         logging.error(T("Cannot create backup file for %s"), bakname)
         logging.info("Traceback: ", exc_info=True)
@@ -1001,12 +1001,12 @@ def save_config(force=False):
         shutil.copymode(bakname, filename)
         CFG_MODIFIED = False
         res = True
-    except:
+    except Exception:
         logging.error(T("Cannot write to INI file %s"), filename)
         logging.info("Traceback: ", exc_info=True)
         try:
             remove_file(filename)
-        except:
+        except Exception:
             pass
         # Restore INI file from backup
         renamer(bakname, filename)
@@ -1049,7 +1049,7 @@ def create_config_backup() -> Union[str, bool]:
                 with open(CFG_OBJ.filename, "rb") as data:
                     zip_ref.writestr(DEF_INI_FILE, data.read())
         return clip_path(complete_path)
-    except:
+    except Exception:
         logging.info("Failed to create backup: ", exc_info=True)
         return False
 
@@ -1062,7 +1062,7 @@ def validate_config_backup(config_backup_data: bytes) -> bool:
                 # Will throw KeyError if not present
                 zip_ref.getinfo(DEF_INI_FILE)
                 return True
-    except:
+    except Exception:
         return False
 
 
@@ -1097,7 +1097,7 @@ def restore_config_backup(config_backup_data: bytes):
                         # File not in archive
                         pass
                 save_config()
-    except:
+    except Exception:
         logging.warning(T("Could not restore backup"))
         logging.info("Traceback: ", exc_info=True)
 

--- a/sabnzbd/database.py
+++ b/sabnzbd/database.py
@@ -119,7 +119,7 @@ class HistoryDB:
             try:
                 self.cursor.execute(command, args)
                 return True
-            except:
+            except Exception:
                 error = str(sys.exc_info()[1])
                 if tries > 0 and "is locked" in error:
                     logging.debug("Database locked, wait and retry")
@@ -135,7 +135,7 @@ class HistoryDB:
                     self.close()
                     try:
                         remove_file(HistoryDB.db_path)
-                    except:
+                    except Exception:
                         pass
                     HistoryDB.startup_done = False
                     self.connect()
@@ -149,7 +149,7 @@ class HistoryDB:
                     logging.info("Traceback: ", exc_info=True)
                     try:
                         self.connection.rollback()
-                    except:
+                    except Exception:
                         # Can fail in case of automatic rollback
                         logging.debug("Rollback Failed:", exc_info=True)
             return False
@@ -198,7 +198,7 @@ class HistoryDB:
         try:
             self.cursor.close()
             self.connection.close()
-        except:
+        except Exception:
             logging.error(T("Failed to close database, see log"))
             logging.info("Traceback: ", exc_info=True)
 
@@ -418,7 +418,7 @@ class HistoryDB:
         if self.execute("""SELECT script_log FROM history WHERE nzo_id = ?""", (nzo_id,)):
             try:
                 data = ubtou(zlib.decompress(self.cursor.fetchone()["script_log"]))
-            except:
+            except Exception:
                 pass
         return data
 
@@ -556,7 +556,7 @@ def unpack_history_info(item: sqlite3.Row) -> Dict[str, Any]:
         parsed_stage_log = []
         try:
             all_stages_lines = lst.split("\r\n")
-        except:
+        except Exception:
             logging.warning(T("Invalid stage logging in history for %s"), item["name"])
             logging.debug("Lines: %s", lst)
             all_stages_lines = []
@@ -564,13 +564,13 @@ def unpack_history_info(item: sqlite3.Row) -> Dict[str, Any]:
         for stage_lines in all_stages_lines:
             try:
                 key, logs = stage_lines.split(":::")
-            except:
+            except Exception:
                 logging.info('Missing key:::logs "%s"', stage_lines)
                 continue
             stage = {"name": key, "actions": []}
             try:
                 stage["actions"] = logs.split(";")
-            except:
+            except Exception:
                 logging.warning(T("Invalid stage logging in history for %s"), item["name"])
                 logging.debug("Logs: %s", logs)
             parsed_stage_log.append(stage)

--- a/sabnzbd/decoder.py
+++ b/sabnzbd/decoder.py
@@ -45,7 +45,7 @@ try:
     # Verify version to at least match minor version
     if SABCTOOLS_VERSION[:3] != SABCTOOLS_VERSION_REQUIRED[:3]:
         raise ImportError
-except:
+except Exception:
     SABCTOOLS_ENABLED = False
 
 
@@ -122,7 +122,7 @@ def decode(article: Article, data_view: memoryview):
                     decoded_data = decode_uu(article, bytes(data_view))
                     logging.debug("Found uu-encoded article %s in job %s", art_id, nzo.final_name)
                     article_success = True
-                except:
+                except Exception:
                     pass
             # Only bother with further checks if uu-decoding didn't work out
             if not article_success:
@@ -150,7 +150,7 @@ def decode(article: Article, data_view: memoryview):
             if search_new_server(article):
                 return
 
-    except:
+    except Exception:
         logging.warning(T("Unknown Error while decoding %s"), art_id)
         logging.info("Traceback: ", exc_info=True)
 

--- a/sabnzbd/deobfuscate_filenames.py
+++ b/sabnzbd/deobfuscate_filenames.py
@@ -181,7 +181,7 @@ def get_biggest_file(filelist: List[str]) -> str:
             return filelist[0]
         else:
             return False
-    except:
+    except Exception:
         if len(filelist) == 1:
             # the only file, so biggest
             return filelist[0]

--- a/sabnzbd/directunpacker.py
+++ b/sabnzbd/directunpacker.py
@@ -84,7 +84,7 @@ class DirectUnpacker(threading.Thread):
                 self.active_instance.stdout.close()
                 self.active_instance.stdin.close()
                 self.active_instance.wait(timeout=2)
-        except:
+        except Exception:
             logging.debug("Exception in reset_active()", exc_info=True)
             pass
 
@@ -384,7 +384,7 @@ class DirectUnpacker(threading.Thread):
         if not self.unpack_dir_info:
             try:
                 self.unpack_dir_info = prepare_extraction_path(self.nzo)
-            except:
+            except Exception:
                 # Prevent fatal crash if directory creation fails
                 self.abort()
                 return
@@ -515,7 +515,7 @@ class DirectUnpacker(threading.Thread):
                             # Flat-unpack, so remove foldername from RarFile output
                             f = os.path.join(extraction_path, os.path.basename(rm_file))
                             remove_file(f)
-                    except:
+                    except Exception:
                         # The user will have to remove it themselves
                         logging.info(
                             "Failed to clean Direct Unpack after aborting %s", rarfile_nzf.filename, exc_info=True

--- a/sabnzbd/dirscanner.py
+++ b/sabnzbd/dirscanner.py
@@ -79,7 +79,7 @@ class DirScanner(threading.Thread):
             if dirscan_dir != self.dirscan_dir:
                 self.ignored = {}
                 self.suspected = {}
-        except:
+        except Exception:
             self.ignored = {}  # Will hold all unusable files and the
             # successfully processed ones that cannot be deleted
             self.suspected = {}  # Will hold name/attributes of suspected candidates
@@ -174,7 +174,7 @@ class DirScanner(threading.Thread):
                             del self.suspected[path]
 
                     yield path, catdir, stat_tuple
-        except:
+        except Exception:
             if not self.error_reported and not catdir:
                 logging.error(T("Cannot read Watched Folder %s"), filesystem.clip_path(folder))
                 logging.info("Traceback: ", exc_info=True)

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -615,7 +615,7 @@ class Downloader(Thread):
                             try:
                                 logging.info("%s@%s: Initiating connection", nw.thrdnum, server.host)
                                 nw.init_connect()
-                            except:
+                            except Exception:
                                 logging.error(
                                     T("Failed to initialize %s@%s with reason: %s"),
                                     nw.thrdnum,
@@ -682,7 +682,7 @@ class Downloader(Thread):
                 process_nw_queue.put_multiple(read)
                 process_nw_queue.join()
 
-        except:
+        except Exception:
             logging.error(T("Fatal error in Downloader"), exc_info=True)
 
     def process_nw_worker(self, read_fds: Dict[int, NewsWrapper], nw_queue: MultiAddQueue):
@@ -695,7 +695,7 @@ class Downloader(Thread):
                 # The read_fds is passed by reference, so we can access its items!
                 self.process_nw(read_fds[nw_queue.get()])
                 nw_queue.task_done()
-        except:
+        except Exception:
             # We cannot break out of the Downloader from here, so just pause
             logging.error(T("Fatal error in Downloader"), exc_info=True)
             self.pause()
@@ -988,7 +988,7 @@ class Downloader(Thread):
         except socket.error as err:
             logging.info("Looks like server closed connection: %s", err)
             self.__reset_nw(nw, "Server broke off connection", warn=True)
-        except:
+        except Exception:
             logging.error(T("Suspect error in downloader"))
             logging.info("Traceback: ", exc_info=True)
             self.__reset_nw(nw, "Server broke off connection", warn=True)

--- a/sabnzbd/emailer.py
+++ b/sabnzbd/emailer.py
@@ -86,14 +86,14 @@ def send_email(message, email_to, test=None):
             mailconn = smtplib.SMTP_SSL(server, port)
             mailconn.ehlo()
             logging.debug("Connected to server %s:%s", server, port)
-        except:
+        except Exception:
             # Non SSL mail server
             logging.debug("Non-SSL mail server detected reconnecting to server %s:%s", server, port)
 
             try:
                 mailconn = smtplib.SMTP(server, port)
                 mailconn.ehlo()
-            except:
+            except Exception:
                 logging.info("Traceback: ", exc_info=True)
                 return errormsg(T("Failed to connect to mail server"))
 
@@ -103,7 +103,7 @@ def send_email(message, email_to, test=None):
             try:
                 mailconn.starttls()
                 mailconn.ehlo()
-            except:
+            except Exception:
                 logging.info("Traceback: ", exc_info=True)
                 return errormsg(T("Failed to initiate TLS connection"))
 
@@ -117,7 +117,7 @@ def send_email(message, email_to, test=None):
                 return errormsg(T("Failed to authenticate to mail server"))
             except smtplib.SMTPException:
                 return errormsg(T("No suitable authentication method was found"))
-            except:
+            except Exception:
                 logging.info("Traceback: ", exc_info=True)
                 return errormsg(T("Unknown authentication failure in mail server"))
 
@@ -132,13 +132,13 @@ def send_email(message, email_to, test=None):
             msg = errormsg("The server didn't accept the from_addr.")
         except smtplib.SMTPDataError:
             msg = errormsg("The server replied with an unexpected error code (other than a refusal of a recipient).")
-        except:
+        except Exception:
             logging.info("Traceback: ", exc_info=True)
             msg = errormsg(T("Failed to send e-mail"))
 
         try:
             mailconn.close()
-        except:
+        except Exception:
             logging.info("Traceback: ", exc_info=True)
             errormsg(T("Failed to close mail connection"))
 
@@ -162,7 +162,7 @@ def send_with_template(prefix, parm, test=None):
     if path and os.path.exists(path):
         try:
             email_templates = glob.glob(os.path.join(path, "%s-*.tmpl" % prefix))
-        except:
+        except Exception:
             logging.error(T("Cannot find email templates in %s"), path)
     else:
         path = os.path.join(sabnzbd.DIR_PROG, DEF_EMAIL_TMPL)

--- a/sabnzbd/encoding.py
+++ b/sabnzbd/encoding.py
@@ -81,7 +81,7 @@ def correct_cherrypy_encoding(inputstring: str) -> str:
     """convert inputstring with separate, individual chars (1-255) to valid string (with UTF8 encoding)"""
     try:
         return inputstring.encode("raw_unicode_escape").decode("utf8")
-    except:
+    except Exception:
         # not possible to convert to UTF8, so don't change anything:
         return inputstring
 

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -69,7 +69,7 @@ def get_ext(filename: str) -> str:
     """Return lowercased file extension"""
     try:
         return os.path.splitext(filename)[1].lower()
-    except:
+    except Exception:
         return ""
 
 
@@ -120,7 +120,7 @@ def get_filename(path: str) -> str:
     """Return path without the file extension"""
     try:
         return os.path.split(path)[1]
-    except:
+    except Exception:
         return ""
 
 
@@ -141,7 +141,7 @@ def is_size(filepath: str, size: int) -> bool:
     """Return True if filepath exists and is specified size"""
     try:
         return os.path.getsize(filepath) == size
-    except:
+    except Exception:
         return False
 
 
@@ -435,7 +435,7 @@ def same_directory(a: str, b: str) -> int:
         if os.path.samefile(a, b) is True:
             return 1
         return is_subfolder
-    except:
+    except Exception:
         if int(a == b):
             return 1
         else:
@@ -564,7 +564,7 @@ def fix_unix_encoding(folder: str):
                 if name != new_name:
                     try:
                         renamer(os.path.join(root, name), os.path.join(root, new_name))
-                    except:
+                    except Exception:
                         logging.info("Cannot correct name of %s", os.path.join(root, name))
 
 
@@ -629,7 +629,7 @@ def set_chmod(path: str, permissions: int, allow_failures: bool = False):
     try:
         logging.debug("Applying permissions %s (octal) to %s", oct(permissions), path)
         os.chmod(path, permissions)
-    except:
+    except Exception:
         if not allow_failures and not sabnzbd.misc.match_str(path, IGNORED_FILES_AND_FOLDERS):
             logging.error(T("Cannot change permissions of %s"), clip_path(path))
             logging.info("Traceback: ", exc_info=True)
@@ -809,7 +809,7 @@ def move_to_path(path: str, new_path: str) -> Tuple[bool, Optional[str]]:
     if overwrite and os.path.exists(new_path):
         try:
             os.remove(new_path)
-        except:
+        except Exception:
             overwrite = False
     if not overwrite:
         new_path = get_unique_filename(new_path)
@@ -827,7 +827,7 @@ def move_to_path(path: str, new_path: str) -> Tuple[bool, Optional[str]]:
             try:
                 shutil.copyfile(path, new_path)
                 os.remove(path)
-            except:
+            except Exception:
                 # Check if the old-file actually exists (possible delete-delays)
                 if not os.path.exists(path):
                     logging.debug("File not moved, original path gone: %s", path)
@@ -850,7 +850,7 @@ def cleanup_empty_directories(path: str):
                 try:
                     remove_dir(root)
                     repeat = True
-                except:
+                except Exception:
                     pass
         if not repeat:
             break
@@ -859,7 +859,7 @@ def cleanup_empty_directories(path: str):
     if not os.listdir(path):
         try:
             remove_dir(path)
-        except:
+        except Exception:
             pass
 
 
@@ -965,7 +965,7 @@ def remove_all(path: str, pattern: str = "*", keep_folder: bool = False, recursi
             logging.debug("Removing dir recursively %s", path)
             try:
                 shutil.rmtree(path)
-            except:
+            except Exception:
                 logging.info("Cannot remove folder %s", path, exc_info=True)
         else:
             # Get files based on pattern
@@ -977,14 +977,14 @@ def remove_all(path: str, pattern: str = "*", keep_folder: bool = False, recursi
                 if os.path.isfile(f):
                     try:
                         remove_file(f)
-                    except:
+                    except Exception:
                         logging.info("Cannot remove file %s", f, exc_info=True)
                 elif recursive:
                     remove_all(f, pattern, False, True)
             if not keep_folder:
                 try:
                     remove_dir(path)
-                except:
+                except Exception:
                     logging.info("Cannot remove folder %s", path, exc_info=True)
 
 
@@ -1047,7 +1047,7 @@ def diskspace_base(dir_to_check: str) -> Tuple[float, float]:
         try:
             available, disk_size, total_free = win32api.GetDiskFreeSpaceEx(dir_to_check)
             return disk_size / GIGI, available / GIGI
-        except:
+        except Exception:
             return 0.0, 0.0
     elif sabnzbd.MACOS:
         # MacOS diskfree ... via c-lib call statfs()
@@ -1066,7 +1066,7 @@ def diskspace_base(dir_to_check: str) -> Tuple[float, float]:
             else:
                 available = float(s.f_bavail) * float(s.f_frsize)
             return disk_size / GIGI, available / GIGI
-        except:
+        except Exception:
             return 0.0, 0.0
     else:
         return 20.0, 10.0
@@ -1096,7 +1096,7 @@ def get_new_id(prefix, folder, check_list=None):
             head, tail = os.path.split(path)
             if not check_list or tail not in check_list:
                 return tail
-        except:
+        except Exception:
             logging.error(T("Failure in tempfile.mkstemp"))
             logging.info("Traceback: ", exc_info=True)
             break
@@ -1119,7 +1119,7 @@ def save_data(data, _id, path, do_pickle=True, silent=False):
                 else:
                     data_file.write(data)
             break
-        except:
+        except Exception:
             if silent:
                 # This can happen, probably a removed folder
                 pass
@@ -1155,7 +1155,7 @@ def load_data(data_id, path, remove=True, do_pickle=True, silent=False):
 
         if remove:
             remove_file(path)
-    except:
+    except Exception:
         logging.error(T("Loading %s failed"), path)
         logging.info("Traceback: ", exc_info=True)
         return None
@@ -1169,7 +1169,7 @@ def remove_data(_id: str, path: str):
     try:
         if os.path.exists(path):
             remove_file(path)
-    except:
+    except Exception:
         logging.debug("Failed to remove %s", path)
 
 
@@ -1223,7 +1223,7 @@ def save_compressed(folder: str, filename: str, data_fp: BinaryIO) -> str:
                 # We only need minimal compression to prevent huge files
                 with gzip.GzipFile(filename, mode="wb", compresslevel=1, fileobj=tgz_file) as gzip_file:
                     shutil.copyfileobj(data_fp, gzip_file)
-        except:
+        except Exception:
             logging.error(T("Saving %s failed"), full_nzb_path)
             logging.info("Traceback: ", exc_info=True)
     else:
@@ -1251,14 +1251,14 @@ def directory_is_writable_with_file(mydir, myfilename):
     if os.path.exists(filename):
         try:
             os.remove(filename)
-        except:
+        except Exception:
             return False
     try:
         with open(filename, "w") as f:
             f.write("Some random content")
         os.remove(filename)
         return True
-    except:
+    except Exception:
         return False
 
 

--- a/sabnzbd/getipaddress.py
+++ b/sabnzbd/getipaddress.py
@@ -85,7 +85,7 @@ def dnslookup() -> bool:
     try:
         addresslookup(sabnzbd.cfg.selftest_host())
         result = True
-    except:
+    except Exception:
         result = False
     logging.debug("DNS Lookup = %s (in %.2f seconds)", result, time.time() - start)
     return result
@@ -138,7 +138,7 @@ def public_ip(family: int = socket.AF_UNSPEC) -> Optional[str]:
         # Make sure it's a valid IPv4 or IPv6 address
         if not sabnzbd.misc.is_ipv4_addr(client_ip) and not sabnzbd.misc.is_ipv6_addr(client_ip):
             raise ValueError
-    except:
+    except Exception:
         logging.debug(
             "Failed to get public address from %s (%s)",
             sabnzbd.cfg.selftest_host(),
@@ -165,7 +165,7 @@ def local_ipv6() -> Optional[str]:
             # IPv6 prefix for documentation purpose
             s_ipv6.connect(("2001:db8::8080", 80))
             ipv6_address = s_ipv6.getsockname()[0]
-    except:
+    except Exception:
         ipv6_address = None
 
     # If text is updated, make sure to update log-anonymization

--- a/sabnzbd/happyeyeballs.py
+++ b/sabnzbd/happyeyeballs.py
@@ -116,7 +116,7 @@ def do_socket_connect(result_queue: queue.Queue, addrinfo: AddrInfo, timeout: in
             )
         finally:
             s.close()
-    except:
+    except Exception:
         pass
 
 
@@ -163,7 +163,7 @@ def happyeyeballs(
                             ipv6_addrinfo.append(addrinfo)
                         else:
                             ipv4_addrinfo.append(addrinfo)
-            except:
+            except Exception:
                 # Did we fail on the first getaddrinfo already?
                 # Otherwise, we failed on the IPv6 alternative address, and those failures can be ignored
                 if not ipv4_addrinfo and not ipv6_addrinfo:

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -614,7 +614,7 @@ def get_access_info():
 
     try:
         addresses = socket.getaddrinfo(host, None)
-    except:
+    except Exception:
         addresses = []
 
     if web_host == "0.0.0.0":
@@ -1050,7 +1050,7 @@ class ConfigGeneral:
             if config.validate_config_backup(config_backup_data):
                 sabnzbd.RESTORE_DATA = config_backup_data
                 return sabnzbd.api.report(data={"success": True, "restart_req": True})
-        except:
+        except Exception:
             pass
         return sabnzbd.api.report(error=T("Invalid backup archive"))
 
@@ -1552,7 +1552,7 @@ def Strip(txt):
     """Return stripped string, can handle None"""
     try:
         return txt.strip()
-    except:
+    except Exception:
         return None
 
 
@@ -1615,12 +1615,12 @@ class ConfigScheduling:
             conf["schedlines"].append(line)
             try:
                 enabled, m, h, day_numbers, action = line.split(" ", 4)
-            except:
+            except Exception:
                 continue
             action = action.strip()
             try:
                 action, value = action.split(" ", 1)
-            except:
+            except Exception:
                 value = ""
             value = value.strip()
             if value and not value.lower().strip("0123456789kmgtp%."):
@@ -1998,7 +1998,7 @@ def GetRssLog(feed):
         good.sort(key=lambda job: job["age_ms"], reverse=True)
         bad.sort(key=lambda job: job["age_ms"], reverse=True)
         done.sort(key=lambda job: job["time_downloaded_ms"], reverse=True)
-    except:
+    except Exception:
         # Let the javascript do it then..
         pass
 

--- a/sabnzbd/lang.py
+++ b/sabnzbd/lang.py
@@ -96,7 +96,7 @@ def is_rtl(lang):
     """returns True if given lang is a right-to-left language. Default: False."""
     try:
         return LanguageTable.get(lang, "en")[3]
-    except:
+    except Exception:
         return False
 
 

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -131,7 +131,7 @@ def format_time_left(totalseconds: int, short_format: bool = False) -> str:
                     return "%s:%s:%s" % (hours, minutes, seconds)
             else:
                 return "%s:%s" % (minutes, seconds)
-        except:
+        except Exception:
             pass
     if short_format:
         return "0:00"
@@ -161,7 +161,7 @@ def calc_age(date: datetime.datetime, trans: bool = False) -> str:
             return "%d%s" % (date_diff.seconds / 3600, h)
         else:
             return "%d%s" % (date_diff.seconds / 60, m)
-    except:
+    except Exception:
         return "-"
 
 
@@ -347,7 +347,7 @@ def convert_filter(text):
         txt = wildcard_to_re(text)
     try:
         return re.compile(txt, re.I)
-    except:
+    except Exception:
         logging.debug("Could not compile regex: %s", text)
         return None
 
@@ -367,7 +367,7 @@ def cat_convert(cat):
                 indexer = raw_cats[ucat["name"]].newzbin()
                 if not isinstance(indexer, list):
                     indexer = [indexer]
-            except:
+            except Exception:
                 indexer = []
             for name in indexer:
                 if re.search("^%s$" % wildcard_to_re(name), cat, re.I):
@@ -439,7 +439,7 @@ def get_from_url(url: str) -> Optional[str]:
         req.add_header("User-Agent", "SABnzbd/%s" % sabnzbd.__version__)
         with urllib.request.urlopen(req) as response:
             return ubtou(response.read())
-    except:
+    except Exception:
         return None
 
 
@@ -455,7 +455,7 @@ def convert_version(text):
             elif m.group(4).lower() == "beta":
                 version = version + 40
             version = version + int(m.group(5))
-        except:
+        except Exception:
             version = version + 99
             test = False
     return version, test
@@ -503,14 +503,14 @@ def check_latest_version():
     try:
         latest_label = version_data[0]
         url = version_data[1]
-    except:
+    except Exception:
         latest_label = ""
         url = ""
 
     try:
         latest_testlabel = version_data[2]
         url_beta = version_data[3]
-    except:
+    except Exception:
         latest_testlabel = ""
         url_beta = ""
 
@@ -564,7 +564,7 @@ def upload_file_to_sabnzbd(url, fp):
             if username and password:
                 url = "%s&ma_username=%s&ma_password=%s" % (url, username, password)
         get_from_url(url)
-    except:
+    except Exception:
         logging.error(T("Failed to upload file: %s"), fp)
         logging.info("Traceback: ", exc_info=True)
 
@@ -588,7 +588,7 @@ def from_units(val: str) -> float:
             val = m.group(1)
         try:
             return float(val)
-        except:
+        except Exception:
             return 0.0
     else:
         return 0.0
@@ -709,7 +709,7 @@ def get_cache_limit():
         # We make sure it's at least a valid value
         if mem_bytes > from_units("32M"):
             return to_units(mem_bytes)
-    except:
+    except Exception:
         pass
 
     # Always at least minimum on Windows/macOS
@@ -778,7 +778,7 @@ def get_cpu_name():
                         cputype = myline.split(":", 1)[1]  # get everything after the first ":"
                         break  # we're done
         cputype = platform_btou(cputype)
-    except:
+    except Exception:
         # An exception, maybe due to a subprocess call gone wrong
         pass
 
@@ -789,7 +789,7 @@ def get_cpu_name():
         try:
             # Not found, so let's fall back to platform()
             cputype = platform.platform()
-        except:
+        except Exception:
             # Can fail on special platforms (like Snapcraft or embedded)
             pass
 
@@ -821,14 +821,14 @@ def get_platform_description() -> str:
                 if virt := run_command(["systemd-detect-virt"], stderr=subprocess.DEVNULL).strip():
                     if virt != "none":
                         platform_tags.append(virt)
-            except:
+            except Exception:
                 pass
 
             try:
                 # Only present in Python 3.10+
                 # Can print nicer description like "Ubuntu 24.02 LTS"
                 platform_tags.append(platform.freedesktop_os_release()["PRETTY_NAME"])
-            except:
+            except Exception:
                 pass
 
     if not platform_tags:
@@ -864,14 +864,14 @@ def memory_usage():
         return "V=%sM R=%sM" % (virt, res)
     except IOError:
         pass
-    except:
+    except Exception:
         logging.debug("Error retrieving memory usage")
         logging.info("Traceback: ", exc_info=True)
 
 
 try:
     _PAGE_SIZE = os.sysconf("SC_PAGE_SIZE")
-except:
+except Exception:
     _PAGE_SIZE = 0
 _HAVE_STATM = _PAGE_SIZE and memory_usage()
 
@@ -882,7 +882,7 @@ def loadavg():
     if not sabnzbd.WINDOWS and not sabnzbd.MACOS:
         try:
             p = "%.2f | %.2f | %.2f" % os.getloadavg()
-        except:
+        except Exception:
             pass
         if _HAVE_STATM:
             p = "%s | %s" % (p, memory_usage())
@@ -932,7 +932,7 @@ def str_conv(value: Any, default: str = "") -> str:
         return default
     try:
         return str(value)
-    except:
+    except Exception:
         return default
 
 
@@ -941,7 +941,7 @@ def int_conv(value: Any, default: int = 0) -> int:
     Returns 0 or requested default value"""
     try:
         return int(value)
-    except:
+    except Exception:
         return default
 
 
@@ -959,7 +959,7 @@ def create_https_certificates(ssl_cert, ssl_key):
         private_key = generate_key(key_size=2048, output_file=ssl_key)
         generate_local_cert(private_key, days_valid=3560, output_file=ssl_cert, LN="SABnzbd", ON="SABnzbd")
         logging.info("Self-signed certificates generated successfully")
-    except:
+    except Exception:
         logging.error(T("Error creating SSL key and certificate"))
         logging.info("Traceback: ", exc_info=True)
         return False
@@ -1006,7 +1006,7 @@ def get_all_passwords(nzo) -> List[str]:
                         "Your password file contains more than 30 passwords, testing all these passwords takes a lot of time. Try to only list useful passwords."
                     )
                 )
-        except:
+        except Exception:
             logging.warning(T("Failed to read the password file %s"), pw_file)
             logging.info("Traceback: ", exc_info=True)
 
@@ -1163,7 +1163,7 @@ def ip_extract() -> List[str]:
     if sabnzbd.WINDOWS or not program:
         try:
             info = socket.getaddrinfo(socket.gethostname(), None)
-        except:
+        except Exception:
             # Hostname does not resolve, use localhost
             info = socket.getaddrinfo("localhost", None)
         for item in info:
@@ -1319,7 +1319,7 @@ def run_script(script: str):
         try:
             script_output = run_command([script_path], env=sabnzbd.newsunpack.create_env())
             logging.info("Output of script %s: \n%s", script, script_output)
-        except:
+        except Exception:
             logging.info("Failed script %s, Traceback: ", script, exc_info=True)
 
 
@@ -1356,7 +1356,7 @@ def request_repair():
     try:
         with open(path, "w") as f:
             f.write("\n")
-    except:
+    except Exception:
         pass
 
 
@@ -1366,7 +1366,7 @@ def check_repair_request():
     if os.path.exists(path):
         try:
             remove_file(path)
-        except:
+        except Exception:
             pass
         return True
     return False

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -248,7 +248,7 @@ def external_processing(
 
             # Show current line in history
             nzo.set_action_line(T("Running script"), line)
-    except:
+    except Exception:
         logging.debug("Failed script %s, Traceback: ", extern_proc, exc_info=True)
         return "Cannot run script %s\r\n" % extern_proc, -1
 
@@ -368,7 +368,7 @@ def match_ts(file: str) -> Tuple[str, int]:
     try:
         setname = file[: match.start()]
         setname += ".ts"
-    except:
+    except Exception:
         setname = ""
     return setname, num
 
@@ -379,13 +379,13 @@ def clean_up_joinables(names: List[str]):
         if os.path.exists(name):
             try:
                 remove_file(name)
-            except:
+            except Exception:
                 pass
         name1 = name + ".1"
         if os.path.exists(name1):
             try:
                 remove_file(name1)
-            except:
+            except Exception:
                 pass
 
 
@@ -478,7 +478,7 @@ def file_join(nzo: NzbObject, workdir_complete: str, joinables: List[str]) -> Tu
             else:
                 msg = T("[%s] Joined %s files") % (joinable_set, size)
                 nzo.set_unpack_info("Filejoin", msg, setname)
-    except:
+    except Exception:
         msg = sys.exc_info()[1]
         nzo.fail_msg = T("File join of %s failed") % msg
         nzo.set_unpack_info(
@@ -558,7 +558,7 @@ def rar_unpack(nzo: NzbObject, workdir_complete: str, one_folder: bool, rars: Li
                     rarpath, len(rar_sets[rar_set]), one_folder, nzo, rar_set, extraction_path
                 )
                 success = not fail
-            except:
+            except Exception:
                 success = False
                 fail = 1
                 msg = sys.exc_info()[1]
@@ -911,7 +911,7 @@ def unseven(nzo: NzbObject, workdir_complete: str, one_folder: bool, sevens: Lis
             for seven in seven_sets[seven_set]:
                 try:
                     remove_file(seven)
-                except:
+                except Exception:
                     logging.warning(T("Deleting %s failed!"), seven)
         new_files.extend(new_files_set)
 
@@ -1070,7 +1070,7 @@ def par2_repair(nzo: NzbObject, setname: str) -> Tuple[bool, bool]:
             else:
                 logging.info("Par verify failed on %s!", parfile)
                 return readd, False
-        except:
+        except Exception:
             msg = sys.exc_info()[1]
             nzo.fail_msg = T("Repairing failed, %s") % msg
             logging.error(T("Error %s while running par2_repair on set %s"), msg, setname)
@@ -1114,7 +1114,7 @@ def par2_repair(nzo: NzbObject, setname: str) -> Tuple[bool, bool]:
                         remove_file(filepath)
                     except OSError:
                         logging.warning(T("Deleting %s failed!"), filepath)
-    except:
+    except Exception:
         msg = sys.exc_info()[1]
         nzo.fail_msg = T("Repairing failed, %s") % msg
         logging.error(T('Error "%s" while running par2_repair on set %s'), msg, setname, exc_info=True)
@@ -1429,7 +1429,7 @@ def create_env(nzo: Optional[NzbObject] = None, extra_env_fields: Dict[str, Any]
                     env["SAB_" + field.upper()] = str(field_value * 1)
                 else:
                     env["SAB_" + field.upper()] = str(field_value)
-            except:
+            except Exception:
                 # Catch key errors
                 pass
 
@@ -1453,7 +1453,7 @@ def create_env(nzo: Optional[NzbObject] = None, extra_env_fields: Dict[str, Any]
                 env["SAB_" + field.upper()] = str(extra_env_fields[field])
             else:
                 env["SAB_" + field.upper()] = ""
-        except:
+        except Exception:
             # Catch key errors
             pass
 
@@ -1480,10 +1480,10 @@ def rar_volumelist(rarfile_path: str, password: str, known_volumes: List[str]) -
         if password:
             try:
                 zf.setpassword(password)
-            except:
+            except Exception:
                 pass
         zf_volumes = zf.volumelist()
-    except:
+    except Exception:
         zf_volumes = []
 
     # Remove duplicates
@@ -1606,7 +1606,7 @@ def unrar_check(rar: str) -> Tuple[int, bool]:
     if rar:
         try:
             version = run_command([rar])
-        except:
+        except Exception:
             return version, original
         original = "Alexander Roshal" in version
 
@@ -1625,7 +1625,7 @@ def sevenzip_check(sevenzip: str) -> str:
             # Example: 7-Zip (z) 21.06 (x64) : Copyright (c) 1999-2021 Igor Pavlov : 2021-11-24
             #          7-Zip (a) 24.03 (x86) : Copyright (c) 1999-2024 Igor Pavlov : 2024-03-23
             return re.search(r"(\d+\.\d+).*Copyright", seven_command_output).group(1)
-        except:
+        except Exception:
             pass
     return ""
 
@@ -1635,7 +1635,7 @@ def par2_turbo_check(par2_path: str) -> bool:
     try:
         if "par2cmdline-turbo" in run_command([par2_path, "-V"]):
             return True
-    except:
+    except Exception:
         pass
     return False
 
@@ -1660,7 +1660,7 @@ def is_sfv_file(myfile: str) -> bool:
             else:
                 # non-ASCII, so not SFV
                 return False
-    except:
+    except Exception:
         # the with-open() went wrong, so not an existing file, so certainly not a SFV file
         return False
 
@@ -1839,7 +1839,7 @@ def pre_queue(nzo: NzbObject, pp, cat):
 
         try:
             p = build_and_run_command(command, env=create_env(nzo, extra_env_fields))
-        except:
+        except Exception:
             logging.debug("Failed script %s, Traceback: ", script_path, exc_info=True)
             return values
 

--- a/sabnzbd/notifier.py
+++ b/sabnzbd/notifier.py
@@ -51,7 +51,7 @@ if sabnzbd.WINDOWS:
         # Set a custom AUMID to display the right icon, it is written to the registry by the installer
         shell.SetCurrentProcessExplicitAppUserModelID("SABnzbd")
         _HAVE_WINDOWS_TOASTER = True
-    except:
+    except Exception:
         # Sending toasts on non-supported platforms results in segfaults
         _HAVE_WINDOWS_TOASTER = False
 
@@ -64,7 +64,7 @@ try:
     # Without DISPLAY, notify2 cannot autolaunch a dbus-daemon
     if not hasattr(notify2, "init") or "DISPLAY" not in os.environ:
         _HAVE_NTFOSD = False
-except:
+except Exception:
     _HAVE_NTFOSD = False
 
 
@@ -217,7 +217,7 @@ def send_notify_osd(title, message):
     # when there's no active notification daemon
     try:
         _NTFOSD = _NTFOSD or notify2.init("SABnzbd")
-    except:
+    except Exception:
         _NTFOSD = False
 
     if _NTFOSD:
@@ -225,7 +225,7 @@ def send_notify_osd(title, message):
         try:
             note = notify2.Notification(title, message, icon)
             note.show()
-        except:
+        except Exception:
             # Apparently not implemented on this system
             logging.info(error)
             return error
@@ -248,7 +248,7 @@ def send_notification_center(title: str, msg: str, notification_type: str, actio
                 break
 
         sabnzbd.MACOSTRAY.send_notification(title, subtitle, msg, button_text, button_action)
-    except:
+    except Exception:
         logging.info(T("Failed to send macOS notification"))
         logging.debug("Traceback: ", exc_info=True)
         return T("Failed to send macOS notification")
@@ -280,7 +280,7 @@ def send_prowl(title, msg, notification_type, force=False, test=None):
         try:
             urllib.request.urlopen(url)
             return ""
-        except:
+        except Exception:
             logging.warning(T("Failed to send Prowl message"))
             logging.info("Traceback: ", exc_info=True)
             return T("Failed to send Prowl message")
@@ -365,7 +365,7 @@ def send_apprise(title, msg, notification_type, force=False, test=None):
         ):
             return T("Failed to send one or more Apprise Notifications")
 
-    except:
+    except Exception:
         logging.warning(T("Failed to send Apprise message"))
         logging.info("Traceback: ", exc_info=True)
         return T("Failed to send Apprise message")
@@ -434,7 +434,7 @@ def do_send_pushover(body):
             return T("Failed to send pushover message")
         else:
             return ""
-    except:
+    except Exception:
         logging.warning(T("Failed to send pushover message"))
         logging.info("Traceback: ", exc_info=True)
         return T("Failed to send pushover message")
@@ -468,7 +468,7 @@ def send_pushbullet(title, msg, notification_type, force=False, test=None):
         else:
             logging.info("Successfully sent to Pushbullet")
 
-    except:
+    except Exception:
         logging.warning(T("Failed to send pushbullet message"))
         logging.info("Traceback: ", exc_info=True)
         return T("Failed to send pushbullet message")
@@ -506,7 +506,7 @@ def send_nscript(title, msg, notification_type, force=False, test=None):
                 )
                 output = p.stdout.read()
                 ret = p.wait()
-            except:
+            except Exception:
                 logging.info("Failed to run script %s", script, exc_info=True)
 
             if ret:
@@ -540,7 +540,7 @@ def send_windows(title: str, msg: str, notification_type: str, actions: Optional
             notification_sender.show_toast(toast_notification)
         elif sabnzbd.WINTRAY and not sabnzbd.WINTRAY.terminate:
             sabnzbd.WINTRAY.sendnotification(title, msg)
-    except:
+    except Exception:
         logging.info(T("Failed to send Windows notification"))
         logging.debug("Traceback: ", exc_info=True)
         return T("Failed to send Windows notification")

--- a/sabnzbd/nzbparser.py
+++ b/sabnzbd/nzbparser.py
@@ -175,7 +175,7 @@ def process_nzb_archive_file(
         else:
             logging.info("File %s is not a supported archive!", filename)
             return AddNzbFileResult.ERROR, []
-    except:
+    except Exception:
         logging.info(T("Cannot read %s"), path, exc_info=True)
         return AddNzbFileResult.RETRY, []
 
@@ -225,7 +225,7 @@ def process_nzb_archive_file(
                         # Duplicate or unwanted extension directed to history
                         sabnzbd.NzbQueue.fail_to_history(err.nzo)
                         nzo_ids.append(err.nzo.nzo_id)
-                    except:
+                    except Exception:
                         # Something else is wrong, show error
                         logging.error(T("Error while adding %s, removing"), name, exc_info=True)
                     finally:
@@ -335,7 +335,7 @@ def process_single_nzb(
         # Duplicate or unwanted extension directed to history
         sabnzbd.NzbQueue.fail_to_history(err.nzo)
         nzo_ids.append(err.nzo.nzo_id)
-    except:
+    except Exception:
         # Something else is wrong, show error
         logging.error(T("Error while adding %s, removing"), filename, exc_info=True)
         result = AddNzbFileResult.ERROR
@@ -407,7 +407,7 @@ def nzbfile_parser(full_nzb_path: str, nzo):
                 try:
                     file_date = datetime.datetime.fromtimestamp(int(element.attrib.get("date")))
                     file_timestamp = int(element.attrib.get("date"))
-                except:
+                except Exception:
                     file_date = datetime.datetime.fromtimestamp(time_now)
                     file_timestamp = time_now
 
@@ -448,7 +448,7 @@ def nzbfile_parser(full_nzb_path: str, nzo):
                             else:
                                 raw_article_db[partnum] = (article_id, segment_size)
                                 file_bytes += segment_size
-                        except:
+                        except Exception:
                             # In case of missing attributes
                             pass
 

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -79,7 +79,7 @@ class NzbQueue:
                         if not repair:
                             panic_queue(os.path.join(cfg.admin_dir.get_path(), QUEUE_FILE_NAME))
                             exit_sab(2)
-            except:
+            except Exception:
                 nzo_ids = []
                 logging.error(
                     T("Error loading %s, corrupt file detected"),
@@ -117,7 +117,7 @@ class NzbQueue:
                     else:
                         try:
                             remove_file(item)
-                        except:
+                        except Exception:
                             pass
 
     @NzbQueueLocker
@@ -192,7 +192,7 @@ class NzbQueue:
                     nzo = NzbObject(name, password=password, nzbname=name, reuse=repair_folder)
                     self.add(nzo)
                     nzo_ids = [nzo.nzo_id]
-                except:
+                except Exception:
                     # NzoObject can throw exceptions if duplicate or unwanted etc
                     logging.info("Skipping %s due to exception", name, exc_info=True)
                     nzo_ids = []
@@ -207,7 +207,7 @@ class NzbQueue:
         """Send back job to queue after successful pre-check"""
         try:
             nzb_path = globber_full(old_nzo.admin_path, "*.gz")[0]
-        except:
+        except Exception:
             logging.info("Failed to find NZB file after pre-check (%s)", old_nzo.nzo_id)
             return
 
@@ -472,7 +472,7 @@ class NzbQueue:
             # Allow an index as second parameter, easier for some skins
             i = int(item_id_2)
             item_id_2 = self.__nzo_list[i].nzo_id
-        except:
+        except Exception:
             pass
         try:
             nzo1 = self.__nzo_table[item_id_1]
@@ -497,7 +497,7 @@ class NzbQueue:
             # if id1 is surrounded by items of a different priority then change its priority to match
             if nzo2_priority != nzo1_priority and nzo3_priority != nzo1_priority or nzo2_priority > nzo1_priority:
                 nzo1.priority = nzo2_priority
-        except:
+        except Exception:
             nzo1.priority = nzo2_priority
         item_id_pos1 = -1
         item_id_pos2 = -1
@@ -656,7 +656,7 @@ class NzbQueue:
             )
             return pos
 
-        except:
+        except Exception:
             return -1
 
     @NzbQueueLocker
@@ -666,7 +666,7 @@ class NzbQueue:
             for nzo_id in nzo_ids:
                 n = self.__set_priority(nzo_id, priority)
             return n
-        except:
+        except Exception:
             return -1
 
     def has_forced_jobs(self) -> bool:

--- a/sabnzbd/nzbstuff.py
+++ b/sabnzbd/nzbstuff.py
@@ -466,7 +466,7 @@ class NzbFile(TryList):
         try:
             logging.debug("Removing article database for %s", self.nzf_id)
             remove_file(os.path.join(self.nzo.admin_path, self.nzf_id))
-        except:
+        except Exception:
             pass
 
     def __getstate__(self):
@@ -880,13 +880,13 @@ class NzbObject(TryList):
                 self.duplicate_check(repeat=True)
             try:
                 pp = int(pq_pp)
-            except:
+            except Exception:
                 pp = None
             if pq_cat:
                 cat = pq_cat
             try:
                 priority = int(pq_priority)
-            except:
+            except Exception:
                 priority = DEFAULT_PRIORITY
             if pq_script and is_valid_script(pq_script):
                 script = pq_script
@@ -1011,7 +1011,7 @@ class NzbObject(TryList):
                     # Remove and add it back after the position of the first rar
                     self.files.remove(lastrarnzf)
                     self.files.insert(firstrarpos + 1, lastrarnzf)
-                except:
+                except Exception:
                     logging.debug("The lastrar swap did not go well")
 
     @synchronized(TRYLIST_LOCK)
@@ -1297,7 +1297,7 @@ class NzbObject(TryList):
                 self.bytes += nzf.bytes
                 self.bytes_tried += nzf.bytes
                 self.bytes_downloaded += nzf.bytes
-        except:
+        except Exception:
             logging.error(T("Error importing %s"), self.final_name)
             logging.info("Traceback: ", exc_info=True)
 

--- a/sabnzbd/osxmenu.py
+++ b/sabnzbd/osxmenu.py
@@ -274,7 +274,7 @@ class SABnzbdDelegate(NSObject):
             self.pauseUpdate()
             self.speedlimitUpdate()
             self.diskspaceUpdate()
-        except:
+        except Exception:
             logging.info("[osx] Exception", exc_info=True)
 
     def queueUpdate(self):
@@ -311,7 +311,7 @@ class SABnzbdDelegate(NSObject):
                 menu_queue_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(T("Empty"), "", "")
                 self.menu_queue.addItem_(menu_queue_item)
             self.queue_menu_item.setSubmenu_(self.menu_queue)
-        except:
+        except Exception:
             logging.info("[osx] queueUpdate Exception", exc_info=True)
 
     def historyUpdate(self):
@@ -356,7 +356,7 @@ class SABnzbdDelegate(NSObject):
                 menu_history_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(T("Empty"), "", "")
                 self.menu_history.addItem_(menu_history_item)
             self.history_menu_item.setSubmenu_(self.menu_history)
-        except:
+        except Exception:
             logging.info("[osx] historyUpdate Exception", exc_info=True)
 
     def warningsUpdate(self):
@@ -375,7 +375,7 @@ class SABnzbdDelegate(NSObject):
             else:
                 self.warnings_menu_item.setTitle_("%s : 0" % (T("Warnings")))
                 self.warnings_menu_item.setHidden_(YES)
-        except:
+        except Exception:
             logging.info("[osx] warningsUpdate Exception", exc_info=True)
 
     def stateUpdate(self):
@@ -409,7 +409,7 @@ class SABnzbdDelegate(NSObject):
 
             if not config.get_servers():
                 self.state_menu_item.setTitle_(T("Go to wizard"))
-        except:
+        except Exception:
             logging.info("[osx] stateUpdate Exception", exc_info=True)
 
     def pauseUpdate(self):
@@ -422,7 +422,7 @@ class SABnzbdDelegate(NSObject):
                 self.status_item.setImage_(self.icons["idle"])
                 self.resume_menu_item.setHidden_(YES)
                 self.pause_menu_item.setHidden_(NO)
-        except:
+        except Exception:
             logging.info("[osx] pauseUpdate Exception", exc_info=True)
 
     def speedlimitUpdate(self):
@@ -436,7 +436,7 @@ class SABnzbdDelegate(NSObject):
                         menuitem.setState_(NSOnState)
                     else:
                         menuitem.setState_(NSOffState)
-        except:
+        except Exception:
             logging.info("[osx] speedlimitUpdate Exception", exc_info=True)
 
     def diskspaceUpdate(self):
@@ -447,7 +447,7 @@ class SABnzbdDelegate(NSObject):
             self.incompletefolder_menu_item.setTitle_(
                 "%s (%.2f GB)" % (T("Incomplete Folder"), diskspace()["download_dir"][1])
             )
-        except:
+        except Exception:
             logging.info("[osx] diskspaceUpdate Exception", exc_info=True)
 
     def setMenuTitle_(self, text):
@@ -467,7 +467,7 @@ class SABnzbdDelegate(NSObject):
 
             title = NSAttributedString.alloc().initWithString_attributes_(text, titleAttributes)
             self.status_item.setAttributedTitle_(title)
-        except:
+        except Exception:
             logging.info("[osx] setMenuTitle Exception", exc_info=True)
 
     def openBrowserAction_(self, sender):

--- a/sabnzbd/panic.py
+++ b/sabnzbd/panic.py
@@ -244,7 +244,7 @@ def launch_a_browser(url, force=False):
             webbrowser.open(url, 2, True)
         else:
             logging.info("Not showing panic message in webbrowser, no support found")
-    except:
+    except Exception:
         logging.warning(T("Cannot launch the browser, probably not found"))
         logging.info("Traceback: ", exc_info=True)
 

--- a/sabnzbd/par2file.py
+++ b/sabnzbd/par2file.py
@@ -66,7 +66,7 @@ def is_par2_file(filepath: str) -> bool:
             with open(filepath, "rb") as f:
                 buf = f.read(8)
                 return buf.startswith(PAR_PKT_ID)
-        except:
+        except Exception:
             pass
     return False
 
@@ -98,7 +98,7 @@ def analyse_par2(name: str, filepath: Optional[str] = None) -> Tuple[str, int, i
                         if PAR_RECOVERY_ID in buf:
                             block += 1
                         buf = f.read(128)
-            except:
+            except Exception:
                 pass
     return setname, vol, block
 
@@ -234,7 +234,7 @@ def parse_par2_file(fname: str, md5of16k: Dict[bytes, str]) -> Tuple[str, Dict[s
                     duplicates16k.append(par2info.hash16k)
                     table[par2info.filename].has_duplicate = True
 
-    except:
+    except Exception:
         logging.info("Par2 parser crashed in file %s", fname)
         logging.debug("Traceback: ", exc_info=True)
         table = {}

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -147,7 +147,7 @@ class PostProcessor(Thread):
                 logging.warning(T("Old queue detected, use Status->Repair to convert the queue"))
             elif isinstance(history_queue, list):
                 self.history_queue = [nzo for nzo in history_queue if os.path.exists(nzo.download_path)]
-        except:
+        except Exception:
             logging.info("Corrupt %s file, discarding", POSTPROC_QUEUE_FILE_NAME)
             logging.info("Traceback: ", exc_info=True)
 
@@ -183,7 +183,7 @@ class PostProcessor(Thread):
         """Remove given nzo from the queue"""
         try:
             self.history_queue.remove(nzo)
-        except:
+        except Exception:
             pass
         self.save()
         history_updated()
@@ -206,7 +206,7 @@ class PostProcessor(Thread):
                         # Try to kill any external running process
                         self.external_process.kill()
                         logging.info("Killed external process %s", self.external_process.args[0])
-                    except:
+                    except Exception:
                         pass
                 result = True
             return result
@@ -231,7 +231,7 @@ class PostProcessor(Thread):
             search_text = search.strip().replace("*", ".*").replace(" ", ".*") + ".*?"
             try:
                 re_search = re.compile(search_text, re.I)
-            except:
+            except Exception:
                 logging.error(T("Failed to compile regex for search term: %s"), search_text)
 
         # Need a copy to prevent race conditions
@@ -514,7 +514,7 @@ def process_job(nzo: NzbObject) -> bool:
 
                 try:
                     newfiles = rename_and_collapse_folder(tmp_workdir_complete, workdir_complete, newfiles)
-                except:
+                except Exception:
                     logging.error(
                         T('Error renaming "%s" to "%s"'),
                         clip_path(tmp_workdir_complete),
@@ -616,7 +616,7 @@ def process_job(nzo: NzbObject) -> bool:
         # See if we need to start an alternative or remove the duplicates
         sabnzbd.NzbQueue.handle_duplicate_alternatives(nzo, all_ok)
 
-    except:
+    except Exception:
         logging.error(T("Post Processing Failed for %s (%s)"), filename, T("see logfile"))
         logging.info("Traceback: ", exc_info=True)
 
@@ -650,7 +650,7 @@ def process_job(nzo: NzbObject) -> bool:
     # Clean up the NZO data
     try:
         nzo.purge_data(delete_all_data=all_ok)
-    except:
+    except Exception:
         logging.error(T("Cleanup of %s failed."), nzo.final_name)
         logging.info("Traceback: ", exc_info=True)
 
@@ -743,7 +743,7 @@ def prepare_extraction_path(nzo: NzbObject) -> Tuple[str, str, Sorter, bool, Opt
 
         try:
             renamer(workdir_complete, tmp_workdir_complete)
-        except:
+        except Exception:
             pass  # On failure, just use the original name
 
         # Is the unique path different? Then we also need to modify the final path
@@ -970,7 +970,7 @@ def rar_renamer(nzo: NzbObject) -> int:
             ).filelist()
             try:
                 rarvolnr[rar_vol]
-            except:
+            except Exception:
                 # does not yet exist, so create:
                 rarvolnr[rar_vol] = {}
             rarvolnr[rar_vol][file_to_check] = rar_contents  # store them for matching (if needed)
@@ -1013,7 +1013,7 @@ def rar_renamer(nzo: NzbObject) -> int:
     for rar_set_number in range(1, highest_rar + 1):
         try:
             how_many_here = len(rarvolnr[rar_set_number])
-        except:
+        except Exception:
             # rarset does not exist at all
             logging.warning("rarset %s is missing completely, so I can't deobfuscate.", rar_set_number)
             return 0
@@ -1114,10 +1114,10 @@ def cleanup_list(wdir: str, skip_nzb: bool):
                             try:
                                 logging.info("Removing unwanted file %s", entry.path)
                                 remove_file(entry.path)
-                            except:
+                            except Exception:
                                 logging.error(T("Removing %s failed"), clip_path(entry.path))
                                 logging.info("Traceback: ", exc_info=True)
-        except:
+        except Exception:
             logging.info("Traceback: ", exc_info=True)
 
 
@@ -1211,7 +1211,7 @@ def remove_samples(path: str):
             try:
                 logging.info("Removing unwanted sample file %s", path)
                 remove_file(path)
-            except:
+            except Exception:
                 logging.error(T("Removing %s failed"), clip_path(path))
                 logging.info("Traceback: ", exc_info=True)
     else:
@@ -1239,7 +1239,7 @@ def rename_and_collapse_folder(oldpath: str, newpath: str, files: List[str]) -> 
     renamer(oldpath, newpath)
     try:
         remove_dir(orgpath)
-    except:
+    except Exception:
         pass
     return files
 
@@ -1252,7 +1252,7 @@ def set_marker(folder: str) -> Optional[str]:
         try:
             fp = open(path, "w")
             fp.close()
-        except:
+        except Exception:
             logging.info("Cannot create marker file %s", path)
             logging.info("Traceback: ", exc_info=True)
             name = None
@@ -1265,7 +1265,7 @@ def del_marker(path: str):
         logging.debug("Removing marker file %s", path)
         try:
             remove_file(path)
-        except:
+        except Exception:
             logging.info("Cannot remove marker file %s", path)
             logging.info("Traceback: ", exc_info=True)
 

--- a/sabnzbd/powersup.py
+++ b/sabnzbd/powersup.py
@@ -50,7 +50,7 @@ def win_hibernate():
     try:
         win_power_privileges()
         win32api.SetSystemPowerState(False, True)
-    except:
+    except Exception:
         logging.error(T("Failed to hibernate system"))
         logging.info("Traceback: ", exc_info=True)
 
@@ -60,7 +60,7 @@ def win_standby():
     try:
         win_power_privileges()
         win32api.SetSystemPowerState(True, True)
-    except:
+    except Exception:
         logging.error(T("Failed to standby system"))
         logging.info("Traceback: ", exc_info=True)
 
@@ -83,7 +83,7 @@ def osx_shutdown():
     """Shutdown macOS system, never returns"""
     try:
         subprocess.call(["osascript", "-e", 'tell app "System Events" to shut down'])
-    except:
+    except Exception:
         logging.error(T("Error while shutting down system"))
         logging.info("Traceback: ", exc_info=True)
     os._exit(0)
@@ -94,7 +94,7 @@ def osx_standby():
     try:
         subprocess.call(["pmset", "sleepnow"])
         time.sleep(10)
-    except:
+    except Exception:
         logging.error(T("Failed to standby system"))
         logging.info("Traceback: ", exc_info=True)
 

--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -89,7 +89,7 @@ class RSSReader:
             if self.jobs:
                 for feed in self.jobs:
                     remove_obsolete(self.jobs[feed], list(self.jobs[feed]))
-        except:
+        except Exception:
             logging.warning(T("Cannot read %s"), RSS_FILE_NAME)
             logging.info("Traceback: ", exc_info=True)
 
@@ -479,7 +479,7 @@ class RSSReader:
         if feed in self.jobs:
             try:
                 return self.jobs[feed]
-            except:
+            except Exception:
                 return {}
         else:
             return {}
@@ -660,7 +660,7 @@ def _get_link(entry):
         try:
             link = entry.enclosures[0]["href"]
             size = int(entry.enclosures[0]["length"])
-        except:
+        except Exception:
             pass
 
     # GUID usually has URL to result on page
@@ -675,19 +675,19 @@ def _get_link(entry):
             m = _RE_SIZE1.search(desc) or _RE_SIZE2.search(desc)
             if m:
                 size = from_units(m.group(1))
-        except:
+        except Exception:
             pass
 
     # Try newznab attribute first, this is the correct one
     try:
         # Convert it to format that calc_age understands
         age = datetime.datetime(*entry["newznab"]["usenetdate_parsed"][:6])
-    except:
+    except Exception:
         # Date from feed (usually lags behind)
         try:
             # Convert it to format that calc_age understands
             age = datetime.datetime(*entry.published_parsed[:6])
-        except:
+        except Exception:
             pass
     finally:
         # We need to convert it to local timezone, feedparser always returns UTC

--- a/sabnzbd/scheduler.py
+++ b/sabnzbd/scheduler.py
@@ -85,10 +85,10 @@ class Scheduler:
 
             try:
                 enabled, m, h, d, action_name = schedule.split()
-            except:
+            except Exception:
                 try:
                     enabled, m, h, d, action_name, argument_list = schedule.split(None, 5)
-                except:
+                except Exception:
                     continue  # Bad schedule, ignore
 
             if argument_list:
@@ -98,7 +98,7 @@ class Scheduler:
             try:
                 m = int(m)
                 h = int(h)
-            except:
+            except Exception:
                 logging.warning(T("Bad schedule %s at %s:%s"), action_name, m, h)
                 continue
 
@@ -274,7 +274,7 @@ class Scheduler:
             action = ev[1]
             try:
                 value = ev[2]
-            except:
+            except Exception:
                 value = None
             if action == "pause":
                 paused = True
@@ -311,12 +311,12 @@ class Scheduler:
             elif action == "enable_server":
                 try:
                     servers[value] = 1
-                except:
+                except Exception:
                     logging.warning(T("Schedule for non-existing server %s"), value)
             elif action == "disable_server":
                 try:
                     servers[value] = 0
-                except:
+                except Exception:
                     logging.warning(T("Schedule for non-existing server %s"), value)
 
         # Special case, a priority was passed, so evaluate only that and return state
@@ -350,7 +350,7 @@ class Scheduler:
                 if bool(item.enable()) != bool(value):
                     item.enable.set(value)
                     sabnzbd.Downloader.init_server(serv, serv)
-            except:
+            except Exception:
                 pass
         config.save_config()
 
@@ -473,10 +473,10 @@ def sort_schedules(all_events, now=None):
         try:
             # Note: the last parameter can have spaces (category name)!
             enabled, m, h, dd, action, parms = schedule.split(None, 5)
-        except:
+        except Exception:
             try:
                 enabled, m, h, dd, action = schedule.split(None, 4)
-            except:
+            except Exception:
                 continue  # Bad schedule, ignore
         action = action.strip()
         if dd == "*":
@@ -510,7 +510,7 @@ def enable_server(server):
     """Enable server (scheduler only)"""
     try:
         config.get_config("servers", server).enable.set(1)
-    except:
+    except Exception:
         logging.warning(T("Trying to set status of non-existing server %s"), server)
         return
     config.save_config()
@@ -521,7 +521,7 @@ def disable_server(server):
     """Disable server (scheduler only)"""
     try:
         config.get_config("servers", server).enable.set(0)
-    except:
+    except Exception:
         logging.warning(T("Trying to set status of non-existing server %s"), server)
         return
     config.save_config()

--- a/sabnzbd/sorting.py
+++ b/sabnzbd/sorting.py
@@ -855,7 +855,7 @@ def rename_similar(folder: str, skip_ext: str, name: str, skipped_files: Optiona
                 try:
                     logging.debug("Rename: %s to %s", path, newpath)
                     renamer(path, newpath)
-                except:
+                except Exception:
                     logging.error(T("Failed to rename similar file: %s to %s"), clip_path(path), clip_path(newpath))
                     logging.info("Traceback: ", exc_info=True)
     cleanup_empty_directories(folder)

--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -156,7 +156,7 @@ class URLGrabber(Thread):
                         try:
                             item = hdr.lower()
                             value = fetch_request.headers[hdr]
-                        except:
+                        except Exception:
                             continue
 
                         # Skip empty values
@@ -294,9 +294,9 @@ class URLGrabber(Thread):
                 # Always clean up what we wrote to disk
                 try:
                     sabnzbd.filesystem.remove_file(path)
-                except:
+                except Exception:
                     pass
-            except:
+            except Exception:
                 logging.error(T("URLGRABBER CRASHED"), exc_info=True)
                 logging.debug("URLGRABBER Traceback: ", exc_info=True)
 

--- a/sabnzbd/utils/certgen.py
+++ b/sabnzbd/utils/certgen.py
@@ -66,7 +66,7 @@ def generate_local_cert(private_key, days_valid=3560, output_file="cert.cert", L
         mylocalipv4 = local_ipv4()
         if mylocalipv4:
             san_list.append(x509.IPAddress(ipaddress.IPv4Address(str(mylocalipv4))))
-    except:
+    except Exception:
         pass
 
     cert = (

--- a/sabnzbd/utils/diskspeed.py
+++ b/sabnzbd/utils/diskspeed.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
             print("Disk writing speed: %.2f Mbytes per second" % SPEED)
         else:
             print("No measurement possible. Check that directory is writable.")
-    except:
+    except Exception:
         print("Something went wrong. I don't know what")
         raise
 

--- a/sabnzbd/utils/rarfile.py
+++ b/sabnzbd/utils/rarfile.py
@@ -411,7 +411,7 @@ def is_rarfile(xfile):
         rar_ver = _get_rar_version(xfile)
         if rar_ver:
             return "RAR%d" % rar_ver
-    except:
+    except Exception:
         pass
     return None
 
@@ -1132,7 +1132,7 @@ class CommonParser(object):
 
             # now read actual header
             return self._parse_block_header(fd)
-        except:
+        except Exception:
             # SABnzbd-edit:
             # Catch all errors
             self._set_error("Broken header in RAR file")
@@ -1216,7 +1216,7 @@ class CommonParser(object):
             tmpf.write(suffix)
             tmpf.close()
             rf.close()
-        except:
+        except Exception:
             rf.close()
             tmpf.close()
             os.unlink(tmpname)
@@ -2989,7 +2989,7 @@ def membuf_tempfile(memfile):
                 break
             tmpf.write(buf)
         tmpf.close()
-    except:
+    except Exception:
         tmpf.close()
         os.unlink(tmpname)
         raise

--- a/sabnzbd/utils/rarvolinfo.py
+++ b/sabnzbd/utils/rarvolinfo.py
@@ -86,7 +86,7 @@ def get_rar_extension(myrarfile):
 
                 # Combine into the extension
                 org_extension = "part%03d.rar" % volumenumber
-    except:
+    except Exception:
         pass
 
     return volumenumber, org_extension
@@ -100,5 +100,5 @@ if __name__ == "__main__":
         myfile = sys.argv[1]
         print("File:", myfile)
         print("Volume and extension:", get_rar_extension(myfile))
-    except:
+    except Exception:
         print("Please specify rar file as parameter")

--- a/sabnzbd/utils/ssdp.py
+++ b/sabnzbd/utils/ssdp.py
@@ -119,7 +119,7 @@ OPT: "http://schemas.upnp.org/upnp/1/0/"; ns=01
                 with socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP) as sock:
                     sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, MULTICAST_TTL)
                     sock.sendto(self.__mySSDPbroadcast, (MCAST_GRP, MCAST_PORT))
-            except:
+            except Exception:
                 # probably no network
                 pass
 

--- a/sabnzbd/utils/systrayiconthread.py
+++ b/sabnzbd/utils/systrayiconthread.py
@@ -156,7 +156,7 @@ class SysTrayIconThread(Thread):
         )
         try:
             win32gui.Shell_NotifyIcon(message, self.notify_id)
-        except:
+        except Exception:
             # Timeouts can occur after system comes out of standby/hibernate
             pass
 

--- a/sabnzbd/zconfig.py
+++ b/sabnzbd/zconfig.py
@@ -29,7 +29,7 @@ try:
     from threading import Thread
 
     _HAVE_BONJOUR = True
-except:
+except Exception:
     _HAVE_BONJOUR = False
 
 import sabnzbd
@@ -92,7 +92,7 @@ def set_bonjour(host=None, port=None):
     except sabnzbd.utils.pybonjour.BonjourError as e:
         _BONJOUR_OBJECT = None
         logging.debug("Failed to start Bonjour service: %s", str(e))
-    except:
+    except Exception:
         _BONJOUR_OBJECT = None
         logging.debug("Failed to start Bonjour service due to non-pybonjour related problem", exc_info=True)
     else:

--- a/scripts/Sample-PostProc.py
+++ b/scripts/Sample-PostProc.py
@@ -23,7 +23,7 @@ for item in os.environ:
 # More intelligent parsing:
 try:
     (scriptname, directory, orgnzbname, jobname, reportnumber, category, group, postprocstatus, url) = sys.argv
-except:
+except Exception:
     print("No SAB compliant number of commandline parameters found (should be 8):", len(sys.argv) - 1)
     sys.exit(1)  # non-zero return code
 
@@ -33,7 +33,7 @@ print("jobname is:", jobname)
 try:
     sabversion = os.environ["SAB_VERSION"]
     print("SAB_VERSION is:", sabversion)
-except:
+except Exception:
     pass
 
 """ your code here """

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1129,7 +1129,7 @@ class TestRenamer:
         try:
             # Should fail
             filesystem.renamer(filename, newfilename)
-        except:
+        except Exception:
             pass
         assert os.path.isfile(filename)
         assert not os.path.isfile(newfilename)
@@ -1139,7 +1139,7 @@ class TestRenamer:
         newfilename = os.path.join(dirname, "newsubdir", "newfile.txt")
         try:
             filesystem.renamer(filename, newfilename, create_local_directories=True)
-        except:
+        except Exception:
             pass
         assert not os.path.isfile(filename)
         assert os.path.isfile(newfilename)
@@ -1149,7 +1149,7 @@ class TestRenamer:
         newfilename = os.path.join(dirname, "newsubdir", "deepersubdir", "newfile.txt")
         try:
             filesystem.renamer(filename, newfilename, create_local_directories=True)
-        except:
+        except Exception:
             pass
         assert not os.path.isfile(filename)
         assert os.path.isfile(newfilename)
@@ -1159,7 +1159,7 @@ class TestRenamer:
         newfilename = os.path.join(dirname, "..", "newsubdir", "newfile.txt")
         try:
             filesystem.renamer(filename, newfilename, create_local_directories=True)
-        except:
+        except Exception:
             pass
         assert os.path.isfile(filename)
         assert not os.path.isfile(newfilename)

--- a/tests/test_functional_misc.py
+++ b/tests/test_functional_misc.py
@@ -154,7 +154,7 @@ class TestExtractPot:
             subprocess.Popen(lang_command.split()).communicate(timeout=30)
             lang_command = "git checkout @ -- %s/../po/email/SABemail.pot" % SAB_BASE_DIR
             subprocess.Popen(lang_command.split()).communicate(timeout=30)
-        except:
+        except Exception:
             pass
 
 

--- a/tests/test_postproc.py
+++ b/tests/test_postproc.py
@@ -51,7 +51,7 @@ class TestPostProc:
             # create a fresh copy
             try:
                 shutil.copytree(sourcedir, workingdir)
-            except:
+            except Exception:
                 pytest.fail("Could not create copy of files for rar_renamer")
 
             # And now let the magic happen:
@@ -69,7 +69,7 @@ class TestPostProc:
             # Remove workingdir again
             try:
                 shutil.rmtree(workingdir)
-            except:
+            except Exception:
                 pytest.fail("Could not remove existing workingdir %s for rar_renamer" % workingdir)
 
             return number_renamed_files

--- a/tools/extract_pot.py
+++ b/tools/extract_pot.py
@@ -77,7 +77,7 @@ def get_a_line(line_src, number):
         # We include 2 lines extra, since sometimes the "logging.warning"
         # can be on the line above, due to code-formatting
         return "".join(FILE_CACHE[line_src][number - 3 : number])
-    except:
+    except Exception:
         return ""
 
 


### PR DESCRIPTION
Any bare `except:` also catches BaseException (KeyboardInterrupt and SystemExit among others, see [exception hierarchy](https://docs.python.org/3/library/exceptions.html#exception-hierarchy) in the python documentation) which is almost always unintended and undesirable.

This PR changes all bare excepts to only catch regular exceptions.