### PR TITLE
Fix deadlock in hard_reset/remove_socket

### DIFF
--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -438,6 +438,7 @@ class NewsWrapper:
             logging.info("Traceback: ", exc_info=True)
             sabnzbd.Downloader.reset_nw(self, "Server broke off connection", warn=True)
 
+    @synchronized(DOWNLOADER_LOCK)
     def hard_reset(self, wait: bool = True):
         """Destroy and restart"""
         with self.lock:


### PR DESCRIPTION
reset_nw acquires DOWNLOADER_LOCK first, then calls hard_reset which acquires nw.lock
hard_reset could be called directly mainly downloader.stop() or server.stop() and acquire nw.lock first, then need DOWNLOADER_LOCK for remove_socket and close

T1 has DOWNLOADER_LOCK wants nw.lock
T2 has nw.lock wants DOWNLOADER_LOCK
