### PR TITLE
check nsis file exists before use

### DIFF
--- a/tools/make_mo.py
+++ b/tools/make_mo.py
@@ -197,10 +197,11 @@ def main():
     print("Main program MO files")
     process_po_folder(DOMAIN, PO_DIR)
 
-    print("NSIS MO files")
-    process_po_folder(DOMAIN_NSIS, PO_NSIS_DIR)
-    print("Patch NSIS script")
-    patch_nsis()
+    if os.path.exists(NSIS):
+        print("NSIS MO files")
+        process_po_folder(DOMAIN_NSIS, PO_NSIS_DIR)
+        print("Patch NSIS script")
+        patch_nsis()
 
     print("Remove temporary MO files")
     remove_mo_files()


### PR DESCRIPTION
to ensure tools/makemo also works without the windows installer present (e.g. in the extracted -src tarball).