### PR TITLE
Fix premature end_job when register_article promotes a par2

### DIFF
--- a/sabnzbd/nzb/object.py
+++ b/sabnzbd/nzb/object.py
@@ -707,7 +707,8 @@ class NzbObject(TryList):
             for new_nzf in self.extrapars[setname]:
                 # Add it to the top
                 if self.add_parfile(new_nzf):
-                    break
+                    return True
+        return False
 
     def get_extra_blocks(self, setname: str, needed_blocks: int) -> int:
         """We want par2-files of all sets that are similar to this one
@@ -1051,6 +1052,8 @@ class NzbObject(TryList):
         """
         if not parfile.completed and parfile not in self.files and parfile not in self.finished_files:
             parfile.reset_try_list()
+            # Reset NZO TryList
+            self.reset_try_list()
             self.files.insert(0, parfile)
             self.bytes_tried -= parfile.bytes_left
             return True

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -739,7 +739,8 @@ class NzbQueue:
                 sabnzbd.Assembler.process(nzo, nzf, file_done, article=article)
             elif sabnzbd.par2file.has_par2_in_filename(nzf.filename):
                 # Broken par2 file, try to get another one
-                nzo.promote_par2(nzf)
+                if nzo.promote_par2(nzf):
+                    post_done = False
 
         # Save bookkeeping in case of crash
         if file_done and (nzo.next_save is None or time.time() > nzo.next_save):


### PR DESCRIPTION
Resending #3352 because something went wrong with GitHub merging.

> I belive this is at least one of the cause of the 4.5.5 issue which requires `stop_idle_jobs` to resolve.
>
> In `register_article` when registering I think the last article in the last currently queued file.
>
> tl;dr `not self.files` is True but `nzo.promote_par2(nzf)` adds a file, so the invalid state is used and `self.end_job(nzo)` is called when there is in fact still a file to download, and the nzo should be removed from try lists when a par2 is promoted this way.
>
> - `articles_left, file_done, post_done = nzo.remove_article(article, success)` returns `post_done = True`
> - `nzf.type is None` and `sabnzbd.par2file.has_par2_in_filename(nzf.filename) == True` so `nzo.promote_par2(nzf)` is called adding a par2 file via `add_parfile` - this inserts into nzo.files
>- `if post_done` sees a stale True and prematurely calls `end_job` which sets `removed_from_queue = True` and sends it to the assembler, ~10 seconds later `stop_idle_jobs` sees `nzo.all_servers_in_try_list(active_servers)` and calls `nzo.reset_try_list()` allowing the queue to process it again
>
>In the fix `add_parfile` also resets the nzo trylist because it's not enough to just do the file, `nzo.get_articles` may have already added the server to the nzo trylist. `prospective_add` already does this reset.
>
>There is a lesser issue with `next_article_search` that makes rarely used servers slow to react that I'll look at fixing separately.