### PR TITLE
Increase test file size for sparse support detection

### DIFF
--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -54,6 +54,7 @@ from sabnzbd.constants import (
     IGNORED_FILES_AND_FOLDERS,
     DEF_LOG_FILE,
     DEX_FILE_EXTENSION_MAX,
+    MEBI,
 )
 from sabnzbd.encoding import correct_unknown_encoding, utob, limit_encoded_length
 import rarfile
@@ -1429,7 +1430,7 @@ def is_sparse_supported(check_dir: str) -> bool:
     """Check if a directory supports sparse files"""
     sparse_file = tempfile.NamedTemporaryFile(dir=check_dir, delete=False)
     try:
-        sabctools.sparse(sparse_file.fileno(), 64)
+        sabctools.sparse(sparse_file.fileno(), int(MEBI))
         sparse_file.close()
         return is_sparse(sparse_file.name)
     finally:

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -1427,7 +1427,14 @@ def is_sparse(path: str) -> bool:
 
 
 def is_sparse_supported(check_dir: str) -> bool:
-    """Check if a directory supports sparse files"""
+    """
+    Check if a directory supports sparse files.
+
+    A 1 MiB sparse file is created because some filesystems allocate at
+    least one physical block even for sparse files. Using a size that spans
+    many 512-byte blocks ensures we can reliably detect whether fewer
+    blocks than the logical size were actually allocated.
+    """
     sparse_file = tempfile.NamedTemporaryFile(dir=check_dir, delete=False)
     try:
         sabctools.sparse(sparse_file.fileno(), int(MEBI))


### PR DESCRIPTION
Some filesystems can allocate zero blocks, others allocate 1 or few.

One of the checks is doing `st_blocks * 512 < st_size` which will fail if 1 or more blocks have actually been allocated, fix is to create a file larger than a few 512 byte blocks.

Had a report of a user seeing this behaviour on ZFS, 1 block was allocated and 1*512 is greater than 64 bytes.