### PR TITLE
Make conditional_cache exception safe

### DIFF
--- a/sabnzbd/decorators.py
+++ b/sabnzbd/decorators.py
@@ -86,6 +86,9 @@ def conditional_cache(cache_time: int):
         def wrapper(*args, **kwargs):
             current_time = time.time()
 
+            # Exclude force from the cache key
+            force = kwargs.pop("force", False)
+
             # Create cache key using functools._make_key
             try:
                 key = functools._make_key(args, kwargs, typed=False)
@@ -95,15 +98,16 @@ def conditional_cache(cache_time: int):
                 # If args/kwargs aren't hashable, skip caching entirely
                 return func(*args, **kwargs)
 
-            # Allow force kward to skip cache
-            if not kwargs.get("force"):
+            # Allow force kwarg to skip cache
+            if not force:
                 # Check if we have a valid cached result
-                if key in cache:
-                    cached_result, timestamp = cache[key]
-                    if current_time - timestamp < cache_time:
+                entry = cache.get(key)
+                if entry is not None:
+                    cached_result, expires_at = entry
+                    if current_time < expires_at:
                         return cached_result
                     # Cache entry expired, remove it
-                    del cache[key]
+                    cache.pop(key, None)
 
             # Call the original function
             result = func(*args, **kwargs)
@@ -111,7 +115,7 @@ def conditional_cache(cache_time: int):
             # Only cache non-empty results
             # This excludes None, [], {}, "", 0, False, etc.
             if result:
-                cache[key] = (result, current_time)
+                cache[key] = (result, current_time + cache_time)
 
             return result
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -315,3 +315,33 @@ class TestConditionalCache:
         assert all(result == "result_test" for result in results)
         # call_count should be small (ideally 1, but could be more due to race conditions)
         assert call_count <= 5
+
+    def test_conditional_cache_force(self):
+        """Test that conditional_cache forces entries after specified time"""
+        call_count = 0
+
+        @conditional_cache(cache_time=5)
+        def test_func(value):
+            nonlocal call_count
+            call_count += 1
+            return f"result_{value}"
+
+        # First call
+        result1 = test_func("test")
+        assert result1 == "result_test"
+        assert call_count == 1
+
+        # Second call immediately - should use cache
+        result2 = test_func("test")
+        assert result2 == "result_test"
+        assert call_count == 1
+
+        # Third call - force so should execute function again
+        result3 = test_func("test", force=True)
+        assert result3 == "result_test"
+        assert call_count == 2
+
+        # Fourth call - should use cache
+        result4 = test_func("test")
+        assert result4 == "result_test"
+        assert call_count == 2


### PR DESCRIPTION
Fixes #3311

This is still not thread-safe, that is two threads could both calculate and store a value in the cache.
But it's not necessary that it is, simply adjusting it so during a race it doesn't raise exceptions is good enough.

Also exclude force from the key and removes a TTL addition on each lookup

```py
# Excluding force from the key resolves this issue

diskspace()
# WRITE SOMETHING
a = diskspace(force=True)
b = diskspace()
assert a == b
```