### PR TITLE
Fix bug when bandwidth limit is removed

### DIFF
--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -800,7 +800,7 @@ class Downloader(Thread):
                 and sabnzbd.BPSMeter.bps + sabnzbd.BPSMeter.sum_cached_amount > self.bandwidth_limit
             ):
                 sabnzbd.BPSMeter.update()
-                while sabnzbd.BPSMeter.bps > self.bandwidth_limit:
+                while self.bandwidth_limit and sabnzbd.BPSMeter.bps > self.bandwidth_limit:
                     time.sleep(0.01)
                     sabnzbd.BPSMeter.update()
 


### PR DESCRIPTION
While testing I had restricted speeds by setting ‘Maximum line speed’ then while downloading I removed the restriction (empty field) and observed the speed collapse to 0 or almost because it’s a float and never actually hits 0 exactly, it takes quite a while to decay to displaying zero in the UI.

It remained stuck reading 0 for a while until I added a new limit.

Initially the check is True and it starts enforcing the speed limit, however the value of ` self.bandwidth_limit` then changes to 0 so it becomes `while sabnzbd.BPSMeter.bps > 0` and loops indefinitely.