### PR TITLE
Fix history api race causing stale data

### DIFF
--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -564,8 +564,14 @@ def _api_history_default(value: str, kwargs: dict[str, Union[str, list[str]]]) -
     failed_only = bool_conv(kwargs.get("failed_only"))
     nzo_ids = clean_comma_separated_list(kwargs.get("nzo_ids"))
 
+    # Snapshot the counter once to avoid racing with history_updated() calls
+    # between the staleness check and the response — if the counter changes
+    # mid-request the client would record the newer value but receive stale
+    # data, causing it to skip the real update on the next poll.
+    current_history_update = sabnzbd.LAST_HISTORY_UPDATE
+
     # Do we need to send anything?
-    if last_history_update == sabnzbd.LAST_HISTORY_UPDATE:
+    if last_history_update == current_history_update:
         return report(keyword="history", data=False)
 
     if failed_only:
@@ -593,7 +599,7 @@ def _api_history_default(value: str, kwargs: dict[str, Union[str, list[str]]]) -
         statuses=statuses,
         nzo_ids=nzo_ids,
     )
-    history["last_history_update"] = sabnzbd.LAST_HISTORY_UPDATE
+    history["last_history_update"] = current_history_update
     history["version"] = sabnzbd.__version__
     return report(keyword="history", data=history)
 

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -38,7 +38,7 @@ import ipaddress
 import socks
 import math
 import rarfile
-from threading import Thread
+from threading import Thread, RLock
 from collections.abc import Iterable
 from typing import Union, Any, AnyStr, Optional, Collection
 
@@ -54,7 +54,7 @@ from sabnzbd.constants import (
 )
 import sabnzbd.config as config
 import sabnzbd.cfg as cfg
-from sabnzbd.decorators import conditional_cache
+from sabnzbd.decorators import conditional_cache, synchronized
 from sabnzbd.encoding import ubtou, platform_btou
 from sabnzbd.filesystem import userxbit, make_script_path, remove_file, strip_extensions
 
@@ -91,6 +91,9 @@ RE_SUBJECT_BASIC_FILENAME = re.compile(r"\b([\w\-+()' .,]+(?:\[[\w\-/+()' .,]*][
 
 # Check if strings are defined for AM and PM
 HAVE_AMPM = bool(time.strftime("%p"))
+
+# The history counter need to be made atomic to ensure consistency.
+HISTORY_COUNTER_LOCK = RLock()
 
 
 def helpful_warning(msg, *args, **kwargs):
@@ -1470,6 +1473,7 @@ def keep_awake():
                     sleepless.allow_sleep()
 
 
+@synchronized(HISTORY_COUNTER_LOCK)
 def history_updated():
     """To make sure we always have a fresh history"""
     sabnzbd.LAST_HISTORY_UPDATE += 1


### PR DESCRIPTION
Fixes #3055

The bug/race is that:

- `sabnzbd.LAST_HISTORY_UPDATE` is read for the first check
- Builds the history response
- Reads `sabnzbd.LAST_HISTORY_UPDATE` again for the response

Between the two `LAST_HISTORY_UPDATE` reads it can increment and the client gets stale history data paired with the latest `LAST_HISTORY_UPDATE`, then subsequent calls it never gets the latest history.

Fix is to capture the counter once at the start.

Secondary issue is `history_updated` being called from multiple threads, without a lock it is not atomic so the concurrent calls can lose increments.