### PR TITLE
Reduce chance of assembly starting before filenames are available

### DIFF
--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -206,7 +206,7 @@ class Assembler(Thread):
             return False
         # Always write
         if article_has_first_part and filename_checked and not import_finished:
-            return True
+            return nzf.prepare_filepath() is not None
         next_ready = (next_article := nzf.assembler_next_article) and (next_article.decoded or next_article.on_disk)
         # Trigger every 5 seconds if next article is decoded or on_disk
         if next_ready and time.monotonic() > self.queued_next_time.get(nzf.nzf_id, 0):
@@ -261,7 +261,7 @@ class Assembler(Thread):
 
                 try:
                     # Prepare filepath
-                    if not (filepath := nzf.prepare_filepath()):
+                    if not (filepath := nzf.prepare_filepath(force=file_done)):
                         logging.debug("Prepare filepath failed for file %s in job %s", nzf.filename, nzo.final_name)
                         continue
 

--- a/sabnzbd/nzb/file.py
+++ b/sabnzbd/nzb/file.py
@@ -40,6 +40,7 @@ from sabnzbd.filesystem import (
 )
 from sabnzbd.misc import int_conv, subject_name_extractor
 from sabnzbd.decorators import synchronized
+from sabnzbd.par2file import has_par2_in_filename
 
 
 ##############################################################################
@@ -213,17 +214,22 @@ class NzbFile(TryList):
         This ensures we have attempted to extract md5of16k and filename information
         before creating the filepath.
         """
-        # The first article of decodetable is always the lowest
-        first_article = self.decodetable[0]
-        # If it's still in nzo.first_articles, it hasn't been processed yet
-        return first_article not in self.nzo.first_articles
+        # par2 files don't need par2 rename info, just wait for own first article
+        if self.is_par2 or has_par2_in_filename(self.filename):
+            # The first article of decodetable is always the lowest
+            first_article = self.decodetable[0]
+            # If it's still in nzo.first_articles, it hasn't been processed yet
+            return first_article not in self.nzo.first_articles
+        # Non-par2 files wait for ALL first articles to be done,
+        # making it likely handle_par2 has populated md5of16k
+        return not self.nzo.first_articles
 
-    def prepare_filepath(self):
+    def prepare_filepath(self, force: bool = False):
         """Do all checks before making the final path"""
         if not self.filepath:
             # Wait for the first article to be processed so we can get md5of16k
             # and proper filename before creating the filepath
-            if not self.first_article_processed():
+            if not force and not self.first_article_processed():
                 return None
 
             self.nzo.verify_nzf_filename(self)

--- a/sabnzbd/nzb/object.py
+++ b/sabnzbd/nzb/object.py
@@ -1341,17 +1341,18 @@ class NzbObject(TryList):
 
         # If we have the md5, use it to rename
         if nzf.md5of16k and self.md5of16k:
-            # Don't check again, even if no match
-            nzf.filename_checked = True
             # Find the match and rename
-            if nzf.md5of16k in self.md5of16k:
-                new_filename = self.md5of16k[nzf.md5of16k]
+            if new_filename := self.md5of16k.get(nzf.md5of16k, None):
                 # Was it even new?
                 if new_filename != nzf.filename:
                     logging.info("Detected filename based on par2: %s -> %s", nzf.filename, new_filename)
                     self.renamed_file(new_filename, nzf.filename)
                     nzf.filename = new_filename
+                nzf.filename_checked = True
                 return
+            else:
+                # Don't check again, even if no match
+                nzf.filename_checked = True
 
         # Fallback to yenc/nzb name (also when there is no partnum=1)
         # We also keep the NZB name in case it ends with ".par2" (usually correct)


### PR DESCRIPTION
Files could be created with obfuscated names because prepare_filepath only waited for each file's own first article - par2 may not have been assembled yet, so md5of16k wasn't populated when verify_nzf_filename ran.

- first_article_processed(): Non-par2 files now wait for all first_articles to complete, not just their own. Since mini-par2 files download first and are typically single-article, handle_par2 has almost always populated md5of16k by then. Par2 files still only wait for their own first article.
- prepare_filepath(force): Accepts force=True (passed by the assembler on file_done) to bypass the gate, preventing completed files from being dropped if they finish before all first articles are done.
- should_queue_nzf(): Early-write path now checks prepare_filepath() so it respects the new gating

This doesn't eliminate the race entirely but it reduces the window significantly because it encourages par2 to be assembled before other files.

**Before:** race starts when that file's first article is downloaded. Before the par2 has been assembled and handle_par2 is called - par2 might not have even downloaded yet.
**New:** race starts when the last first article completes, until handle_par2 finishes. Files are sorted so mini-par2 are first, so the chance that the assembler has ran for a par2 and populated md5of16k by the time all first articles are finished is high.