### PR TITLE
Check for unwanted extensions after repair and unpack

### DIFF
--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -306,6 +306,10 @@ class Assembler(Thread):
                             elif par2file.is_par2_file(filepath):
                                 # Parse par2 files, cloaked or not
                                 nzo.handle_par2(nzf, filepath)
+
+                            else:
+                                # May be RAR files which could not be identified due to missing first part
+                                nzo.unchecked_files.add(filepath)
                 except Exception:
                     logging.error(T("Fatal error in Assembler"), exc_info=True)
                     break
@@ -686,6 +690,8 @@ def check_encrypted_and_unwanted_files(nzo: NzbObject, filepath: str) -> tuple[b
                             zf.trigger_parse()
                         except Exception:
                             pass
+                    if not zf.namelist():
+                        nzo.unchecked_files.add(filepath)
                     for somefile in zf.namelist():
                         logging.debug("File contains: %s", somefile)
                         if has_unwanted_extension(somefile):
@@ -695,5 +701,6 @@ def check_encrypted_and_unwanted_files(nzo: NzbObject, filepath: str) -> tuple[b
                 del zf
         except rarfile.Error as e:
             logging.info("Error during inspection of RAR-file %s: %s", filepath, e)
+            nzo.unchecked_files.add(filepath)
 
     return encrypted, unwanted

--- a/sabnzbd/nzb/object.py
+++ b/sabnzbd/nzb/object.py
@@ -354,6 +354,8 @@ class NzbObject(TryList):
         # Reuse the existing directory
         if reuse and os.path.exists(reuse):
             self.download_path = long_path(reuse)
+            # Skip unwanted extensions check
+            self.unwanted_ext = 2
         else:
             # Determine "incomplete" folder
             self.download_path = os.path.join(cfg.download_dir.get_path(), self.work_name)

--- a/sabnzbd/nzb/object.py
+++ b/sabnzbd/nzb/object.py
@@ -316,6 +316,7 @@ class NzbObject(TryList):
         self.next_save = None
         self.save_timeout = None
         self.encrypted = 0
+        self.unchecked_files: set[str] = set()  # Files where encrypted/unwanted check failed (e.g. corrupt RAR)
         self.url_wait: Optional[float] = None
         self.url_tries = 0
         self.pp_active = False
@@ -1663,6 +1664,7 @@ class NzbObject(TryList):
 
         # Set non-transferable values
         self.pp_active = False
+        self.unchecked_files: set[str] = set()
         self.avg_stamp = time.mktime(self.avg_date.timetuple())
         self.url_wait = None
         self.url_tries = 0

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -905,6 +905,9 @@ def check_encrypted_and_unwanted_postproc(nzo: NzbObject, files_to_check: list[s
     # Local import to avoid circular dependency with assembler
     from sabnzbd.assembler import check_encrypted_and_unwanted_files
 
+    # The user may have explicitly resumed/retried and want to skip the unwanted checks
+    skip_unwanted = nzo.unwanted_ext == 2
+
     for filepath in files_to_check:
         if not os.path.exists(filepath):
             continue
@@ -919,7 +922,7 @@ def check_encrypted_and_unwanted_postproc(nzo: NzbObject, files_to_check: list[s
                 nzo.fail_msg = T("Aborted, encryption detected")
                 return True
 
-            if unwanted_file:
+            if unwanted_file and not skip_unwanted:
                 logging.warning(
                     T('In "%s" unwanted extension in RAR file. Unwanted file is %s '),
                     nzo.final_name,
@@ -927,7 +930,7 @@ def check_encrypted_and_unwanted_postproc(nzo: NzbObject, files_to_check: list[s
                 )
                 nzo.fail_msg = T("Aborted, unwanted extension detected")
                 return True
-        else:
+        elif not skip_unwanted:
             # Non-RAR files: check for unwanted extension
             if cfg.unwanted_extensions() and cfg.action_on_unwanted_extensions() and has_unwanted_extension(filepath):
                 logging.warning(

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -923,22 +923,28 @@ def check_encrypted_and_unwanted_postproc(nzo: NzbObject, files_to_check: list[s
                 return True
 
             if unwanted_file and not skip_unwanted:
-                logging.warning(
-                    T('In "%s" unwanted extension in RAR file. Unwanted file is %s '),
-                    nzo.final_name,
-                    unwanted_file,
-                )
+                # Don't repeat the warning
+                if nzo.unwanted_ext == 0:
+                    logging.warning(
+                        T('In "%s" unwanted extension in RAR file. Unwanted file is %s '),
+                        nzo.final_name,
+                        unwanted_file,
+                    )
                 nzo.fail_msg = T("Aborted, unwanted extension detected")
+                nzo.unwanted_ext = 1
                 return True
         elif not skip_unwanted:
             # Non-RAR files: check for unwanted extension
             if cfg.unwanted_extensions() and cfg.action_on_unwanted_extensions() and has_unwanted_extension(filepath):
-                logging.warning(
-                    T('In "%s" unwanted extension found: %s'),
-                    nzo.final_name,
-                    os.path.basename(filepath),
-                )
+                # Don't repeat the warning
+                if nzo.unwanted_ext == 0:
+                    logging.warning(
+                        T('In "%s" unwanted extension found: %s'),
+                        nzo.final_name,
+                        os.path.basename(filepath),
+                    )
                 nzo.fail_msg = T("Aborted, unwanted extension detected")
+                nzo.unwanted_ext = 1
                 return True
     return False
 

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -73,6 +73,7 @@ from sabnzbd.filesystem import (
     get_unique_filename,
     get_ext,
     get_filename,
+    has_unwanted_extension,
 )
 from sabnzbd.nzb import NzbObject
 from sabnzbd.sorting import Sorter
@@ -436,10 +437,22 @@ def process_job(nzo: NzbObject) -> bool:
 
         # Par processing, if enabled
         if all_ok and flag_repair:
+            # Snapshot files before repair for comparison afterwards
+            files_before_repair = set(listdir_full(nzo.download_path))
+
             par_error, re_add = parring(nzo)
             if re_add:
                 # Try to get more par files
                 return False
+
+            # After repair, re-check files that failed during assembly and any new files created by repair
+            if not par_error:
+                files_after_repair = set(listdir_full(nzo.download_path))
+                new_repair_files = files_after_repair - files_before_repair
+                files_to_check = [f for f in nzo.unchecked_files if os.path.exists(f)]
+                files_to_check.extend(new_repair_files)
+                if files_to_check and check_encrypted_and_unwanted_postproc(nzo, files_to_check):
+                    all_ok = False
 
         # If we don't need extra par2, we can disconnect
         if not sabnzbd.NzbQueue.actives(grabs=False) and cfg.autodisconnect():
@@ -479,6 +492,12 @@ def process_job(nzo: NzbObject) -> bool:
                 logging.info("Running unpacker on %s", filename)
                 unpack_error, newfiles = unpacker(nzo, tmp_workdir_complete, one_folder)
                 logging.info("Unpacked files %s", newfiles)
+
+                # Check newly unpacked files for encrypted/unwanted content
+                if newfiles and not unpack_error:
+                    if check_encrypted_and_unwanted_postproc(nzo, newfiles):
+                        all_ok = False
+                        unpack_error = True
 
                 # Sanitize the resulting files
                 newfiles = sanitize_files(filelist=newfiles)
@@ -875,6 +894,50 @@ def parring(nzo: NzbObject) -> tuple[bool, bool]:
 
     logging.info("Verification and repair finished for %s", nzo.final_name)
     return par_error, re_add
+
+
+def check_encrypted_and_unwanted_postproc(nzo: NzbObject, files_to_check: list[str]) -> bool:
+    """Check files for encryption and unwanted extensions during post-processing.
+    Used to re-check files that could not be inspected during assembly (e.g. corrupt RARs
+    that needed par2 repair) and to check new files created by repair or unpacking.
+    Returns True if the job should be aborted.
+    """
+    # Local import to avoid circular dependency with assembler
+    from sabnzbd.assembler import check_encrypted_and_unwanted_files
+
+    for filepath in files_to_check:
+        if not os.path.exists(filepath):
+            continue
+
+        if rarfile.is_rarfile(filepath):
+            rar_encrypted, unwanted_file = check_encrypted_and_unwanted_files(nzo, filepath)
+            if rar_encrypted:
+                logging.warning(
+                    T('Aborted job "%s" because of encrypted RAR file (if supplied, all passwords were tried)'),
+                    nzo.final_name,
+                )
+                nzo.fail_msg = T("Aborted, encryption detected")
+                return True
+
+            if unwanted_file:
+                logging.warning(
+                    T('In "%s" unwanted extension in RAR file. Unwanted file is %s '),
+                    nzo.final_name,
+                    unwanted_file,
+                )
+                nzo.fail_msg = T("Aborted, unwanted extension detected")
+                return True
+        else:
+            # Non-RAR files: check for unwanted extension
+            if cfg.unwanted_extensions() and cfg.action_on_unwanted_extensions() and has_unwanted_extension(filepath):
+                logging.warning(
+                    T('In "%s" unwanted extension found: %s'),
+                    nzo.final_name,
+                    os.path.basename(filepath),
+                )
+                nzo.fail_msg = T("Aborted, unwanted extension detected")
+                return True
+    return False
 
 
 def try_sfv_check(nzo: NzbObject) -> Optional[bool]:

--- a/tests/test_postproc.py
+++ b/tests/test_postproc.py
@@ -391,3 +391,324 @@ class TestNzbOnlyDownload:
 
         # Verify process_single_nzb was NOT called
         mock_process_single_nzb.assert_not_called()
+
+
+class TestCheckEncryptedAndUnwantedPostproc:
+    """Tests for check_encrypted_and_unwanted_postproc"""
+
+    @staticmethod
+    def _make_nzo(**overrides):
+        nzo = mock.Mock()
+        nzo.final_name = "TestJob"
+        nzo.unwanted_ext = 0
+        nzo.encrypted = 0
+        nzo.fail_msg = ""
+        for k, v in overrides.items():
+            setattr(nzo, k, v)
+        return nzo
+
+    @mock.patch("sabnzbd.assembler.check_encrypted_and_unwanted_files")
+    @mock.patch("sabnzbd.postproc.rarfile.is_rarfile", return_value=True)
+    def test_rar_with_unwanted_extension_aborts(self, _mock_is_rar, mock_check, tmp_path):
+        """RAR containing an unwanted file is detected and aborts"""
+        rar = tmp_path / "test.rar"
+        rar.write_bytes(b"data")
+        mock_check.return_value = (False, "malware.exe")
+
+        nzo = self._make_nzo()
+        assert postproc.check_encrypted_and_unwanted_postproc(nzo, [str(rar)]) is True
+        assert "unwanted" in nzo.fail_msg.lower()
+
+    @mock.patch("sabnzbd.assembler.check_encrypted_and_unwanted_files")
+    @mock.patch("sabnzbd.postproc.rarfile.is_rarfile", return_value=True)
+    def test_rar_with_encryption_aborts(self, _mock_is_rar, mock_check, tmp_path):
+        """Encrypted RAR is detected and aborts"""
+        rar = tmp_path / "test.rar"
+        rar.write_bytes(b"data")
+        mock_check.return_value = (True, None)
+
+        nzo = self._make_nzo()
+        assert postproc.check_encrypted_and_unwanted_postproc(nzo, [str(rar)]) is True
+        assert "encryption" in nzo.fail_msg.lower()
+
+    @mock.patch("sabnzbd.postproc.rarfile.is_rarfile", return_value=False)
+    def test_non_rar_unwanted_extension_aborts(self, _mock_is_rar, tmp_path):
+        """Plain file with an unwanted extension is detected"""
+        bad_file = tmp_path / "payload.exe"
+        bad_file.write_bytes(b"data")
+
+        nzo = self._make_nzo()
+
+        @set_config({"unwanted_extensions": ["exe"], "action_on_unwanted_extensions": 2})
+        def _run():
+            return postproc.check_encrypted_and_unwanted_postproc(nzo, [str(bad_file)])
+
+        assert _run() is True
+        assert "unwanted" in nzo.fail_msg.lower()
+
+    @mock.patch("sabnzbd.postproc.rarfile.is_rarfile", return_value=False)
+    def test_non_rar_allowed_extension_passes(self, _mock_is_rar, tmp_path):
+        """Plain file with an allowed extension passes"""
+        good_file = tmp_path / "movie.mkv"
+        good_file.write_bytes(b"data")
+
+        nzo = self._make_nzo()
+
+        @set_config({"unwanted_extensions": ["exe"], "action_on_unwanted_extensions": 2})
+        def _run():
+            return postproc.check_encrypted_and_unwanted_postproc(nzo, [str(good_file)])
+
+        assert _run() is False
+
+    @mock.patch("sabnzbd.assembler.check_encrypted_and_unwanted_files")
+    @mock.patch("sabnzbd.postproc.rarfile.is_rarfile", return_value=True)
+    def test_retry_skips_unwanted_in_rar(self, _mock_is_rar, mock_check, tmp_path):
+        """unwanted_ext == 2 (retry override) skips unwanted-in-RAR checks"""
+        rar = tmp_path / "test.rar"
+        rar.write_bytes(b"data")
+        mock_check.return_value = (False, "malware.exe")
+
+        nzo = self._make_nzo(unwanted_ext=2)
+        assert postproc.check_encrypted_and_unwanted_postproc(nzo, [str(rar)]) is False
+
+    @mock.patch("sabnzbd.postproc.rarfile.is_rarfile", return_value=False)
+    def test_retry_skips_unwanted_plain_file(self, _mock_is_rar, tmp_path):
+        """unwanted_ext == 2 (retry override) skips plain-file unwanted checks"""
+        bad_file = tmp_path / "payload.exe"
+        bad_file.write_bytes(b"data")
+
+        nzo = self._make_nzo(unwanted_ext=2)
+
+        @set_config({"unwanted_extensions": ["exe"], "action_on_unwanted_extensions": 2})
+        def _run():
+            return postproc.check_encrypted_and_unwanted_postproc(nzo, [str(bad_file)])
+
+        assert _run() is False
+
+    @mock.patch("sabnzbd.assembler.check_encrypted_and_unwanted_files")
+    @mock.patch("sabnzbd.postproc.rarfile.is_rarfile", return_value=True)
+    def test_retry_still_checks_encryption(self, _mock_is_rar, mock_check, tmp_path):
+        """unwanted_ext == 2 (retry override) still detects encrypted RARs"""
+        rar = tmp_path / "test.rar"
+        rar.write_bytes(b"data")
+        mock_check.return_value = (True, None)
+
+        nzo = self._make_nzo(unwanted_ext=2)
+        assert postproc.check_encrypted_and_unwanted_postproc(nzo, [str(rar)]) is True
+
+    def test_nonexistent_files_skipped(self):
+        """Files that no longer exist are silently skipped"""
+        nzo = self._make_nzo()
+        assert postproc.check_encrypted_and_unwanted_postproc(nzo, ["/no/such/file.rar"]) is False
+
+    @mock.patch("sabnzbd.assembler.check_encrypted_and_unwanted_files")
+    @mock.patch("sabnzbd.postproc.rarfile.is_rarfile", return_value=True)
+    def test_clean_rar_passes(self, _mock_is_rar, mock_check, tmp_path):
+        """RAR with no issues passes"""
+        rar = tmp_path / "clean.rar"
+        rar.write_bytes(b"data")
+        mock_check.return_value = (False, None)
+
+        nzo = self._make_nzo()
+        assert postproc.check_encrypted_and_unwanted_postproc(nzo, [str(rar)]) is False
+
+
+class TestPostProcUnwantedFileDiscovery:
+    """Tests verifying which files get passed to the unwanted check
+    after par2 repair and after unpacking."""
+
+    @staticmethod
+    def _make_nzo(download_path, **overrides):
+        nzo = mock.Mock()
+        nzo.final_name = "TestJob"
+        nzo.fail_msg = ""
+        nzo.repair = True
+        nzo.unpack = True
+        nzo.delete = True
+        nzo.precheck = False
+        nzo.cat = None
+        nzo.script = "None"
+        nzo.url = ""
+        nzo.status = Status.QUEUED
+        nzo.direct_unpacker = None
+        nzo.download_path = str(download_path)
+        nzo.admin_path = str(download_path / "__admin__")
+        nzo.unchecked_files = set()
+        nzo.unwanted_ext = 0
+        nzo.encrypted = 0
+        nzo.pp_or_finished = False
+        for k, v in overrides.items():
+            setattr(nzo, k, v)
+        return nzo
+
+    @mock.patch("sabnzbd.postproc.check_encrypted_and_unwanted_postproc")
+    @mock.patch("sabnzbd.postproc.parring")
+    @mock.patch("sabnzbd.postproc.notifier")
+    @mock.patch("sabnzbd.postproc.globber", return_value=["__admin__", "file1"])
+    def test_unchecked_files_rechecked_after_repair(self, _glob, _notif, mock_parring, mock_check, tmp_path):
+        """Files that failed the assembler check (in unchecked_files) are
+        re-checked after par2 repair completes successfully."""
+        # Set up download dir with a file that was "unchecked" during assembly
+        download_path = tmp_path / "incomplete" / "job"
+        download_path.mkdir(parents=True)
+        rar_file = download_path / "data.part1.rar"
+        rar_file.write_bytes(b"repaired-rar-data")
+
+        nzo = self._make_nzo(download_path, unchecked_files={str(rar_file)})
+        mock_parring.return_value = (False, False)  # no par_error, no re_add
+        mock_check.return_value = False
+
+        with mock.patch("sabnzbd.postproc.listdir_full", return_value=[str(rar_file)]):
+            postproc.parring = mock_parring
+            # Simulate the repair section of process_job
+            files_before = set(postproc.listdir_full(nzo.download_path))
+            mock_parring(nzo)
+            files_after = set(postproc.listdir_full(nzo.download_path))
+
+            new_repair_files = files_after - files_before
+            files_to_check = [f for f in nzo.unchecked_files if os.path.exists(f)]
+            files_to_check.extend(new_repair_files)
+            if files_to_check:
+                postproc.check_encrypted_and_unwanted_postproc(nzo, files_to_check)
+
+        # The previously-unchecked rar must be in the check list
+        mock_check.assert_called_once()
+        checked_files = mock_check.call_args[0][1]
+        assert str(rar_file) in checked_files
+
+    @mock.patch("sabnzbd.postproc.check_encrypted_and_unwanted_postproc")
+    def test_new_files_from_repair_checked(self, mock_check, tmp_path):
+        """Files that appear after par2 repair (e.g. reconstructed from
+        par2 recovery data) are detected and checked."""
+        download_path = tmp_path / "incomplete" / "job"
+        download_path.mkdir(parents=True)
+
+        existing_file = download_path / "data.part1.rar"
+        existing_file.write_bytes(b"existing")
+
+        nzo = self._make_nzo(download_path)
+        mock_check.return_value = False
+
+        # Snapshot "before" with only the existing file
+        files_before = {str(existing_file)}
+
+        # Simulate par2 creating a new reconstructed file
+        hidden_file = download_path / "hidden_payload.rar"
+        hidden_file.write_bytes(b"was-hidden-in-par2-data")
+
+        # Snapshot "after"
+        files_after = {str(existing_file), str(hidden_file)}
+
+        new_repair_files = files_after - files_before
+        files_to_check = list(new_repair_files)
+        if files_to_check:
+            postproc.check_encrypted_and_unwanted_postproc(nzo, files_to_check)
+
+        mock_check.assert_called_once()
+        checked_files = mock_check.call_args[0][1]
+        assert str(hidden_file) in checked_files
+        # The pre-existing file should NOT be in the new-files list
+        assert str(existing_file) not in checked_files
+
+    @mock.patch("sabnzbd.postproc.check_encrypted_and_unwanted_postproc")
+    def test_renamed_files_from_repair_checked(self, mock_check, tmp_path):
+        """Files renamed by par2 (obfuscated;real name) appear as new
+        in the after-repair snapshot and are checked."""
+        download_path = tmp_path / "incomplete" / "job"
+        download_path.mkdir(parents=True)
+
+        obfuscated = download_path / "a1b2c3d4e5.xyz"
+        obfuscated.write_bytes(b"obfuscated-rar")
+
+        nzo = self._make_nzo(download_path)
+        mock_check.return_value = False
+
+        # Snapshot "before" with obfuscated name
+        files_before = {str(obfuscated)}
+
+        # Simulate par2 renaming the file
+        real_name = download_path / "movie.part1.rar"
+        obfuscated.rename(real_name)
+
+        # Snapshot "after" – the obfuscated name is gone, real name appeared
+        files_after = {str(real_name)}
+
+        new_repair_files = files_after - files_before
+        files_to_check = list(new_repair_files)
+        if files_to_check:
+            postproc.check_encrypted_and_unwanted_postproc(nzo, files_to_check)
+
+        mock_check.assert_called_once()
+        checked_files = mock_check.call_args[0][1]
+        assert str(real_name) in checked_files
+
+    @mock.patch("sabnzbd.postproc.check_encrypted_and_unwanted_postproc")
+    def test_unpacked_nested_files_checked(self, mock_check, tmp_path):
+        """Files extracted by the unpacker (including from nested archives)
+        are passed to the unwanted check."""
+        workdir_complete = tmp_path / "complete" / "job"
+        workdir_complete.mkdir(parents=True)
+
+        # Simulate files the unpacker would return
+        extracted_rar = workdir_complete / "nested.rar"
+        extracted_rar.write_bytes(b"nested-rar")
+        extracted_plain = workdir_complete / "readme.txt"
+        extracted_plain.write_bytes(b"text")
+        extracted_bad = workdir_complete / "hidden.exe"
+        extracted_bad.write_bytes(b"bad")
+
+        newfiles = [str(extracted_rar), str(extracted_plain), str(extracted_bad)]
+
+        nzo = self._make_nzo(tmp_path / "incomplete" / "job")
+        mock_check.return_value = False
+
+        # This mirrors the post-unpack check in process_job
+        if newfiles:
+            postproc.check_encrypted_and_unwanted_postproc(nzo, newfiles)
+
+        mock_check.assert_called_once()
+        checked_files = mock_check.call_args[0][1]
+        assert str(extracted_rar) in checked_files
+        assert str(extracted_plain) in checked_files
+        assert str(extracted_bad) in checked_files
+
+    @mock.patch("sabnzbd.postproc.check_encrypted_and_unwanted_postproc")
+    def test_unchecked_plus_new_files_combined(self, mock_check, tmp_path):
+        """Both unchecked files from assembly AND new files from repair
+        are combined into a single check call."""
+        download_path = tmp_path / "incomplete" / "job"
+        download_path.mkdir(parents=True)
+
+        # File that failed the assembler check
+        corrupt_rar = download_path / "corrupt.part1.rar"
+        corrupt_rar.write_bytes(b"was-corrupt-now-repaired")
+
+        # File that already existed and was fine
+        existing = download_path / "good.part2.rar"
+        existing.write_bytes(b"existing")
+
+        nzo = self._make_nzo(download_path, unchecked_files={str(corrupt_rar)})
+        mock_check.return_value = False
+
+        files_before = {str(corrupt_rar), str(existing)}
+
+        # Par2 repair reconstructs a missing file
+        reconstructed = download_path / "good.part3.rar"
+        reconstructed.write_bytes(b"reconstructed")
+
+        files_after = {str(corrupt_rar), str(existing), str(reconstructed)}
+
+        new_repair_files = files_after - files_before
+        files_to_check = [f for f in nzo.unchecked_files if os.path.exists(f)]
+        files_to_check.extend(new_repair_files)
+        if files_to_check:
+            postproc.check_encrypted_and_unwanted_postproc(nzo, files_to_check)
+
+        mock_check.assert_called_once()
+        checked_files = mock_check.call_args[0][1]
+        # corrupt_rar was unchecked, must now be checked
+        assert str(corrupt_rar) in checked_files
+        # reconstructed is new, must be checked
+        assert str(reconstructed) in checked_files
+        # existing was already fine, should NOT be checked again
+        assert str(existing) not in checked_files


### PR DESCRIPTION
Fixes #3361

Still a work in progress but it doesn't appear there would be much to it.

- [x] Needs tests
- [ ] Remove local import of `check_encrypted_and_unwanted_files` - move it somewhere else to avoid circular import, but probably refactor to avoid the repetition
- [x] Allow skipping the check on resumed jobs
- [x] Allow skipping the check on retried jobs
- [ ] May need adding to NzbObjectSaver but should probably use relative paths first, or just at runtime and list the directory to populate on restart i.e. treat all as unchecked on restart
- [ ] Possibly only needs to check after unpack when enable_recursive is enabled
- [ ] Check direct unpack is checked
- [ ] Behaviour on fail after unpack; probably needs to delete unpack result instead of leaving extracted files, else will be an orphaned job
- [ ] Probably exclude \_\_admin\_\_