### PR TITLE
Add database indexes

### DIFF
--- a/sabnzbd/database.py
+++ b/sabnzbd/database.py
@@ -413,13 +413,13 @@ class HistoryDB:
             SELECT EXISTS(
                 SELECT 1
                 FROM history
-                WHERE md5sum = ? AND status != ?
-            
-                UNION ALL
-            
+                WHERE md5sum = ?
+                  AND status != ?
+            ) OR EXISTS(
                 SELECT 1
                 FROM history
-                WHERE name = ? COLLATE NOCASE AND status != ?
+                WHERE name = ? COLLATE NOCASE
+                  AND status != ?
             ) as found
             """,
             (md5sum, Status.FAILED, name, Status.FAILED),

--- a/sabnzbd/database.py
+++ b/sabnzbd/database.py
@@ -395,16 +395,11 @@ class HistoryDB:
             SELECT EXISTS(
                 SELECT 1
                 FROM history
-                WHERE md5sum = ?
-                  AND status != ?
-            ) OR EXISTS(
-                SELECT 1
-                FROM history
-                WHERE name = ? COLLATE NOCASE
+                WHERE (name = ? COLLATE NOCASE OR md5sum = ?)
                   AND status != ?
             ) as found
             """,
-            (md5sum, Status.FAILED, name, Status.FAILED),
+            (name, md5sum, Status.FAILED),
         ):
             return bool(self.cursor.fetchone()["found"])
         return False

--- a/sabnzbd/database.py
+++ b/sabnzbd/database.py
@@ -119,7 +119,6 @@ class HistoryDB:
                     self.execute("PRAGMA user_version = 6;")
                     and self.execute("CREATE UNIQUE INDEX idx_history_nzo_id ON history(nzo_id);")
                     and self.execute("CREATE INDEX idx_history_archive_completed ON history(archive, completed DESC);")
-                    and self.execute("CREATE INDEX idx_history_completed_bytes ON history(completed, bytes);")
                     and self.execute(
                         "CREATE INDEX idx_history_duplicate_key_active ON history(duplicate_key) WHERE status != 'Failed';"
                     )
@@ -214,7 +213,6 @@ class HistoryDB:
         self.execute("CREATE UNIQUE INDEX idx_history_nzo_id ON history(nzo_id);")
         # Completed
         self.execute("CREATE INDEX idx_history_archive_completed ON history(archive, completed DESC);")
-        self.execute("CREATE INDEX idx_history_completed_bytes ON history(completed, bytes);")
         # Duplicates
         self.execute(
             "CREATE INDEX idx_history_duplicate_key_active ON history(duplicate_key) WHERE status != 'Failed';"

--- a/sabnzbd/database.py
+++ b/sabnzbd/database.py
@@ -114,6 +114,22 @@ class HistoryDB:
                 _ = self.execute("PRAGMA user_version = 5;") and self.execute(
                     "ALTER TABLE history ADD COLUMN time_added INTEGER;"
                 )
+            if version < 6:
+                _ = (
+                    self.execute("PRAGMA user_version = 6;")
+                    and self.execute("CREATE UNIQUE INDEX idx_history_nzo_id ON history(nzo_id);")
+                    and self.execute("CREATE INDEX idx_history_archive_completed ON history(archive, completed DESC);")
+                    and self.execute("CREATE INDEX idx_history_completed_bytes ON history(completed, bytes);")
+                    and self.execute(
+                        "CREATE INDEX idx_history_duplicate_key_active ON history(duplicate_key) WHERE status != 'Failed';"
+                    )
+                    and self.execute(
+                        "CREATE INDEX idx_history_name_nocase_active ON history(name COLLATE NOCASE) WHERE status != 'Failed';"
+                    )
+                    and self.execute(
+                        "CREATE INDEX idx_history_md5sum_active ON history(md5sum) WHERE status != 'Failed';"
+                    )
+                )
 
             HistoryDB.startup_done = True
 
@@ -194,7 +210,19 @@ class HistoryDB:
             "time_added" INTEGER
         )
         """)
-        self.execute("PRAGMA user_version = 5;")
+        self.execute("PRAGMA user_version = 6;")
+        self.execute("CREATE UNIQUE INDEX idx_history_nzo_id ON history(nzo_id);")
+        # Completed
+        self.execute("CREATE INDEX idx_history_archive_completed ON history(archive, completed DESC);")
+        self.execute("CREATE INDEX idx_history_completed_bytes ON history(completed, bytes);")
+        # Duplicates
+        self.execute(
+            "CREATE INDEX idx_history_duplicate_key_active ON history(duplicate_key) WHERE status != 'Failed';"
+        )
+        self.execute(
+            "CREATE INDEX idx_history_name_nocase_active ON history(name COLLATE NOCASE) WHERE status != 'Failed';"
+        )
+        self.execute("CREATE INDEX idx_history_md5sum_active ON history(md5sum) WHERE status != 'Failed';")
 
     def close(self):
         """Close database connection"""
@@ -367,33 +395,39 @@ class HistoryDB:
 
     def have_duplicate_key(self, duplicate_key: str) -> bool:
         """Check whether History contains this duplicate key"""
-        total = 0
         if self.execute(
             """
-            SELECT COUNT(*) 
-            FROM History 
-            WHERE 
-                duplicate_key = ? AND 
-                STATUS != ?""",
+            SELECT EXISTS(
+                SELECT 1
+                FROM history
+                WHERE duplicate_key = ? AND status != ?
+            ) as found
+            """,
             (duplicate_key, Status.FAILED),
         ):
-            total = self.cursor.fetchone()["COUNT(*)"]
-        return total > 0
+            return bool(self.cursor.fetchone()["found"])
+        return False
 
     def have_name_or_md5sum(self, name: str, md5sum: str) -> bool:
         """Check whether this name or md5sum is already in History"""
-        total = 0
         if self.execute(
             """
-            SELECT COUNT(*) 
-            FROM History 
-            WHERE 
-                ( LOWER(name) = LOWER(?) OR md5sum = ? ) AND 
-                STATUS != ?""",
-            (name, md5sum, Status.FAILED),
+            SELECT EXISTS(
+                SELECT 1
+                FROM history
+                WHERE md5sum = ? AND status != ?
+            
+                UNION ALL
+            
+                SELECT 1
+                FROM history
+                WHERE name = ? COLLATE NOCASE AND status != ?
+            ) as found
+            """,
+            (md5sum, Status.FAILED, name, Status.FAILED),
         ):
-            total = self.cursor.fetchone()["COUNT(*)"]
-        return total > 0
+            return bool(self.cursor.fetchone()["found"])
+        return False
 
     def get_history_size(self) -> tuple[int, int, int]:
         """Returns the total size of the history and

--- a/sabnzbd/database.py
+++ b/sabnzbd/database.py
@@ -119,15 +119,6 @@ class HistoryDB:
                     self.execute("PRAGMA user_version = 6;")
                     and self.execute("CREATE UNIQUE INDEX idx_history_nzo_id ON history(nzo_id);")
                     and self.execute("CREATE INDEX idx_history_archive_completed ON history(archive, completed DESC);")
-                    and self.execute(
-                        "CREATE INDEX idx_history_duplicate_key_active ON history(duplicate_key) WHERE status != 'Failed';"
-                    )
-                    and self.execute(
-                        "CREATE INDEX idx_history_name_nocase_active ON history(name COLLATE NOCASE) WHERE status != 'Failed';"
-                    )
-                    and self.execute(
-                        "CREATE INDEX idx_history_md5sum_active ON history(md5sum) WHERE status != 'Failed';"
-                    )
                 )
 
             HistoryDB.startup_done = True
@@ -211,16 +202,7 @@ class HistoryDB:
         """)
         self.execute("PRAGMA user_version = 6;")
         self.execute("CREATE UNIQUE INDEX idx_history_nzo_id ON history(nzo_id);")
-        # Completed
         self.execute("CREATE INDEX idx_history_archive_completed ON history(archive, completed DESC);")
-        # Duplicates
-        self.execute(
-            "CREATE INDEX idx_history_duplicate_key_active ON history(duplicate_key) WHERE status != 'Failed';"
-        )
-        self.execute(
-            "CREATE INDEX idx_history_name_nocase_active ON history(name COLLATE NOCASE) WHERE status != 'Failed';"
-        )
-        self.execute("CREATE INDEX idx_history_md5sum_active ON history(md5sum) WHERE status != 'Failed';")
 
     def close(self):
         """Close database connection"""


### PR DESCRIPTION
Currently the majority if not all of the history database queries require full scans of the database, adding a few indexes gives the database much less work to do for queries.

There are other queries that could benefit from indexes, but they are rarely used so I just focused on those updating by nzo_id, paginating history, and checking for duplicates.

This is probably the most important, the main fetch_history with no filters does something like

> EXPLAIN QUERY PLAN SELECT * FROM history WHERE archive is null ORDER BY completed desc LIMIT 10

SCAN history
USE TEMP B-TREE FOR ORDER BY

Without any indexes this involves creating temporary structures, scanning and copying ALL records where archive is null, then sorting by completed (the b-tree handles it) and returning the first 10, or skipping and returning 10.

SEARCH history USING INDEX idx_history_archive_completed (archive=?)

With indexes this doesn't use temporary structures, they are already sorted and filtered and it just needs to take records until it has 10.

SABs itself has some optimisations to avoid full api calls if nothing has changed, other API consumers do not.

> EXPLAIN QUERY PLAN SELECT EXISTS(
                SELECT 1
                FROM history
                WHERE duplicate_key = ? AND status != "Failed"
            ) as found

SCAN CONSTANT ROW
SCALAR SUBQUERY 1
SEARCH history USING INDEX idx_history_duplicate_key_active (duplicate_key=?)

> EXPLAIN QUERY PLAN SELECT EXISTS(
                SELECT 1
                FROM history
                WHERE md5sum = ? AND status != "Failed"            
                UNION ALL
                SELECT 1
                FROM history
                WHERE name = ? COLLATE NOCASE AND status != "Failed"
            ) as found

SCAN CONSTANT ROW
SCALAR SUBQUERY 2
COMPOUND QUERY
LEFT-MOST SUBQUERY
SEARCH history USING INDEX idx_history_md5sum_active (md5sum=?)
UNION ALL
SEARCH history USING INDEX idx_history_name_nocase_active (name=?)

SQLite does not like OR queries, it would have to pick one of the indexes for the query. By splitting this up both subqueries hit the indexes.
There is also a NOCASE index for the name matching, avoids the on demand LOWER(name) which would require table scans.

> EXPLAIN QUERY PLAN SELECT sum(bytes) FROM history WHERE completed > ?

SEARCH history USING COVERING INDEX idx_history_completed_bytes (completed>?)

The index contains all the data required for sum(bytes) queries, no need to lookup the record in the main table.
