### PR TITLE
Perform diskspace check on complete directory for nzo

### DIFF
--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1860,13 +1860,13 @@ def build_header(webdir: str = "", for_template: bool = True, trans_functions: b
     header["pause_int"] = sabnzbd.Scheduler.pause_int()
     header["paused_all"] = sabnzbd.PAUSED_ALL
 
-    diskspace_info = diskspace()
-    header["diskspace1"] = "%.2f" % diskspace_info.download_dir.free
-    header["diskspace2"] = "%.2f" % diskspace_info.complete_dir.free
-    header["diskspace1_norm"] = to_units(diskspace_info.download_dir.free * GIGI)
-    header["diskspace2_norm"] = to_units(diskspace_info.complete_dir.free * GIGI)
-    header["diskspacetotal1"] = "%.2f" % diskspace_info.download_dir.size
-    header["diskspacetotal2"] = "%.2f" % diskspace_info.complete_dir.size
+    download_dir, complete_dir = diskspace()
+    header["diskspace1"] = "%.2f" % download_dir.free
+    header["diskspace2"] = "%.2f" % complete_dir.free
+    header["diskspace1_norm"] = to_units(download_dir.free * GIGI)
+    header["diskspace2_norm"] = to_units(complete_dir.free * GIGI)
+    header["diskspacetotal1"] = "%.2f" % download_dir.size
+    header["diskspacetotal2"] = "%.2f" % complete_dir.size
     header["speedlimit"] = str(sabnzbd.Downloader.bandwidth_perc)
     header["speedlimit_abs"] = str(sabnzbd.Downloader.bandwidth_limit)
 

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1861,12 +1861,12 @@ def build_header(webdir: str = "", for_template: bool = True, trans_functions: b
     header["paused_all"] = sabnzbd.PAUSED_ALL
 
     diskspace_info = diskspace()
-    header["diskspace1"] = "%.2f" % diskspace_info["download_dir"][1]
-    header["diskspace2"] = "%.2f" % diskspace_info["complete_dir"][1]
-    header["diskspace1_norm"] = to_units(diskspace_info["download_dir"][1] * GIGI)
-    header["diskspace2_norm"] = to_units(diskspace_info["complete_dir"][1] * GIGI)
-    header["diskspacetotal1"] = "%.2f" % diskspace_info["download_dir"][0]
-    header["diskspacetotal2"] = "%.2f" % diskspace_info["complete_dir"][0]
+    header["diskspace1"] = "%.2f" % diskspace_info.download_dir.free
+    header["diskspace2"] = "%.2f" % diskspace_info.complete_dir.free
+    header["diskspace1_norm"] = to_units(diskspace_info.download_dir.free * GIGI)
+    header["diskspace2_norm"] = to_units(diskspace_info.complete_dir.free * GIGI)
+    header["diskspacetotal1"] = "%.2f" % diskspace_info.download_dir.size
+    header["diskspacetotal2"] = "%.2f" % diskspace_info.complete_dir.size
     header["speedlimit"] = str(sabnzbd.Downloader.bandwidth_perc)
     header["speedlimit_abs"] = str(sabnzbd.Downloader.bandwidth_limit)
 

--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -26,7 +26,7 @@ import re
 import threading
 from threading import Thread
 import ctypes
-from typing import Optional, NamedTuple, Union, Literal
+from typing import Optional, NamedTuple, Union
 import rarfile
 import time
 
@@ -325,7 +325,7 @@ class Assembler(Thread):
         """Check diskspace requirements.
         If not enough space left, pause downloader and send email"""
         diskspace_info = diskspace(force=True, complete_dir=get_complete_directory(nzo)[0])
-        full_dir: Optional[Literal["download_dir", "complete_dir"]] = None
+        full_dir: Optional[str] = None
         required_space = (cfg.download_free.get_float() + nzf.bytes) / GIGI
         if diskspace_info.download_dir.free < required_space:
             full_dir = "download_dir"
@@ -344,7 +344,10 @@ class Assembler(Thread):
                 required_space = (complete_free + nzo.bytes) / GIGI
 
             if required_space and diskspace_info.complete_dir.free < required_space:
-                full_dir = "complete_dir"
+                if diskspace_info.complete_dir.path == sabnzbd.cfg.complete_dir.get_path():
+                    full_dir = "complete_dir"
+                else:
+                    full_dir = diskspace_info.complete_dir.path
 
         if full_dir:
             logging.warning(T("Too little diskspace forcing PAUSE"))

--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -26,7 +26,7 @@ import re
 import threading
 from threading import Thread
 import ctypes
-from typing import Optional, NamedTuple, Union
+from typing import Optional, NamedTuple, Union, Literal
 import rarfile
 import time
 
@@ -324,26 +324,26 @@ class Assembler(Thread):
     def diskspace_check(nzo: NzbObject, nzf: NzbFile):
         """Check diskspace requirements.
         If not enough space left, pause downloader and send email"""
-        freespace = diskspace(force=True, complete_dir=get_complete_directory(nzo)[0])
-        full_dir = None
+        diskspace_info = diskspace(force=True, complete_dir=get_complete_directory(nzo)[0])
+        full_dir: Optional[Literal["download_dir", "complete_dir"]] = None
         required_space = (cfg.download_free.get_float() + nzf.bytes) / GIGI
-        if freespace["download_dir"][1] < required_space:
+        if diskspace_info.download_dir.free < required_space:
             full_dir = "download_dir"
 
         # Enough space in download_dir, check complete_dir
-        complete_free = cfg.complete_free.get_float()
-        if complete_free > 0 and not full_dir:
+        if not full_dir:
+            complete_free = cfg.complete_free.get_float()
             required_space = 0
             if cfg.direct_unpack():
                 # We unpack while we download, so we should check every time
                 # if the unpack maybe already filled up the drive
-                required_space = complete_free / GIGI
+                required_space = (complete_free + nzf.bytes) / GIGI
             elif nzo.bytes_tried > (nzo.bytes - nzo.bytes_par2) * 0.95:
                 # Since only at 100% unpack is started, continue
                 # downloading until 95% complete before checking
                 required_space = (complete_free + nzo.bytes) / GIGI
 
-            if required_space and freespace["complete_dir"][1] < required_space:
+            if required_space and diskspace_info.complete_dir.free < required_space:
                 full_dir = "complete_dir"
 
         if full_dir:

--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -324,10 +324,10 @@ class Assembler(Thread):
     def diskspace_check(nzo: NzbObject, nzf: NzbFile):
         """Check diskspace requirements.
         If not enough space left, pause downloader and send email"""
-        diskspace_info = diskspace(force=True, complete_dir=get_complete_directory(nzo)[0])
+        download_dir, complete_dir = diskspace(force=True, complete_dir=get_complete_directory(nzo)[0])
         full_dir: Optional[str] = None
         required_space = (cfg.download_free.get_float() + nzf.bytes) / GIGI
-        if diskspace_info.download_dir.free < required_space:
+        if download_dir.free < required_space:
             full_dir = "download_dir"
 
         # Enough space in download_dir, check complete_dir
@@ -343,11 +343,11 @@ class Assembler(Thread):
                 # downloading until 95% complete before checking
                 required_space = (complete_free + nzo.bytes) / GIGI
 
-            if required_space and diskspace_info.complete_dir.free < required_space:
-                if diskspace_info.complete_dir.path == sabnzbd.cfg.complete_dir.get_path():
+            if required_space and complete_dir.free < required_space:
+                if complete_dir.path == sabnzbd.cfg.complete_dir.get_path():
                     full_dir = "complete_dir"
                 else:
-                    full_dir = diskspace_info.complete_dir.path
+                    full_dir = complete_dir.path
 
         if full_dir:
             logging.warning(T("Too little diskspace forcing PAUSE"))

--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -55,6 +55,7 @@ from sabnzbd.constants import (
 import sabnzbd.cfg as cfg
 from sabnzbd.nzb import NzbFile, NzbObject, Article
 import sabnzbd.par2file as par2file
+from sabnzbd.postproc import get_complete_directory
 
 
 class AssemblerTask(NamedTuple):
@@ -323,7 +324,7 @@ class Assembler(Thread):
     def diskspace_check(nzo: NzbObject, nzf: NzbFile):
         """Check diskspace requirements.
         If not enough space left, pause downloader and send email"""
-        freespace = diskspace(force=True)
+        freespace = diskspace(force=True, complete_dir=get_complete_directory(nzo)[0])
         full_dir = None
         required_space = (cfg.download_free.get_float() + nzf.bytes) / GIGI
         if freespace["download_dir"][1] < required_space:

--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -337,7 +337,7 @@ class Assembler(Thread):
             if cfg.direct_unpack():
                 # We unpack while we download, so we should check every time
                 # if the unpack maybe already filled up the drive
-                required_space = (complete_free + nzf.bytes) / GIGI
+                required_space = complete_free / GIGI
             elif nzo.bytes_tried > (nzo.bytes - nzo.bytes_par2) * 0.95:
                 # Since only at 100% unpack is started, continue
                 # downloading until 95% complete before checking

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -1024,12 +1024,14 @@ def diskspace_base(dir_to_check: str) -> tuple[float, float]:
 
 
 @conditional_cache(cache_time=10)
-def diskspace(force: bool = False) -> dict[str, tuple[float, float]]:
+def diskspace(force: bool = False, complete_dir: Optional[str] = None) -> dict[str, tuple[float, float]]:
     """Wrapper to keep results cached by conditional_cache
     If called with force=True, the wrapper will clear the results"""
+    if complete_dir is None:
+        complete_dir = sabnzbd.cfg.complete_dir.get_path()
     return {
         "download_dir": diskspace_base(sabnzbd.cfg.download_dir.get_path()),
-        "complete_dir": diskspace_base(sabnzbd.cfg.complete_dir.get_path()),
+        "complete_dir": diskspace_base(complete_dir),
     }
 
 

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -997,9 +997,6 @@ class Diskspace:
     size: float = 0.0
     free: float = 0.0
 
-    def __getitem__(self, key: str) -> Diskspace:
-        return getattr(self, key)
-
 
 def diskspace_base(dir_to_check: str) -> Diskspace:
     """Return amount of free and used diskspace in GBytes"""

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -992,22 +992,16 @@ def remove_all(path: str, pattern: str = "*", keep_folder: bool = False, recursi
 # Diskfree
 ##############################################################################
 @dataclass(frozen=True)
-class DiskspaceItem:
+class Diskspace:
     path: str
     size: float = 0.0
     free: float = 0.0
 
-
-@dataclass(frozen=True)
-class Diskspace:
-    download_dir: DiskspaceItem
-    complete_dir: DiskspaceItem
-
-    def __getitem__(self, key: str) -> DiskspaceItem:
+    def __getitem__(self, key: str) -> Diskspace:
         return getattr(self, key)
 
 
-def diskspace_base(dir_to_check: str) -> DiskspaceItem:
+def diskspace_base(dir_to_check: str) -> Diskspace:
     """Return amount of free and used diskspace in GBytes"""
     # Find first folder level that exists in the path
     x = "x"
@@ -1018,9 +1012,9 @@ def diskspace_base(dir_to_check: str) -> DiskspaceItem:
         # windows diskfree
         try:
             available, disk_size, total_free = win32api.GetDiskFreeSpaceEx(dir_to_check)
-            return DiskspaceItem(path=dir_to_check, size=disk_size / GIGI, free=available / GIGI)
+            return Diskspace(path=dir_to_check, size=disk_size / GIGI, free=available / GIGI)
         except Exception:
-            return DiskspaceItem(path=dir_to_check)
+            return Diskspace(path=dir_to_check)
     elif hasattr(os, "statvfs"):
         # posix diskfree
         try:
@@ -1033,23 +1027,20 @@ def diskspace_base(dir_to_check: str) -> DiskspaceItem:
                 available = float(sys.maxsize) * float(s.f_frsize)
             else:
                 available = float(s.f_bavail) * float(s.f_frsize)
-            return DiskspaceItem(path=dir_to_check, size=disk_size / GIGI, free=available / GIGI)
+            return Diskspace(path=dir_to_check, size=disk_size / GIGI, free=available / GIGI)
         except Exception:
-            return DiskspaceItem(path=dir_to_check)
+            return Diskspace(path=dir_to_check)
     else:
-        return DiskspaceItem(path=dir_to_check, size=20.0, free=10.0)
+        return Diskspace(path=dir_to_check, size=20.0, free=10.0)
 
 
 @conditional_cache(cache_time=10)
-def diskspace(force: bool = False, complete_dir: Optional[str] = None) -> Diskspace:
+def diskspace(force: bool = False, complete_dir: Optional[str] = None) -> tuple[Diskspace, Diskspace]:
     """Wrapper to keep results cached by conditional_cache
     If called with force=True, the wrapper will clear the results"""
     if not complete_dir:
         complete_dir = sabnzbd.cfg.complete_dir.get_path()
-    return Diskspace(
-        download_dir=diskspace_base(sabnzbd.cfg.download_dir.get_path()),
-        complete_dir=diskspace_base(complete_dir),
-    )
+    return diskspace_base(sabnzbd.cfg.download_dir.get_path()), diskspace_base(complete_dir)
 
 
 def get_new_id(prefix: str, folder: str, check_list: Optional[list] = None) -> str:

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -34,6 +34,7 @@ import fnmatch
 import stat
 import ctypes
 import random
+from dataclasses import dataclass
 from typing import Union, Any, Optional, BinaryIO
 
 try:
@@ -990,7 +991,22 @@ def remove_all(path: str, pattern: str = "*", keep_folder: bool = False, recursi
 ##############################################################################
 # Diskfree
 ##############################################################################
-def diskspace_base(dir_to_check: str) -> tuple[float, float]:
+@dataclass(slots=True, frozen=True)
+class DiskspaceItem:
+    size: float = 0.0
+    free: float = 0.0
+
+
+@dataclass(slots=True, frozen=True)
+class Diskspace:
+    download_dir: DiskspaceItem
+    complete_dir: DiskspaceItem
+
+    def __getitem__(self, key: str) -> DiskspaceItem:
+        return getattr(self, key)
+
+
+def diskspace_base(dir_to_check: str) -> DiskspaceItem:
     """Return amount of free and used diskspace in GBytes"""
     # Find first folder level that exists in the path
     x = "x"
@@ -1001,9 +1017,9 @@ def diskspace_base(dir_to_check: str) -> tuple[float, float]:
         # windows diskfree
         try:
             available, disk_size, total_free = win32api.GetDiskFreeSpaceEx(dir_to_check)
-            return disk_size / GIGI, available / GIGI
+            return DiskspaceItem(size=disk_size / GIGI, free=available / GIGI)
         except Exception:
-            return 0.0, 0.0
+            return DiskspaceItem()
     elif hasattr(os, "statvfs"):
         # posix diskfree
         try:
@@ -1016,23 +1032,23 @@ def diskspace_base(dir_to_check: str) -> tuple[float, float]:
                 available = float(sys.maxsize) * float(s.f_frsize)
             else:
                 available = float(s.f_bavail) * float(s.f_frsize)
-            return disk_size / GIGI, available / GIGI
+            return DiskspaceItem(size=disk_size / GIGI, free=available / GIGI)
         except Exception:
-            return 0.0, 0.0
+            return DiskspaceItem()
     else:
-        return 20.0, 10.0
+        return DiskspaceItem(size=20.0, free=10.0)
 
 
 @conditional_cache(cache_time=10)
-def diskspace(force: bool = False, complete_dir: Optional[str] = None) -> dict[str, tuple[float, float]]:
+def diskspace(force: bool = False, complete_dir: Optional[str] = None) -> Diskspace:
     """Wrapper to keep results cached by conditional_cache
     If called with force=True, the wrapper will clear the results"""
-    if complete_dir is None:
+    if not complete_dir:
         complete_dir = sabnzbd.cfg.complete_dir.get_path()
-    return {
-        "download_dir": diskspace_base(sabnzbd.cfg.download_dir.get_path()),
-        "complete_dir": diskspace_base(complete_dir),
-    }
+    return Diskspace(
+        download_dir=diskspace_base(sabnzbd.cfg.download_dir.get_path()),
+        complete_dir=diskspace_base(complete_dir),
+    )
 
 
 def get_new_id(prefix: str, folder: str, check_list: Optional[list] = None) -> str:

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -991,13 +991,13 @@ def remove_all(path: str, pattern: str = "*", keep_folder: bool = False, recursi
 ##############################################################################
 # Diskfree
 ##############################################################################
-@dataclass(slots=True, frozen=True)
+@dataclass(frozen=True)
 class DiskspaceItem:
     size: float = 0.0
     free: float = 0.0
 
 
-@dataclass(slots=True, frozen=True)
+@dataclass(frozen=True)
 class Diskspace:
     download_dir: DiskspaceItem
     complete_dir: DiskspaceItem

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -993,6 +993,7 @@ def remove_all(path: str, pattern: str = "*", keep_folder: bool = False, recursi
 ##############################################################################
 @dataclass(frozen=True)
 class DiskspaceItem:
+    path: str
     size: float = 0.0
     free: float = 0.0
 
@@ -1017,9 +1018,9 @@ def diskspace_base(dir_to_check: str) -> DiskspaceItem:
         # windows diskfree
         try:
             available, disk_size, total_free = win32api.GetDiskFreeSpaceEx(dir_to_check)
-            return DiskspaceItem(size=disk_size / GIGI, free=available / GIGI)
+            return DiskspaceItem(path=dir_to_check, size=disk_size / GIGI, free=available / GIGI)
         except Exception:
-            return DiskspaceItem()
+            return DiskspaceItem(path=dir_to_check)
     elif hasattr(os, "statvfs"):
         # posix diskfree
         try:
@@ -1032,11 +1033,11 @@ def diskspace_base(dir_to_check: str) -> DiskspaceItem:
                 available = float(sys.maxsize) * float(s.f_frsize)
             else:
                 available = float(s.f_bavail) * float(s.f_frsize)
-            return DiskspaceItem(size=disk_size / GIGI, free=available / GIGI)
+            return DiskspaceItem(path=dir_to_check, size=disk_size / GIGI, free=available / GIGI)
         except Exception:
-            return DiskspaceItem()
+            return DiskspaceItem(path=dir_to_check)
     else:
-        return DiskspaceItem(size=20.0, free=10.0)
+        return DiskspaceItem(path=dir_to_check, size=20.0, free=10.0)
 
 
 @conditional_cache(cache_time=10)

--- a/sabnzbd/macosmenu.py
+++ b/sabnzbd/macosmenu.py
@@ -441,12 +441,12 @@ class SABnzbdDelegate(NSObject):
 
     def diskspaceUpdate(self):
         try:
-            diskspace_info = diskspace()
+            download_dir, complete_dir = diskspace()
             self.completefolder_menu_item.setTitle_(
-                "%s (%.2f GB)" % (T("Complete Folder"), diskspace_info.complete_dir.free)
+                "%s (%.2f GB)" % (T("Complete Folder"), complete_dir.free)
             )
             self.incompletefolder_menu_item.setTitle_(
-                "%s (%.2f GB)" % (T("Incomplete Folder"), diskspace_info.download_dir.free)
+                "%s (%.2f GB)" % (T("Incomplete Folder"), download_dir.free)
             )
         except Exception:
             logging.info("[macos] diskspaceUpdate Exception", exc_info=True)

--- a/sabnzbd/macosmenu.py
+++ b/sabnzbd/macosmenu.py
@@ -441,11 +441,12 @@ class SABnzbdDelegate(NSObject):
 
     def diskspaceUpdate(self):
         try:
+            diskspace_info = diskspace()
             self.completefolder_menu_item.setTitle_(
-                "%s (%.2f GB)" % (T("Complete Folder"), diskspace()["complete_dir"][1])
+                "%s (%.2f GB)" % (T("Complete Folder"), diskspace_info.complete_dir.free)
             )
             self.incompletefolder_menu_item.setTitle_(
-                "%s (%.2f GB)" % (T("Incomplete Folder"), diskspace()["download_dir"][1])
+                "%s (%.2f GB)" % (T("Incomplete Folder"), diskspace_info.download_dir.free)
             )
         except Exception:
             logging.info("[macos] diskspaceUpdate Exception", exc_info=True)

--- a/sabnzbd/macosmenu.py
+++ b/sabnzbd/macosmenu.py
@@ -442,12 +442,8 @@ class SABnzbdDelegate(NSObject):
     def diskspaceUpdate(self):
         try:
             download_dir, complete_dir = diskspace()
-            self.completefolder_menu_item.setTitle_(
-                "%s (%.2f GB)" % (T("Complete Folder"), complete_dir.free)
-            )
-            self.incompletefolder_menu_item.setTitle_(
-                "%s (%.2f GB)" % (T("Incomplete Folder"), download_dir.free)
-            )
+            self.completefolder_menu_item.setTitle_("%s (%.2f GB)" % (T("Complete Folder"), complete_dir.free))
+            self.incompletefolder_menu_item.setTitle_("%s (%.2f GB)" % (T("Incomplete Folder"), download_dir.free))
         except Exception:
             logging.info("[macos] diskspaceUpdate Exception", exc_info=True)
 

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -718,13 +718,10 @@ def process_job(nzo: NzbObject) -> bool:
     return True
 
 
-def prepare_extraction_path(nzo: NzbObject) -> tuple[str, str, Sorter, bool, Optional[str]]:
-    """Based on the information that we have, generate
-    the extraction path and create the directory.
-    Separated so it can be called from DirectUnpacker
-    """
+def get_complete_directory(nzo: NzbObject) -> tuple[str, Sorter, bool]:
+    """Get the complete directory for a nzo.
+    Seperated so the Assembler can check for a category override."""
     create_job_dir = True
-    marker_file = None
 
     # Determine category directory
     catdir = config.get_category(nzo.cat).dir()
@@ -752,6 +749,17 @@ def prepare_extraction_path(nzo: NzbObject) -> tuple[str, str, Sorter, bool, Opt
         create_job_dir = True
 
     complete_dir = sanitize_and_trim_path(complete_dir)
+
+    return complete_dir, file_sorter, create_job_dir
+
+
+def prepare_extraction_path(nzo: NzbObject) -> tuple[str, str, Sorter, bool, Optional[str]]:
+    """Based on the information that we have, generate
+    the extraction path and create the directory.
+    Separated so it can be called from DirectUnpacker
+    """
+    complete_dir, file_sorter, create_job_dir = get_complete_directory(nzo)
+    marker_file = None
 
     if not create_job_dir:
         workdir_complete = create_all_dirs(complete_dir, apply_permissions=True)

--- a/sabnzbd/scheduler.py
+++ b/sabnzbd/scheduler.py
@@ -29,7 +29,7 @@ import sabnzbd.downloader
 import sabnzbd.misc
 import sabnzbd.config as config
 import sabnzbd.cfg as cfg
-from sabnzbd.filesystem import diskspace, diskspace_base
+from sabnzbd.filesystem import diskspace_base
 from sabnzbd.constants import LOW_PRIORITY, NORMAL_PRIORITY, HIGH_PRIORITY
 
 DAILY_RANGE = list(range(1, 8))
@@ -395,8 +395,10 @@ class Scheduler:
             self.cancel_resume_task()
             return
 
-        if full_dir in ("download_dir", "complete_dir"):
-            disk_free = diskspace(force=True)[full_dir].free
+        if full_dir == "download_dir":
+            disk_free = diskspace_base(sabnzbd.cfg.download_dir.get_path()).free
+        elif full_dir == "complete_dir":
+            disk_free = diskspace_base(sabnzbd.cfg.complete_dir.get_path()).free
         else:
             disk_free = diskspace_base(full_dir).free
         if disk_free > required_space:

--- a/sabnzbd/scheduler.py
+++ b/sabnzbd/scheduler.py
@@ -395,7 +395,7 @@ class Scheduler:
             self.cancel_resume_task()
             return
 
-        disk_free = diskspace(force=True)[full_dir][1]
+        disk_free = diskspace(force=True)[full_dir].free
         if disk_free > required_space:
             logging.info("Resuming, %s has %d GB free, needed %d GB", full_dir, disk_free, required_space)
             sabnzbd.Downloader.resume()

--- a/sabnzbd/scheduler.py
+++ b/sabnzbd/scheduler.py
@@ -29,7 +29,7 @@ import sabnzbd.downloader
 import sabnzbd.misc
 import sabnzbd.config as config
 import sabnzbd.cfg as cfg
-from sabnzbd.filesystem import diskspace
+from sabnzbd.filesystem import diskspace, diskspace_base
 from sabnzbd.constants import LOW_PRIORITY, NORMAL_PRIORITY, HIGH_PRIORITY
 
 DAILY_RANGE = list(range(1, 8))
@@ -395,7 +395,10 @@ class Scheduler:
             self.cancel_resume_task()
             return
 
-        disk_free = diskspace(force=True)[full_dir].free
+        if full_dir in ("download_dir", "complete_dir"):
+            disk_free = diskspace(force=True)[full_dir].free
+        else:
+            disk_free = diskspace_base(full_dir).free
         if disk_free > required_space:
             logging.info("Resuming, %s has %d GB free, needed %d GB", full_dir, disk_free, required_space)
             sabnzbd.Downloader.resume()

--- a/sabnzbd/scheduler.py
+++ b/sabnzbd/scheduler.py
@@ -410,7 +410,12 @@ class Scheduler:
             self.cancel_resume_task()
 
     def plan_diskspace_resume(self, full_dir: str, required_space: float):
-        """Create regular check for free disk space"""
+        """
+        Create regular check for free disk space
+
+        :param str full_dir: "download_dir", "complete_dir", or directory path
+        :param float required_space: Disk space required to resume
+        """
         self.cancel_resume_task()
         logging.info("Will resume when %s has more than %d GB free space", full_dir, required_space)
         self.resume_task = self.scheduler.add_interval_task(

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -23,6 +23,8 @@ from types import SimpleNamespace
 from zlib import crc32
 
 from sabnzbd.assembler import Assembler
+from sabnzbd.constants import GIGI
+from sabnzbd.filesystem import Diskspace
 from sabnzbd.nzb import Article, NzbFile, NzbObject
 from tests.testhelper import *
 
@@ -313,3 +315,139 @@ class TestAssembler:
         Assembler.assemble(self.nzo, self.nzf, file_done=True, allow_non_contiguous=False, direct_write=True)
         assert assembler.call_count == 3
         self._assert_expected_content(self.nzf, expected)
+
+
+class TestDiskspaceCheck:
+    """Tests for Assembler.diskspace_check"""
+
+    @pytest.fixture(autouse=True)
+    def setup_mocks(self):
+        self.nzo = mock.Mock()
+        self.nzo.bytes = int(2 * GIGI)
+        self.nzo.bytes_tried = 0
+        self.nzo.bytes_par2 = 0
+
+        self.nzf = mock.Mock()
+        self.nzf.bytes = int(0.5 * GIGI)
+
+        self.mock_downloader = mock.Mock()
+        self.mock_scheduler = mock.Mock()
+        self.mock_notifier = mock.Mock()
+        self.mock_emailer = mock.Mock()
+
+        try:
+            sabnzbd.Downloader = self.mock_downloader
+            sabnzbd.Scheduler = self.mock_scheduler
+            sabnzbd.notifier = self.mock_notifier
+            sabnzbd.emailer = self.mock_emailer
+
+            with (
+                mock.patch("sabnzbd.assembler.diskspace") as self.mock_diskspace,
+                mock.patch("sabnzbd.assembler.get_complete_directory") as self.mock_get_complete_dir,
+                mock.patch("sabnzbd.assembler.cfg") as self.mock_cfg,
+                mock.patch("sabnzbd.cfg.complete_dir") as self.mock_complete_dir_cfg,
+            ):
+                # Defaults: plenty of space, no direct_unpack, autoresume on
+                self.mock_get_complete_dir.return_value = ("/complete", None, True)
+                self.mock_cfg.download_free.get_float.return_value = 1 * GIGI
+                self.mock_cfg.complete_free.get_float.return_value = 2 * GIGI
+                self.mock_cfg.direct_unpack.return_value = False
+                self.mock_cfg.fulldisk_autoresume.return_value = True
+                self.mock_complete_dir_cfg.get_path.return_value = "/complete"
+                yield
+        finally:
+            del sabnzbd.Downloader
+            del sabnzbd.Scheduler
+            del sabnzbd.notifier
+            del sabnzbd.emailer
+
+    def _set_diskspace(self, download_free_gb: float, complete_free_gb: float, complete_path: str = "/complete"):
+        self.mock_diskspace.return_value = (
+            Diskspace(path="/download", free=download_free_gb),
+            Diskspace(path=complete_path, free=complete_free_gb),
+        )
+
+    def test_download_dir_full(self):
+        """Pause when download_dir has insufficient space"""
+        # download_free=1GiB, nzf.bytes=0.5GiB => required = 1.5 GiB, free = 1.0 GiB
+        self._set_diskspace(download_free_gb=1.0, complete_free_gb=50.0)
+        Assembler.diskspace_check(self.nzo, self.nzf)
+
+        expected_required = (1 * GIGI + self.nzf.bytes) / GIGI
+        self.mock_downloader.pause.assert_called_once()
+        self.mock_scheduler.plan_diskspace_resume.assert_called_once_with("download_dir", expected_required)
+
+    def test_complete_dir_full_direct_unpack(self):
+        """Pause when complete_dir is full during direct_unpack"""
+        self._set_diskspace(download_free_gb=50.0, complete_free_gb=1.0)
+        self.mock_cfg.direct_unpack.return_value = True
+
+        Assembler.diskspace_check(self.nzo, self.nzf)
+
+        expected_required = (2 * GIGI) / GIGI
+        self.mock_downloader.pause.assert_called_once()
+        self.mock_scheduler.plan_diskspace_resume.assert_called_once_with("complete_dir", expected_required)
+
+    def test_complete_dir_full_near_completion(self):
+        """Pause when complete_dir is full and download is >95% done"""
+        self.nzo.bytes_tried = int(self.nzo.bytes * 0.96)
+        self.nzo.bytes_par2 = 0
+        self._set_diskspace(download_free_gb=50.0, complete_free_gb=1.0)
+
+        Assembler.diskspace_check(self.nzo, self.nzf)
+
+        expected_required = (2 * GIGI + self.nzo.bytes) / GIGI  # (complete_free + nzo.bytes)
+        self.mock_downloader.pause.assert_called_once()
+        self.mock_scheduler.plan_diskspace_resume.assert_called_once_with("complete_dir", expected_required)
+
+    def test_complete_dir_no_check_below_95_percent(self):
+        """No complete_dir check when download is below 95% and not direct_unpack"""
+        self.nzo.bytes_tried = int(self.nzo.bytes * 0.50)
+        self._set_diskspace(download_free_gb=50.0, complete_free_gb=0.1)
+
+        Assembler.diskspace_check(self.nzo, self.nzf)
+
+        self.mock_downloader.pause.assert_not_called()
+        self.mock_scheduler.plan_diskspace_resume.assert_not_called()
+
+    def test_complete_dir_custom_path(self):
+        """full_dir is the actual path when complete_dir differs from default"""
+        custom_path = "/custom/complete"
+        self.mock_get_complete_dir.return_value = (custom_path, None, True)
+        self._set_diskspace(download_free_gb=50.0, complete_free_gb=1.0, complete_path=custom_path)
+        self.mock_cfg.direct_unpack.return_value = True
+
+        Assembler.diskspace_check(self.nzo, self.nzf)
+
+        self.mock_downloader.pause.assert_called_once()
+        self.mock_scheduler.plan_diskspace_resume.assert_called_once_with(custom_path, mock.ANY)
+
+    def test_enough_space(self):
+        """No action when both dirs have sufficient space"""
+        self._set_diskspace(download_free_gb=50.0, complete_free_gb=50.0)
+
+        Assembler.diskspace_check(self.nzo, self.nzf)
+
+        self.mock_downloader.pause.assert_not_called()
+        self.mock_scheduler.plan_diskspace_resume.assert_not_called()
+        self.mock_notifier.send_notification.assert_not_called()
+        self.mock_emailer.diskfull_mail.assert_not_called()
+
+    def test_autoresume_disabled(self):
+        """plan_diskspace_resume not called when fulldisk_autoresume is off"""
+        self._set_diskspace(download_free_gb=1.0, complete_free_gb=50.0)
+        self.mock_cfg.fulldisk_autoresume.return_value = False
+
+        Assembler.diskspace_check(self.nzo, self.nzf)
+
+        self.mock_downloader.pause.assert_called_once()
+        self.mock_scheduler.plan_diskspace_resume.assert_not_called()
+
+    def test_download_dir_full_notifications(self):
+        """Verify notifications and email are sent on disk full"""
+        self._set_diskspace(download_free_gb=1.0, complete_free_gb=50.0)
+
+        Assembler.diskspace_check(self.nzo, self.nzf)
+
+        self.mock_notifier.send_notification.assert_called_once()
+        self.mock_emailer.diskfull_mail.assert_called_once()


### PR DESCRIPTION
Related to discussion in #3329 the assembler diskspace_check currently doesn't check the per-category override of the complete directory.

I've split the logic in `prepare_extraction_path` so we can get a return of the base path for the complete directory, without creating anything.

Thereby allowing the diskspace requirements to be applied to the directories the job is using.
