### PR TITLE
Fix server test if connection closed

### DIFF
--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1425,7 +1425,7 @@ def test_nntp_server_dict(kwargs: dict[str, Union[str, list[str]]]) -> tuple[boo
 
     try:
         nw.init_connect()
-        while test_server.active:
+        while test_server.active and nw.nntp:
             nw.write()
             nw.read(on_response=on_response)
             if nw.ready:


### PR DESCRIPTION
Found while testing behaviour when after auth the server responds with 502, the connection is reset but nw.write() tries to use nw.nntp which is now None.