### PR TITLE
Fix assembler waiting for failed articles

### DIFF
--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -731,6 +731,9 @@ class NzbQueue:
         articles_left, file_done, post_done = nzo.remove_article(article, success)
 
         if not nzo.precheck:
+            # Mark as on_disk so assembler knows it can skip this article
+            if not success:
+                article.on_disk = True
             # The type is only set if sabctools could decode the article
             if nzf.type:
                 sabnzbd.Assembler.process(nzo, nzf, file_done, article=article)


### PR DESCRIPTION
Cache usage grows to store the whole file and does not write until file_done because failed articles are not marked decoded or on_disk so the assembler cannot progress until file_done.

Primarily happens here:

https://github.com/sabnzbd/sabnzbd/blob/d215d4b0d7bb35b6fce90a0a96966a37a6f6a1fc/sabnzbd/downloader.py#L564-L569

But also from `reset_nw(..., retry_article=False)` which is for too many tries on a server, consider it missing.
However search_new_server could fail if out of servers to try.

Not checked substantially but I suspect it's also a problem in 4.5.5

For article retries in the future, could look for `not decoded and on_disk`