### PR TITLE
Make behaviour after reset more robust

### DIFF
--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -695,7 +695,7 @@ class Downloader(Thread):
                     if events := self.selector.select(timeout=1.0):
                         for key, ev in events:
                             nw = key.data
-                            process_nw_queue.put((nw, ev, nw.reset_gen))
+                            process_nw_queue.put((nw, ev, nw.generation))
                 else:
                     events = []
                     BPSMeter.reset()
@@ -739,26 +739,26 @@ class Downloader(Thread):
             logging.error(T("Fatal error in Downloader"), exc_info=True)
             self.pause()
 
-    def process_nw(self, nw: NewsWrapper, event: int, gen: int):
+    def process_nw(self, nw: NewsWrapper, event: int, generation: int):
         """Receive data from a NewsWrapper and handle the response"""
         # Drop stale items
-        if nw.reset_gen != gen:
+        if nw.generation != generation:
             return
         if event & selectors.EVENT_READ:
-            self.process_nw_read(nw, gen)
+            self.process_nw_read(nw, generation)
             # If read caused a reset, don't proceed to write
-            if nw.reset_gen != gen:
+            if nw.generation != generation:
                 return
         if event & selectors.EVENT_WRITE:
             nw.write()
 
-    def process_nw_read(self, nw: NewsWrapper, gen: int) -> None:
+    def process_nw_read(self, nw: NewsWrapper, generation: int) -> None:
         bytes_received: int = 0
         bytes_pending: int = 0
 
-        while nw.decoder and nw.reset_gen == gen:
+        while nw.decoder and nw.generation == generation:
             try:
-                n, bytes_pending = nw.read(nbytes=bytes_pending, gen=gen)
+                n, bytes_pending = nw.read(nbytes=bytes_pending, generation=generation)
                 bytes_received += n
             except ssl.SSLWantReadError:
                 return
@@ -776,7 +776,7 @@ class Downloader(Thread):
                 break
 
         # Ignore metrics for reset connections
-        if nw.reset_gen != gen:
+        if nw.generation != generation:
             return
 
         server = nw.server

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -694,7 +694,8 @@ class Downloader(Thread):
                 if self.selector.get_map():
                     if events := self.selector.select(timeout=1.0):
                         for key, ev in events:
-                            process_nw_queue.put((key.data, ev))
+                            nw = key.data
+                            process_nw_queue.put((nw, ev, nw.reset_gen))
                 else:
                     events = []
                     BPSMeter.reset()
@@ -738,20 +739,26 @@ class Downloader(Thread):
             logging.error(T("Fatal error in Downloader"), exc_info=True)
             self.pause()
 
-    def process_nw(self, nw: NewsWrapper, event: int):
+    def process_nw(self, nw: NewsWrapper, event: int, gen: int):
         """Receive data from a NewsWrapper and handle the response"""
+        # Drop stale items
+        if nw.reset_gen != gen:
+            return
         if event & selectors.EVENT_READ:
-            self.process_nw_read(nw)
+            self.process_nw_read(nw, gen)
+            # If read caused a reset, don't proceed to write
+            if nw.reset_gen != gen:
+                return
         if event & selectors.EVENT_WRITE:
             nw.write()
 
-    def process_nw_read(self, nw: NewsWrapper) -> None:
+    def process_nw_read(self, nw: NewsWrapper, gen: int) -> None:
         bytes_received: int = 0
         bytes_pending: int = 0
 
-        while nw.decoder:
+        while nw.decoder and nw.reset_gen == gen:
             try:
-                n, bytes_pending = nw.read(nbytes=bytes_pending)
+                n, bytes_pending = nw.read(nbytes=bytes_pending, gen=gen)
                 bytes_received += n
             except ssl.SSLWantReadError:
                 return
@@ -767,6 +774,10 @@ class Downloader(Thread):
 
             if not bytes_pending:
                 break
+
+        # Ignore metrics for reset connections
+        if nw.reset_gen != gen:
+            return
 
         server = nw.server
 

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -74,13 +74,14 @@ class NewsWrapper:
         "_response_queue",
         "selector_events",
         "lock",
-        "reset_gen",
+        "generation",
     )
 
-    def __init__(self, server, thrdnum, block=False):
+    def __init__(self, server: sabnzbd.downloader.Server, thrdnum: int, block: bool = False, generation: int = 0):
         self.server: sabnzbd.downloader.Server = server
         self.thrdnum: int = thrdnum
         self.blocking: bool = block
+        self.generation: int = generation
 
         self.timeout: Optional[float] = None
 
@@ -105,9 +106,6 @@ class NewsWrapper:
         self._response_queue: deque[Optional[sabnzbd.nzbarticle.Article]] = deque()
         self.selector_events = 0
         self.lock: threading.Lock = threading.Lock()
-        # Preserve reset generation across resets
-        if not hasattr(self, "reset_gen"):
-            self.reset_gen: int = 0
 
     @property
     def article(self) -> Optional["sabnzbd.nzbarticle.Article"]:
@@ -283,16 +281,19 @@ class NewsWrapper:
                 logging.debug("Thread %s@%s: %s done", self.thrdnum, server.host, article.article)
 
     def read(
-        self, nbytes: int = 0, on_response: Optional[Callable[[int, str], None]] = None, gen: Optional[int] = None
+        self,
+        nbytes: int = 0,
+        on_response: Optional[Callable[[int, str], None]] = None,
+        generation: Optional[int] = None,
     ) -> Tuple[int, Optional[int]]:
         """Receive data, return #bytes, #pendingbytes
         :param nbytes: maximum number of bytes to read
         :param on_response: callback for each complete response received
-        :param gen: expected reset generation
+        :param generation: expected reset generation
         :return: #bytes, #pendingbytes
         """
-        if gen is None:
-            gen = self.reset_gen
+        if generation is None:
+            generation = self.generation
 
         # NewsWrapper is being reset
         if not self.decoder:
@@ -314,11 +315,11 @@ class NewsWrapper:
 
         self.decoder.process(bytes_recv)
         for response in self.decoder:
-            if self.reset_gen != gen:
+            if self.generation != generation:
                 break
             with self.lock:
                 # Re-check under lock to avoid racing with hard_reset
-                if self.reset_gen != gen or not self._response_queue:
+                if self.generation != generation or not self._response_queue:
                     break
                 article = self._response_queue.popleft()
             if on_response:
@@ -416,7 +417,7 @@ class NewsWrapper:
         """Destroy and restart"""
         with self.lock:
             # Increase generation so concurrent uses can observe the reset
-            self.reset_gen += 1
+            self.generation += 1
             # Drain unsent requests
             if self.next_request:
                 _, article = self.next_request
@@ -433,7 +434,7 @@ class NewsWrapper:
             self.nntp = None
 
         # Reset all variables (including the NNTP connection)
-        self.__init__(self.server, self.thrdnum)
+        self.__init__(self.server, self.thrdnum, generation=self.generation)
 
         # Wait before re-using this newswrapper
         if wait:

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -74,6 +74,7 @@ class NewsWrapper:
         "_response_queue",
         "selector_events",
         "lock",
+        "reset_gen",
     )
 
     def __init__(self, server, thrdnum, block=False):
@@ -104,6 +105,9 @@ class NewsWrapper:
         self._response_queue: deque[Optional[sabnzbd.nzbarticle.Article]] = deque()
         self.selector_events = 0
         self.lock: threading.Lock = threading.Lock()
+        # Preserve reset generation across resets
+        if not hasattr(self, "reset_gen"):
+            self.reset_gen: int = 0
 
     @property
     def article(self) -> Optional["sabnzbd.nzbarticle.Article"]:
@@ -279,15 +283,17 @@ class NewsWrapper:
                 logging.debug("Thread %s@%s: %s done", self.thrdnum, server.host, article.article)
 
     def read(
-        self,
-        nbytes: int = 0,
-        on_response: Optional[Callable[[int, str], None]] = None,
+        self, nbytes: int = 0, on_response: Optional[Callable[[int, str], None]] = None, gen: Optional[int] = None
     ) -> Tuple[int, Optional[int]]:
         """Receive data, return #bytes, #pendingbytes
         :param nbytes: maximum number of bytes to read
         :param on_response: callback for each complete response received
+        :param gen: expected reset generation
         :return: #bytes, #pendingbytes
         """
+        if gen is None:
+            gen = self.reset_gen
+
         # NewsWrapper is being reset
         if not self.decoder:
             return 0, None
@@ -308,7 +314,12 @@ class NewsWrapper:
 
         self.decoder.process(bytes_recv)
         for response in self.decoder:
+            if self.reset_gen != gen:
+                break
             with self.lock:
+                # Re-check under lock to avoid racing with hard_reset
+                if self.reset_gen != gen or not self._response_queue:
+                    break
                 article = self._response_queue.popleft()
             if on_response:
                 on_response(response.status_code, response.message)
@@ -404,6 +415,8 @@ class NewsWrapper:
     def hard_reset(self, wait: bool = True):
         """Destroy and restart"""
         with self.lock:
+            # Increase generation so concurrent uses can observe the reset
+            self.reset_gen += 1
             # Drain unsent requests
             if self.next_request:
                 _, article = self.next_request

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -77,7 +77,7 @@ class NewsWrapper:
         "generation",
     )
 
-    def __init__(self, server: sabnzbd.downloader.Server, thrdnum: int, block: bool = False, generation: int = 0):
+    def __init__(self, server: "sabnzbd.downloader.Server", thrdnum: int, block: bool = False, generation: int = 0):
         self.server: sabnzbd.downloader.Server = server
         self.thrdnum: int = thrdnum
         self.blocking: bool = block

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -416,8 +416,6 @@ class NewsWrapper:
     def hard_reset(self, wait: bool = True):
         """Destroy and restart"""
         with self.lock:
-            # Increase generation so concurrent uses can observe the reset
-            self.generation += 1
             # Drain unsent requests
             if self.next_request:
                 _, article = self.next_request
@@ -433,8 +431,9 @@ class NewsWrapper:
             self.nntp.close(send_quit=self.connected)
             self.nntp = None
 
-        # Reset all variables (including the NNTP connection)
-        self.__init__(self.server, self.thrdnum, generation=self.generation)
+        with self.lock:
+            # Reset all variables (including the NNTP connection) and increment the generation counter
+            self.__init__(self.server, self.thrdnum, generation=self.generation + 1)
 
         # Wait before re-using this newswrapper
         if wait:


### PR DESCRIPTION
Fixes #3226

This adds checks in several places that the connection has not been reset since the select operation was enqueued. It also checks before writing and checks if _response_queue is empty before popleft.
I called it `reset_gen` rather than `resets` or similar because I wanted to avoid indicating that it's allowed to reset it to 0.