### PR TITLE
Fix nzb deadlocks

### DIFF
--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -474,12 +474,7 @@ class Assembler(Thread):
                 if not direct_write:
                     cfg.direct_write.set(False)
                     return False
-                with nzf.lock:
-                    # Is this the next article to keep writing sequentially
-                    idx = nzf.assembler_next_index
-                    if idx >= len(nzf.decodetable) or article != nzf.decodetable[idx]:
-                        idx = None
-                Assembler.write(fd, idx, nzf, article, data)
+                Assembler.write(fd, None, nzf, article, data)
             except FileNotFoundError:
                 # nzo has probably been deleted, ArticleCache tries the fallback and handles it
                 return False
@@ -540,13 +535,17 @@ class Assembler(Thread):
         nzf.update_crc32(article.crc32, len(data))
         article.on_disk = True
         sabnzbd.Assembler.update_ready_bytes(nzf, -len(data))
-        if nzf_index is not None:
-            with nzf.lock:
-                # assembler_next_index is the lowest index that has not yet been written sequentially from the start of the file.
-                # If this was the next required index to remain sequential, it can be incremented which allows the assmebler to
-                # resume without rechecking articles that are already known to be on disk.
-                if nzf.assembler_next_index == nzf_index:
-                    nzf.assembler_next_index += 1
+        with nzf.lock:
+            # assembler_next_index is the lowest index that has not yet been written sequentially from the start of the file.
+            # If this was the next required index to remain sequential, it can be incremented which allows the assembler to
+            # resume without rechecking articles that are already known to be on disk.
+            # If nzf_index is None, determine it now.
+            if nzf_index is None:
+                idx = nzf.assembler_next_index
+                if idx < len(nzf.decodetable) and article == nzf.decodetable[idx]:
+                    nzf_index = idx
+            if nzf_index is not None and nzf.assembler_next_index == nzf_index:
+                nzf.assembler_next_index += 1
         return written
 
     @staticmethod

--- a/sabnzbd/nzb/article.py
+++ b/sabnzbd/nzb/article.py
@@ -138,13 +138,12 @@ class Article(TryList):
         """Let article get new fetcher and reset try lists of file and job.
         Locked so all resets are performed at once.
         Must acquire nzo lock first, then nzf lock (which is self.lock) to prevent deadlock."""
-        with self.nzf.nzo.lock:
-            with self.lock:
-                if remove_fetcher_from_try_list:
-                    self.remove_from_try_list(self.fetcher)
-                self.fetcher = None
-                self.tries = 0
-                self.nzf.reset_try_list()
+        with self.nzf.nzo.lock, self.lock:
+            if remove_fetcher_from_try_list:
+                self.remove_from_try_list(self.fetcher)
+            self.fetcher = None
+            self.tries = 0
+            self.nzf.reset_try_list()
             self.nzf.nzo.reset_try_list()
 
     def get_article(self, server: Server, servers: list[Server]):

--- a/sabnzbd/nzb/article.py
+++ b/sabnzbd/nzb/article.py
@@ -134,16 +134,18 @@ class Article(TryList):
         self.fetcher_priority = 0
         super().reset_try_list()
 
-    @synchronized()
     def allow_new_fetcher(self, remove_fetcher_from_try_list: bool = True):
         """Let article get new fetcher and reset try lists of file and job.
-        Locked so all resets are performed at once"""
-        if remove_fetcher_from_try_list:
-            self.remove_from_try_list(self.fetcher)
-        self.fetcher = None
-        self.tries = 0
-        self.nzf.reset_try_list()
-        self.nzf.nzo.reset_try_list()
+        Locked so all resets are performed at once.
+        Must acquire nzo lock first, then nzf lock (which is self.lock) to prevent deadlock."""
+        with self.nzf.nzo.lock:
+            with self.lock:
+                if remove_fetcher_from_try_list:
+                    self.remove_from_try_list(self.fetcher)
+                self.fetcher = None
+                self.tries = 0
+                self.nzf.reset_try_list()
+            self.nzf.nzo.reset_try_list()
 
     def get_article(self, server: Server, servers: list[Server]):
         """Return article when appropriate for specified server"""

--- a/sabnzbd/nzb/file.py
+++ b/sabnzbd/nzb/file.py
@@ -247,26 +247,25 @@ class NzbFile(TryList):
 
         Note: there could be non-sequential direct writes already beyond this point
         """
-        with self.file_lock:
-            # If last written article has valid yenc headers
-            if self.assembler_next_index:
-                article = self.decodetable[self.assembler_next_index - 1]
-                if article.on_disk and article.data_size:
-                    return article.data_begin + article.data_size
+        # If last written article has valid yenc headers
+        if self.assembler_next_index:
+            article = self.decodetable[self.assembler_next_index - 1]
+            if article.on_disk and article.data_size:
+                return article.data_begin + article.data_size
 
-            # Fallback to summing decoded size
-            offset = 0
-            for article in self.decodetable[: self.assembler_next_index]:
-                if not article.on_disk:
-                    break
-                if article.data_size:
-                    offset = article.data_begin + article.decoded_size
-                elif article.decoded_size is not None:
-                    # queues from <= 4.5.5 do not have this attribute
-                    offset += article.decoded_size
-                elif os.path.exists(self.filepath):
-                    # fallback for <= 4.5.5 because files were always opened in append mode, so use the file size
-                    return os.path.getsize(self.filepath)
+        # Fallback to summing decoded size
+        offset = 0
+        for article in self.decodetable[: self.assembler_next_index]:
+            if not article.on_disk:
+                break
+            if article.data_size:
+                offset = article.data_begin + article.decoded_size
+            elif article.decoded_size is not None:
+                # queues from <= 4.5.5 do not have this attribute
+                offset += article.decoded_size
+            elif os.path.exists(self.filepath):
+                # fallback for <= 4.5.5 because files were always opened in append mode, so use the file size
+                return os.path.getsize(self.filepath)
         return offset
 
     @synchronized()


### PR DESCRIPTION
Fixes several lock ordering issues, and simplifies some to avoid any deadlock risk.

The order locks are acquired must always be NzbObject > NzbFile
This means `@synchronized()` cannot always be used.

**allow_new_fetcher** nzf.lock => nzo.lock
**remove_article** nzo.lock => nzf.lock

This is the one most likely to occur, missing articles on multiple receive threads.

**contiguous_offset** nzf.lock => file_lock
**Assember.open** file_lock => nzf.lock (contiguous_offset)
**Assember.assemble_article** file_lock => nzf.lock

A few other similar ordering problems.
