### PR TITLE
Fix binding outgoing ip test when ipv6 is available

### DIFF
--- a/tests/test_newswrapper.py
+++ b/tests/test_newswrapper.py
@@ -40,6 +40,7 @@ from sabnzbd import newswrapper
 from sabnzbd.get_addrinfo import AddrInfo
 
 TEST_HOST = "127.0.0.1"
+TEST_HOST_IPV6 = "::1"
 TEST_PORT = portend.find_available_local_port()
 TEST_DATA = b"connection_test"
 
@@ -186,15 +187,16 @@ class TestNewsWrapper:
         time.sleep(1.0)
 
     @pytest.mark.parametrize(
-        "local_ip, ip_protocol",
+        "test_host, local_ip, ip_protocol",
         [
-            (get_local_ip(protocol_version=IPProtocolVersion.IPV4), IPProtocolVersion.IPV4),
-            (get_local_ip(protocol_version=IPProtocolVersion.IPV6), IPProtocolVersion.IPV6),
-            ("", None),
+            (TEST_HOST, get_local_ip(protocol_version=IPProtocolVersion.IPV4), IPProtocolVersion.IPV4),
+            (TEST_HOST_IPV6, get_local_ip(protocol_version=IPProtocolVersion.IPV6), IPProtocolVersion.IPV6),
+            (TEST_HOST, "", None),
+            (TEST_HOST_IPV6, "", None),
         ],
     )
     def test_socket_binding_outgoing_ip(
-        self, local_ip: Optional[str], ip_protocol: Optional[IPProtocolVersion], monkeypatch
+        self, test_host: str, local_ip: Optional[str], ip_protocol: Optional[IPProtocolVersion], monkeypatch
     ):
         """Test to make sure that the binding of outgoing interface works as expected."""
         if local_ip is None and ip_protocol is not None:
@@ -208,9 +210,9 @@ class TestNewsWrapper:
         nw.blocking = True
         nw.thrdnum = 1
         nw.server = mock.Mock()
-        nw.server.host = TEST_HOST
+        nw.server.host = test_host
         nw.server.port = TEST_PORT
-        nw.server.info = AddrInfo(*socket.getaddrinfo(TEST_HOST, TEST_PORT, 0, socket.SOCK_STREAM)[0])
+        nw.server.info = AddrInfo(*socket.getaddrinfo(test_host, TEST_PORT, 0, socket.SOCK_STREAM)[0])
         nw.server.timeout = 10
         nw.server.ssl = True
         nw.server.ssl_context = None
@@ -238,7 +240,7 @@ class TestNewsWrapper:
             # On Linux and macOS, the error code is ECONNREFUSED
             assert excinfo.value.errno == errno.ECONNREFUSED
 
-        current_ip, _ = nntp.sock.getsockname()
+        current_ip = nntp.sock.getsockname()[0]
         if local_ip != "":
             assert current_ip == local_ip
         else:


### PR DESCRIPTION
GitHub action runners are ipv4 only, but it fails locally on a system with a routable ipv6 address.

```
(TestNewsWrapper.test_socket_binding_outgoing_ip[####:####:####:####:####:####:####:####-IPProtocolVersion.IPV6])
'0.0.0.0' != '####:####:####:####:####:####:####:####'

Expected :'####:####:####:####:####:####:####:####'
Actual   :'0.0.0.0'
```
