### PR TITLE
builder/package.py: stop mangling test data (#2274)

### DIFF
--- a/builder/package.py
+++ b/builder/package.py
@@ -471,7 +471,10 @@ if __name__ == "__main__":
             shutil.copyfile(source_file, os.path.join(src_folder, source_file))
 
         # Make sure all line-endings are correct
+        # Skip test data directories which contain binary files with misleading extensions
         for input_filename in glob.glob("%s/**/*.*" % src_folder, recursive=True):
+            if os.path.join("tests", "data", "") in input_filename:
+                continue
             base, ext = os.path.splitext(input_filename)
             if ext.lower() not in (".py", ".txt", ".css", ".js", ".tmpl", ".sh", ".cmd"):
                 continue


### PR DESCRIPTION
Broke tests on Debian/Ubuntu, they reported it, never figured it out.

On Gentoo we skipped the failing test for years but 'just plain fails' didn't sit right with me. We found the tests only fail using release tarball, not git.

package.py script 'fixes' the line endings on .txt extensions but doesn't account for a stillrarbutnotagoodname.txt rar binary in the test data.

This breaks tests on anyone using the release tarballs. So we skip mangling the test data to allow for downstream CI to work.