### PR TITLE
Address low throughput reporting in diskspeed.py

### DIFF
--- a/sabnzbd/utils/diskspeed.py
+++ b/sabnzbd/utils/diskspeed.py
@@ -7,14 +7,7 @@ import sys
 import logging
 import time
 
-BUFFERSIZE = [
-    16 * 1024 * 1024,
-    32 * 1024 * 1024,
-    128 * 1024 * 1024
-]
-
-# Prepare the whole buffer now for better write performance later
-buffer = os.urandom(BUFFERSIZE[-1]); # Dump 128 MB of trash in RAM
+BUFFERSIZE = 16 * 1024 * 1024
 
 def diskspeedmeasure(dirname: str) -> float:
     """Returns writing speed to my_dirname in MB/s
@@ -22,6 +15,9 @@ def diskspeedmeasure(dirname: str) -> float:
     Then divide bytes written by time passed
     In case of problems (ie non-writable dir or file), return 0.0
     """
+    # Prepare the whole buffer now for better write performance later
+    buffer = os.urandom(BUFFERSIZE); # Dump 16 MB of trash in RAM
+    
     start = time.time()
     maxtime = 1 # sec
     total_written = 0
@@ -35,11 +31,12 @@ def diskspeedmeasure(dirname: str) -> float:
         maxtime += start
         
         # Start looping
-        for i in range(len(BUFFERSIZE)):
+        for i in range(1,5):
             # Stop writing next buffer block, if time exceeds limit
             if time.perf_counter() >= maxtime:
                 break
-            total_written += os.write(fp_testfile, buffer[0:BUFFERSIZE[i]])
+            # Increase chunk size after each iteration
+            total_written += os.write(fp_testfile, buffer * (i**2))
             os.fsync(fp_testfile)
             
         total_time = time.perf_counter() - start

--- a/sabnzbd/utils/diskspeed.py
+++ b/sabnzbd/utils/diskspeed.py
@@ -17,9 +17,9 @@ def diskspeedmeasure(dirname: str) -> float:
     In case of problems (ie non-writable dir or file), return 0.0
     """
     # Prepare the whole buffer now for better write performance later
-    buffer = os.urandom(BUFFERSIZE); 
+    buffer = os.urandom(BUFFERSIZE) 
     # Dump 16 MB of trash in RAM
-    
+
     start = time.time()
     maxtime = 1  # sec
     total_written = 0
@@ -30,7 +30,7 @@ def diskspeedmeasure(dirname: str) -> float:
         # Use low-level I/O
         fp_testfile = os.open(
             filename, os.O_CREAT | os.O_WRONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_SYNC", 0), 0o777
-            )
+        )
         start = time.perf_counter()
         maxtime += start
 
@@ -42,7 +42,7 @@ def diskspeedmeasure(dirname: str) -> float:
             # Increase chunk size after each iteration
             total_written += os.write(fp_testfile, buffer * (i**2))
             os.fsync(fp_testfile)
-            
+
         total_time = time.perf_counter() - start
         # Have to use low-level close
         os.close(fp_testfile)

--- a/sabnzbd/utils/diskspeed.py
+++ b/sabnzbd/utils/diskspeed.py
@@ -7,8 +7,14 @@ import sys
 import logging
 import time
 
-_DUMP_DATA_SIZE = 256 * 1024 * 1024 # Increased buffer for better write performance
+BUFFERSIZE = [
+    16 * 1024 * 1024,
+    32 * 1024 * 1024,
+    128 * 1024 * 1024
+]
 
+# Prepare the whole buffer now for better write performance later
+buffer = os.urandom(BUFFERSIZE[-1]); # Dump 128 MB of trash in RAM
 
 def diskspeedmeasure(dirname: str) -> float:
     """Returns writing speed to my_dirname in MB/s
@@ -16,25 +22,27 @@ def diskspeedmeasure(dirname: str) -> float:
     Then divide bytes written by time passed
     In case of problems (ie non-writable dir or file), return 0.0
     """
-    dump_data = os.urandom(_DUMP_DATA_SIZE)
     start = time.time()
-    maxtime = 3  # sec
+    maxtime = 1 # sec
     total_written = 0
+    total_time = 0
     filename = os.path.join(dirname, "outputTESTING.txt")
-    
+
     try:
         # Use low-level I/O
-        fp_testfile = os.open(filename, os.O_CREAT | os.O_WRONLY | getattr(os, "os.O_BINARY", 0) | os.O_SYNC, 0o777)
+        fp_testfile = os.open(filename, os.O_CREAT | os.O_WRONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_SYNC", 0), 0o777)
         start = time.perf_counter()
         maxtime += start
         
         # Start looping
-        while time.perf_counter() < maxtime:
-            total_written += os.write(fp_testfile, dump_data)
+        for i in range(len(BUFFERSIZE)):
+            # Stop writing next buffer block, if time exceeds limit
+            if time.perf_counter() >= maxtime:
+                break
+            total_written += os.write(fp_testfile, buffer[0:BUFFERSIZE[i]])
             os.fsync(fp_testfile)
-
+            
         total_time = time.perf_counter() - start
-
         # Have to use low-level close
         os.close(fp_testfile)
         # Remove the file
@@ -64,14 +72,9 @@ if __name__ == "__main__":
         print("Using current working directory")
 
     try:
-        measure = 0.0
-        tries = 2
-        for _ in range(tries):
-            measure +=diskspeedmeasure(DIRNAME)
-        SPEED = measure / tries
-
+        SPEED = max(diskspeedmeasure(DIRNAME), diskspeedmeasure(DIRNAME))
         if SPEED:
-            print("Disk writing speed: %.2f Mbytes per second" % SPEED)
+            print("Disk writing speed: %.2f MBytes per second" % SPEED)
         else:
             print("No measurement possible. Check that directory is writable.")
     except Exception:

--- a/sabnzbd/utils/diskspeed.py
+++ b/sabnzbd/utils/diskspeed.py
@@ -9,6 +9,7 @@ import time
 
 BUFFERSIZE = 16 * 1024 * 1024
 
+
 def diskspeedmeasure(dirname: str) -> float:
     """Returns writing speed to my_dirname in MB/s
     method: keep writing a file, until certain time is passed.
@@ -16,22 +17,25 @@ def diskspeedmeasure(dirname: str) -> float:
     In case of problems (ie non-writable dir or file), return 0.0
     """
     # Prepare the whole buffer now for better write performance later
-    buffer = os.urandom(BUFFERSIZE); # Dump 16 MB of trash in RAM
+    buffer = os.urandom(BUFFERSIZE); 
+    # Dump 16 MB of trash in RAM
     
     start = time.time()
-    maxtime = 1 # sec
+    maxtime = 1  # sec
     total_written = 0
     total_time = 0
     filename = os.path.join(dirname, "outputTESTING.txt")
 
     try:
         # Use low-level I/O
-        fp_testfile = os.open(filename, os.O_CREAT | os.O_WRONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_SYNC", 0), 0o777)
+        fp_testfile = os.open(
+            filename, os.O_CREAT | os.O_WRONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_SYNC", 0), 0o777
+            )
         start = time.perf_counter()
         maxtime += start
-        
+
         # Start looping
-        for i in range(1,5):
+        for i in range(1, 5):
             # Stop writing next buffer block, if time exceeds limit
             if time.perf_counter() >= maxtime:
                 break

--- a/sabnzbd/utils/diskspeed.py
+++ b/sabnzbd/utils/diskspeed.py
@@ -17,7 +17,7 @@ def diskspeedmeasure(dirname: str) -> float:
     In case of problems (ie non-writable dir or file), return 0.0
     """
     # Prepare the whole buffer now for better write performance later
-    buffer = os.urandom(BUFFERSIZE) 
+    buffer = os.urandom(BUFFERSIZE)
     # Dump 16 MB of trash in RAM
 
     start = time.time()

--- a/sabnzbd/utils/diskspeed.py
+++ b/sabnzbd/utils/diskspeed.py
@@ -7,7 +7,7 @@ import sys
 import logging
 import time
 
-_DUMP_DATA_SIZE = 10 * 1024 * 1024
+_DUMP_DATA_SIZE = 256 * 1024 * 1024 # Increased buffer for better write performance
 
 
 def diskspeedmeasure(dirname: str) -> float:
@@ -18,30 +18,28 @@ def diskspeedmeasure(dirname: str) -> float:
     """
     dump_data = os.urandom(_DUMP_DATA_SIZE)
     start = time.time()
-    maxtime = 0.5  # sec
+    maxtime = 3  # sec
     total_written = 0
     filename = os.path.join(dirname, "outputTESTING.txt")
-
+    
     try:
         # Use low-level I/O
-        try:
-            fp_testfile = os.open(filename, os.O_CREAT | os.O_WRONLY | os.O_BINARY, 0o777)
-        except AttributeError:
-            fp_testfile = os.open(filename, os.O_CREAT | os.O_WRONLY, 0o777)
-
+        fp_testfile = os.open(filename, os.O_CREAT | os.O_WRONLY | getattr(os, "os.O_BINARY", 0) | os.O_SYNC, 0o777)
+        start = time.perf_counter()
+        maxtime += start
+        
         # Start looping
-        total_time = 0.0
-        while total_time < maxtime:
-            start = time.time()
-            os.write(fp_testfile, dump_data)
+        while time.perf_counter() < maxtime:
+            total_written += os.write(fp_testfile, dump_data)
             os.fsync(fp_testfile)
-            total_time += time.time() - start
-            total_written += _DUMP_DATA_SIZE
+
+        total_time = time.perf_counter() - start
 
         # Have to use low-level close
         os.close(fp_testfile)
         # Remove the file
         os.remove(filename)
+
     except OSError:
         # Could not write, so ... report 0.0
         logging.debug("Failed to measure disk speed on %s", dirname)
@@ -66,7 +64,12 @@ if __name__ == "__main__":
         print("Using current working directory")
 
     try:
-        SPEED = max(diskspeedmeasure(DIRNAME), diskspeedmeasure(DIRNAME))
+        measure = 0.0
+        tries = 2
+        for _ in range(tries):
+            measure +=diskspeedmeasure(DIRNAME)
+        SPEED = measure / tries
+
         if SPEED:
             print("Disk writing speed: %.2f Mbytes per second" % SPEED)
         else:


### PR DESCRIPTION
I noticed that the current version of `diskspeed.py` reports significantly lower throughput values than what is realistically achievable. Depending on the storage device and connection, the benchmark output shows only about half of the possible write speed.

To validate this, I used fio under Linux to measure sequential write performance. I ran `fio` with the following parameters:
```
fio --name=seqtest --rw=write --bs=128k --ioengine=libaio --size=10G --numjobs=1 --direct=1 --iodepth=1 --group_reporting --filename=/home/<USER>/10g.test
```
My `fio` results were:
SATA SSD: 508 MiB/s (533 MB/s)
ZFS HDD Pool: 507 MiB/s (531 MB/s)
NVMe SSD: 1002 MiB/s (1051 MB/s)

After noticing the discrepancy, I looked into the script and also read through the discussion at https://github.com/sabnzbd/sabnzbd/discussions/2846, where this issue had already been mentioned.

At first, I suspected synced writes to be the main cause, but after experimenting with changes to the `urandom` buffer and testing several other parameters, I arrived at the current version included in this PR. I also incorporated some code improvements from @mnightingale from the discussion. Additionally, the benchmark duration has been increased from 0.5 seconds to 3 seconds, which can potentially be reduced again, but it currently provides much more consistent results for me.

The new script now produces the following values:
SATA SSD: 461.95 MB/s
ZFS HDD Pool: 483.65 MB/s
NVMe SSD: 1034.10 MB/s

These numbers are significantly closer to the `fio` results compared to the previous version, which reported:
SATA SSD: 247.40 MB/s
ZFS HDD Pool: 195.40 MB/s
NVMe SSD: 917.30 MB/s