### PR TITLE
Increase max pipelining

### DIFF
--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -535,7 +535,7 @@ ssdp_broadcast_interval = OptionNumber("misc", "ssdp_broadcast_interval", 15, mi
 ext_rename_ignore = OptionList("misc", "ext_rename_ignore", validation=lower_case_ext)
 unrar_parameters = OptionStr("misc", "unrar_parameters", validation=supported_unrar_parameters)
 outgoing_nntp_ip = OptionStr("misc", "outgoing_nntp_ip")
-pipelining_requests = OptionNumber("misc", "pipelining_requests", DEF_PIPELINING_REQUESTS, minval=1, maxval=10)
+pipelining_requests = OptionNumber("misc", "pipelining_requests", DEF_PIPELINING_REQUESTS, minval=1, maxval=20)
 
 
 ##############################################################################


### PR DESCRIPTION
Since there haven't been any issues reported so far can we increase a little, from testing it's only useful for quite high latency.

Someone on Discord noticed the wiki already says up to 20 is allowed so that would be correct now.