### PR TITLE
Fix deadlock from downloader receive thread

### DIFF
--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -745,15 +745,16 @@ class Downloader(Thread):
         """Worker for the daemon thread to process results.
         Wrapped in try/except because in case of an exception, logging
         might get lost and the queue.join() would block forever."""
-        try:
-            logging.debug("Starting Downloader receive thread: %s", current_thread().name)
-            while True:
+        logging.debug("Starting Downloader receive thread: %s", current_thread().name)
+        while True:
+            try:
                 self.process_nw(*nw_queue.get())
+            except Exception:
+                # We cannot break out of the Downloader from here, so just pause
+                logging.error(T("Fatal error in Downloader"), exc_info=True)
+                self.pause()
+            finally:
                 nw_queue.task_done()
-        except Exception:
-            # We cannot break out of the Downloader from here, so just pause
-            logging.error(T("Fatal error in Downloader"), exc_info=True)
-            self.pause()
 
     def process_nw(self, nw: NewsWrapper, event: int, generation: int):
         """Receive data from a NewsWrapper and handle the response"""


### PR DESCRIPTION
In the current implementation if `self.process_nw(*nw_queue.get())` raises an exception the receive thread will exit, leaving `task_done()`skipped and `process_nw_queue.join()` will block forever.

The primary time I’ve seen this happen is when running out of disk space.