### PR TITLE
Limit rar passwords to 127 characters

### DIFF
--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -50,6 +50,7 @@ from sabnzbd.constants import (
     ARTICLE_CACHE_NON_CONTIGUOUS_FLUSH_PERCENTAGE,
     ASSEMBLER_WRITE_INTERVAL,
     ASSEMBLER_TRIGGER_PERCENTAGE,
+    RAR_MAX_PASSWORD,
 )
 import sabnzbd.cfg as cfg
 from sabnzbd.nzb import NzbFile, NzbObject, Article
@@ -643,6 +644,8 @@ def check_encrypted_and_unwanted_files(nzo: NzbObject, filepath: str) -> tuple[b
 
                         for password in passwords:
                             if password:
+                                # RAR supports passwords up to 127 characters, can be removed once rarfile>4.2
+                                password = password[:RAR_MAX_PASSWORD]
                                 logging.info('Trying password "%s" on job "%s"', password, nzo.final_name)
                                 try:
                                     zf.setpassword(password)

--- a/sabnzbd/constants.py
+++ b/sabnzbd/constants.py
@@ -24,6 +24,7 @@ QUEUE_VERSION = 10
 POSTPROC_QUEUE_VERSION = 2
 
 REC_RAR_VERSION = 550
+RAR_MAX_PASSWORD = 127  #: Max number of utf-16 chars in passwords.
 
 ANFO = namedtuple("ANFO", "article_sum cache_size cache_limit")
 


### PR DESCRIPTION
Truncates passwords to the maximum RAR files support.

Fixes #3275