### PR TITLE
Save nzo after last file_done even if before next_save

### DIFF
--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -754,7 +754,7 @@ class NzbQueue:
                     post_done = False
 
         # Save bookkeeping in case of crash
-        if file_done and (nzo.next_save is None or time.time() > nzo.next_save):
+        if file_done and (post_done or nzo.next_save is None or time.time() > nzo.next_save):
             nzo.save_to_disk()
             sabnzbd.BPSMeter.save()
             if nzo.save_timeout is None:


### PR DESCRIPTION
`nzo.next_save` is 120-300 seconds depending on size.

So for example at 100MB/s you could download ~8GB and have only saved state after the first file completed.

This is usually not a problem, because it's also saved on shutdown.

It's important for #3406 because I want to be able to load the state from disk for finished jobs.