### PR TITLE
Skip selenium tests on unsupported aarch64 platform

### DIFF
--- a/tests/test_functional_config.py
+++ b/tests/test_functional_config.py
@@ -19,6 +19,7 @@
 tests.test_functional_config - Basic testing if Config pages work
 """
 
+import sysconfig
 from selenium.common.exceptions import NoSuchElementException, UnexpectedAlertPresentException, NoAlertPresentException
 from selenium.webdriver.common.by import By
 from pytest_httpserver import HTTPServer
@@ -27,6 +28,7 @@ from pytest_httpserver import HTTPServer
 from tests.testhelper import *
 
 
+@pytest.mark.skipif(sysconfig.get_platform() == "linux-aarch64", reason="Selenium does not support linux-aarch64")
 class TestBasicPages(SABnzbdBaseTest):
     def test_base_pages(self):
         # Quick-check of all Config pages
@@ -76,6 +78,7 @@ class TestBasicPages(SABnzbdBaseTest):
                 assert submit_btn.text == "Save Changes"
 
 
+@pytest.mark.skipif(sysconfig.get_platform() == "linux-aarch64", reason="Selenium does not support linux-aarch64")
 class TestConfigLogin(SABnzbdBaseTest):
     def test_login(self):
         # Test if base page works
@@ -156,6 +159,7 @@ class TestConfigLogin(SABnzbdBaseTest):
         assert "/login/" not in self.driver.current_url
 
 
+@pytest.mark.skipif(sysconfig.get_platform() == "linux-aarch64", reason="Selenium does not support linux-aarch64")
 class TestConfigCategories(SABnzbdBaseTest):
     category_name = "testCat"
 
@@ -172,6 +176,7 @@ class TestConfigCategories(SABnzbdBaseTest):
         assert self.category_name not in self.driver.page_source
 
 
+@pytest.mark.skipif(sysconfig.get_platform() == "linux-aarch64", reason="Selenium does not support linux-aarch64")
 class TestConfigRSS(SABnzbdBaseTest):
     rss_name = "_SeleniumFeed"
 
@@ -251,6 +256,7 @@ class TestConfigRSS(SABnzbdBaseTest):
         assert get_api_result("resume") == {"status": True}
 
 
+@pytest.mark.skipif(sysconfig.get_platform() == "linux-aarch64", reason="Selenium does not support linux-aarch64")
 class TestConfigServers(SABnzbdBaseTest):
     server_name = "_SeleniumServer"
 

--- a/tests/test_functional_downloads.py
+++ b/tests/test_functional_downloads.py
@@ -18,11 +18,13 @@
 """
 tests.test_functional_downloads - Test the downloading flow
 """
+import sysconfig
 from tests.testhelper import *
 from flaky import flaky
 
 
 @flaky
+@pytest.mark.skipif(sysconfig.get_platform() == "linux-aarch64", reason="Selenium does not support linux-aarch64")
 class TestDownloadFlow(DownloadFlowBasics):
     def test_download_basic_rar5(self):
         self.download_nzb("basic_rar5", ["My_Test_Download.bin"])

--- a/tests/test_functional_misc.py
+++ b/tests/test_functional_misc.py
@@ -21,6 +21,7 @@ tests.test_functional_misc - Functional tests of various functions
 import shutil
 import subprocess
 import sys
+import sysconfig
 
 import sabnzbd.encoding
 from sabnzbd.filesystem import save_compressed
@@ -28,6 +29,7 @@ from sabnzbd.constants import JOB_ADMIN
 from tests.testhelper import *
 
 
+@pytest.mark.skipif(sysconfig.get_platform() == "linux-aarch64", reason="Selenium does not support linux-aarch64")
 class TestShowLogging(SABnzbdBaseTest):
     def test_showlog(self):
         """Test the output of the filtered-log button"""
@@ -43,6 +45,7 @@ class TestShowLogging(SABnzbdBaseTest):
         assert "[misc]" in log_result
 
 
+@pytest.mark.skipif(sysconfig.get_platform() == "linux-aarch64", reason="Selenium does not support linux-aarch64")
 class TestQueueRepair(SABnzbdBaseTest):
     def test_queue_repair(self):
         """Test full queue repair by manually adding an orphaned job"""
@@ -90,6 +93,7 @@ class TestQueueRepair(SABnzbdBaseTest):
         assert get_api_result("resume") == {"status": True}
 
 
+@pytest.mark.skipif(sysconfig.get_platform() == "linux-aarch64", reason="Selenium does not support linux-aarch64")
 class TestSamplePostProc:
     def test_sample_post_proc(self):
         """Make sure we don't break things"""
@@ -125,6 +129,7 @@ class TestSamplePostProc:
         assert env["SAB_VERSION"] in script_output
 
 
+@pytest.mark.skipif(sysconfig.get_platform() == "linux-aarch64", reason="Selenium does not support linux-aarch64")
 class TestExtractPot:
     def test_extract_pot(self):
         """Simple test if translation extraction still works"""
@@ -160,6 +165,7 @@ class TestExtractPot:
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Skipping on Windows")
 @pytest.mark.skipif(sys.platform.startswith("darwin"), reason="Fails for now due to PyObjC problem")
+@pytest.mark.skipif(sysconfig.get_platform() == "linux-aarch64", reason="Selenium does not support linux-aarch64")
 class TestDaemonizing(SABnzbdBaseTest):
     def test_daemonizing(self):
         """Simple test to see if daemon-mode still works.

--- a/tests/test_functional_sorting.py
+++ b/tests/test_functional_sorting.py
@@ -19,6 +19,7 @@
 tests.test_functional_sorting - Test downloads with season sorting and sequential files
 """
 import os
+import sysconfig
 from tests.testhelper import *
 from flaky import flaky
 import sabnzbd.config as config
@@ -31,6 +32,7 @@ INI_FILE = "sabnzbd.sorting.ini"
 
 @flaky
 @pytest.mark.usefixtures("run_sabnzbd")
+@pytest.mark.skipif(sysconfig.get_platform() == "linux-aarch64", reason="Selenium does not support linux-aarch64")
 class TestDownloadSorting(DownloadFlowBasics):
     def test_sorter_settings_conversion(self):
         """Read the ini file after the sabnzbd test instance completed startup


### PR DESCRIPTION
Selenium Manager does not support linux-aarch64 platforms.

When tests are run on this platform, any selenium tests will be skipped.

https://github.com/SeleniumHQ/selenium/issues/13542