### PR TITLE
Revert allow_new_fetcher for stuck jobs

### DIFF
--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -912,8 +912,6 @@ class NzbQueue:
                                 next_article.fetcher is not None,
                                 next_article.tries,
                             )
-                            if not next_article.decoded and not next_article.on_disk:
-                                next_article.allow_new_fetcher()
                         logging.info("Resetting bad trylist for file %s in job %s", nzf.filename, nzo.final_name)
                         nzf.reset_try_list()
 


### PR DESCRIPTION
Revert part of #3308 it causes too many issues because it triggers when it's not stuck.
Too much of a pain to check all the uses of fetcher.

Requests that are stuck should timeout by server.timeout and reset, so I'll focus on that aspect instead.

I may fix the trylist stuff first then reevaluate, I was going to save it for the release after next.
Alternatively maybe log nw activity, especially if idle but have a pending response as that might help narrow down where it has gone wrong.