### PR TITLE
Fix stuck queue when articles complete while removed from queue

### DIFF
--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -500,7 +500,12 @@ class NewsWrapper:
         retry_article: bool = True,
     ) -> None:
         """Discard an article back to the queue"""
-        if article and not article.nzf.nzo.removed_from_queue:
+        if article:
+            # The job might return to the queue in the future so clear the current server
+            if article.nzf.nzo.removed_from_queue:
+                article.allow_new_fetcher()
+                return
+
             # Only some errors should count towards the total tries for each server
             if count_article_try:
                 article.tries += 1


### PR DESCRIPTION
Fixes one issue causing #3389

The linked issue triggers a situation where the item moves back and forth between the queue and postproc, the use of `article.nzf.nzo.removed_from_queue` allowed discarded requests to be ignored leaving the request never sent but left assigned to a server resulting in a stuck queue if the item is return to the queue.