### PR TITLE
Skip adding postproc items to the history if they are already completed

### DIFF
--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1895,7 +1895,13 @@ def build_history(
 
 def add_active_history(postproc_queue: List[NzbObject], items: List[Dict[str, Any]]):
     """Get the active history queue and add it to the existing items list"""
+    nzo_ids = set([nzo["nzo_id"] for nzo in items])
+
     for nzo in postproc_queue:
+        # Skip already in history
+        if nzo.nzo_id in nzo_ids:
+            continue
+
         # This output has to be the same as fetch_history!
         item = {
             "completed": int(time.time()),


### PR DESCRIPTION
Fixes #3113

Is this what you were thinking?

Created the set to avoid looping through the list multiple times if several items are postprocessing.

It could be a little smarter by not creating the set if items is empty, or that could be in `build_history` and skip the `reverse + add_active_history + reverse`.

```py
    # Add the postproc items to the top of the history
    # Reverse the queue to add items to the top (faster than insert)
    if any(postproc_queue):
        items.reverse()
        add_active_history(postproc_queue, items)
        items.reverse()

    total_items += postproc_queue_size
```

I can add a test, I think I'd do something like `test_add_active_history_consistency` but try calling `add_active_history` multiple times with the same nzo then check the length.

