### PR TITLE
Only increment assembler next index if expected

### DIFF
--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -400,7 +400,8 @@ class Assembler(Thread):
                         offset += article.decoded_size
                     if not skipped:
                         with nzf.lock:
-                            nzf.assembler_next_index = idx + 1
+                            if nzf.assembler_next_index == idx:
+                                nzf.assembler_next_index = idx + 1
                     continue
 
                 # stop if next piece not yet decoded


### PR DESCRIPTION
Applies the same logic as Assember.write.

I don't believe it caused any problem, it's just if assemble occurs at the same time as assemble_article (cache full) it might cause articles to be processed more than once.