### PR TITLE
Use SNAP_NAME env var for more precise snap detection

### DIFF
--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -826,7 +826,7 @@ def get_platform_description() -> str:
             platform_tags.append("Flatpak")
         elif "APPIMAGE" in os.environ:
             platform_tags.append("AppImage")
-        elif os.environ.get('SNAP_NAME') == 'sabnzbd':
+        elif os.environ.get("SNAP_NAME") == "sabnzbd":
             platform_tags.append("Snap")
         else:
             # Check for other forms of virtualization

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -826,7 +826,7 @@ def get_platform_description() -> str:
             platform_tags.append("Flatpak")
         elif "APPIMAGE" in os.environ:
             platform_tags.append("AppImage")
-        elif "SNAP" in os.environ:
+        elif os.environ.get('SNAP_NAME') == 'sabnzbd':
             platform_tags.append("Snap")
         else:
             # Check for other forms of virtualization


### PR DESCRIPTION
Correct check for sabnzbd running as snap. No more false info due to running sabnzbd from source with uv-with-snap.