### PR TITLE
Ignore all OSError from FakeNNTPServer

### DIFF
--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -57,8 +57,8 @@ class FakeNNTPServer:
                 conn, addr = self.server_socket.accept()
                 self.connections.append(conn)
                 threading.Thread(target=self._handle_client, args=(conn,), daemon=True).start()
-            except socket.timeout:
-                continue
+            except OSError:
+                pass
 
     def _handle_client(self, conn):
         try:


### PR DESCRIPTION
Notices logs like these, not an issue just the test server being shutdown.

```
  Traceback (most recent call last):
    File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
      self.run()
    File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/threading.py", line 982, in run
      self._target(*self._args, **self._kwargs)
    File "/home/runner/work/sabnzbd/sabnzbd/tests/test_downloader.py", line 57, in _accept_loop
      conn, addr = self.server_socket.accept()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/opt/hostedtoolcache/Python/3.11.14/x64/lib/python3.11/socket.py", line 294, in accept
      fd, addr = self._accept()
                 ^^^^^^^^^^^^^^
  OSError: [Errno 9] Bad file descriptor
```
