### PR TITLE
Fix failing downloader tests and make tests less fragile

### DIFF
--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -28,7 +28,7 @@ import sys
 import ssl
 import time
 from datetime import date
-from typing import Optional, Union, Deque
+from typing import Optional, Union, Deque, Callable
 
 import sabctools
 
@@ -173,7 +173,6 @@ class Server:
     def stop(self):
         """Remove all connections and cached articles from server"""
         for nw in self.idle_threads:
-            sabnzbd.Downloader.remove_socket(nw)
             nw.hard_reset()
         self.idle_threads = set()
         self.reset_article_queue()
@@ -375,6 +374,9 @@ class Downloader(Thread):
     def add_socket(self, nw: NewsWrapper):
         """Add a socket to be watched for read or write availability"""
         if nw.nntp:
+            server = nw.server
+            server.idle_threads.remove(nw)
+            server.busy_threads.add(nw)
             try:
                 self.selector.register(nw.nntp.fileno, selectors.EVENT_READ | selectors.EVENT_WRITE, nw)
                 nw.selector_events = selectors.EVENT_READ | selectors.EVENT_WRITE
@@ -395,6 +397,10 @@ class Downloader(Thread):
     def remove_socket(self, nw: NewsWrapper):
         """Remove a socket to be watched"""
         if nw.nntp:
+            server = nw.server
+            server.busy_threads.discard(nw)
+            server.idle_threads.add(nw)
+            nw.timeout = None
             try:
                 self.selector.unregister(nw.nntp.fileno)
                 nw.selector_events = 0
@@ -649,11 +655,9 @@ class Downloader(Thread):
                         if not server.get_article(peek=True):
                             break
 
-                        server.idle_threads.remove(nw)
-                        server.busy_threads.add(nw)
-
-                        if nw.connected:
-                            self.add_socket(nw)
+                        if nw.connected or nw.nntp:
+                            if nw.prepare_request():
+                                self.add_socket(nw)
                         else:
                             try:
                                 logging.info("%s@%s: Initiating connection", nw.thrdnum, server.host)
@@ -924,13 +928,6 @@ class Downloader(Thread):
             logging.info("Thread %s@%s: %s", nw.thrdnum, nw.server.host, reset_msg)
         elif reset_msg:
             logging.debug("Thread %s@%s: %s", nw.thrdnum, nw.server.host, reset_msg)
-
-        # Make sure this NewsWrapper is in the idle threads
-        nw.server.busy_threads.discard(nw)
-        nw.server.idle_threads.add(nw)
-
-        # Make sure it is not in the readable sockets
-        self.remove_socket(nw)
 
         # Discard the article request which failed
         nw.discard(article, count_article_try=count_article_try, retry_article=retry_article)

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -374,9 +374,8 @@ class Downloader(Thread):
     def add_socket(self, nw: NewsWrapper):
         """Add a socket to be watched for read or write availability"""
         if nw.nntp:
-            server = nw.server
-            server.idle_threads.remove(nw)
-            server.busy_threads.add(nw)
+            nw.server.idle_threads.remove(nw)
+            nw.server.busy_threads.add(nw)
             try:
                 self.selector.register(nw.nntp.fileno, selectors.EVENT_READ | selectors.EVENT_WRITE, nw)
                 nw.selector_events = selectors.EVENT_READ | selectors.EVENT_WRITE
@@ -386,7 +385,7 @@ class Downloader(Thread):
     @synchronized(DOWNLOADER_LOCK)
     def modify_socket(self, nw: NewsWrapper, events: int):
         """Modify the events socket are watched for"""
-        if nw.nntp and nw.selector_events != events:
+        if nw.nntp and nw.selector_events != events and not nw.blocking:
             try:
                 self.selector.modify(nw.nntp.fileno, events, nw)
                 nw.selector_events = events
@@ -397,9 +396,8 @@ class Downloader(Thread):
     def remove_socket(self, nw: NewsWrapper):
         """Remove a socket to be watched"""
         if nw.nntp:
-            server = nw.server
-            server.busy_threads.discard(nw)
-            server.idle_threads.add(nw)
+            nw.server.busy_threads.discard(nw)
+            nw.server.idle_threads.add(nw)
             nw.timeout = None
             try:
                 self.selector.unregister(nw.nntp.fileno)

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -201,8 +201,8 @@ class NewsWrapper:
     def on_response(self, response: sabctools.NNTPResponse, article: Optional["sabnzbd.nzb.Article"]) -> None:
         """A response to a NNTP request is received"""
         self.concurrent_requests.release()
-        if not self.blocking:
-            sabnzbd.Downloader.modify_socket(self, EVENT_READ | EVENT_WRITE)
+        # After each response this socket needs be available for writing again
+        sabnzbd.Downloader.modify_socket(self, EVENT_READ | EVENT_WRITE)
         server = self.server
         article_done = response.status_code in (220, 222) and article
 

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -201,7 +201,8 @@ class NewsWrapper:
     def on_response(self, response: sabctools.NNTPResponse, article: Optional["sabnzbd.nzb.Article"]) -> None:
         """A response to a NNTP request is received"""
         self.concurrent_requests.release()
-        sabnzbd.Downloader.modify_socket(self, EVENT_READ | EVENT_WRITE)
+        if not self.blocking:
+            sabnzbd.Downloader.modify_socket(self, EVENT_READ | EVENT_WRITE)
         server = self.server
         article_done = response.status_code in (220, 222) and article
 
@@ -333,6 +334,36 @@ class NewsWrapper:
             return bytes_recv, pending
         return bytes_recv, None
 
+    def prepare_request(self) -> bool:
+        """Queue an article request if appropriate."""
+        server = self.server
+
+        # Do not pipeline requests until authentication is completed (connected)
+        if self.connected or not self._response_queue:
+            server_ready = (
+                server.active
+                and not server.restart
+                and not (
+                    sabnzbd.Downloader.no_active_jobs()
+                    or sabnzbd.Downloader.shutdown
+                    or sabnzbd.Downloader.paused_for_postproc
+                )
+            )
+
+            if server_ready:
+                # Queue the next article if none exists
+                if not self.next_request and (article := server.get_article()):
+                    self.next_request = self.body(article)
+                    return True
+            else:
+                # Server not ready, discard any queued next_request
+                if self.next_request and self.next_request[1]:
+                    self.discard(self.next_request[1], count_article_try=False, retry_article=True)
+                    self.next_request = None
+
+        # Return True if there is work queued or in flight
+        return bool(self.next_request or self._response_queue)
+
     def write(self):
         """Send data to server"""
         server = self.server
@@ -346,23 +377,7 @@ class NewsWrapper:
                     # Still unsent data, wait for next EVENT_WRITE
                     return
 
-            if self.connected:
-                if (
-                    server.active
-                    and not server.restart
-                    and not (
-                        sabnzbd.Downloader.no_active_jobs()
-                        or sabnzbd.Downloader.shutdown
-                        or sabnzbd.Downloader.paused_for_postproc
-                    )
-                ):
-                    # Prepare the next request
-                    if not self.next_request and (article := server.get_article()):
-                        self.next_request = self.body(article)
-                elif self.next_request and self.next_request[1]:
-                    # Discard the next request
-                    self.discard(self.next_request[1], count_article_try=False, retry_article=True)
-                    self.next_request = None
+            self.prepare_request()
 
             # If no pending buffer, try to send new command
             if not self.send_buffer and self.next_request:
@@ -398,8 +413,6 @@ class NewsWrapper:
                     and (not server.active or server.restart or not self.timeout or time.time() > self.timeout)
                 ):
                     # Make socket available again
-                    server.busy_threads.discard(self)
-                    server.idle_threads.add(self)
                     sabnzbd.Downloader.remove_socket(self)
 
         except (BlockingIOError, ssl.SSLWantWriteError):
@@ -427,11 +440,11 @@ class NewsWrapper:
                 if article := self._response_queue.popleft():
                     self.discard(article, count_article_try=False, retry_article=True)
 
-        if self.nntp:
-            self.nntp.close(send_quit=self.connected)
-            self.nntp = None
+            if self.nntp:
+                sabnzbd.Downloader.remove_socket(self)
+                self.nntp.close(send_quit=self.connected)
+                self.nntp = None
 
-        with self.lock:
             # Reset all variables (including the NNTP connection) and increment the generation counter
             self.__init__(self.server, self.thrdnum, generation=self.generation + 1)
 

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -199,7 +199,7 @@ class NewsWrapper:
     def on_response(self, response: sabctools.NNTPResponse, article: Optional["sabnzbd.nzb.Article"]) -> None:
         """A response to a NNTP request is received"""
         self.concurrent_requests.release()
-        # After each response this socket needs be available for writing again
+        # After each response this socket needs to be available for writing again
         sabnzbd.Downloader.modify_socket(self, EVENT_READ | EVENT_WRITE)
         server = self.server
         article_done = response.status_code in (220, 222) and article

--- a/tests/test_functional_adding_nzbs_clean.py
+++ b/tests/test_functional_adding_nzbs_clean.py
@@ -70,14 +70,16 @@ class TestAddingNZBsClean:
             )
 
             # Wait for the job to be removed and appear in the history
-            for _ in range(10):
+            for _ in range(100):
                 try:
                     history = get_api_result(mode="history", extra_arguments={"nzo_ids": job1["nzo_ids"][0]})["history"]
                     assert history["slots"][0]["nzo_id"] == job1["nzo_ids"][0]
                     assert history["slots"][0]["status"] == "Failed"
                     break
                 except (IndexError, AssertionError):
-                    time.sleep(1)
+                    time.sleep(0.1)
+            else:
+                pytest.fail("Job did not appear in history")
 
             # Now the second job should no longer be paused and labelled
             queue = get_api_result(mode="queue", extra_arguments={"nzo_ids": job2["nzo_ids"][0]})
@@ -96,14 +98,18 @@ class TestAddingNZBsClean:
             assert job["nzo_ids"]
 
             # Wait for the job to be removed and appear in the history
-            for _ in range(10):
+            for _ in range(100):
                 try:
-                    assert not get_api_result(mode="queue", extra_arguments={"nzo_ids": job["nzo_ids"][0]})["queue"]
+                    queue = get_api_result(mode="queue", extra_arguments={"nzo_ids": job["nzo_ids"][0]})["queue"]
+                    assert not queue["slots"]
                     history = get_api_result(mode="history", extra_arguments={"nzo_ids": job["nzo_ids"][0]})["history"]
                     assert history["slots"][0]["nzo_id"] == job["nzo_ids"][0]
                     assert history["slots"][0]["status"] == "Failed"
+                    break
                 except (IndexError, AssertionError):
-                    time.sleep(1)
+                    time.sleep(0.1)
+            else:
+                pytest.fail("Job did not appear in history")
 
             # Reset and clean up
             get_api_result(

--- a/tests/test_functional_downloads.py
+++ b/tests/test_functional_downloads.py
@@ -19,10 +19,8 @@
 tests.test_functional_downloads - Test the downloading flow
 """
 from tests.testhelper import *
-from flaky import flaky
 
 
-@flaky
 class TestDownloadFlow(DownloadFlowBasics):
     def test_download_basic_rar5(self):
         self.download_nzb("basic_rar5", ["My_Test_Download.bin"])

--- a/tests/test_functional_sorting.py
+++ b/tests/test_functional_sorting.py
@@ -20,7 +20,6 @@ tests.test_functional_sorting - Test downloads with season sorting and sequentia
 """
 import os
 from tests.testhelper import *
-from flaky import flaky
 import sabnzbd.config as config
 
 
@@ -29,7 +28,6 @@ import sabnzbd.config as config
 INI_FILE = "sabnzbd.sorting.ini"
 
 
-@flaky
 @pytest.mark.usefixtures("run_sabnzbd")
 class TestDownloadSorting(DownloadFlowBasics):
     def test_sorter_settings_conversion(self):

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -348,7 +348,7 @@ class DownloadFlowBasics(SABnzbdBaseTest):
         if dir_name_as_job_name:
             test_job_name = os.path.basename(nzb_dir)
         else:
-            # replace "-" because guessit thinks AB01-9999 is episodes 1 to 9999 and take a long time
+            # replace "-" because guessit thinks AB01-9999 is episodes 1 to 9999 and takes a long time
             test_job_name = "TestDownload_%s" % str(uuid.uuid4()).replace("-", "")
         job = get_api_result("addlocalfile", extra_arguments={"name": nzb_path, "nzbname": test_job_name})
         assert job["nzo_ids"]
@@ -417,9 +417,9 @@ class DownloadFlowBasics(SABnzbdBaseTest):
         # Verify if the garbage collection works (see #1628)
         # We need to give it a second to calm down and clear the variables
         for _ in range(100):
-            time.sleep(0.1)
             gc_results = get_api_result("gc_stats")["value"]
             if not gc_results:
                 break
+            time.sleep(0.1)
         else:
             pytest.fail(f"Objects were left in memory after the job finished! {gc_results}")

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -21,6 +21,7 @@ tests.testhelper - Basic helper functions
 import io
 import os
 import time
+import uuid
 from http.client import RemoteDisconnected
 from typing import BinaryIO, Optional
 
@@ -336,6 +337,10 @@ class DownloadFlowBasics(SABnzbdBaseTest):
         # Verify if the server was setup before we start
         self.is_server_configured()
 
+        # Delete all jobs from queue and history
+        for mode in ("queue", "history"):
+            get_api_result(mode=mode, extra_arguments={"name": "delete", "value": "all", "del_files": 1})
+
         # Create NZB
         nzb_path = create_nzb(nzb_dir)
 
@@ -343,56 +348,78 @@ class DownloadFlowBasics(SABnzbdBaseTest):
         if dir_name_as_job_name:
             test_job_name = os.path.basename(nzb_dir)
         else:
-            test_job_name = "testfile_%s" % time.time()
-        api_result = get_api_result("addlocalfile", extra_arguments={"name": nzb_path, "nzbname": test_job_name})
-        assert api_result["status"]
+            # replace "-" because guessit thinks AB01-9999 is episodes 1 to 9999 and take a long time
+            test_job_name = "TestDownload_%s" % str(uuid.uuid4()).replace("-", "")
+        job = get_api_result("addlocalfile", extra_arguments={"name": nzb_path, "nzbname": test_job_name})
+        assert job["nzo_ids"]
+        assert job["status"]
+        job_nzo_id = job["nzo_ids"][0]
 
         # Remove NZB-file
         os.remove(nzb_path)
 
-        # See how it's doing
-        self.open_page("http://%s:%s/" % (SAB_HOST, SAB_PORT))
+        completed_dir = None
+        queue = {}
+        history = {}
 
-        # We wait for 20 seconds to let it complete
-        for _ in range(20):
+        # Wait for the job to be removed and appear in the history
+        for _ in range(200):
             try:
-                # Locate status of our job
-                status_text = self.driver.find_element(
-                    By.XPATH,
-                    (
-                        '//div[@id="history-tab"]//tr[td/div/span[contains(text(), "%s")]]/td[contains(@class, "status")]'
-                        % test_job_name
-                    ),
-                ).text
-                # Always sleep to give it some time
-                time.sleep(1)
-                if status_text == "Completed":
-                    break
-            except WebDriverException:
-                time.sleep(1)
+                queue = get_api_result(mode="queue", extra_arguments={"nzo_ids": job_nzo_id})["queue"]
+                assert not queue["slots"]
+                history = get_api_result(mode="history", extra_arguments={"nzo_ids": job_nzo_id})["history"]
+                assert history["slots"][0]["nzo_id"] == job_nzo_id
+                assert history["slots"][0]["status"] == "Completed"
+                completed_dir = history["slots"][0]["storage"]
+                assert completed_dir  # has finished postproc
+                if os.path.isfile(completed_dir):
+                    completed_dir = os.path.dirname(completed_dir)
+                break
+            except (IndexError, AssertionError):
+                time.sleep(0.1)
         else:
-            pytest.fail("Download did not complete")
+            if not completed_dir:
+                completed_dir = os.path.join(SAB_COMPLETE_DIR, test_job_name)
+            completed_files = filesystem.globber(completed_dir, "*")
+            if queue.get("slots"):
+                pytest.fail("Download did not complete: it is still in the queue, queue=%s" % queue.get("slots"))
+            if history.get("slots"):
+                pytest.fail(
+                    "Download did not complete: it is in the history, history=%s, completed_files=%s"
+                    % (
+                        history.get("slots"),
+                        completed_files,
+                    )
+                )
+            # Not in the queue or history
+            pytest.fail(
+                "Download did not complete: not in the queue or history, completed_files=%s" % (completed_files,)
+            )
 
         # Verify all files in the expected file_output are present among the completed files.
         # Sometimes par2 can also be included, but we accept that. For example when small
         # par2 files get assembled in after the download already finished (see #1509)
-        for _ in range(10):
-            completed_files = filesystem.globber(os.path.join(SAB_COMPLETE_DIR, test_job_name), "*")
+        for i in range(100):
+            completed_files = filesystem.globber(completed_dir, "*")
             try:
                 for filename in file_output:
                     assert filename in completed_files
                 # All filenames found
                 break
             except AssertionError:
-                print("Expected filename %s not found in completed_files %s" % (filename, completed_files))
-                # Wait a sec before trying again with a fresh list of completed files
-                time.sleep(1)
+                if i % 10 == 0:
+                    print("Expected filename %s not found in completed_files %s" % (filename, completed_files))
+                # Wait before trying again with a fresh list of completed files
+                time.sleep(0.1)
         else:
             pytest.fail("Time ran out waiting for expected filenames to show up")
 
         # Verify if the garbage collection works (see #1628)
         # We need to give it a second to calm down and clear the variables
-        time.sleep(2)
-        gc_results = get_api_result("gc_stats")["value"]
-        if gc_results:
+        for _ in range(100):
+            time.sleep(0.1)
+            gc_results = get_api_result("gc_stats")["value"]
+            if not gc_results:
+                break
+        else:
             pytest.fail(f"Objects were left in memory after the job finished! {gc_results}")


### PR DESCRIPTION
Fixes #3250

There were a few issues in the downloader logic:

- "Timed Out" in logs, was a race where idle_threads/busy_threads collided so a socket could be removed from listening but in busy_threads
- `nw.timeout = None` was missing which prevented kick starting idle threads, it used to be in soft_reset, that still kind of happens but it's remove_socket now.
- The biggest issue was if 8 connections were initially made, but they do not all immediately have article requests queued, they return to idle_threads. Then there were bugs related to those idle connections having not completed the authentication flow so not `connected` and not getting more work assigned.
- Split the logic for queuing the next request for a server and allow downloader to call it to kick start requests.

Test improvements:

- Made `download_nzb` helper less fragile
  - Clear queue/history between tests
  - When random job names are used use `"TestDownload_%s" % str(uuid.uuid4()).replace("-", "")` so deobfuscator won't get involved and they are easier to see in logs instead of many timestamps within 5 minutes of each other
  - Use API instead of selenium for reliability, it was matching name, but the name requested isn't always what it is created as
  - Sleep less between checks = quicker tests
  - Log more meaningful information about failure, queue, history, and completed files.
- Because download_nzb is less fragile I have removed flaky from download tests, it hid the failures
- Fixed assertions in `test_functional_adding_nzbs_clean.py` - it's where I copied the api tests from and found its assertions failed after 10 seconds and it carried on anyway, it does it twice so that's ~20 seconds saved

Shaves a few minutes off the test times, removing time.sleep(1) helps a lot.

`test_download_unicode_made_on_windows` fails on all platforms because it tries to deobfuscate, which used to waste 20 seconds due to flaky, so only ~10 seconds now. Will recreate it as a separate PR.

---

I ran test_functional_downloads.py 6000 times overnight without a failure.
