### PR TITLE
Allow direct write usage without the cache

### DIFF
--- a/sabnzbd/articlecache.py
+++ b/sabnzbd/articlecache.py
@@ -63,7 +63,7 @@ class ArticleCache(threading.Thread):
             self.__cache_upper_limit = 4 * GIGI
 
     def change_direct_write(self, direct_write: bool) -> None:
-        self.__direct_write = direct_write and self.__cache_limit > 1
+        self.__direct_write = direct_write
 
     def stop(self):
         self.shutdown = True
@@ -128,7 +128,6 @@ class ArticleCache(threading.Thread):
         self.__non_contiguous_trigger = self.__cache_limit * ARTICLE_CACHE_NON_CONTIGUOUS_FLUSH_PERCENTAGE
         if self.__cache_limit:
             logging.debug("Article cache trigger:%s", to_units(self.__non_contiguous_trigger))
-        self.change_direct_write(cfg.direct_write())
 
     @synchronized(ARTICLE_COUNTER_LOCK)
     def reserve_space(self, data_size: int) -> bool:
@@ -227,7 +226,7 @@ class ArticleCache(threading.Thread):
         # Save data, but don't complain when destination folder is missing
         # because this flush may come after completion of the NZO.
         # Direct write to destination if cache is being used
-        if self.__cache_limit and self.__direct_write and sabnzbd.Assembler.assemble_article(article, data):
+        if self.__direct_write and sabnzbd.Assembler.assemble_article(article, data):
             with article.nzf.nzo.lock:
                 article.nzf.nzo.saved_articles.discard(article)
             return

--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -88,7 +88,6 @@ class Assembler(Thread):
         """Called when cache limit changes"""
         self.cache_limit = limit
         self.assembler_trigger = max(1, int(self.cache_limit * ASSEMBLER_TRIGGER_PERCENTAGE))
-        self.calculate_delay_trigger()
         self.change_direct_write(cfg.direct_write())
         logging.debug(
             "Assembler trigger=%s, delay=%s",
@@ -97,7 +96,7 @@ class Assembler(Thread):
         )
 
     def change_direct_write(self, direct_write: bool) -> None:
-        self.direct_write = direct_write and self.assembler_trigger > 0
+        self.direct_write = direct_write
         self.calculate_delay_trigger()
 
     def calculate_delay_trigger(self):


### PR DESCRIPTION
I was not intending implementing this for 5.0.0 because I thought it would need to keep files open which would make it overly complicated. However, it appears to work perfectly fine opening the file for each article - which is what it would be doing previously to write temporary files anyway.

This is not usually a recommended setup because it had a temporary file penalty (write, read, write) and constant IO activity. However, when using SSD storage, it seems to work well[^1] almost indistinguishable from using the cache (even at 2GB/s+)

I will need to update the wiki a little bit (cache not required, but not recommended for HDD users) - will do so in a day or two.

[^1]: Windows suffers a little (no pwrite) but still managed 700+MB/s on my system. Opening and closing files so much may trigger antivirus but that is no different to when using temporary files.