### PR TITLE
Fix pipelining connection read/write logic errors

### DIFF
--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -300,7 +300,7 @@ class Downloader(Thread):
         # macOS/BSD will default to KqueueSelector, it's very efficient but produces separate events for READ and WRITE.
         # Which causes problems when two receive threads are both trying to use the connection while it is resetting.
         if selectors.DefaultSelector is getattr(selectors, "KqueueSelector", None):
-            self.selector: selectors.BaseSelector = selectors.SelectSelector()
+            self.selector: selectors.BaseSelector = selectors.PollSelector()
         else:
             self.selector: selectors.BaseSelector = selectors.DefaultSelector()
 

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -299,11 +299,10 @@ class Downloader(Thread):
 
         # macOS/BSD will default to KqueueSelector, it's very efficient but produces separate events for READ and WRITE.
         # Which causes problems when two receive threads are both trying to use the connection while it is resetting.
-        self.selector: selectors.BaseSelector = (
-            selectors.SelectSelector()
-            if isinstance(selectors.DefaultSelector(), selectors.KqueueSelector)
-            else selectors.DefaultSelector()
-        )
+        if selectors.DefaultSelector is getattr(selectors, "KqueueSelector", None):
+            self.selector: selectors.BaseSelector = selectors.SelectSelector()
+        else:
+            self.selector: selectors.BaseSelector = selectors.DefaultSelector()
 
         self.servers: list[Server] = []
         self.timers: dict[str, list[float]] = {}

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -297,7 +297,13 @@ class Downloader(Thread):
 
         self.force_disconnect: bool = False
 
-        self.selector: selectors.DefaultSelector = selectors.DefaultSelector()
+        # macOS/BSD will default to KqueueSelector, it's very efficient but produces separate events for READ and WRITE.
+        # Which causes problems when two receive threads are both trying to use the connection while it is resetting.
+        self.selector: selectors.BaseSelector = (
+            selectors.SelectSelector()
+            if isinstance(selectors.DefaultSelector(), selectors.KqueueSelector)
+            else selectors.DefaultSelector()
+        )
 
         self.servers: list[Server] = []
         self.timers: dict[str, list[float]] = {}

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -23,6 +23,7 @@ import errno
 import socket
 import threading
 from collections import deque
+from contextlib import suppress
 from selectors import EVENT_READ, EVENT_WRITE
 from threading import Thread
 import time
@@ -659,8 +660,9 @@ class NNTP:
         self.closed = True
         try:
             if send_quit:
-                self.sock.sendall(b"QUIT\r\n")
-                time.sleep(0.01)
+                with suppress(socket.error):
+                    self.sock.sendall(b"QUIT\r\n")
+                    time.sleep(0.01)
             self.sock.close()
         except Exception as e:
             logging.info("%s@%s: Failed to close socket (error=%s)", self.nw.thrdnum, self.nw.server.host, str(e))

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -415,7 +415,7 @@ class NewsWrapper:
                 sabnzbd.Downloader.remove_socket(self)
         except socket.error as err:
             logging.info("Looks like server closed connection: %s", err)
-            sabnzbd.Downloader.reset_nw(self, "Server broke off connection", warn=True)
+            sabnzbd.Downloader.reset_nw(self, "Server broke off connection", warn=True, wait=False)
         except Exception:
             logging.error(T("Suspect error in downloader"))
             logging.info("Traceback: ", exc_info=True)

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -315,10 +315,8 @@ class NewsWrapper:
         self.decoder.process(bytes_recv)
         if self.decoder:
             for response in self.decoder:
-                if self.generation != generation:
-                    break
                 with self.lock:
-                    # Re-check under lock to avoid racing with hard_reset
+                    # Check generation under lock to avoid racing with hard_reset
                     if self.generation != generation or not self._response_queue:
                         break
                     article = self._response_queue.popleft()

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -390,12 +390,12 @@ class NewsWrapper:
 
                 if self.concurrent_requests.acquire(blocking=False):
                     command, article = self.next_request
-                    self.next_request = None
                     if article:
                         nzo = article.nzf.nzo
                         if nzo.removed_from_queue or nzo.status is Status.PAUSED and nzo.priority is not FORCE_PRIORITY:
                             self.discard(article, count_article_try=False, retry_article=True)
                             self.concurrent_requests.release()
+                            self.next_request = None
                             return
 
                     if sabnzbd.LOG_ALL:
@@ -404,6 +404,7 @@ class NewsWrapper:
                     # If this fails, it will propagate and throw a Downloader-error
                     self.nntp.sock.sendall(command)
                     self._response_queue.append(article)
+                    self.next_request = None
                 else:
                     # Concurrency limit reached; wait until a response is read to prevent hot looping on EVENT_WRITE
                     sabnzbd.Downloader.modify_socket(self, EVENT_READ)

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -103,7 +103,8 @@ class NewsWrapper:
         )
         self._response_queue: deque[Optional[sabnzbd.nzb.Article]] = deque()
         self.selector_events = 0
-        self.lock: threading.Lock = threading.Lock()
+        if getattr(self, "lock", None) is None:
+            self.lock: threading.Lock = threading.Lock()
 
     @property
     def article(self) -> Optional["sabnzbd.nzb.Article"]:


### PR DESCRIPTION
This fixes several issues I've found while investigating #3266

- When write failed, self.next_request was already set to None so the request was lost and never sent, preventing progress
- macOS used KqueueSelector which creates separate selector events for READ and WRITE, which has logic issues because the rest of the code wasn’t expecting or written to handle that – things like read and write trying to reset the connection from different threads, or write being executed before read. I resolved by making macOS use selectors.SelectSelector.
- Newswrapper lock was recreated when \_\_init\_\_ was called; I didn’t find it causing an issue but best to prevent that
- A connection error (closed connection) during a write would timeout for the server default, on reads this is only 5 seconds, so I’ve made it consistent.
- Close might not call sock.close if sending QUIT failed; not 100% sure it matters but probasbly best to ensure the socket is closed regardless
- Removed a redundant generation check

The main other one is #3216 I'm not sure if these changes help or resolve that but it will take a bit longer to figure out.
edit: I don't see it occuring anything like as often, not at all in the last 24 hours, but it wasn't downloading that whole time. I suspect it was due to KqueueSelector, will maybe leave the underlying issue unresolved since it's been like this since 4.0

I think you mentioned it before, but shall I split reinitialising into a separate method, rather than checking if lock is already set? `def reset()` or something?

The best way I've found to test this failure was to restart my NNTP server.