### PR TITLE
Abort DirectUnpack on retryable errors

### DIFF
--- a/sabnzbd/directunpacker.py
+++ b/sabnzbd/directunpacker.py
@@ -258,10 +258,11 @@ class DirectUnpacker(threading.Thread):
                     extracted = []
 
                     # Are there more files left?
-                    while not self.nzo.removed_from_queue and not self.next_sets:
+                    with self.next_file_lock:
                         logging.debug("Direct Unpack for %s waiting for more sets", self.nzo.final_name)
-                        with self.next_file_lock:
-                            self.next_file_lock.wait()
+                        self.next_file_lock.wait_for(
+                            lambda: self.nzo.removed_from_queue or self.next_sets or self.killed
+                        )
 
                     # Is there another set to do?
                     logging.debug(
@@ -377,9 +378,8 @@ class DirectUnpacker(threading.Thread):
         """Wait for the correct volume to appear but stop if it was killed
         or the NZB is in post-processing and no new files will be downloaded.
         """
-        while not self.have_next_volume() and not self.killed and not self.nzo.pp_active:
-            with self.next_file_lock:
-                self.next_file_lock.wait()
+        with self.next_file_lock:
+            self.next_file_lock.wait_for(lambda: self.have_next_volume() or self.killed or self.nzo.pp_active)
 
     @synchronized(START_STOP_LOCK)
     def create_unrar_instance(self):

--- a/sabnzbd/directunpacker.py
+++ b/sabnzbd/directunpacker.py
@@ -340,6 +340,10 @@ class DirectUnpacker(threading.Thread):
                         self.duplicate_lines = 0
                     last_volume_linebuf = linebuf
 
+            elif linebuf.endswith(b"[R]etry, [A]bort "):
+                logging.info("Error in DirectUnpack of %s: %s", self.cur_setname, platform_btou(linebuf.strip()))
+                self.abort(b"A")
+
         # Add last line and write any new output
         if linebuf:
             unrar_log.append(platform_btou(linebuf.strip()))
@@ -453,7 +457,7 @@ class DirectUnpacker(threading.Thread):
         logging.info("DirectUnpacked volume %s for %s", self.cur_volume, self.cur_setname)
 
     @synchronized(START_STOP_LOCK)
-    def abort(self):
+    def abort(self, abort_input: bytes = b"Q"):
         """Abort running instance and delete generated files"""
         if not self.killed and self.cur_setname:
             logging.info("Aborting DirectUnpack for %s", self.cur_setname)
@@ -466,7 +470,7 @@ class DirectUnpacker(threading.Thread):
             if self.active_instance:
                 # First we try to abort gracefully
                 try:
-                    self.active_instance.stdin.write(b"Q\n")
+                    self.active_instance.stdin.write(abort_input + b"\n")
                     time.sleep(0.2)
                 except IOError:
                     pass


### PR DESCRIPTION
This handles the `linebuf.endswith(b"[R]etry, [A]bort ")` case, I have only implemented this in the direct unpacker for now since post processing needs more changes - it needs to read lines without `\n` like the direct unpacker. It may be worth a refactor in the future so there is only one class handling unpacking, with a `non-interactive` mode for post-processing.

Some systems will already handle this because they see a `not enough space on the disk`, but that's a system error message rather than from unrar itself so the message will vary by platform and perhaps filesystem. I did see it not handle disk quota errors. For this reason I think it's better to handle errors/messages from unrar itself.

The other changes I included are to fix a couple of race conditions:

```py
while not self.have_next_volume() and not self.killed and not self.nzo.pp_active:
    with self.next_file_lock:
        self.next_file_lock.wait()
```

There is a window were after the while condition is checked, somewhere calls notify before we call wait. Causing a lost wakeup.