### PR TITLE
Diskspeed improvements

### DIFF
--- a/sabnzbd/utils/diskspeed.py
+++ b/sabnzbd/utils/diskspeed.py
@@ -7,22 +7,20 @@ import sys
 import logging
 import time
 
-BUFFERSIZE = 16 * 1024 * 1024
 
-
-def diskspeedmeasure(dirname: str) -> float:
+def diskspeedmeasure(dirname: str, maxtime: float = 1.0, passes: int = 4, chunksize: int = 16 * 1024 * 1024) -> float:
     """Returns writing speed to my_dirname in MB/s
     method: keep writing a file, until certain time is passed.
     Then divide bytes written by time passed
     In case of problems (ie non-writable dir or file), return 0.0
     """
-    maxtime = 1  # sec
+    total_time = 0
     total_written = 0
     filename = os.path.join(dirname, "outputTESTING.txt")
 
     # Prepare the whole buffer now for better write performance later
     # This is done before timing starts to exclude buffer creation from measurement
-    buffer = os.urandom(BUFFERSIZE)
+    buffer = memoryview(os.urandom(chunksize * (passes**2)))
 
     try:
         # Use low-level I/O
@@ -33,20 +31,17 @@ def diskspeedmeasure(dirname: str) -> float:
         )
 
         overall_start = time.perf_counter()
-        maxtime = overall_start + 1
-        total_time = 0.0
+        maxtime += overall_start
 
         # Start looping
-        for i in range(1, 5):
+        for i in range(1, passes + 1):
             # Stop writing next buffer block, if time exceeds limit
             if time.perf_counter() >= maxtime:
                 break
-            # Prepare the data chunk outside of timing
-            data_chunk = buffer * (i**2)
 
             # Only measure the actual write and sync operations
             write_start = time.perf_counter()
-            total_written += os.write(fp_testfile, data_chunk)
+            total_written += os.write(fp_testfile, buffer[: chunksize * (i**2)])
             os.fsync(fp_testfile)
             total_time += time.perf_counter() - write_start
 
@@ -54,11 +49,13 @@ def diskspeedmeasure(dirname: str) -> float:
         os.close(fp_testfile)
         # Remove the file
         os.remove(filename)
-
     except OSError:
         # Could not write, so ... report 0.0
         logging.debug("Failed to measure disk speed on %s", dirname)
         return 0.0
+    finally:
+        # Explicitly clear the reference to the large buffer
+        del buffer
 
     megabyte_per_second = round(total_written / total_time / 1024 / 1024, 1)
     logging.debug(


### PR DESCRIPTION
Following discussion in #3197

- Allocating 480 MB anyway so slice a 256 MB buffer instead
- Memory use: 282 MB vs 298 MB, or 154 MB with 8 MB base size
- Explicitly clears buffer when function finishes, I’m not sure it does much without gc.collect() though
- Can pass maxtime, passes, and chunksize arguments to the function

Results wise I'm seeing little difference looping the 16MB and 8MB except on a ZFS HDD pool.

The actual measurement is unchanged, just made more adaptable.

As a further improvement to mitigate the memory usage increase I suggest getting the total physical memory of the system and adjust chunksize as appropriate.
