### PR TITLE
Fix likely cause of stuck jobs

### DIFF
--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -558,10 +558,6 @@ class Downloader(Thread):
     @staticmethod
     def decode(article: "sabnzbd.nzb.Article", response: Optional[sabctools.NNTPResponse] = None):
         """Decode article"""
-        # Need a better way of draining requests
-        if article.nzf.nzo.removed_from_queue:
-            return
-
         # Article was requested and fetched, update article stats for the server
         sabnzbd.BPSMeter.register_server_article_tried(article.fetcher.id)
 


### PR DESCRIPTION
I think I've finally found the problem:

```
2026-03-13 10:43:38,808::DEBUG::[newswrapper:237] Thread 9@news-eu.newshosting.com: Article d4uz4bc9ql610w@bgpr649w.231ab missing (error=430)
2026-03-13 10:43:43,486::DEBUG::[newswrapper:237] Thread 3@news-eu.newshosting.com: Article d4uz4bc9ql610w@bgpr649w.231ab missing (error=430)
2026-03-13 10:43:45,849::INFO::[nzbqueue:763] [sabnzbd.nzbqueue.register_article] Ending job <JOB>
2026-03-13 10:43:45,981::DEBUG::[newswrapper:237] Thread 3@news-us.newshosting.com: Article d4uz4bc9ql610w@bgpr649w.231ab missing (error=430)
2026-03-13 10:44:26,867::DEBUG::[nzbqueue:905] Next article to assemble for file <HASH>b45941f.vol03-07.par2 is <Article: article=d4uz4bc9ql610w@bgpr649w.231ab, bytes=792531, art_id=None>, decoded: False, on_disk: False, decoded_size: None, has_fetcher: True, tries: 1
```

Notice `Ending job` comes before the missing article, so `removed_from_queue = True` and the failed request is never registered. I was always assuming it was assigned to the next server, but I think it's still assigned to the one that failed and is never being registered to be able to try the next one.

This was added in the pipelining changes, and I should have removed it once it was correctly handled in `hard_reset` and `reset_article_queue`.

Related #3287