### PR TITLE
Cleanup file_done logic

### DIFF
--- a/sabnzbd/nzb/file.py
+++ b/sabnzbd/nzb/file.py
@@ -167,12 +167,13 @@ class NzbFile(TryList):
         return article
 
     @synchronized()
-    def remove_article(self, article: Article, success: bool) -> int:
+    def remove_article(self, article: Article, success: bool) -> bool:
         """Handle completed article, possibly end of file"""
         if self.articles.pop(article, None) is not None:
             if success:
                 self.bytes_left -= article.bytes
-        return len(self.articles)
+        # Only on fully loaded files we can know if it's really done
+        return self.import_finished and not self.articles
 
     def set_par2(self, setname, vol, blocks):
         """Designate this file as a par2 file"""

--- a/sabnzbd/nzb/object.py
+++ b/sabnzbd/nzb/object.py
@@ -797,12 +797,7 @@ class NzbObject(TryList):
                     job_can_succeed = self.check_first_article_availability()
 
         # Remove from file-tracking
-        articles_left = nzf.remove_article(article, success)
-        file_done = not articles_left
-
-        # Only on fully loaded files we can know if it's really done
-        if not nzf.import_finished:
-            file_done = False
+        file_done = nzf.remove_article(article, success)
 
         # File completed, remove and do checks
         if file_done:
@@ -821,7 +816,7 @@ class NzbObject(TryList):
             return True, True, True
 
         # Check if there are any files left here, so the check is inside the NZO_LOCK
-        return articles_left, file_done, not self.files
+        return file_done, not self.files
 
     def check_existing_files(self, wdir: str):
         """Check if downloaded files already exits, for these set NZF to complete"""

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -739,7 +739,7 @@ class NzbQueue:
             nzf.reset_try_list()
             return
 
-        articles_left, file_done, post_done = nzo.remove_article(article, success)
+        file_done, post_done = nzo.remove_article(article, success)
 
         if not nzo.precheck:
             # Mark as on_disk so assembler knows it can skip this article


### PR DESCRIPTION
Due to other changes we don't use `len(self.articles)` anymore, so lets shift the `file_done` logic into `remove_article`.