### PR TITLE
Filter rss enclosures by application/x-nzb mimetype

### DIFF
--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -649,19 +649,26 @@ def _get_link(entry):
     """Retrieve the post link from this entry
     Returns (link, category, size)
     """
+    link = None
     size = 0
     age = datetime.datetime.now()
 
     # Try standard link and enclosures first
-    link = entry.link
-    if not link:
-        link = entry.links[0].href
     if "enclosures" in entry:
         try:
-            link = entry.enclosures[0]["href"]
-            size = int(entry.enclosures[0]["length"])
+            for enclosure in entry["enclosures"]:
+                if "type" in enclosure and enclosure["type"] != "application/x-nzb":
+                    continue
+
+                link = enclosure["href"]
+                size = int(enclosure["length"])
+                break
         except Exception:
             pass
+    else:
+        link = entry.link
+        if not link:
+            link = entry.links[0].href
 
     # GUID usually has URL to result on page
     infourl = None

--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -654,7 +654,7 @@ def _get_link(entry):
     age = datetime.datetime.now()
 
     # Try standard link and enclosures first
-    if "enclosures" in entry:
+    if "enclosures" in entry and entry["enclosures"]:
         try:
             for enclosure in entry["enclosures"]:
                 if "type" in enclosure and enclosure["type"] != "application/x-nzb":

--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -724,7 +724,7 @@ def _get_link(entry):
 
         return link, infourl, category, size, age, season, episode
     else:
-        logging.warning(T("Empty RSS entry found (%s)"), link)
+        logging.info(T("Empty RSS entry found (%s)"), link)
         return None, None, "", 0, None, 0, 0
 
 

--- a/tests/data/rss_enclosure_multiple.xml
+++ b/tests/data/rss_enclosure_multiple.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0">
+  <channel>
+    <title>My RSS Feed</title>
+    <link>https://sabnzbd.org/</link>
+    <item>
+      <title>TITLE</title>
+      <link>http://LINK</link>
+      <comments>COMMENTS</comments>
+      <enclosure url="http://TORRENT_LINK" type="application/x-bittorrent" length="100" />
+      <enclosure url="http://NZB_LINK" type="application/x-nzb" length="200" />
+      <pubDate>Tue, 20 May 2025 18:21:01 +0000</pubDate>
+      <guid isPermaLink="true">https://sabnzbd.org/rss_enclosure_multiple</guid>
+    </item>
+  </channel>
+</rss>

--- a/tests/data/rss_enclosure_no_nzb.xml
+++ b/tests/data/rss_enclosure_no_nzb.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0">
+  <channel>
+    <title>My RSS Feed</title>
+    <link>https://sabnzbd.org/</link>
+    <item>
+      <title>TITLE</title>
+      <link>http://LINK</link>
+      <comments>COMMENTS</comments>
+      <enclosure url="http://TORRENT_LINK" type="application/x-bittorrent" length="100" />
+      <pubDate>Tue, 20 May 2025 18:21:01 +0000</pubDate>
+      <guid isPermaLink="true">https://sabnzbd.org/rss_enclosure_no_nzb</guid>
+    </item>
+  </channel>
+</rss>

--- a/tests/data/rss_link.xml
+++ b/tests/data/rss_link.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0">
+  <channel>
+    <title>My RSS Feed</title>
+    <link>https://sabnzbd.org/</link>
+    <item>
+      <title>TITLE</title>
+      <link>http://LINK</link>
+      <comments>COMMENTS</comments>
+      <description><![CDATA[<strong>Total Size</strong>: 200.0 B]]></description>
+      <pubDate>Tue, 20 May 2025 18:21:01 +0000</pubDate>
+      <guid isPermaLink="true">https://sabnzbd.org/rss_link</guid>
+    </item>
+  </channel>
+</rss>

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -36,6 +36,8 @@ from unittest import mock
 from urllib3.exceptions import ProtocolError
 import xmltodict
 import functools
+from werkzeug import Request
+from werkzeug.utils import send_from_directory
 
 import sabnzbd
 import sabnzbd.cfg as cfg
@@ -162,6 +164,11 @@ def create_and_read_nzb_fp(nzbdir: str, metadata: Optional[Dict[str, str]] = Non
     # Remove the created NZB-file
     os.remove(nzb_path)
     return io.BytesIO(nzb_data)
+
+
+def httpserver_handler_data_dir(request: Request):
+    """Respond to a httpserver request with a file in SAB_DATA_DIR"""
+    return send_from_directory(directory=SAB_DATA_DIR, path=request.path.lstrip("/"), environ=request.environ)
 
 
 def random_name(length: int = 16) -> str:


### PR DESCRIPTION
I think this resolves #2952 although the PR does not provide the functionality requested, I think this is a better solution which achieves the same outcome.

Currently RSS processing takes the first link from the entry, but if there are any [enclosure elements](https://www.rssboard.org/rss-specification#ltenclosuregtSubelementOfLtitemgt) it takes the first url.

However, it doesn’t handle that an item may have multiple enclosures, and type is a required field with the file’s MIME type so the first enclosure may not be the nzb.

Using the RSS example given https://feed.animetosho.org/rss2 you can often see items have multiple enclosures with types `application/x-bittorrent` or `application/x-nzb` but the nzb is often not initially available, the current code appears to try adding the torrent.

Although type is a required field, I did allow it to be missing, maybe there are bad implementations out there. But happy to make it require the expected type if you would prefer.

The only issue I can see is it may fall through to the `Empty RSS entry found` warning more often which could be annoying, maybe add a special option to ignore it?

@bytemerger you may wish to see if this resolves your need for #3089
