### PR TITLE
Fix queuing requests on reset connections

### DIFF
--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -262,7 +262,11 @@ class NewsWrapper:
 
                 # Ditch this thread, we don't know what data we got now so the buffer can be bad
                 sabnzbd.Downloader.reset_nw(
-                    self, f"Server error or unknown status code: {response.status_code}", wait=False, article=article
+                    self,
+                    f"Server error or unknown status code: {response.status_code}",
+                    wait=False,
+                    article=article,
+                    retry_article=response.status_code != 0,  # could be 0 if response violates nntp protocol see #3327
                 )
                 return
 
@@ -316,11 +320,15 @@ class NewsWrapper:
                 with self.lock:
                     # Check generation under lock to avoid racing with hard_reset
                     if self.generation != generation or not self._response_queue:
-                        break
+                        return bytes_recv, None
                     article = self._response_queue.popleft()
                 if on_response:
                     on_response(response.status_code, response.message)
                 self.on_response(response, article)
+
+            # on_response may have reset the connection
+            if self.generation != generation:
+                return bytes_recv, None
 
             # After each response this socket may need to be made available to write the next request,
             # or removed from socket monitoring to prevent hot looping.


### PR DESCRIPTION
Fixes #3327 and #3287

`Received unknown status code 0 for article` means the decoder saw a response line but couldn't extract the status code from the first 3 characters which doesn’t match the nntp protocol. The status_code remains 0 and passed back to Python and should be handled as the unknown state and reset.

I did actually see this error from a real server, an nzb failed a few times then a few minutes later worked fine. I'm not sure if I was hitting different server nodes or it had self healed itself. Unfortunately I didn't get a chance to dump the responses.

I've tested with a server which always responds with in invalid response for a specific article.

The problem is this trigger the `allow_new_fetcher` path, resets `article.tries` and retries the same server, which could have the same issue again.
I've changed it to `retry_article=response.status_code != 0` so that it moves on to a different server, it probably shouldn't but I'm not sure what the behaviour should be for required servers.

https://github.com/sabnzbd/sabnzbd/blob/9b1b503ce6f2b70df39d2296aed4b7e296f2f18f/sabnzbd/newswrapper.py#L499-L507

`not self.server.required` is part of the issue, even if it remembered tries if it's a required server it would still retry indefinitely.
`article.allow_new_fetcher()` resets `article.tries`

So, this works but it doesn't seem ideal because if a server has some temporary internal error and is returning invalid responses but is required we shouldn't just move on to lower priority servers but I'm not sure what the behaviour should be?

Perhaps if status is 0 it should increment `server.bad_cons` and trigger `maybe_block_server`? But if there is only one required server it could still be stuck.

---

The read part is the main bug, the most common path is `on_response` may reset the connection, then `prepare_request` sets `next_request` on a NewsWrapper with no nntp instance and the request gets overwritten during the authentication phase.