### PR TITLE
Revert pipelining stat/head check

### DIFF
--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -236,15 +236,9 @@ class NewsWrapper:
 
             elif response.status_code == 500:
                 if article.nzf.nzo.precheck:
-                    # Did we try "STAT" already?
-                    if not server.have_stat:
-                        # Hopless server, just discard
-                        logging.info("Server %s does not support STAT or HEAD, precheck not possible", server.host)
-                        article_done = True
-                    else:
-                        # Assume "STAT" command is not supported
-                        server.have_stat = False
-                        logging.debug("Server %s does not support STAT, trying HEAD", server.host)
+                    # Assume "STAT" command is not supported
+                    server.have_stat = False
+                    logging.debug("Server %s does not support STAT", server.host)
                 else:
                     # Assume "BODY" command is not supported
                     server.have_body = False


### PR DESCRIPTION
This is a minor revert to the 4.5.5 behaviour because what I was trying to achieve is not possible when requests may be pipelined, and frankly it's not going to happen anyway (server not supporting stat or head).

If we pipeline 3 requests (stat <1>, stat <2>, stat <3>), the first gets 500 (stat not supported) so we set have_stat = False
The problem is those other requests are still on there way so we can't just assume all further precheck responses were HEAD requests.

So I've just reverted it to the 4.5.5 behaviour of any precheck 500 response assume it was a stat request.

https://github.com/sabnzbd/sabnzbd/blob/11ba9ae12ade8c8f2abb42d44ea35efdd361fae5/sabnzbd/downloader.py#L769-L777
