### PR TITLE
Fix read/write actions after reset_nw

### DIFF
--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -749,7 +749,7 @@ class Downloader(Thread):
         bytes_received: int = 0
         bytes_pending: int = 0
 
-        while True:
+        while nw.decoder:
             try:
                 n, bytes_pending = nw.read(nbytes=bytes_pending)
                 bytes_received += n

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -288,6 +288,10 @@ class NewsWrapper:
         :param on_response: callback for each complete response received
         :return: #bytes, #pendingbytes
         """
+        # NewsWrapper is being reset
+        if not self.decoder:
+            return 0, None
+
         # Receive data into the decoder pre-allocated buffer
         if not nbytes and self.nntp.nw.server.ssl and not self.nntp.nw.blocking and sabctools.openssl_linked:
             # Use patched version when downloading
@@ -379,7 +383,7 @@ class NewsWrapper:
                     not self.send_buffer
                     and not self.next_request
                     and not self._response_queue
-                    and (not server.active or server.restart or time.time() > self.timeout)
+                    and (not server.active or server.restart or not self.timeout or time.time() > self.timeout)
                 ):
                     # Make socket available again
                     server.busy_threads.discard(self)


### PR DESCRIPTION
I think this fixes #3222

I tested it by placing self.reset_nw calls between read and writes here, simulating such call occuring in read.

 https://github.com/sabnzbd/sabnzbd/blob/c4211df8dc8ae52bcdf19f700d45620083f0d681/sabnzbd/downloader.py#L741-L746

It's a little odd the newswrapper instance gets reused instead of replaced, but I think this is ok, the socket is already unregistered so won't be selected again.