### PR TITLE
Fix queue cannot be loaded

### DIFF
--- a/sabnzbd/nzb/article.py
+++ b/sabnzbd/nzb/article.py
@@ -19,6 +19,7 @@
 sabnzbd.article - Article and TryList classes for NZB downloading
 """
 import logging
+import threading
 from typing import Optional
 
 import sabnzbd
@@ -214,6 +215,7 @@ class Article(TryList):
             except KeyError:
                 # Handle new attributes
                 setattr(self, item, None)
+        self.lock = threading.RLock()
         super().__setstate__(dict_.get("try_list", []))
         self.fetcher = None
         self.fetcher_priority = 0

--- a/sabnzbd/nzb/article.py
+++ b/sabnzbd/nzb/article.py
@@ -218,7 +218,6 @@ class Article(TryList):
         self.fetcher = None
         self.fetcher_priority = 0
         self.tries = 0
-        self.lock = self.nzf.nzo.lock
 
     def __repr__(self):
         return "<Article: article=%s, bytes=%s, art_id=%s>" % (self.article, self.bytes, self.art_id)

--- a/sabnzbd/nzb/article.py
+++ b/sabnzbd/nzb/article.py
@@ -122,8 +122,8 @@ class Article(TryList):
         self.on_disk: bool = False
         self.crc32: Optional[int] = None
         self.nzf = nzf  # NzbFile reference
-        # Share NzbObject lock for job-wide atomicity of try-list ops
-        self.lock = nzf.nzo.lock
+        # Share NzbFile lock for file-wide atomicity of try-list ops
+        self.lock = nzf.lock
 
     @synchronized()
     def reset_try_list(self):

--- a/sabnzbd/nzb/file.py
+++ b/sabnzbd/nzb/file.py
@@ -297,13 +297,15 @@ class NzbFile(TryList):
             except KeyError:
                 # Handle new attributes
                 setattr(self, item, None)
-        super().__setstate__(dict_.get("try_list", []))
         self.lock = threading.RLock()
         self.file_lock = threading.RLock()
         self.assembler_next_index = 0
         if isinstance(self.articles, list):
             # Converted from list to dict
             self.articles = {x: x for x in self.articles}
+        for article in self.articles:
+            article.lock = self.lock
+        super().__setstate__(dict_.get("try_list", []))
 
     def __eq__(self, other: "NzbFile"):
         """Assume it's the same file if the number bytes and first article

--- a/sabnzbd/nzb/object.py
+++ b/sabnzbd/nzb/object.py
@@ -1663,8 +1663,8 @@ class NzbObject(TryList):
             except KeyError:
                 # Handle new attributes
                 setattr(self, item, None)
-        super().__setstate__(dict_.get("try_list", []))
         self.lock = threading.RLock()
+        super().__setstate__(dict_.get("try_list", []))
 
         # Set non-transferable values
         self.pp_active = False

--- a/tests/test_nzbqueue.py
+++ b/tests/test_nzbqueue.py
@@ -1,0 +1,110 @@
+#!/usr/bin/python3 -OO
+# Copyright 2007-2025 by The SABnzbd-Team (sabnzbd.org)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+tests.test_nzbqueue - Testing functions in nzbqueue.py
+"""
+from types import SimpleNamespace
+
+from sabnzbd.downloader import Server
+from sabnzbd.nzb import NzbObject, NzbFile
+from sabnzbd.nzbqueue import NzbQueue
+from tests.testhelper import *
+
+
+@pytest.fixture()
+def nzbqueue_env(monkeypatch, mocker, tmp_path):
+    sabnzbd.Scheduler = mocker.Mock()
+    sabnzbd.Scheduler.analyse = mocker.Mock(return_value=False)
+    sabnzbd.ArticleCache = mocker.Mock()
+    sabnzbd.Assembler = mocker.Mock()
+    sabnzbd.BPSMeter = mocker.Mock()
+    sabnzbd.Downloader = SimpleNamespace(paused=False)
+    sabnzbd.Downloader.servers = [
+        Server(
+            server_id="testserver1",
+            displayname="testserver1",
+            host=SAB_NEWSSERVER_HOST,
+            port=SAB_NEWSSERVER_PORT,
+            timeout=30,
+            threads=8,
+            priority=0,
+            use_ssl=False,
+            ssl_verify=3,
+            ssl_ciphers="",
+            pipelining_requests=mocker.Mock(return_value=1),
+        )
+    ]
+    monkeypatch.setattr(sabnzbd.cfg.admin_dir, "get_path", lambda: str(tmp_path))
+    monkeypatch.setattr(sabnzbd.cfg.download_dir, "get_path", lambda: str(tmp_path))
+
+    yield
+
+    del sabnzbd.Downloader
+    del sabnzbd.BPSMeter
+    del sabnzbd.Assembler
+    del sabnzbd.ArticleCache
+    del sabnzbd.Scheduler
+
+
+def make_dummy_nzo(name: str, priority: int = NORMAL_PRIORITY, files: int = 50, articles: int = 200) -> NzbObject:
+    work_name = f"job-{name}"
+
+    article_size = 750_000
+    nzo = NzbObject(work_name, priority=priority)
+    nzo.files = [
+        NzbFile(
+            date=nzo.avg_date,
+            subject=f"test-file-{file}",
+            raw_article_db=[[f"{file}-article-{article}", article_size] for article in range(articles)],
+            file_bytes=article_size * articles,
+            nzo=nzo,
+        )
+        for file in range(files)
+    ]
+
+    return nzo
+
+
+@pytest.mark.usefixtures("nzbqueue_env")
+class TestNzbQueue:
+    def test_save_and_restore_(self):
+        q = NzbQueue()
+        joba = make_dummy_nzo("a")
+        jobb = make_dummy_nzo("b")
+        q.add(joba)
+        q.add(jobb)
+
+        # Mark one of joba articles as tried
+        article = list(joba.files[0].articles)[0]
+        article.add_to_try_list(sabnzbd.Downloader.servers[0])
+        q.save()
+
+        # Both should be in the queue
+        assert q.get_nzo(joba.nzo_id)
+        assert q.get_nzo(jobb.nzo_id)
+
+        # Reload the queue with no repair
+        q = NzbQueue()
+        q.read_queue(0)
+        joba = q.get_nzo(joba.nzo_id)
+        jobb = q.get_nzo(jobb.nzo_id)
+        assert joba
+        assert jobb
+
+        # Try list restored
+        assert sabnzbd.Downloader.servers[0] in list(joba.files[0].articles)[0].try_list


### PR DESCRIPTION
Fixes #3269

I've used nzf level locks, it makes setting them simpler.

Part I missed initially is that `super().__setstate__(dict_.get("try_list", []))` is called from file and needs `self.lock` on article, so it needs to come after the locks have been restored.

I think I could make an argument for at least the lock initialisation lines being executed before anything else in `__setstate__` methods.

I've tried this with:
- Items added to the queue with no downloading
- Items added and partially downloaded, so trylist is restored