### PR TITLE
Fix RSS 'Next scan at' time not updating after manual scan

### DIFF
--- a/sabnzbd/scheduler.py
+++ b/sabnzbd/scheduler.py
@@ -450,6 +450,9 @@ class Scheduler:
 
     def force_rss(self):
         """Add a one-time RSS scan, one second from now"""
+        # Update the next_run time to be current time + rss_rate minutes
+        # This ensures the next scheduled scan is rss_rate minutes after the manual scan
+        sabnzbd.RSSReader.next_run = time.time() + cfg.rss_rate() * 60
         self.scheduler.add_single_task(sabnzbd.RSSReader.run, "RSS", 1)
 
 

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -50,57 +50,59 @@ class TestRSS:
         import sabnzbd.rss
         from sabnzbd import cfg
         import time
-        
+
         # Save original values
         original_rss_reader = sabnzbd.rss.RSSReader
         original_rss_rate = cfg.rss_rate()
-        
+
         try:
             # Create a mock RSSReader class
             class MockRSSReader:
                 next_run = 0
-                
+
                 @classmethod
                 def run(cls):
                     pass
-            
+
             # Replace the RSSReader class with our mock
-            monkeypatch.setattr(sabnzbd.rss, 'RSSReader', MockRSSReader)
-            
+            monkeypatch.setattr(sabnzbd.rss, "RSSReader", MockRSSReader)
+
             # Also patch the sabnzbd.RSSReader reference that the scheduler uses
-            monkeypatch.setattr('sabnzbd.RSSReader', MockRSSReader, raising=False)
-            
+            monkeypatch.setattr("sabnzbd.RSSReader", MockRSSReader, raising=False)
+
             # Mock the scheduler's scheduler attribute to avoid initializing the real one
             original_scheduler_init = sabnzbd.scheduler.Scheduler.__init__
+
             def mock_scheduler_init(self, *args, **kwargs):
                 self.scheduler = MagicMock()
                 self.pause_end = None
                 self.resume_task = None
                 self.restart_scheduler = False
                 self.pp_pause_event = False
-            
-            monkeypatch.setattr(sabnzbd.scheduler.Scheduler, '__init__', mock_scheduler_init)
-            
+
+            monkeypatch.setattr(sabnzbd.scheduler.Scheduler, "__init__", mock_scheduler_init)
+
             # Create a scheduler instance
             sched = sabnzbd.scheduler.Scheduler()
-            
+
             # Set a fixed time for testing
             test_time = 1000000.0
-            
+
             # Mock time.time() to return our test time
-            monkeypatch.setattr(time, 'time', lambda: test_time)
-            
+            monkeypatch.setattr(time, "time", lambda: test_time)
+
             # Set rss_rate to 1 minute for testing and mock the cfg.rss_rate() method
-            monkeypatch.setattr(cfg, 'rss_rate', lambda: 1)
-            
+            monkeypatch.setattr(cfg, "rss_rate", lambda: 1)
+
             # Call force_rss
             sched.force_rss()
-            
+
             # Verify next_run was updated to test_time + 60 seconds
             expected_next_run = test_time + 60
-            assert MockRSSReader.next_run == expected_next_run, \
-                f"next_run should be {expected_next_run}, got {MockRSSReader.next_run}"
-                
+            assert (
+                MockRSSReader.next_run == expected_next_run
+            ), f"next_run should be {expected_next_run}, got {MockRSSReader.next_run}"
+
         finally:
             # Restore original values
             monkeypatch.undo()

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -68,7 +68,13 @@ class TestRSS:
             monkeypatch.setattr(sabnzbd.rss, "RSSReader", MockRSSReader)
 
             # Also patch the sabnzbd.RSSReader reference that the scheduler uses
-            monkeypatch.setattr("sabnzbd.RSSReader", MockRSSReader, raising=False)
+            # Use try/except to handle different Python versions
+            try:
+                # Python 3.7+ supports the raising parameter
+                monkeypatch.setattr("sabnzbd.RSSReader", MockRSSReader, raising=False)
+            except TypeError:
+                # Fallback for older Python versions
+                monkeypatch.setattr("sabnzbd.RSSReader", MockRSSReader)
 
             # Mock the scheduler's scheduler attribute to avoid initializing the real one
             original_scheduler_init = sabnzbd.scheduler.Scheduler.__init__


### PR DESCRIPTION
## Problem
When a user manually triggers an RSS feed scan using the 'Read All Feeds Now' button, the 'Next scan at' time in the UI does not update to reflect the new scheduled time. This can cause confusion as users expect the next scan to happen after the configured RSS interval from the manual trigger time.

Original bug report: https://github.com/sabnzbd/sabnzbd/issues/2979

## Root Cause
The [force_rss()] method in scheduler.py was only scheduling a one-time scan without updating the  time. This meant that while a manual scan would run immediately, the next scheduled scan would still use the old [next_run] time.

## Solution
Modified the [force_rss()] method to update the  time to be the current time plus the configured RSS interval (in minutes). This ensures that after a manual scan, the next automatic scan will happen after the expected interval.

## Testing
1. Added a new test case [test_force_rss_updates_next_run] that verifies the [next_run] time is correctly updated when [force_rss()] is called.
2. The test mocks the necessary components to isolate the functionality:
   - Mocks the RSSReader class to track the [next_run] time
   - Mocks  to provide consistent test timing
   - Mocks the scheduler to avoid starting background threads
3. Verified that all existing tests pass with the changes.