### PR TITLE
Ignore missing data and consume OSError

### DIFF
--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -455,11 +455,8 @@ class Assembler(Thread):
                     cfg.direct_write.set(False)
                     return False
                 Assembler.write(fd, None, nzf, article, data)
-            except FileNotFoundError:
-                # nzo has probably been deleted, ArticleCache tries the fallback and handles it
-                return False
-            except IOError:
-                # Probably not enough disk space
+            except OSError:
+                # nzo has probably been deleted or not enough disk space, ArticleCache tries the fallback and handles it
                 return False
             finally:
                 os.close(fd)

--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -408,8 +408,8 @@ class Assembler(Thread):
                         continue
                     break
 
-                # Could be empty in case nzo was deleted or a previous write attempt encountered errno.ENOSPC and data
-                # was removed from the cache but could not be written to disk.
+                # Could be empty in case nzo was deleted or a previous write attempt failed and the data was removed
+                # from the cache but could not be written to disk.
                 data = load_article(article)
                 if not data:
                     logging.info("No data found when trying to write %s", article)

--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -408,17 +408,11 @@ class Assembler(Thread):
                         continue
                     break
 
-                # Could be empty in case nzo was deleted
-                data = load_article(article)
-                if not data:
-                    if file_done:
-                        continue
-                    if allow_non_contiguous:
-                        skipped = True
-                        continue
-                    else:
-                        logging.info("No data found when trying to write %s", article)
-                    break
+                # Could be empty in case nzo was deleted or a previous write attempt encountered errno.ENOSPC and data
+                # was removed from the cache but could not be written to disk.
+                if not (data := load_article(article)):
+                    logging.info("No data found when trying to write %s", article)
+                    continue
 
                 # If required open the file
                 if fd is None:
@@ -462,6 +456,9 @@ class Assembler(Thread):
                 Assembler.write(fd, None, nzf, article, data)
             except FileNotFoundError:
                 # nzo has probably been deleted, ArticleCache tries the fallback and handles it
+                return False
+            except IOError:
+                # Probably not enough disk space
                 return False
             finally:
                 os.close(fd)

--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -410,7 +410,8 @@ class Assembler(Thread):
 
                 # Could be empty in case nzo was deleted or a previous write attempt encountered errno.ENOSPC and data
                 # was removed from the cache but could not be written to disk.
-                if not (data := load_article(article)):
+                data = load_article(article)
+                if not data:
                     logging.info("No data found when trying to write %s", article)
                     continue
 


### PR DESCRIPTION
First is an incorrect logic change from [4.5.5](https://github.com/sabnzbd/sabnzbd/blob/77f7490aeae60cce9de0afb7ecd3f573bae33946/sabnzbd/assembler.py#L181-L195)

`sabnzbd.ArticleCache.load_article` - load and remove data from the cache
The write raises `errno.ENOSPC` which is caught in assemble, but that article data is now lost, `article.on_disk` is not set and will be attempted again on the next assemble for the file.
Hence, the previous `break` behaviour was incorrect, if the data which is expected because of `article.decoded` is not present it will never get any further.
The `file_done` and `allow_non_contiguous` checks are redundant.

A possibly better solution I can implement but different to 4.5.5 would be to catch the IOError and put the data back in the cache, but it would still have to be allowed to silently fail - if the cache is full it'll do `__flush_article_to_disk => assemble_article (fail) => sabnzbd.filesystem.save_data (silent fail)`. Or skip the known failure and go straight to sabnzbd.filesystem.save_data. I think that's likely to introduce bugs or be complicated though, it might work ok for normal priority because it'll pause, but force will soldier on and complete the job without writing everything.

---

The second is if the cache is full `__flush_article_to_disk` will call `assemble_article` which could fail with errno.ENOSPC, so it needs to catch that and report a failure to revert to `sabnzbd.filesystem.save_data` which will fail silently.