### PR TITLE
Only wake servers while requests are available

### DIFF
--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -657,6 +657,9 @@ class Downloader(Thread):
                             break
 
                         if nw.connected:
+                            # Assign a request immediately if NewsWrapper is ready, if we wait until the socket is
+                            # selected all idle connections will be activated when there may only be one request
+                            nw.prepare_request()
                             self.add_socket(nw)
                         elif not nw.nntp:
                             try:


### PR DESCRIPTION
I removed this in the connected/ready changes because I wanted to check it wasn’t a cause of problems.

I think connections will only go idle after completing auth, but I’m not 100% so I didn’t make it conditional.

It prevents waking up all connections when there are few requests for them, resulting in most immediately going idle again.