### PR TITLE
Fix articles may be added to the cache for finished jobs

### DIFF
--- a/sabnzbd/articlecache.py
+++ b/sabnzbd/articlecache.py
@@ -153,12 +153,12 @@ class ArticleCache(threading.Thread):
     def save_article(self, article: Article, data: bytearray):
         """Save article in cache, either memory or disk"""
         nzo = article.nzf.nzo
-        # Skip if already post-processing or fully finished
-        if nzo.pp_or_finished:
-            return
 
         # Register article for bookkeeping in case the job is deleted
         with nzo.lock:
+            # Skip if already post-processing or fully finished, check inside lock to synchronize with purge_data
+            if nzo.pp_or_finished:
+                return
             nzo.saved_articles.add(article)
 
         if article.lowest_partnum and not (article.nzf.import_finished or article.nzf.filename_checked):


### PR DESCRIPTION
Sort of related to #3261 however because of #3264 `purge_articles` is called while holding `nzo.lock` so save/load_article can't modify `nzo.saved_articles` anymore.

But there is still a toctou race condition which could result in an article being added to the cache while it is being purged, leaving orphan articles in the cache.