### PR TITLE
Reserve filenames for NzbFile

### DIFF
--- a/sabnzbd/nzb/file.py
+++ b/sabnzbd/nzb/file.py
@@ -229,8 +229,12 @@ class NzbFile(TryList):
 
             self.nzo.verify_nzf_filename(self)
             filename = sanitize_filename(self.filename)
-            self.filepath = get_unique_filename(os.path.join(self.nzo.download_path, filename))
-            self.filename = get_filename(self.filepath)
+            # Must acquire nzo lock first, then nzf lock to prevent deadlock.
+            with self.nzo.lock, self.lock:
+                if self.filepath:
+                    return self.filepath
+                self.filepath = self.nzo.get_unique_filepath(filename)
+                self.filename = get_filename(self.filepath)
         return self.filepath
 
     @property

--- a/sabnzbd/nzb/object.py
+++ b/sabnzbd/nzb/object.py
@@ -274,6 +274,7 @@ class NzbObject(TryList):
         self.files: list[NzbFile] = []  # List of all NZFs
         self.files_table: dict[str, NzbFile] = {}  # Dictionary of NZFs indexed using NZF_ID
         self.renames: dict[str, str] = {}  # Dictionary of all renamed files
+        self.filenames: set[str] = set()  # Reserved filenames
 
         self.finished_files: list[NzbFile] = []  # List of all finished NZFs
 
@@ -1388,6 +1389,23 @@ class NzbObject(TryList):
         else:
             self.renames[name_set] = old_name
 
+    @synchronized()
+    def get_unique_filepath(self, filename: str) -> str:
+        """
+        Ensure a unique filepath by appending .N before extension if needed
+        """
+        directory = self.download_path
+        base_name, ext = os.path.splitext(filename)
+        candidate = filename
+        path = os.path.join(directory, candidate)
+        num = 1
+        while candidate in self.filenames or os.path.exists(path):
+            candidate = f"{base_name}.{num}{ext}"
+            path = os.path.join(directory, candidate)
+            num += 1
+        self.filenames.add(candidate)
+        return path
+
     @property
     def admin_path(self):
         """Return the full path for my job-admin folder"""
@@ -1667,6 +1685,10 @@ class NzbObject(TryList):
         self.url_tries = 0
         self.to_be_removed = False
         self.direct_unpacker = None
+        self.filenames = set()
+        for nzf in self.files_table.values():
+            if nzf.filepath:
+                self.filenames.add(get_filename(nzf.filepath))
 
         # Attributes added since 3.0.0
         if self.bytes_par2 is None:


### PR DESCRIPTION
Split from #3400 and fixes another issue with #3389

An nzb may import initially with all or multiple files having exactly the same name, `prepare_filepath()` may see neither on disk yet and allow multiple NzbFile to use the same path. I've resolved this by tracking reserved paths on the nzo at runtime.