### PR TITLE
Fix race when direct unpacker is killed

### DIFF
--- a/sabnzbd/directunpacker.py
+++ b/sabnzbd/directunpacker.py
@@ -351,14 +351,14 @@ class DirectUnpacker(threading.Thread):
         if unrar_log:
             logging.debug("DirectUnpack Unrar output: \n%s", "\n".join(unrar_log))
 
-        # Make more space
-        self.reset_active()
-        if self in ACTIVE_UNPACKERS:
-            ACTIVE_UNPACKERS.remove(self)
-        logging.debug("Closing DirectUnpack for %s", self.nzo.final_name)
-
-        # Set the thread to killed so it never gets restarted by accident
-        self.killed = True
+        with START_STOP_LOCK:
+            # Set the thread to killed so it never gets restarted by accident
+            self.killed = True
+            # Make more space
+            self.reset_active()
+            if self in ACTIVE_UNPACKERS:
+                ACTIVE_UNPACKERS.remove(self)
+            logging.debug("Closing DirectUnpack for %s", self.nzo.final_name)
 
     def have_next_volume(self):
         """Check if next volume of set is available, start


### PR DESCRIPTION
Fixes #3347

AI mostly found it after feeding it the symptoms and log.

> The race is between run()'s final cleanup and add() checking state. Here's the sequence:
>
>1. run() calls self.reset_active() (line 355) → sets active_instance = None
>2. add() acquires START_STOP_LOCK, enters
>3. check_requirements() checks self.killed → still False → passes
>4. Line 151: not self.active_instance → True (reset in step 1)
>5. Meanwhile run() finishes, sets self.killed = True (line 361), returns → thread dies
>6. Back in add(): not self.is_alive() → True (thread just died)
>7. self.start() → crash — thread already ran once
>
> The root cause: run()'s final cleanup (lines 355–361) is not protected by START_STOP_LOCK, so add() can observe a half-updated state — active_instance is None and killed is still False, and is_alive() flips to False between the two checks.

The order doesn't matter but it is required that both `self.reset_active()` and `self.killed = True` are called under the lock.