### PR TITLE
Fix inconsistent NzbFile sorting

### DIFF
--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -1404,48 +1404,6 @@ def create_work_name(name: str) -> str:
         return name.strip()
 
 
-def nzf_cmp_name(nzf1, nzf2):
-    """Comparison function for sorting NZB files.
-    The comparison will sort .par2 files to the top of the queue followed by .rar files,
-    they will then be sorted by name.
-
-    Note: nzf1 and nzf2 should be NzbFile objects, but we can't import that here
-    to avoid circular dependencies.
-    """
-    nzf1_name = nzf1.filename.lower()
-    nzf2_name = nzf2.filename.lower()
-
-    # Determine vol-pars
-    is_par1 = ".vol" in nzf1_name and ".par2" in nzf1_name
-    is_par2 = ".vol" in nzf2_name and ".par2" in nzf2_name
-
-    # mini-par2 in front
-    if not is_par1 and nzf1_name.endswith(".par2"):
-        return -1
-    if not is_par2 and nzf2_name.endswith(".par2"):
-        return 1
-
-    # vol-pars go to the back
-    if is_par1 and not is_par2:
-        return 1
-    if is_par2 and not is_par1:
-        return -1
-
-    # Prioritize .rar files above any other type of file (other than vol-par)
-    m1 = RAR_RE.search(nzf1_name)
-    m2 = RAR_RE.search(nzf2_name)
-    if m1 and not (is_par2 or m2):
-        return -1
-    elif m2 and not (is_par1 or m1):
-        return 1
-    # Force .rar to come before 'r00'
-    if m1 and m1.group(1) == ".rar":
-        nzf1_name = nzf1_name.replace(".rar", ".r//")
-    if m2 and m2.group(1) == ".rar":
-        nzf2_name = nzf2_name.replace(".rar", ".r//")
-    return sabnzbd.misc.cmp(nzf1_name, nzf2_name)
-
-
 def is_sparse(path: str) -> bool:
     """Check if a path is a sparse file"""
     info = os.stat(path)

--- a/sabnzbd/nzb/file.py
+++ b/sabnzbd/nzb/file.py
@@ -23,7 +23,7 @@ import datetime
 import logging
 import os
 import threading
-from typing import Optional
+from typing import Optional, Any
 
 import sabctools
 from sabnzbd.nzb.article import TryList, Article
@@ -36,6 +36,7 @@ from sabnzbd.filesystem import (
     get_new_id,
     save_data,
     load_data,
+    RAR_RE,
 )
 from sabnzbd.misc import int_conv, subject_name_extractor
 from sabnzbd.decorators import synchronized
@@ -282,6 +283,36 @@ class NzbFile(TryList):
             bytes_ready += article.decoded_size
         return bytes_ready
 
+    def sort_key(self) -> tuple[int, Any]:
+        """Comparison function for sorting NZB files.
+        The comparison will sort .par2 files to the top of the queue followed by .rar files,
+        they will then be sorted by name.
+        """
+        name = self.filename.lower()
+
+        is_par2 = name.endswith(".par2")
+        is_vol_par2 = is_par2 and ".vol" in name
+        is_mini_par2 = is_par2 and not is_vol_par2
+
+        m = RAR_RE.search(name)
+        is_rar = bool(m)
+        is_main_rar = is_rar and m.group(1) == "rar"
+
+        if is_mini_par2:
+            group = 0
+        elif is_rar:
+            group = 1
+        elif is_vol_par2:
+            group = 3
+        else:
+            group = 2
+
+        # Prioritize .rar files above any other type of file (other than vol-par)
+        if is_main_rar:
+            name = name.replace(".rar", ".r//")
+
+        return group, name
+
     def __getstate__(self):
         """Save to pickle file, selecting attributes"""
         dict_ = {}
@@ -307,6 +338,9 @@ class NzbFile(TryList):
         for article in self.articles:
             article.lock = self.lock
         super().__setstate__(dict_.get("try_list", []))
+
+    def __lt__(self, other: "NzbFile"):
+        return self.sort_key() < other.sort_key()
 
     def __eq__(self, other: "NzbFile"):
         """Assume it's the same file if the number bytes and first article

--- a/sabnzbd/nzb/file.py
+++ b/sabnzbd/nzb/file.py
@@ -283,35 +283,49 @@ class NzbFile(TryList):
             bytes_ready += article.decoded_size
         return bytes_ready
 
-    def sort_key(self) -> tuple[int, Any]:
+    def sort_key(self) -> tuple[Any, ...]:
         """Comparison function for sorting NZB files.
+
         The comparison will sort .par2 files to the top of the queue followed by .rar files,
         they will then be sorted by name.
         """
         name = self.filename.lower()
+        base, ext = os.path.splitext(name)
 
-        is_par2 = name.endswith(".par2")
-        is_vol_par2 = is_par2 and ".vol" in name
+        is_par2 = ext == ".par2"
+        is_vol_par2 = is_par2 and ".vol" in base
         is_mini_par2 = is_par2 and not is_vol_par2
 
         m = RAR_RE.search(name)
         is_rar = bool(m)
         is_main_rar = is_rar and m.group(1) == "rar"
 
+        # Initially group by mini-par2, other files, vol-par2
         if is_mini_par2:
-            group = 0
-        elif is_rar:
-            group = 1
+            tier = 0
         elif is_vol_par2:
-            group = 3
+            tier = 2
         else:
-            group = 2
+            tier = 1
 
-        # Prioritize .rar files above any other type of file (other than vol-par)
-        if is_main_rar:
-            name = name.replace(".rar", ".r//")
+        if tier == 1:
+            if is_rar and m:
+                # strip matched RAR suffix including leading dot (.part01.rar, .rar, .r00, ...)
+                group_base = name[: m.start()]
+                local_group = 0
+                type_rank = 0 if is_main_rar else 1
+            else:
+                # nfo, sfv, sample.mkv, etc.
+                group_base = base
+                local_group = 1
+                type_rank = 0
+        else:
+            # mini/vol par2 ignore the group base
+            group_base = ""
+            local_group = 0
+            type_rank = 0
 
-        return group, name
+        return tier, group_base, local_group, type_rank, name
 
     def __getstate__(self):
         """Save to pickle file, selecting attributes"""

--- a/sabnzbd/nzb/object.py
+++ b/sabnzbd/nzb/object.py
@@ -25,7 +25,6 @@ import re
 import logging
 import datetime
 import threading
-import functools
 import difflib
 from typing import Any, Optional, Union, BinaryIO, Deque
 
@@ -94,7 +93,6 @@ from sabnzbd.filesystem import (
     strip_extensions,
     get_ext,
     create_work_name,
-    nzf_cmp_name,
     RAR_RE,
 )
 from sabnzbd.par2file import FilePar2Info, has_par2_in_filename, analyse_par2, parse_par2_file, is_par2_file
@@ -580,7 +578,7 @@ class NzbObject(TryList):
         """Sort the files in the NZO based on name and type
         and then optimize for unwanted extensions search.
         """
-        self.files.sort(key=functools.cmp_to_key(nzf_cmp_name))
+        self.files.sort()
 
         # In the hunt for Unwanted Extensions:
         # The file with the unwanted extension often is in the first or the last rar file

--- a/tests/test_nzbfile.py
+++ b/tests/test_nzbfile.py
@@ -18,6 +18,7 @@
 """
 tests.test_nzbfile - Testing functions in nzb/file.py
 """
+
 from datetime import datetime
 
 from sabnzbd.nzb import NzbObject, NzbFile

--- a/tests/test_nzbfile.py
+++ b/tests/test_nzbfile.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python3 -OO
+# Copyright 2007-2025 by The SABnzbd-Team (sabnzbd.org)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+tests.test_nzbfile - Testing functions in nzb/file.py
+"""
+from datetime import datetime
+
+from sabnzbd.nzb import NzbObject, NzbFile
+
+from tests.testhelper import *
+
+
+@pytest.mark.usefixtures("clean_cache_dir")
+class TestNzbFile:
+    @set_config({"download_dir": SAB_CACHE_DIR})
+    @pytest.mark.parametrize(
+        "filenames",
+        [
+            [
+                "hello.world.par2",
+                "hello.world.part01.rar",
+                "hello.world.part02.rar",
+                "hello.world.part03.rar",
+                "hello.world.sample.mkv",
+                "hello.world.sfv",
+                "hello.world.nfo",
+                "hello.world.vol000-001.par2",
+                "hello.world.vol001-003.par2",
+            ],
+            [
+                "a.s01e01.par2",
+                "a.s01e01.vol000-001.par2",
+                "a.s01e01.vol001-003.par2",
+                "a.s01e02.par2",
+                "a.s01e02.vol000-001.par2",
+                "a.s01e02.rar",
+                "a.s01e02.vol000-001.par2",
+                "a.s01e03.rar",
+                "a.s01e03.r00",
+                "a.s01e01.rar",
+                "a.s01e01.sfv",
+                "a.s01e03.r01",
+                "a.s01e02.r00",
+                "a.s01e03.par2",
+                "a.s01e01.sample.mkv",
+                "a.s01e02.sample.mkv",
+                "a.s01e03.sample.mkv",
+            ],
+        ],
+    )
+    def test_sort_is_consistent(self, filenames: list[str]):
+        """Test sorting of nzb files is deterministic, this is that the order of input does not matter."""
+        nzo = NzbObject("test")
+
+        def make_nzf(filename: str):
+            return NzbFile(
+                date=datetime.now(),
+                subject=filename,
+                raw_article_db=[(filename, 0)],
+                file_bytes=0,
+                nzo=nzo,
+            )
+
+        files1 = [make_nzf(filename) for filename in filenames]
+        files2 = [make_nzf(filename) for filename in reversed(filenames)]
+
+        files1.sort()
+        files2.sort()
+
+        assert [f.filename for f in files1] == [f.filename for f in files2]


### PR DESCRIPTION
This has been bugging me for a while, I couldn't understand why sorting of files was inconsistent, most of the times it was correct but some nzbs would be in odd orders.

Basically the sort function is not deterministic, that is the order it outputs depends on the order of the input.

You can compare the current method by switching the test to:

```py
files1.sort(key=functools.cmp_to_key(nzf_cmp_name))
files2.sort(key=functools.cmp_to_key(nzf_cmp_name))
```

What this is showing is depending on the original order, the result after sorting is different.

```
E         Full diff:
E           [
E         +     'a.s01e03.par2',
E         +     'a.s01e02.par2',
E               'a.s01e01.par2',
E         -     'a.s01e02.par2',
E         -     'a.s01e03.par2',
E               'a.s01e01.rar',
E               'a.s01e02.r00',
E               'a.s01e02.rar',
E               'a.s01e03.r00',
E               'a.s01e03.r01',
E               'a.s01e03.rar',
E               'a.s01e01.sample.mkv',
E               'a.s01e01.sfv',
E               'a.s01e02.sample.mkv',
E               'a.s01e03.sample.mkv',
E               'a.s01e01.vol000-001.par2',
E               'a.s01e01.vol001-003.par2',
E               'a.s01e02.vol000-001.par2',
E               'a.s01e02.vol000-001.par2',
E           ]
```

Now it actually always sorts it as the following, which I think was the intention.
I resisted the temptation of trying to improve it to group by the base name, maybe some other time.

```
a.s01e01.par2
a.s01e02.par2
a.s01e03.par2
a.s01e01.rar
a.s01e02.rar
a.s01e02.r00
a.s01e03.rar
a.s01e03.r00
a.s01e03.r01
a.s01e01.sample.mkv
a.s01e01.sfv
a.s01e02.sample.mkv
a.s01e03.sample.mkv
a.s01e01.vol000-001.par2
a.s01e01.vol001-003.par2
a.s01e02.vol000-001.par2
a.s01e02.vol000-001.par2
```