### PR TITLE
Use UUID4 for nzo_id and rekey existing duplicates

### DIFF
--- a/sabnzbd/constants.py
+++ b/sabnzbd/constants.py
@@ -49,7 +49,7 @@ JOB_ADMIN = "__ADMIN__"
 VERIFIED_FILE = "__verified__"
 RENAMES_FILE = "__renames__"
 ATTRIB_FILE = "SABnzbd_attrib"
-NZO_FILE = "SABnzbd_nzo"
+NZO_FILE = "SABnzbd_nzo_data"
 REPAIR_REQUEST = "repair-all.sab"
 
 SABCTOOLS_VERSION_REQUIRED = "9.4.0"

--- a/sabnzbd/constants.py
+++ b/sabnzbd/constants.py
@@ -49,6 +49,7 @@ JOB_ADMIN = "__ADMIN__"
 VERIFIED_FILE = "__verified__"
 RENAMES_FILE = "__renames__"
 ATTRIB_FILE = "SABnzbd_attrib"
+NZO_FILE = "SABnzbd_nzo"
 REPAIR_REQUEST = "repair-all.sab"
 
 SABCTOOLS_VERSION_REQUIRED = "9.4.0"

--- a/sabnzbd/database.py
+++ b/sabnzbd/database.py
@@ -116,22 +116,38 @@ class HistoryDB:
                     "ALTER TABLE history ADD COLUMN time_added INTEGER;"
                 )
             if version < 7:
-                with self.connection:
-                    self.execute("PRAGMA user_version = 7;")
-                    if self.execute("""
+                try:
+                    self.connection.execute("BEGIN")
+                    self.execute("PRAGMA user_version = 7", raise_on_error=True)
+                    if self.execute(
+                        """
                         WITH duplicates AS (SELECT id, ROW_NUMBER() OVER (PARTITION BY nzo_id ORDER BY id) AS rn FROM history)
                         SELECT id FROM duplicates WHERE rn > 1
-                        """):
+                        """,
+                        raise_on_error=True,
+                    ):
                         for (row_id,) in self.cursor.fetchall():
-                            self.execute("UPDATE history SET nzo_id = ? WHERE id = ?", (str(uuid.uuid4()), row_id))
-                    self.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_history_nzo_id ON history(nzo_id);")
+                            self.execute(
+                                "UPDATE history SET nzo_id = ? WHERE id = ?",
+                                (str(uuid.uuid4()), row_id),
+                                raise_on_error=True,
+                            )
                     self.execute(
-                        "CREATE INDEX IF NOT EXISTS idx_history_archive_completed ON history(archive, completed DESC);"
+                        "CREATE UNIQUE INDEX IF NOT EXISTS idx_history_nzo_id ON history(nzo_id)",
+                        raise_on_error=True,
                     )
+                    self.execute(
+                        "CREATE INDEX IF NOT EXISTS idx_history_archive_completed ON history(archive, completed DESC)",
+                        raise_on_error=True,
+                    )
+                    self.connection.commit()
+                except:
+                    self.connection.rollback()
+                    raise
 
             HistoryDB.startup_done = True
 
-    def execute(self, command: str, args: Sequence = ()) -> bool:
+    def execute(self, command: str, args: Sequence = (), raise_on_error: bool = False) -> bool:
         """Wrapper for executing SQL commands"""
         for tries in (4, 3, 2, 1, 0):
             try:
@@ -145,6 +161,8 @@ class HistoryDB:
                     continue
                 elif "readonly" in error:
                     logging.error(T("Cannot write to History database, check access rights!"))
+                    if raise_on_error:
+                        raise
                     # Report back success, because there's no recovery possible
                     return True
                 elif match_str(error, ("not a database", "malformed", "no such table", "duplicate column name")):
@@ -157,6 +175,8 @@ class HistoryDB:
                         pass
                     HistoryDB.startup_done = False
                     self.connect()
+                    if raise_on_error:
+                        raise sqlite3.DatabaseError(error)
                     # Return False in case of "duplicate column" error
                     # because the column addition in connect() must be terminated
                     return True
@@ -170,6 +190,8 @@ class HistoryDB:
                     except Exception:
                         # Can fail in case of automatic rollback
                         logging.debug("Rollback Failed:", exc_info=True)
+                    if raise_on_error:
+                        raise
             return False
 
     def create_history_db(self):

--- a/sabnzbd/database.py
+++ b/sabnzbd/database.py
@@ -21,6 +21,7 @@ sabnzbd.database - Database Support
 
 import os
 import time
+import uuid
 import zlib
 import logging
 import sys
@@ -114,12 +115,19 @@ class HistoryDB:
                 _ = self.execute("PRAGMA user_version = 5;") and self.execute(
                     "ALTER TABLE history ADD COLUMN time_added INTEGER;"
                 )
-            if version < 6:
-                _ = (
-                    self.execute("PRAGMA user_version = 6;")
-                    and self.execute("CREATE UNIQUE INDEX idx_history_nzo_id ON history(nzo_id);")
-                    and self.execute("CREATE INDEX idx_history_archive_completed ON history(archive, completed DESC);")
-                )
+            if version < 7:
+                with self.connection:
+                    self.execute("PRAGMA user_version = 7;")
+                    if self.execute("""
+                        WITH duplicates AS (SELECT id, ROW_NUMBER() OVER (PARTITION BY nzo_id ORDER BY id) AS rn FROM history)
+                        SELECT id FROM duplicates WHERE rn > 1
+                        """):
+                        for (row_id,) in self.cursor.fetchall():
+                            self.execute("UPDATE history SET nzo_id = ? WHERE id = ?", (str(uuid.uuid4()), row_id))
+                    self.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_history_nzo_id ON history(nzo_id);")
+                    self.execute(
+                        "CREATE INDEX IF NOT EXISTS idx_history_archive_completed ON history(archive, completed DESC);"
+                    )
 
             HistoryDB.startup_done = True
 
@@ -200,7 +208,7 @@ class HistoryDB:
             "time_added" INTEGER
         )
         """)
-        self.execute("PRAGMA user_version = 6;")
+        self.execute("PRAGMA user_version = 7;")
         self.execute("CREATE UNIQUE INDEX idx_history_nzo_id ON history(nzo_id);")
         self.execute("CREATE INDEX idx_history_archive_completed ON history(archive, completed DESC);")
 

--- a/sabnzbd/nzb/object.py
+++ b/sabnzbd/nzb/object.py
@@ -1435,6 +1435,7 @@ class NzbObject(TryList):
             remove_all(self.download_path, recursive=True)
         else:
             # We remove any saved articles and save the renames file
+            remove_all(self.download_path, NZO_FILE, keep_folder=True)
             remove_all(self.download_path, "SABnzbd_nz?_*", keep_folder=True)
             remove_all(self.download_path, "SABnzbd_article_*", keep_folder=True)
             save_data(self.renames, RENAMES_FILE, self.admin_path, silent=True)

--- a/sabnzbd/nzb/object.py
+++ b/sabnzbd/nzb/object.py
@@ -47,6 +47,7 @@ from sabnzbd.constants import (
     MAX_BAD_ARTICLES,
     Status,
     DuplicateStatus,
+    NZO_FILE,
 )
 from sabnzbd.misc import (
     to_units,
@@ -1474,7 +1475,7 @@ class NzbObject(TryList):
         """Save job's admin to disk"""
         self.save_attribs()
         if self.nzo_id and not self.removed_from_queue:
-            save_data(self, self.nzo_id, self.admin_path)
+            save_data(self, NZO_FILE, self.admin_path)
 
     def save_attribs(self):
         """Save specific attributes for Retry"""

--- a/sabnzbd/nzb/object.py
+++ b/sabnzbd/nzb/object.py
@@ -371,7 +371,6 @@ class NzbObject(TryList):
 
         # When doing a retry or repair, remove old cache-files
         if reuse:
-            remove_all(admin_dir, NZO_FILE, keep_folder=True)
             remove_all(admin_dir, "SABnzbd_nz?_*", keep_folder=True)
             remove_all(admin_dir, "SABnzbd_article_*", keep_folder=True)
 
@@ -1430,12 +1429,14 @@ class NzbObject(TryList):
             # If duplicate is discarded during URL-fetches, no nzo_id is known yet
             if self.nzo_id:
                 # Remove temporary file left from URL-fetches
-                remove_data(f"SABnzbd_nzo_{self.nzo_id}", self.admin_path)
+                if self.nzo_id.startswith("SABnzbd_nzo_"):
+                    remove_data(self.nzo_id, self.admin_path)
+                else:
+                    remove_data(f"SABnzbd_nzo_{self.nzo_id}", self.admin_path)
         elif delete_all_data:
             remove_all(self.download_path, recursive=True)
         else:
             # We remove any saved articles and save the renames file
-            remove_all(self.download_path, NZO_FILE, keep_folder=True)
             remove_all(self.download_path, "SABnzbd_nz?_*", keep_folder=True)
             remove_all(self.download_path, "SABnzbd_article_*", keep_folder=True)
             save_data(self.renames, RENAMES_FILE, self.admin_path, silent=True)

--- a/sabnzbd/nzb/object.py
+++ b/sabnzbd/nzb/object.py
@@ -1430,7 +1430,7 @@ class NzbObject(TryList):
             # If duplicate is discarded during URL-fetches, no nzo_id is known yet
             if self.nzo_id:
                 # Remove temporary file left from URL-fetches
-                remove_data(self.nzo_id, self.admin_path)
+                remove_data(f"SABnzbd_nzo_{self.nzo_id}", self.admin_path)
         elif delete_all_data:
             remove_all(self.download_path, recursive=True)
         else:

--- a/sabnzbd/nzb/object.py
+++ b/sabnzbd/nzb/object.py
@@ -371,6 +371,7 @@ class NzbObject(TryList):
 
         # When doing a retry or repair, remove old cache-files
         if reuse:
+            remove_all(admin_dir, NZO_FILE, keep_folder=True)
             remove_all(admin_dir, "SABnzbd_nz?_*", keep_folder=True)
             remove_all(admin_dir, "SABnzbd_article_*", keep_folder=True)
 

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -92,19 +92,24 @@ class NzbQueue:
         folders = []
         for nzo_id in nzo_ids:
             folder, _id = os.path.split(nzo_id)
-            path = get_admin_path(folder, future=False)
+            normal_path = get_admin_path(folder, future=False)
+            future_path = get_admin_path(folder, future=True)
 
-            # Try as normal job
-            nzo = sabnzbd.filesystem.load_data(NZO_FILE, path, remove=False)
-            if not nzo:
-                nzo = sabnzbd.filesystem.load_data(_id, path, remove=False)
-            if not nzo:
+            attempts = [
+                # Try as normal job
+                (normal_path, NZO_FILE, False),
+                (normal_path, _id, False),
                 # Try as future job
-                path = get_admin_path(folder, future=True)
-                nzo = sabnzbd.filesystem.load_data(_id, path)
-            if nzo:
-                self.add(nzo, save=False, quiet=True)
-                folders.append(folder)
+                (future_path, f"SABnzbd_nzo_{_id}", True),
+                (future_path, _id, True),
+            ]
+
+            for path, filename, remove in attempts:
+                nzo = sabnzbd.filesystem.load_data(filename, path, remove=remove)
+                if nzo:
+                    self.add(nzo, save=False, quiet=True)
+                    folders.append(folder)
+                    break
 
         # Scan for any folders in "incomplete" that are not yet in the queue
         if repair:

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -243,7 +243,7 @@ class NzbQueue:
                         # Also includes save_data for NZO
                         nzo.save_to_disk()
                     else:
-                        sabnzbd.filesystem.save_data(nzo, nzo.nzo_id, nzo.admin_path)
+                        sabnzbd.filesystem.save_data(nzo, f"SABnzbd_nzo_{nzo.nzo_id}", nzo.admin_path)
 
         sabnzbd.filesystem.save_admin((QUEUE_VERSION, nzo_ids, []), QUEUE_FILE_NAME)
 

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -22,6 +22,7 @@ sabnzbd.nzbqueue - nzb queue
 import os
 import logging
 import time
+import uuid
 import cherrypy._cpreqbody
 from typing import Union, Optional
 
@@ -45,6 +46,7 @@ from sabnzbd.constants import (
     Status,
     IGNORED_FILES_AND_FOLDERS,
     DuplicateStatus,
+    NZO_FILE,
 )
 
 import sabnzbd.cfg as cfg
@@ -93,7 +95,9 @@ class NzbQueue:
             path = get_admin_path(folder, future=False)
 
             # Try as normal job
-            nzo = sabnzbd.filesystem.load_data(_id, path, remove=False)
+            nzo = sabnzbd.filesystem.load_data(NZO_FILE, path, remove=False)
+            if not nzo:
+                nzo = sabnzbd.filesystem.load_data(_id, path, remove=False)
             if not nzo:
                 # Try as future job
                 path = get_admin_path(folder, future=True)
@@ -312,7 +316,7 @@ class NzbQueue:
     def add(self, nzo: NzbObject, save: bool = True, quiet: bool = False) -> str:
         # Can already be set for future jobs
         if not nzo.nzo_id:
-            nzo.nzo_id = sabnzbd.filesystem.get_new_id("nzo", nzo.admin_path, self.__nzo_table)
+            nzo.nzo_id = str(uuid.uuid4())
 
         # If no files are to be downloaded anymore, send to postproc
         if not nzo.files and not nzo.futuretype:

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -247,6 +247,8 @@ class NzbQueue:
                     if not nzo.futuretype:
                         # Also includes save_data for NZO
                         nzo.save_to_disk()
+                    elif nzo.nzo_id.startswith("SABnzbd_nzo_"):
+                        sabnzbd.filesystem.save_data(nzo, nzo.nzo_id, nzo.admin_path)
                     else:
                         sabnzbd.filesystem.save_data(nzo, f"SABnzbd_nzo_{nzo.nzo_id}", nzo.admin_path)
 

--- a/tests/data/tavern/api_queue_format.yaml
+++ b/tests/data/tavern/api_queue_format.yaml
@@ -56,7 +56,7 @@ stages:
           finish: !anyint
           slots: !anylist
             index: !re_match "[0-9]+"
-            nzo_id: !re_match "SABnzbd_nzo_.*"
+            nzo_id: "!anystr"
             unpackopts: !re_match "-?[0-9]+"
             priority: "!anystr"
             script: "!anystr"

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -223,7 +223,7 @@ class FakeHistoryDB(db.HistoryDB):
             nzo.url = "placeholder_url"
             nzo.status = choice([Status.COMPLETED, choice(self.status_options)])
             nzo.fail_msg = "¡Fracaso absoluto!" if nzo.status == Status.FAILED else ""
-            nzo.nzo_id = "SABnzbd_nzo_%s" % ("".join(choice(ascii_lowercase + digits) for i in range(8)))
+            nzo.nzo_id = str(uuid.uuid4())
             nzo.bytes_downloaded = randint(1024, 1024**4)
             nzo.md5sum = "".join(choice("abcdef" + digits) for i in range(32))
             nzo.repair, nzo.unpack, nzo.delete = pp_to_opts(choice(list(PP_LOOKUP.keys())))  # for "pp"


### PR DESCRIPTION
Fixes #3391

The NZO id wasn't always unique, I suspect there was a bug at some point causing history items to be inserted multiple times.

This switches nzo_id to UUID4 going forward so we don't need to worry about collisions, and rekeys existing duplicates.

- `with self.connection:` runs the migration in a transaction; should get in the habit of doing this, better to fail entirely rather than make some of the changes
- `CREATE [UNIQUE] INDEX IF NOT EXISTS` successful migrations to 6 make no changes to the schema
- `NZO_FILE` because repair job cleans up `SABnzbd_nz?` and there can only be one NZO per admin folder[^1] avoiding path length issues, similar to the SABnzbd_attrib file.

future nzo files are prefixed "SABnzbd_nzo_" but the per queue item file is called "SABnzbd_nzo", most of the changes are dealing with nzo_id no longer having the prefix but there being several cleanups looking for SABnzbd_nz?_* files.

[^1]: existing queue items will have the old naming for \_\_admin\_\_ (SABnzbd_nzo_IDIDIDID), but subsequent saves will be to SABnzbd_nzo, I don't think it's a problem for repairs because it tries to loa SABnzbd_nzo first.