### PR TITLE
patch nzb grab to use socks proxy when socks proxy is set

### DIFF
--- a/sabnzbd/urlgrabber.py
+++ b/sabnzbd/urlgrabber.py
@@ -369,7 +369,8 @@ def _build_request(url: str) -> HTTPResponse:
     req.add_header("Accept-encoding", "gzip")
     if user_passwd:
         req.add_header("Authorization", "Basic " + ubtou(base64.b64encode(utob(user_passwd))).strip())
-    return urllib.request.urlopen(req)
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    return opener.open(req)
 
 
 def _analyse(fetch_request: HTTPResponse, future_nzo: NzbObject):

--- a/tests/test_socks_proxy.py
+++ b/tests/test_socks_proxy.py
@@ -1,0 +1,126 @@
+import socket
+import http.client
+
+import socks
+
+import sabnzbd.cfg as cfg
+import sabnzbd.misc as misc
+
+
+def _restore_state(
+    original_url,
+    original_proxy,
+    original_socket_cls,
+    original_create_conn,
+    original_http_connect,
+    original_https_connect,
+):
+    """Put networking state back the way we found it."""
+    cfg.socks5_proxy_url.set(original_url or "")
+    if original_proxy:
+        socks.set_default_proxy(*original_proxy)
+    else:
+        socks.set_default_proxy(None)
+    socket.socket = original_socket_cls
+    socket.create_connection = original_create_conn
+    http.client.HTTPConnection.connect = original_http_connect
+    http.client.HTTPSConnection.connect = original_https_connect
+
+    # Re-apply the original proxy configuration to keep globals consistent for other tests.
+    misc.set_socks5_proxy()
+
+
+def test_set_socks5_proxy_patches_socket_and_http_connect():
+    original_url = cfg.socks5_proxy_url()
+    original_proxy = socks.socksocket.default_proxy
+    original_socket_cls = misc._ORIGINAL_SOCKET
+    original_create_conn = socket.create_connection
+    original_http_connect = misc._ORIGINAL_HTTP_CONNECT
+    original_https_connect = misc._ORIGINAL_HTTPS_CONNECT
+
+    try:
+        cfg.socks5_proxy_url.set("socks5://user:pass@127.0.0.1:1080")
+        misc.set_socks5_proxy()
+
+        assert socket.socket is socks.socksocket
+        assert socket.create_connection is original_create_conn
+        assert http.client.HTTPConnection.connect is misc._http_connect_with_proxy
+        assert http.client.HTTPSConnection.connect is misc._https_connect_with_proxy
+    finally:
+        _restore_state(
+            original_url,
+            original_proxy,
+            original_socket_cls,
+            original_create_conn,
+            original_http_connect,
+            original_https_connect,
+        )
+
+
+def test_set_socks5_proxy_restores_originals_on_clear():
+    original_url = cfg.socks5_proxy_url()
+    original_proxy = socks.socksocket.default_proxy
+    original_socket_cls = misc._ORIGINAL_SOCKET
+    original_create_conn = socket.create_connection
+    original_http_connect = misc._ORIGINAL_HTTP_CONNECT
+    original_https_connect = misc._ORIGINAL_HTTPS_CONNECT
+
+    try:
+        cfg.socks5_proxy_url.set("socks5://127.0.0.1:1080")
+        misc.set_socks5_proxy()
+
+        cfg.socks5_proxy_url.set("")
+        misc.set_socks5_proxy()
+
+        assert socket.socket is original_socket_cls
+        assert socket.create_connection is original_create_conn
+        assert http.client.HTTPConnection.connect is original_http_connect
+        assert http.client.HTTPSConnection.connect is original_https_connect
+    finally:
+        _restore_state(
+            original_url,
+            original_proxy,
+            original_socket_cls,
+            original_create_conn,
+            original_http_connect,
+            original_https_connect,
+        )
+
+
+def test_http_connection_uses_current_create_connection():
+    original_url = cfg.socks5_proxy_url()
+    original_proxy = socks.socksocket.default_proxy
+    original_socket_cls = misc._ORIGINAL_SOCKET
+    original_create_conn = socket.create_connection
+    original_http_connect = misc._ORIGINAL_HTTP_CONNECT
+    original_https_connect = misc._ORIGINAL_HTTPS_CONNECT
+    original_socket_create = socket.create_connection
+
+    # Simulate a connection created before enabling the proxy
+    conn = http.client.HTTPConnection("example.com")
+
+    try:
+        cfg.socks5_proxy_url.set("socks5://127.0.0.1:1080")
+        misc.set_socks5_proxy()
+
+        def sentinel_create_connection(*args, **kwargs):
+            raise RuntimeError("sentinel")
+
+        socket.create_connection = sentinel_create_connection
+
+        try:
+            conn.connect()
+        except RuntimeError as exc:
+            assert "sentinel" in str(exc)
+        else:
+            raise AssertionError("HTTPConnection.connect did not use the current socket.create_connection")
+    finally:
+        socket.create_connection = original_socket_create
+        _restore_state(
+            original_url,
+            original_proxy,
+            original_socket_cls,
+            original_create_conn,
+            original_http_connect,
+            original_https_connect,
+        )


### PR DESCRIPTION
When SABnzbd is configured with a SOCKS5 proxy, NNTP connections already use that proxy. NZB grabs from indexers, however, still tried to go “direct.”

This PR addresses that.