### PR TITLE
Fix server retention not always applied

### DIFF
--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -191,6 +191,9 @@ class Server:
                 if self.retention and article.nzf.nzo.avg_stamp < time.time() - self.retention:
                     if not peek:
                         sabnzbd.Downloader.decode(article)
+                    # sabnzbd.NzbQueue.get_articles stops after each nzo with articles.
+                    # As a result, if one article is out of retention, all remaining
+                    # entries in article_queue will also be out of retention.
                     while self.article_queue:
                         sabnzbd.Downloader.decode(self.article_queue.pop())
                 else:

--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -188,8 +188,9 @@ class Server:
             if self.article_queue:
                 article = self.article_queue[0] if peek else self.article_queue.popleft()
                 # Mark expired articles as tried on this server
-                if not peek and self.retention and article.nzf.nzo.avg_stamp < time.time() - self.retention:
-                    sabnzbd.Downloader.decode(article)
+                if self.retention and article.nzf.nzo.avg_stamp < time.time() - self.retention:
+                    if not peek:
+                        sabnzbd.Downloader.decode(article)
                     while self.article_queue:
                         sabnzbd.Downloader.decode(self.article_queue.pop())
                 else:


### PR DESCRIPTION
Fixes #3302

The peek option sees if there is a request available without consuming it from `article_queue` but peek was not applying the retention preference which will result subsequent calls taking articles from the prefetch bypassing the retention check entirely and potentially going to an ineligible server.