### PR TITLE
Handle weird anime episode notation

### DIFF
--- a/sabnzbd/sorting.py
+++ b/sabnzbd/sorting.py
@@ -660,6 +660,16 @@ def guess_what(name: str) -> MatchesDict:
         # Unfix the title
         guess["title"] = guess.get("title", "")[len(digit_fix) :]
 
+    # Handle weird anime episode notation, that results in the episode number ending up as the episode title
+    if (
+        guess.get("type") == "episode"
+        and not "episode" in guess
+        and "season" in guess
+        and guess.get("episode_title", "").isdigit()
+    ):
+        guess.setdefault("episode", default=int(guess.get("episode_title")))
+        guess.pop("episode_title")
+
     # Force season to 1 for seasonless episodes with no date
     if guess.get("type") == "episode" and "date" not in guess:
         guess.setdefault("season", 1)

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -76,6 +76,10 @@ class TestSortingFunctions:
             ("Test Date Detection 22.07.14", {"date": datetime.date(2022, 7, 14)}),
             (None, None),  # Jobname missing
             ("", None),
+            (
+                "[PrettyPlease] Who Cares S6 - 42 (720p) [1A2B3C4D]",
+                {"season": 6, "episode": 42, "episode_title": None, "title": "Who Cares"},
+            ),  # Anime
         ],
     )
     def test_guess_what(self, name, result):
@@ -1294,7 +1298,7 @@ class TestSortingSorter:
             assert os.path.exists(job_dir)
 
             # Create "downloaded" files
-            file_size = 42 * 1024**2
+            file_size = 42 * 1024 ** 2
             for filename in data_set:
                 job_filepath = os.path.join(job_dir, filename)
                 # Create only mkv and bar as large files, keep anything else below the sorter's min_size

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -1298,7 +1298,7 @@ class TestSortingSorter:
             assert os.path.exists(job_dir)
 
             # Create "downloaded" files
-            file_size = 42 * 1024 ** 2
+            file_size = 42 * 1024**2
             for filename in data_set:
                 job_filepath = os.path.join(job_dir, filename)
                 # Create only mkv and bar as large files, keep anything else below the sorter's min_size


### PR DESCRIPTION
re: https://forums.sabnzbd.org/viewtopic.php?t=27063

Looks low-risk in terms of this unintentionally catching on something else, so I didn't add any further checks or safeguards (such as a regexp verifying the anime-specific season/episode format is actually used in the input).

Limitation: single episode only (unless someone knows how they format multi-ep stuff and whether/how the guessing function goes off the rails then?).