### PR TITLE
Reduce time to test

### DIFF
--- a/interfaces/Config/templates/staticcfg/js/script.js
+++ b/interfaces/Config/templates/staticcfg/js/script.js
@@ -423,11 +423,11 @@ $(document).ready(function () {
                     do_restart();
                 } else {
                     $('#config_err_msg').text(" ");
-                    setTimeout(config_success, 1000);
+                    setTimeout(config_success, config.disableDelays ? 0 : 1000);
                 }
             } else {
                $('#config_err_msg').text(" ");
-               setTimeout(config_success, 1000);
+               setTimeout(config_success, config.disableDelays ? 0 : 1000);
             }
         },
         error: function () {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,10 @@ select = ["F821"]
 # macOS Bonjour symbols resolved via ctypes/dylib at runtime.
 "sabnzbd/utils/pybonjour.py" = ["F821"]
 "sabnzbd/utils/sleepless.py" = ["F821"]
+
+[tool.pytest.ini_options]
+markers = [
+    "config",
+    "platform",
+    "fake_fs",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,14 +44,14 @@ def clean_cache_dir(request):
     yield request
 
     # Remove cache dir with retries in case it's still running
-    for x in range(10):
+    for x in range(100):
         try:
             shutil.rmtree(SAB_CACHE_DIR)
             break
         except (FileNotFoundError, PermissionError):
             break
         except OSError:
-            time.sleep(1)
+            time.sleep(0.1)
     else:
         print("Unable to remove cache dir")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,8 +35,7 @@ from tests.testhelper import *
 def clean_cache_dir(request):
     # Remove cache if already there
     try:
-        if os.path.isdir(SAB_CACHE_DIR):
-            shutil.rmtree(SAB_CACHE_DIR)
+        shutil.rmtree(SAB_CACHE_DIR, ignore_errors=True)
         # Create an empty placeholder
         os.makedirs(SAB_CACHE_DIR)
     except Exception:
@@ -47,12 +46,14 @@ def clean_cache_dir(request):
     # Remove cache dir with retries in case it's still running
     for x in range(10):
         try:
-            time.sleep(1)
             shutil.rmtree(SAB_CACHE_DIR)
             break
+        except (FileNotFoundError, PermissionError):
+            break
         except OSError:
-            print("Unable to remove cache dir (try %d)" % x)
             time.sleep(1)
+    else:
+        print("Unable to remove cache dir")
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,13 +110,13 @@ def run_sabnzbd(clean_cache_dir, request):
     )
 
     # Wait for SAB to respond
-    for _ in range(30):
+    for _ in range(600):
         try:
             get_url_result()
             # Woohoo, we're up!
             break
         except requests.ConnectionError:
-            time.sleep(1)
+            time.sleep(0.05)
     else:
         # Make sure we clean up
         shutdown_sabnzbd()

--- a/tests/test_api_and_interface.py
+++ b/tests/test_api_and_interface.py
@@ -117,12 +117,12 @@ class TestSecuredExpose:
             set_remote_host_or_ip(hostname=test_hostname)
             self.check_full_access()
 
-    @set_config({"username": "foo", "password": "bar"})
+    @pytest.mark.config({"username": "foo", "password": "bar"})
     def test_check_hostname_not_user_password(self):
         set_remote_host_or_ip(hostname="not_me")
         self.check_full_access(redirect_match=r".*login.*")
 
-    @set_config({"host_whitelist": "test.com, not_evil"})
+    @pytest.mark.config({"host_whitelist": "test.com, not_evil"})
     def test_check_hostname_whitelist(self):
         set_remote_host_or_ip(hostname="test.com")
         self.check_full_access()
@@ -133,7 +133,7 @@ class TestSecuredExpose:
         set_remote_host_or_ip(remote_ip="::ffff:192.168.0.10")
         self.check_full_access()
 
-    @set_config({"local_ranges": "132.10."})
+    @pytest.mark.config({"local_ranges": "132.10."})
     def test_dual_stack_local_ranges(self):
         # Without custom local_ranges this one would be allowed
         set_remote_host_or_ip(remote_ip="::ffff:192.168.0.10")
@@ -209,7 +209,7 @@ class TestSecuredExpose:
         # Reset it
         sabnzbd.cfg.inet_exposure.set(sabnzbd.cfg.inet_exposure.default)
 
-    @set_config({"inet_exposure": 5, "username": "foo", "password": "bar"})
+    @pytest.mark.config({"inet_exposure": 5, "username": "foo", "password": "bar"})
     def test_inet_exposure_login_for_external(self):
         # Local user: full access
         set_remote_host_or_ip()
@@ -219,7 +219,7 @@ class TestSecuredExpose:
         set_remote_host_or_ip(hostname="100.100.100.100", remote_ip="11.11.11.11")
         self.check_full_access(redirect_match=r".*login.*")
 
-    @set_config({"api_warnings": False})
+    @pytest.mark.config({"api_warnings": False})
     def test_no_text_warnings(self):
         assert self.main_page.index() is None
         assert cherrypy.response.status == 403

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -171,7 +171,7 @@ class TestConfig:
         assert not config.validate_config_backup(self.create_dummy_zip("dummyfile"))
         assert config.validate_config_backup(self.create_dummy_zip(DEF_INI_FILE))
 
-    @set_config(
+    @pytest.mark.config(
         {
             "admin_dir": os.path.join(SAB_CACHE_DIR, "test_config_backup"),
             "complete_dir": os.path.join(SAB_COMPLETE_DIR, "test_config_backup"),

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -205,7 +205,7 @@ class TestConditionalCache:
         """Test that conditional_cache expires entries after specified time"""
         call_count = 0
 
-        @conditional_cache(cache_time=0.5)
+        @conditional_cache(cache_time=0.01)
         def test_func(value):
             nonlocal call_count
             call_count += 1
@@ -222,7 +222,7 @@ class TestConditionalCache:
         assert call_count == 1
 
         # Wait for cache to expire
-        time.sleep(0.6)
+        time.sleep(0.02)
 
         # Third call - should execute function again
         result3 = test_func("test")

--- a/tests/test_file_extension.py
+++ b/tests/test_file_extension.py
@@ -37,7 +37,7 @@ class Test_File_Extension:
         assert not file_extension.has_popular_extension("blabla/blabla.yyy")
 
     # user defined ext_rename_ignore
-    @set_config({"ext_rename_ignore": "xxx, yyy, zzz"})
+    @pytest.mark.config({"ext_rename_ignore": "xxx, yyy, zzz"})
     def test_ext_rename_ignore(self):
         assert file_extension.has_popular_extension("blabla/blabla.yyy")
 

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -28,8 +28,7 @@ import unicodedata
 from pathlib import Path
 import tempfile
 
-import pyfakefs.fake_filesystem_unittest as ffs
-from pyfakefs.fake_filesystem import OSType
+from pyfakefs.helpers import set_uid
 
 import sabnzbd.cfg
 import sabnzbd.filesystem as filesystem
@@ -39,7 +38,7 @@ from tests.testhelper import *
 # Set the global uid for fake filesystems to a non-root user;
 # by default this depends on the user running pytest.
 global_uid = 1000
-ffs.set_uid(global_uid)
+set_uid(global_uid)
 
 
 class TestFileFolderNameSanitizer:
@@ -47,7 +46,7 @@ class TestFileFolderNameSanitizer:
         assert filesystem.sanitize_filename(None) is None
         assert filesystem.sanitize_foldername(None) is None
 
-    @set_platform("win32")
+    @pytest.mark.platform("win32")
     def test_colon_handling_windows(self):
         assert filesystem.sanitize_filename("test:aftertest") == "test_aftertest"
         assert filesystem.sanitize_filename(":") == "_"
@@ -56,7 +55,7 @@ class TestFileFolderNameSanitizer:
         # They should act the same
         assert filesystem.sanitize_filename("test:aftertest") == filesystem.sanitize_foldername("test:aftertest")
 
-    @set_platform("macos")
+    @pytest.mark.platform("macos")
     def test_colon_handling_macos(self):
         assert filesystem.sanitize_filename("test:aftertest") == "test_aftertest"
         assert filesystem.sanitize_filename(":aftertest") == "_aftertest"
@@ -67,14 +66,14 @@ class TestFileFolderNameSanitizer:
         assert filesystem.sanitize_filename("test:") == "test_"
         assert filesystem.sanitize_filename("test: ") == "test_"
 
-    @set_platform("linux")
+    @pytest.mark.platform("linux")
     def test_colon_handling_other(self):
         assert filesystem.sanitize_filename("test:aftertest") == "test:aftertest"
         assert filesystem.sanitize_filename(":") == ":"
         assert filesystem.sanitize_filename("test:") == "test:"
         assert filesystem.sanitize_filename("test: ") == "test:"
 
-    @set_platform("win32")
+    @pytest.mark.platform("win32")
     def test_win_devices_on_win(self):
         assert filesystem.sanitize_filename(None) is None
         assert filesystem.sanitize_filename("aux.txt") == "_aux.txt"
@@ -82,7 +81,7 @@ class TestFileFolderNameSanitizer:
         assert filesystem.sanitize_filename("$mft") == "Smft"
         assert filesystem.sanitize_filename("a$mft") == "a$mft"
 
-    @set_platform("linux")
+    @pytest.mark.platform("linux")
     def test_win_devices_not_win(self):
         # Linux and macOS are the same for this
         assert filesystem.sanitize_filename(None) is None
@@ -91,7 +90,7 @@ class TestFileFolderNameSanitizer:
         assert filesystem.sanitize_filename("$mft") == "$mft"
         assert filesystem.sanitize_filename("a$mft") == "a$mft"
 
-    @set_platform("win32")
+    @pytest.mark.platform("win32")
     def test_file_illegal_chars_win32(self):
         assert filesystem.sanitize_filename("test" + filesystem.CH_ILLEGAL_WIN + "aftertest") == (
             "test" + (len(filesystem.CH_ILLEGAL_WIN) * "_") + "aftertest"
@@ -101,14 +100,14 @@ class TestFileFolderNameSanitizer:
             == "test____aftertest"
         )
 
-    @set_platform("win32")
+    @pytest.mark.platform("win32")
     def test_folder_illegal_chars_win32(self):
         assert (
             filesystem.sanitize_foldername("test" + chr(0) + chr(9) + chr(13) + chr(31) + "aftertest")
             == "test____aftertest"
         )
 
-    @set_platform("linux")
+    @pytest.mark.platform("linux")
     def test_file_illegal_chars_linux(self):
         assert filesystem.sanitize_filename("test/aftertest") == "test_aftertest"
         assert filesystem.sanitize_filename("/test") == "_test"
@@ -119,13 +118,13 @@ class TestFileFolderNameSanitizer:
         assert filesystem.sanitize_filename("../") == ".._"
         assert filesystem.sanitize_filename("../test") == ".._test"
 
-    @set_platform("linux")
+    @pytest.mark.platform("linux")
     def test_folder_illegal_chars_linux(self):
         assert filesystem.sanitize_foldername('test"aftertest') == "test_aftertest"
         assert filesystem.sanitize_foldername("test:") == "test_"
         assert filesystem.sanitize_foldername("test<>?*|aftertest") == "test<>?*|aftertest"
 
-    @set_platform("linux")
+    @pytest.mark.platform("linux")
     def test_legal_chars_linux(self):
         # Illegal on Windows but not on Linux, unless sanitize_safe is active.
         # Don't bother with '/' which is illegal in filenames on all platforms.
@@ -137,8 +136,8 @@ class TestFileFolderNameSanitizer:
             assert filesystem.sanitize_filename("test" + char * 2) == ("test" + char * 2).strip()
             assert filesystem.sanitize_filename(char * 2 + "test") == (char * 2 + "test").strip()
 
-    @set_platform("linux")
-    @set_config({"sanitize_safe": True})
+    @pytest.mark.platform("linux")
+    @pytest.mark.config({"sanitize_safe": True})
     def test_sanitize_safe_linux(self):
         # Set sanitize_safe to on, simulating Windows-style restrictions.
         assert filesystem.sanitize_filename("test" + filesystem.CH_ILLEGAL_WIN + "aftertest") == (
@@ -346,21 +345,21 @@ class TestFileFolderNameSanitizer:
         assert sanitizedname == name  # no change
 
 
-class TestSanitizeFiles(ffs.TestCase):
-    def setUp(self):
-        self.setUpPyfakefs()
-        self.fs.os = OSType.WINDOWS
+@pytest.mark.platform("win32")
+@pytest.mark.fake_fs(
+    {
         # Disable randomisation of directory listings
-        self.fs.shuffle_listdir_results = False
-
+        "shuffle_listdir_results": False,
+    }
+)
+class TestSanitizeFiles:
     def test_sanitize_files_input(self):
         assert [] == filesystem.sanitize_files(folder=None)
         assert [] == filesystem.sanitize_files(filelist=None)
         assert [] == filesystem.sanitize_files(folder=None, filelist=None)
 
-    @set_platform("win32")
-    @set_config({"sanitize_safe": True})
-    def test_sanitize_files(self):
+    @pytest.mark.config({"sanitize_safe": True})
+    def test_sanitize_files(self, fake_fs):
         # The very specific tests of sanitize_filename() are above
         # Here we just want to see that sanitize_files() works as expected
         input_list = [r"c:\test\con.man", r"c:\test\foo:bar"]
@@ -370,7 +369,7 @@ class TestSanitizeFiles(ffs.TestCase):
         for kwargs in ({"folder": r"c:\test"}, {"filelist": input_list}):
             # Create source files
             for file in input_list:
-                self.fs.create_file(file)
+                fake_fs.create_file(file)
 
             assert output_list == filesystem.sanitize_files(**kwargs)
 
@@ -397,7 +396,7 @@ class TestSameDirectory:
         assert 0 == filesystem.same_directory("/test/./test", "/test")
 
     @pytest.mark.skipif(sys.platform.startswith("win"), reason="Non-Windows tests")
-    @set_platform("linux")
+    @pytest.mark.platform("linux")
     def test_posix_fun(self):
         assert 1 == filesystem.same_directory("/test", "/test")
         # IEEE 1003.1-2017 par. 4.13 for details
@@ -431,7 +430,7 @@ class TestSameDirectory:
         assert 0 == filesystem.same_directory("/mnt/sabnzbd", "/mnt/sabnzbd-data")
 
     @pytest.mark.skipif(sys.platform.startswith(("win", "darwin")), reason="Requires a case-sensitive filesystem")
-    @set_platform("linux")
+    @pytest.mark.platform("linux")
     def test_capitalization_linux(self):
         assert 2 == filesystem.same_directory("/home/test123", "/home/test123/sub")
         assert 0 == filesystem.same_directory("/test", "/Test")
@@ -444,18 +443,18 @@ class TestClipLongPath:
         assert filesystem.clip_path(None) is None
         assert filesystem.long_path(None) is None
 
-    @set_platform("win32")
+    @pytest.mark.platform("win32")
     def test_clip_path_win(self):
         assert filesystem.clip_path(r"\\?\UNC\test") == r"\\test"
         assert filesystem.clip_path(r"\\?\F:\test") == r"F:\test"
 
-    @set_platform("win32")
+    @pytest.mark.platform("win32")
     def test_nothing_to_clip_win(self):
         assert filesystem.clip_path(r"\\test") == r"\\test"
         assert filesystem.clip_path(r"F:\test") == r"F:\test"
         assert filesystem.clip_path("/test/dir") == "/test/dir"
 
-    @set_platform("linux")
+    @pytest.mark.platform("linux")
     def test_clip_path_non_win(self):
         # Shouldn't have any effect on platforms other than Windows
         assert filesystem.clip_path(r"\\?\UNC\test") == r"\\?\UNC\test"
@@ -464,17 +463,17 @@ class TestClipLongPath:
         assert filesystem.clip_path(r"F:\test") == r"F:\test"
         assert filesystem.clip_path("/test/dir") == "/test/dir"
 
-    @set_platform("win32")
+    @pytest.mark.platform("win32")
     def test_long_path_win(self):
         assert filesystem.long_path(r"\\test") == r"\\?\UNC\test"
         assert filesystem.long_path(r"F:\test") == r"\\?\F:\test"
 
-    @set_platform("win32")
+    @pytest.mark.platform("win32")
     def test_nothing_to_lenghten_win(self):
         assert filesystem.long_path(r"\\?\UNC\test") == r"\\?\UNC\test"
         assert filesystem.long_path(r"\\?\F:\test") == r"\\?\F:\test"
 
-    @set_platform("linux")
+    @pytest.mark.platform("linux")
     def test_long_path_non_win(self):
         # Shouldn't have any effect on platforms other than Windows
         assert filesystem.long_path(r"\\?\UNC\test") == r"\\?\UNC\test"
@@ -485,28 +484,22 @@ class TestClipLongPath:
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Non-Windows tests")
-class TestCheckMountLinux(ffs.TestCase):
-    # Our collection of fake directories
-    test_dirs = ["/media/test/dir", "/mnt/TEST/DIR"]
-
-    def setUp(self):
-        self.setUpPyfakefs()
-        self.fs.path_separator = "/"
-        self.fs.is_case_sensitive = True
-        for test_dir in self.test_dirs:
-            self.fs.create_dir(test_dir, perm_bits=755)
-            # Sanity check the fake filesystem
-            assert os.path.exists(test_dir) is True
-
-    @set_platform("linux")
-    def test_bare_mountpoint_linux(self):
+@pytest.mark.platform("linux")
+@pytest.mark.fake_fs(
+    {
+        "path_separator": "/",
+        "is_case_sensitive": True,
+        "create_dirs": ["/media/test/dir", "/mnt/TEST/DIR"],
+    }
+)
+class TestCheckMountLinux:
+    def test_bare_mountpoint_linux(self, fake_fs):
         assert filesystem.mount_is_available("/media") is True
         assert filesystem.mount_is_available("/media/") is True
         assert filesystem.mount_is_available("/mnt") is True
         assert filesystem.mount_is_available("/mnt/") is True
 
-    @set_platform("linux")
-    def test_existing_dir_linux(self):
+    def test_existing_dir_linux(self, fake_fs):
         assert filesystem.mount_is_available("/media/test") is True
         assert filesystem.mount_is_available("/media/test/dir/") is True
         assert filesystem.mount_is_available("/media/test/DIR/") is True
@@ -514,18 +507,14 @@ class TestCheckMountLinux(ffs.TestCase):
         assert filesystem.mount_is_available("/mnt/TEST/dir/") is True
         assert filesystem.mount_is_available("/mnt/TEST/DIR/") is True
 
-    @set_platform("linux")
-    # Cut down a bit on the waiting time
-    @set_config({"wait_ext_drive": 1})
-    def test_dir_nonexistent_linux(self):
+    def test_dir_nonexistent_linux(self, fake_fs, sleepless):
         # Filesystem is case-sensitive on this platform
         assert filesystem.mount_is_available("/media/TEST") is False  # Issue #1457
         assert filesystem.mount_is_available("/media/TesT/") is False
         assert filesystem.mount_is_available("/mnt/TeSt/DIR") is False
         assert filesystem.mount_is_available("/mnt/test/DiR/") is False
 
-    @set_platform("linux")
-    def test_dir_outsider_linux(self):
+    def test_dir_outsider_linux(self, fake_fs):
         # Outside of /media and /mnt
         assert filesystem.mount_is_available("/test/that/") is True
         # Root directory
@@ -533,115 +522,94 @@ class TestCheckMountLinux(ffs.TestCase):
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Non-Windows tests")
-class TestCheckMountMacOS(ffs.TestCase):
-    # Our faked macos directory
-    test_dir = "/Volumes/test/dir"
-
-    def setUp(self):
-        self.setUpPyfakefs()
-        self.fs.os = OSType.MACOS
-        self.fs.create_dir(self.test_dir, perm_bits=755)
-        # Verify the fake filesystem does its thing
-        assert os.path.exists(self.test_dir) is True
-
-    @set_platform("macos")
-    def test_bare_mountpoint_macos(self):
+@pytest.mark.platform("macos")
+@pytest.mark.fake_fs(
+    {
+        "create_dirs": ["/Volumes/test/dir"],
+    }
+)
+class TestCheckMountMacOS:
+    def test_bare_mountpoint_macos(self, fake_fs):
         assert filesystem.mount_is_available("/Volumes") is True
         assert filesystem.mount_is_available("/Volumes/") is True
 
-    @set_platform("macos")
-    def test_existing_dir_macos(self):
+    def test_existing_dir_macos(self, fake_fs):
         assert filesystem.mount_is_available("/Volumes/test") is True
         assert filesystem.mount_is_available("/Volumes/test/dir/") is True
         # Filesystem is set case-insensitive for this platform
         assert filesystem.mount_is_available("/VOLUMES/test") is True
         assert filesystem.mount_is_available("/volumes/Test/dir/") is True
 
-    @set_platform("macos")
-    # Cut down a bit on the waiting time
-    @set_config({"wait_ext_drive": 1})
-    def test_dir_nonexistent_macos(self):
+    def test_dir_nonexistent_macos(self, fake_fs, sleepless):
         # Within /Volumes
         assert filesystem.mount_is_available("/Volumes/nosuchdir") is False  # Issue #1457
         assert filesystem.mount_is_available("/Volumes/noSuchDir/") is False
         assert filesystem.mount_is_available("/Volumes/nosuchDIR/subdir") is False
         assert filesystem.mount_is_available("/Volumes/NOsuchdir/subdir/") is False
 
-    @set_platform("macos")
-    def test_dir_outsider_macos(self):
+    def test_dir_outsider_macos(self, fake_fs):
         # Outside of /Volumes
         assert filesystem.mount_is_available("/test/that/") is True
         # Root directory
         assert filesystem.mount_is_available("/") is True
 
 
-class TestCheckMountWin(ffs.TestCase):
-    # Our faked windows directory
-    test_dir = r"F:\test\dir"
-
-    def setUp(self):
-        self.setUpPyfakefs()
-        self.fs.os = OSType.WINDOWS
-        self.fs.create_dir(self.test_dir)
-        # Sanity check the fake filesystem
-        assert os.path.exists(self.test_dir) is True
-
-    @set_platform("win32")
-    def test_existing_dir_win(self):
+@pytest.mark.platform("win32")
+@pytest.mark.fake_fs(
+    {
+        "create_dirs": [r"F:\test\dir"],
+    }
+)
+class TestCheckMountWin:
+    def test_existing_dir_win(self, fake_fs):
         assert filesystem.mount_is_available("F:\\test") is True
         assert filesystem.mount_is_available("F:\\test\\dir\\") is True
         # Filesystem and drive letters are case-insensitive on this platform
         assert filesystem.mount_is_available("f:\\Test") is True
         assert filesystem.mount_is_available("f:\\test\\DIR\\") is True
 
-    @set_platform("win32")
-    def test_bare_mountpoint_win(self):
+    def test_bare_mountpoint_win(self, fake_fs, sleepless):
         assert filesystem.mount_is_available("F:\\") is True
         assert filesystem.mount_is_available("Z:\\") is False
 
-    @set_platform("win32")
-    def test_dir_nonexistent_win(self):
+    def test_dir_nonexistent_win(self, fake_fs):
         # The existence of the drive letter is what really matters
         assert filesystem.mount_is_available("F:\\NoSuchDir") is True
         assert filesystem.mount_is_available("F:\\NoSuchDir\\") is True
         assert filesystem.mount_is_available("F:\\NOsuchdir\\subdir") is True
         assert filesystem.mount_is_available("F:\\nosuchDIR\\subdir\\") is True
 
-    @set_platform("win32")
-    # Cut down a bit on the waiting time
-    @set_config({"wait_ext_drive": 1})
-    def test_dir_on_nonexistent_drive_win(self):
+    def test_dir_on_nonexistent_drive_win(self, fake_fs, sleepless):
         # Non-existent drive-letter
         assert filesystem.mount_is_available("H:\\NoSuchDir") is False
         assert filesystem.mount_is_available("E:\\NoSuchDir\\") is False
         assert filesystem.mount_is_available("L:\\NOsuchdir\\subdir") is False
         assert filesystem.mount_is_available("L:\\nosuchDIR\\subdir\\") is False
 
-    @set_platform("win32")
-    def test_dir_outsider_win(self):
+    def test_dir_outsider_win(self, fake_fs):
         # Outside the local filesystem
         assert filesystem.mount_is_available("//test/that/") is True
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Non-Windows tests")
-class TestListdirFull(ffs.TestCase):
-    # Basic fake filesystem setup stanza
-    def setUp(self):
-        self.setUpPyfakefs()
-        self.fs.path_separator = "/"
-        self.fs.is_case_sensitive = True
-
+@pytest.mark.fake_fs(
+    {
+        "path_separator": "/",
+        "is_case_sensitive": True,
+    }
+)
+class TestListdirFull:
     def test_nonexistent_dir(self):
         assert filesystem.listdir_full("/foo/bar") == []
 
-    def test_no_exceptions(self):
+    def test_no_exceptions(self, fake_fs):
         test_files = (
             "/test/dir/file1.ext",
             "/test/dir/file2",
             "/test/dir/sub/sub/sub/dir/file3.ext",
         )
         for file in test_files:
-            self.fs.create_file(file)
+            fake_fs.create_file(file)
             assert os.path.exists(file) is True
         # List our fake directory structure
         results_subdir = filesystem.listdir_full("/test/dir")
@@ -665,10 +633,10 @@ class TestListdirFull(ffs.TestCase):
         assert filesystem.listdir_full(r"/test/dir/sub", recursive=False) == []
         assert len(filesystem.listdir_full(r"/test/dir", recursive=False)) == 2
 
-    def test_exception_appledouble(self):
+    def test_exception_appledouble(self, fake_fs):
         # Anything below a .AppleDouble directory should be omitted
         test_file = "/foo/bar/.AppleDouble/Oooooo.ps"
-        self.fs.create_file(test_file)
+        fake_fs.create_file(test_file)
         assert os.path.exists(test_file) is True
         assert filesystem.listdir_full("/foo") == []
         assert filesystem.listdir_full("/foo/bar") == []
@@ -677,14 +645,14 @@ class TestListdirFull(ffs.TestCase):
         assert filesystem.listdir_full("/foo/bar", recursive=False) == []
         assert filesystem.listdir_full("/foo/bar/.AppleDouble", recursive=False) == []
 
-    def test_exception_dsstore(self):
+    def test_exception_dsstore(self, fake_fs):
         # Anything below a .DS_Store directory should be omitted
         for file in (
             "/some/FILE",
             "/some/.DS_Store/oh.NO",
             "/some/.DS_Store/subdir/The.End",
         ):
-            self.fs.create_file(file)
+            fake_fs.create_file(file)
             assert os.path.exists(file) is True
         assert filesystem.listdir_full("/some") == ["/some/FILE"]
         assert filesystem.listdir_full("/some/.DS_Store/") == []
@@ -693,42 +661,38 @@ class TestListdirFull(ffs.TestCase):
         assert filesystem.listdir_full("/some/.DS_Store/", recursive=False) == []
         assert filesystem.listdir_full("/some/.DS_Store/subdir", recursive=False) == []
 
-    def test_exception_resource_files(self):
+    def test_exception_resource_files(self, fake_fs):
         for file in (
             "/rsc/base_file",
             "/rsc/._base_file",
             "/rsc/not._base_file",
         ):
-            self.fs.create_file(file)
+            fake_fs.create_file(file)
             assert os.path.exists(file) is True
         assert sorted(filesystem.listdir_full("/rsc")) == ["/rsc/base_file", "/rsc/not._base_file"]
 
-    def test_invalid_file_argument(self):
+    def test_invalid_file_argument(self, fake_fs):
         # This is obviously not intended use; the function expects a directory
         # as its argument, not a file. Test anyway.
         test_file = "/dev/sleepy"
-        self.fs.create_file(test_file)
+        fake_fs.create_file(test_file)
         assert os.path.exists(test_file) is True
         assert filesystem.listdir_full(test_file) == []
 
 
-class TestListdirFullWin(ffs.TestCase):
-    # Basic fake filesystem setup stanza
-    def setUp(self):
-        self.setUpPyfakefs()
-        self.fs.os = OSType.WINDOWS
-
+@pytest.mark.platform("win32")
+class TestListdirFullWin:
     def test_nonexistent_dir(self):
         assert filesystem.listdir_full(r"F:\foo\bar") == []
 
-    def test_no_exceptions(self):
+    def test_no_exceptions(self, fake_fs):
         test_files = (
             r"f:\test\dir\file1.ext",
             r"f:\test\dir\file2",
             r"f:\test\dir\sub\sub\sub\dir\file3.ext",
         )
         for file in test_files:
-            self.fs.create_file(file)
+            fake_fs.create_file(file)
             assert os.path.exists(file) is True
         # List our fake directory structure
         results_subdir = filesystem.listdir_full(r"f:\test\dir")
@@ -752,10 +716,10 @@ class TestListdirFullWin(ffs.TestCase):
         assert filesystem.listdir_full(r"F:\test\dir\SUB", recursive=False) == []
         assert len(filesystem.listdir_full(r"f:\test\dir", recursive=False)) == 2
 
-    def test_exception_appledouble(self):
+    def test_exception_appledouble(self, fake_fs):
         # Anything below a .AppleDouble directory should be omitted
         test_file = r"f:\foo\bar\.AppleDouble\Oooooo.ps"
-        self.fs.create_file(test_file)
+        fake_fs.create_file(test_file)
         assert os.path.exists(test_file) is True
         assert filesystem.listdir_full(r"f:\foo") == []
         assert filesystem.listdir_full(r"f:\foo\bar") == []
@@ -764,14 +728,14 @@ class TestListdirFullWin(ffs.TestCase):
         assert filesystem.listdir_full(r"f:\foo\bar", recursive=False) == []
         assert filesystem.listdir_full(r"F:\foo\bar\.AppleDouble", recursive=False) == []
 
-    def test_exception_dsstore(self):
+    def test_exception_dsstore(self, fake_fs):
         # Anything below a .DS_Store directory should be omitted
         for file in (
             r"f:\some\FILE",
             r"f:\some\.DS_Store\oh.NO",
             r"f:\some\.DS_Store\subdir\The.End",
         ):
-            self.fs.create_file(file)
+            fake_fs.create_file(file)
             assert os.path.exists(file) is True
         assert filesystem.listdir_full(r"f:\some") == [r"f:\some\FILE"]
         assert filesystem.listdir_full(r"f:\some\.DS_Store") == []
@@ -780,55 +744,55 @@ class TestListdirFullWin(ffs.TestCase):
         assert filesystem.listdir_full(r"f:\some\.DS_Store", recursive=True) == []
         assert filesystem.listdir_full(r"f:\some\.DS_Store\subdir", recursive=True) == []
 
-    def test_exception_resource_files(self):
+    def test_exception_resource_files(self, fake_fs):
         for file in (
             r"f:\rsc\base_file",
             r"f:\rsc\._base_file",
             r"f:\rsc\not._base_file",
         ):
-            self.fs.create_file(file)
+            fake_fs.create_file(file)
             assert os.path.exists(file) is True
         assert sorted(filesystem.listdir_full(r"f:\rsc")) == [r"f:\rsc\base_file", r"f:\rsc\not._base_file"]
 
-    def test_invalid_file_argument(self):
+    def test_invalid_file_argument(self, fake_fs):
         # This is obviously not intended use; the function expects a directory
         # as its argument, not a file. Test anyway.
         test_file = r"f:\dev\sleepy"
-        self.fs.create_file(test_file)
+        fake_fs.create_file(test_file)
         assert os.path.exists(test_file) is True
         assert filesystem.listdir_full(test_file) == []
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Non-Windows tests")
-class TestGetUniqueDirFilename(ffs.TestCase):
-    # Basic fake filesystem setup stanza
-    def setUp(self):
-        self.setUpPyfakefs()
-        self.fs.path_separator = "/"
-        self.fs.is_case_sensitive = True
-
+@pytest.mark.fake_fs(
+    {
+        "path_separator": "/",
+        "is_case_sensitive": True,
+    }
+)
+class TestGetUniqueDirFilename:
     # Reduce the waiting time when the function calls check_mount()
-    @set_config({"wait_ext_drive": 1})
-    def test_nonexistent_dir(self):
+    @pytest.mark.config({"wait_ext_drive": 1})
+    def test_nonexistent_dir(self, fake_fs, sleepless):
         # Absolute path
         assert filesystem.get_unique_dir("/foo/bar", n=0, create_dir=False) == "/foo/bar"
         # Absolute path in a location that matters to check_mount
         assert filesystem.get_unique_dir("/mnt/foo/bar", n=0, create_dir=False) == "/mnt/foo/bar"
         # Relative path
-        if self.fs.cwd != "/":
+        if fake_fs.cwd != "/":
             os.chdir("/")
         assert filesystem.get_unique_dir("foo/bar", n=0, create_dir=False) == "foo/bar"
 
-    def test_nonexistent_dir_without_permission(self):
+    def test_nonexistent_dir_without_permission(self, fake_fs):
         some_dir = "/foo/bar"
-        self.fs.create_dir(some_dir)
+        fake_fs.create_dir(some_dir)
 
         # Remove write permission from the directory.
         os.chmod(some_dir, 0o500)
 
         assert filesystem.get_unique_dir(os.path.join(some_dir, "nonexistent"), create_dir=True) is False
 
-    def test_creating_dir(self):
+    def test_creating_dir(self, fake_fs):
         # First call also creates the directory for us
         assert filesystem.get_unique_dir("/foo/bar", n=0, create_dir=True) == "/foo/bar"
         # Verify creation of the path
@@ -841,50 +805,43 @@ class TestGetUniqueDirFilename(ffs.TestCase):
         assert filesystem.get_unique_dir("/foo/bar", n=666, create_dir=True) == "/foo/bar.666"
         assert os.path.exists("/foo/bar.666") is True
 
-    def test_nonexistent_file(self):
+    def test_nonexistent_file(self, fake_fs):
         assert filesystem.get_unique_filename("/dir/file.name") == "/dir/file.name"
         # Relative path
         assert filesystem.get_unique_filename("dir/file.name") == "dir/file.name"
 
-    def test_existing_file(self):
+    def test_existing_file(self, fake_fs):
         test_file = "/dir/file.name"
         max_obstruct = 11  # High enough for double digits
-        self.fs.create_file(test_file)
+        fake_fs.create_file(test_file)
         assert os.path.exists(test_file)
         # Create obstructions
         for n in range(1, max_obstruct):
             file_n = "/dir/file." + str(n) + ".name"
-            self.fs.create_file(file_n)
+            fake_fs.create_file(file_n)
             assert os.path.exists(file_n)
         assert filesystem.get_unique_filename(test_file) == "/dir/file." + str(max_obstruct) + ".name"
 
-    def test_existing_file_without_extension(self):
+    def test_existing_file_without_extension(self, fake_fs):
         test_file = "/some/filename"
         # Create obstructions
-        self.fs.create_file(test_file)
+        fake_fs.create_file(test_file)
         assert os.path.exists(test_file)
         first_filename = filesystem.get_unique_filename(test_file)
         assert first_filename == "/some/filename.1"
-        self.fs.create_file(first_filename)
+        fake_fs.create_file(first_filename)
         assert filesystem.get_unique_filename(test_file) == "/some/filename.2"
 
 
 @pytest.mark.skipif(not sys.platform.startswith("win"), reason="Windows specific tests")
-class TestGetUniqueDirFilenameWin(ffs.TestCase):
-    # Basic fake filesystem setup stanza
-    def setUp(self):
-        self.setUpPyfakefs()
-        self.fs.os = OSType.WINDOWS
-
-    # Reduce the waiting time when the function calls check_mount()
-    @set_config({"wait_ext_drive": 1})
-    def test_nonexistent_dir(self):
+class TestGetUniqueDirFilenameWin:
+    def test_nonexistent_dir(self, fake_fs, sleepless):
         # Absolute path
         assert filesystem.get_unique_dir(r"C:\No\Such\Dir", n=0, create_dir=False).lower() == r"c:\no\such\dir"
         # Relative path
         assert filesystem.get_unique_dir(r"foo\bar", n=0, create_dir=False).lower() == r"foo\bar"
 
-    def test_creating_dir(self):
+    def test_creating_dir(self, fake_fs):
         # First call also creates the directory for us
         assert filesystem.get_unique_dir(r"C:\foo\BAR", n=0, create_dir=True).lower() == r"c:\foo\bar"
         # Verify creation of the path
@@ -897,40 +854,35 @@ class TestGetUniqueDirFilenameWin(ffs.TestCase):
         assert filesystem.get_unique_dir(r"c:\Foo\Bar", n=666, create_dir=True).lower() == r"c:\foo\bar.666"
         assert os.path.exists(r"c:\foo\bar.666") is True
 
-    def test_nonexistent_file(self):
+    def test_nonexistent_file(self, fake_fs):
         assert filesystem.get_unique_filename(r"C:\DIR\file.name").lower() == r"c:\dir\file.name"
         # Relative path
         assert filesystem.get_unique_filename(r"DIR\file.name").lower() == r"dir\file.name"
 
-    def test_existing_file(self):
+    def test_existing_file(self, fake_fs):
         test_file = r"C:\dir\file.name"
         max_obstruct = 11  # High enough for double digits
-        self.fs.create_file(test_file)
+        fake_fs.create_file(test_file)
         assert os.path.exists(test_file)
         # Create obstructions
         for n in range(1, max_obstruct):
             file_n = r"C:\dir\file." + str(n) + ".name"
-            self.fs.create_file(file_n)
+            fake_fs.create_file(file_n)
             assert os.path.exists(file_n)
         assert filesystem.get_unique_filename(test_file).lower() == r"c:\dir\file." + str(max_obstruct) + ".name"
 
-    def test_existing_file_without_extension(self):
+    def test_existing_file_without_extension(self, fake_fs):
         test_file = r"c:\some\filename"
         # Create obstructions
-        self.fs.create_file(test_file)
+        fake_fs.create_file(test_file)
         assert os.path.exists(test_file)
         assert filesystem.get_unique_filename(test_file).lower() == r"c:\some\filename.1"
 
 
-class TestCreateAllDirsWin(ffs.TestCase):
-    # Basic fake filesystem setup stanza
-    def setUp(self):
-        self.setUpPyfakefs()
-        self.fs.os = OSType.WINDOWS
-
-    @set_platform("win32")
-    def test_create_all_dirs(self):
-        self.directory = self.fs.create_dir(r"C:\Downloads")
+@pytest.mark.platform("win32")
+class TestCreateAllDirsWin:
+    def test_create_all_dirs(self, fake_fs):
+        self.directory = fake_fs.create_dir(r"C:\Downloads")
         # Also test for no crash when folder already exists
         for folder in (r"C:\Downloads", r"C:\Downloads\Show\Test", r"C:\Downloads\Show\Test2", r"C:\Downloads\Show"):
             assert filesystem.create_all_dirs(folder) == folder
@@ -944,51 +896,58 @@ class PermissionCheckerHelper:
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Non-Windows tests")
-class TestCreateAllDirs(ffs.TestCase, PermissionCheckerHelper):
-    def setUp(self):
-        self.setUpPyfakefs()
-        self.fs.path_separator = "/"
-        self.fs.is_case_sensitive = True
-
-    def test_basic_folder_creation(self):
-        self.fs.create_dir("/test_base")
+@pytest.mark.fake_fs(
+    {
+        "path_separator": "/",
+        "is_case_sensitive": True,
+    }
+)
+class TestCreateAllDirs(PermissionCheckerHelper):
+    def test_basic_folder_creation(self, fake_fs):
+        fake_fs.create_dir("/test_base")
         # Also test for no crash when folder already exists
         for folder in ("/test_base", "/test_base/show/season 1/episode 1", "/test_base/show"):
             assert filesystem.create_all_dirs(folder) == folder
             assert os.path.exists(folder)
 
-    @set_config({"permissions": "0777"})
-    def test_permissions_777(self):
-        self._permissions_runner("/test_base777")
-        self._permissions_runner("/test_base777_nomask", apply_permissions=False)
+    @pytest.mark.config({"permissions": "0777"})
+    def test_permissions_777(self, fake_fs):
+        self._permissions_runner(fake_fs, "/test_base777")
+        self._permissions_runner(fake_fs, "/test_base777_nomask", apply_permissions=False)
 
-    @set_config({"permissions": "0770"})
-    def test_permissions_770(self):
-        self._permissions_runner("/test_base770")
-        self._permissions_runner("/test_base770_nomask", apply_permissions=False)
+    @pytest.mark.config({"permissions": "0770"})
+    def test_permissions_770(self, fake_fs):
+        self._permissions_runner(fake_fs, "/test_base770")
+        self._permissions_runner(fake_fs, "/test_base770_nomask", apply_permissions=False)
 
-    @set_config({"permissions": "0600"})
-    def test_permissions_600(self):
+    @pytest.mark.config({"permissions": "0600"})
+    def test_permissions_600(self, fake_fs):
         with pytest.raises(OSError):  # pyfakefs checks fake permissions now...
-            self._permissions_runner("/test_base600")
-        self._permissions_runner("/test_base600_nomask", apply_permissions=False)
+            self._permissions_runner(fake_fs, "/test_base600")
+        self._permissions_runner(fake_fs, "/test_base600_nomask", apply_permissions=False)
 
-    @set_config({"permissions": "0450"})
-    def test_permissions_450(self):
+    @pytest.mark.config({"permissions": "0450"})
+    def test_permissions_450(self, fake_fs):
         with pytest.raises(OSError):
-            self._permissions_runner("/test_base450", perms_base="0450")
+            self._permissions_runner(fake_fs, "/test_base450", perms_base="0450")
 
-    def test_no_permissions(self):
-        self._permissions_runner("/test_base_perm700", perms_base="0700")
-        self._permissions_runner("/test_base_perm750", perms_base="0750")
+    def test_no_permissions(self, fake_fs):
+        self._permissions_runner(fake_fs, "/test_base_perm700", perms_base="0700")
+        self._permissions_runner(fake_fs, "/test_base_perm750", perms_base="0750")
         with pytest.raises(OSError):  # pyfakefs checks fake permissions now...
-            self._permissions_runner("/test_base_perm600", perms_base="0600")
-        self._permissions_runner("/test_base_perm777", perms_base="0777")
+            self._permissions_runner(fake_fs, "/test_base_perm600", perms_base="0600")
+        self._permissions_runner(fake_fs, "/test_base_perm777", perms_base="0777")
 
-    def _permissions_runner(self, test_base, perms_base="0700", apply_permissions=True):
+    def _permissions_runner(
+        self,
+        fs,
+        test_base,
+        perms_base="0700",
+        apply_permissions=True,
+    ):
         # Create base directory and set the base permissions
         perms_base_int = int(perms_base, 8)
-        self.fs.create_dir(test_base, perms_base_int, apply_umask=False)
+        fs.create_dir(test_base, perms_base_int, apply_umask=False)
         assert os.path.exists(test_base) is True
         self.assert_dir_perms(test_base, perms_base_int)
 
@@ -1007,23 +966,23 @@ class TestCreateAllDirs(ffs.TestCase, PermissionCheckerHelper):
         self.assert_dir_perms(test_base, perms_base_int)
 
 
-class TestSetPermissionsWin(ffs.TestCase):
-    @set_platform("win32")
+@pytest.mark.platform("win32")
+class TestSetPermissionsWin:
     def test_win32(self):
         # Should not do or return anything on Windows
         assert filesystem.set_permissions(r"F:\who\cares", recursive=False) is None
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Non-Windows tests")
-class TestSetPermissions(ffs.TestCase, PermissionCheckerHelper):
-    # Basic fake filesystem setup stanza
-    def setUp(self):
-        self.setUpPyfakefs()
-        self.fs.path_separator = "/"
-        self.fs.is_case_sensitive = True
-        self.fs.umask = int("0022", 8)  # rwxr-xr-x
-
-    def _runner(self, perms_before_test):
+@pytest.mark.fake_fs(
+    {
+        "path_separator": "/",
+        "is_case_sensitive": True,
+        "umask": int("0022", 8),  # rwxr-xr-x
+    }
+)
+class TestSetPermissions(PermissionCheckerHelper):
+    def _runner(self, perms_before_test, fs):
         """
         Generic test runner for permissions testing. The permissions are set per test
         via the relevant sab config option; the filesystem parameter in setUp().
@@ -1042,7 +1001,7 @@ class TestSetPermissions(ffs.TestCase, PermissionCheckerHelper):
 
         # Setup and verify fake dir
         test_dir = "/test"
-        self.fs.create_dir(test_dir, perms_before_test, apply_umask=False)
+        fs.create_dir(test_dir, perms_before_test, apply_umask=False)
         assert os.path.exists(test_dir) is True
         self.assert_dir_perms(test_dir, perms_before_test)
 
@@ -1059,10 +1018,10 @@ class TestSetPermissions(ffs.TestCase, PermissionCheckerHelper):
             # Create the folder, so it has the expected permissions
             if not os.path.exists(basefolder):
                 try:
-                    self.fs.create_dir(basefolder, perms_before_test, apply_umask=False)
+                    fs.create_dir(basefolder, perms_before_test, apply_umask=False)
                 except PermissionError:
-                    ffs.set_uid(0)
-                    self.fs.create_file(file, perms_before_test, apply_umask=False)
+                    set_uid(0)
+                    fs.create_file(file, perms_before_test, apply_umask=False)
             assert os.path.exists(basefolder) is True
             self.assert_dir_perms(basefolder, perms_before_test)
 
@@ -1073,10 +1032,10 @@ class TestSetPermissions(ffs.TestCase, PermissionCheckerHelper):
 
             # Then, create the file
             try:
-                self.fs.create_file(file, file_perms_before_test, apply_umask=False)
+                fs.create_file(file, file_perms_before_test, apply_umask=False)
             except PermissionError:
-                ffs.set_uid(0)
-                self.fs.create_file(file, file_perms_before_test, apply_umask=False)
+                set_uid(0)
+                fs.create_file(file, file_perms_before_test, apply_umask=False)
 
             assert os.path.exists(file) is True
             assert stat.filemode(os.stat(file).st_mode)[1:] == stat.filemode(file_perms_before_test)[1:]
@@ -1099,48 +1058,48 @@ class TestSetPermissions(ffs.TestCase, PermissionCheckerHelper):
                 )
 
         # Cleanup
-        ffs.set_uid(0)
-        self.fs.remove_object(test_dir)
+        set_uid(0)
+        fs.remove_object(test_dir)
         assert os.path.exists(test_dir) is False
-        ffs.set_uid(global_uid)
+        set_uid(global_uid)
 
-    @set_platform("linux")
-    def test_empty_permissions_setting(self):
+    @pytest.mark.platform("linux")
+    def test_empty_permissions_setting(self, fake_fs):
         # World writable directory
-        self._runner("0777")
-        self._runner("0450")
+        self._runner("0777", fake_fs)
+        self._runner("0450", fake_fs)
 
-    @set_platform("linux")
-    @set_config({"permissions": "0760"})
-    def test_dir0777_permissions0760_setting(self):
+    @pytest.mark.platform("linux")
+    @pytest.mark.config({"permissions": "0760"})
+    def test_dir0777_permissions0760_setting(self, fake_fs):
         # World-writable directory, permissions 760
-        self._runner("0777")
+        self._runner("0777", fake_fs)
 
-    @set_platform("linux")
-    @set_config({"permissions": "0617"})
-    def test_dir0450_permissions0617_setting(self):
+    @pytest.mark.platform("linux")
+    @pytest.mark.config({"permissions": "0617"})
+    def test_dir0450_permissions0617_setting(self, fake_fs):
         # Insufficient base access
-        self._runner("0450")
+        self._runner("0450", fake_fs)
 
-    @set_platform("linux")
-    @set_config({"permissions": "2455"})
-    def test_dir0444_permissions2455_setting(self):
+    @pytest.mark.platform("linux")
+    @pytest.mark.config({"permissions": "2455"})
+    def test_dir0444_permissions2455_setting(self, fake_fs):
         # Insufficient access, permissions with setgid (should be stripped)
-        self._runner("0444")
+        self._runner("0444", fake_fs)
 
-    @set_platform("linux")
-    @set_config({"permissions": "4755"})
-    def test_dir1755_permissions4755_setting(self):
+    @pytest.mark.platform("linux")
+    @pytest.mark.config({"permissions": "4755"})
+    def test_dir1755_permissions4755_setting(self, fake_fs):
         # Sticky bit on directory, permissions with setuid (should be stripped)
-        self._runner("1755")
+        self._runner("1755", fake_fs)
 
 
 class TestRenamer:
     # test filesystem.renamer() for different scenario's
-    def test_renamer(self):
+    def test_renamer(self, fake_fs):
         # First of all, create a working directory (with a random name)
         dirname = os.path.join(SAB_DATA_DIR, "testdir" + str(random.randint(10000, 99999)))
-        os.mkdir(dirname)
+        fake_fs.create_dir(dirname)
 
         # base case: rename file within directory
         filename = os.path.join(dirname, "myfile.txt")
@@ -1243,12 +1202,12 @@ class TestUnwantedExtensions:
         ([], False),
     ]
 
-    @set_config({"unwanted_extensions_mode": 0, "unwanted_extensions": test_extensions})
+    @pytest.mark.config({"unwanted_extensions_mode": 0, "unwanted_extensions": test_extensions})
     def test_has_unwanted_extension_blacklist_mode(self):
         for filename, result in self.test_params:
             assert filesystem.has_unwanted_extension(filename) is result
 
-    @set_config({"unwanted_extensions_mode": 1, "unwanted_extensions": test_extensions})
+    @pytest.mark.config({"unwanted_extensions_mode": 1, "unwanted_extensions": test_extensions})
     def test_has_unwanted_extension_whitelist_mode(self):
         for filename, result in self.test_params:
             if filesystem.get_ext(filename):
@@ -1257,12 +1216,12 @@ class TestUnwantedExtensions:
                 # missing extension is never considered unwanted
                 assert filesystem.has_unwanted_extension(filename) is False
 
-    @set_config({"unwanted_extensions_mode": 0, "unwanted_extensions": ""})
+    @pytest.mark.config({"unwanted_extensions_mode": 0, "unwanted_extensions": ""})
     def test_has_unwanted_extension_empty_blacklist(self):
         for filename, result in self.test_params:
             assert filesystem.has_unwanted_extension(filename) is False
 
-    @set_config({"unwanted_extensions_mode": 1, "unwanted_extensions": ""})
+    @pytest.mark.config({"unwanted_extensions_mode": 1, "unwanted_extensions": ""})
     def test_has_unwanted_extension_empty_whitelist(self):
         for filename, result in self.test_params:
             if filesystem.get_ext(filename):

--- a/tests/test_functional_config.py
+++ b/tests/test_functional_config.py
@@ -231,20 +231,12 @@ class TestConfigRSS(SABnzbdBaseTest):
         # Does the page think it's a success?
         assert "Added NZB" in download_btn.text
 
-        # Wait 2 seconds for the fetch
-        time.sleep(2)
-
-        # Let's check the queue
-        for _ in range(10):
-            queue_result_slots = get_api_result("queue")["queue"]["slots"]
-            # Check if the fetch-request was added to the queue
-            if queue_result_slots:
-                break
-            time.sleep(1)
-        else:
-            # The loop never stopped, so we fail
-            pytest.fail("Did not find the RSS job in the queue")
-            return
+        # Check if the fetch-request was added to the queue
+        wait_for(
+            lambda: len(get_api_result("queue")["queue"]["slots"]) > 0,
+            timeout=10,
+            err_msg="Did not find the RSS job in the queue",
+        )
 
         # Let's remove this thing
         get_api_result("queue", extra_arguments={"name": "delete", "value": "all"})

--- a/tests/test_functional_config.py
+++ b/tests/test_functional_config.py
@@ -72,8 +72,11 @@ class TestBasicPages(SABnzbdBaseTest):
                 self.no_page_crash()
             else:
                 # For others if all is fine, button will be back to normal in 1 second
-                time.sleep(1.5)
-                assert submit_btn.text == "Save Changes"
+                wait_for(
+                    lambda: submit_btn.text == "Save Changes",
+                    timeout=1.5,
+                    err_msg=f"submit_btn.text was '{submit_btn.text}' but expected 'Save Changes'",
+                )
 
 
 class TestConfigLogin(SABnzbdBaseTest):
@@ -292,9 +295,12 @@ class TestConfigServers(SABnzbdBaseTest):
 
         # Add and show details
         port_inp.send_keys(Keys.RETURN)
-        time.sleep(1)
-        if not self.selenium_wrapper(self.driver.find_element, By.ID, "host0").is_displayed():
-            self.selenium_wrapper(self.driver.find_element, By.CLASS_NAME, "showserver").click()
+        wait_for(
+            lambda: not self.selenium_wrapper(self.driver.find_element, By.ID, "host0").is_displayed(),
+            timeout=2,
+            err_msg=f"The Add Server interface did not close",
+        )
+        self.selenium_wrapper(self.driver.find_element, By.CLASS_NAME, "showserver").click()
 
     def remove_server(self):
         # Remove the first server and accept the confirmation
@@ -302,8 +308,11 @@ class TestConfigServers(SABnzbdBaseTest):
         self.driver.switch_to.alert.accept()
 
         # Check that it's gone
-        time.sleep(2)
-        assert self.server_name not in self.driver.page_source
+        wait_for(
+            lambda: self.server_name not in self.driver.page_source,
+            timeout=2,
+            err_msg=f"Page still contains '{self.server_name}'",
+        )
 
     def test_add_and_remove_server(self):
         self.open_config_servers()

--- a/tests/test_functional_misc.py
+++ b/tests/test_functional_misc.py
@@ -63,22 +63,12 @@ class TestQueueRepair(SABnzbdBaseTest):
         assert get_api_result("restart_repair") == {"status": True}
 
         # Let's check the queue, this can take long on GitHub Actions
-        for _ in range(60):
-            queue_result_slots = {}
-            try:
-                # Can give timeout if still restarting
-                queue_result_slots = get_api_result("queue", extra_arguments={"limit": 10000})["queue"]["slots"]
-            except requests.exceptions.RequestException:
-                pass
-
-            # Check if the repaired job was added to the queue
-            if queue_result_slots:
-                break
-            time.sleep(1)
-        else:
-            # The loop never stopped, so we fail
-            pytest.fail("Did not find the repaired job in the queue")
-            return
+        queue_result_slots = wait_for(
+            lambda: get_api_result("queue", extra_arguments={"limit": 10000})["queue"]["slots"],
+            timeout=60,
+            err_msg="Did not find the repaired job in the queue",
+            suppress=(requests.exceptions.RequestException,),
+        )
 
         # Verify filename
         assert test_job_name in [slot["filename"] for slot in queue_result_slots]

--- a/tests/test_functional_misc.py
+++ b/tests/test_functional_misc.py
@@ -205,12 +205,19 @@ class TestDaemonizing(SABnzbdBaseTest):
         assert not errs
 
         # It should be online after 3 seconds
-        time.sleep(3.0)
-        assert "version" in get_api_result("version", daemon_host, daemon_port)
+        wait_for(
+            lambda: "version" in get_api_result("version", daemon_host, daemon_port),
+            timeout=3,
+            err_msg="Did not start within 3 seconds",
+        )
 
         # Did it create the PID file
         pid_file = os.path.join(ini_location, "sabnzbd-%d.pid" % daemon_port)
-        assert os.path.exists(pid_file)
+        wait_for(
+            lambda: os.path.exists(pid_file),
+            timeout=3,
+            err_msg="Did not create the PID file",
+        )
 
         # Did it remove the bad log file?
         assert os.path.exists(error_log_path)
@@ -219,7 +226,11 @@ class TestDaemonizing(SABnzbdBaseTest):
         try:
             # Let's shut it down and give it some time to do so
             get_url_result("shutdown", daemon_host, daemon_port)
-            time.sleep(3.0)
+            wait_for(
+                lambda: not os.path.exists(pid_file),
+                timeout=3,
+                err_msg="Did not shutdown within 3 seconds",
+            )
         except requests.exceptions.RequestException:
             # Shutdown can be faster than the request
             pass

--- a/tests/test_functional_misc.py
+++ b/tests/test_functional_misc.py
@@ -199,6 +199,7 @@ class TestDaemonizing(SABnzbdBaseTest):
             lambda: "version" in get_api_result("version", daemon_host, daemon_port),
             timeout=3,
             err_msg="Did not start within 3 seconds",
+            suppress=(requests.exceptions.RequestException,),
         )
 
         # Did it create the PID file

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -137,16 +137,16 @@ class TestInterfaceFunctions:
     @pytest.mark.parametrize("access_type", [1, 2, 3, 4, 5, 6])
     @pytest.mark.parametrize("inet_exposure", [0, 1, 2, 3, 4, 5])
     @pytest.mark.parametrize("verify_xff_header", [False, True])
+    @pytest.mark.config(
+        lambda params: {
+            "local_ranges": params["local_ranges"],
+            "inet_exposure": params["inet_exposure"],
+            "verify_xff_header": params["verify_xff_header"],
+        }
+    )
     def test_check_access(
         self, access_type, inet_exposure, local_ranges, remote_ip, xff_header, verify_xff_header, result_with_xff
     ):
-        @set_config(
-            {
-                "local_ranges": local_ranges,
-                "inet_exposure": inet_exposure,
-                "verify_xff_header": verify_xff_header,
-            }
-        )
         def _func():
             # Insert fake request data
             cherrypy.request.remote.ip = remote_ip
@@ -216,8 +216,12 @@ class TestInterfaceFunctions:
             ([], ["4.3.2.1:56789"], "4.3.2.1:56789"),  # Garbage in, garbage out.
         ],
     )
+    @pytest.mark.config(
+        lambda params: {
+            "local_ranges": params["local_ranges"],
+        }
+    )
     def test_remote_ip_from_xff(self, local_ranges, xff_ips, expected_result):
-        @set_config({"local_ranges": local_ranges})
         def _func():
             # Insert fake request data; should *not* influence the results of the tested function
             cherrypy.request.remote.ip = "6.6.6.6"

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -43,7 +43,7 @@ class TestMisc:
         assert "%H:%M:%S" == misc.time_format("%H:%M:%S")
         assert "%H:%M" == misc.time_format("%H:%M")
 
-    @set_config({"ampm": True})
+    @pytest.mark.config({"ampm": True})
     def test_timeformatampm(self):
         misc.HAVE_AMPM = True
         assert "%I:%M:%S %p" == misc.time_format("%H:%M:%S")
@@ -179,6 +179,28 @@ class TestMisc:
         assert 100 == misc.from_units(misc.to_units(-100))
 
     def test_caller_name(self):
+        def set_config(settings_dict):
+            """Change config-values on the fly, per test"""
+
+            def set_config_decorator(func):
+                @functools.wraps(func)
+                def wrapper_func(*args, **kwargs):
+                    # Setting up as requested
+                    for item, val in settings_dict.items():
+                        getattr(cfg, item).set(val)
+
+                    # Perform test
+                    value = func(*args, **kwargs)
+
+                    # Reset values
+                    for item in settings_dict:
+                        getattr(cfg, item).set(getattr(cfg, item).default)
+                    return value
+
+                return wrapper_func
+
+            return set_config_decorator
+
         @set_config({"log_level": 0})
         def test_wrapper(skip):
             return misc.caller_name(skip=skip)
@@ -205,7 +227,7 @@ class TestMisc:
         assert ("[::1]", 1234) == misc.split_host("[::1]:1234")
         assert ("[2001:db8::8080]", None) == misc.split_host("[2001:db8::8080]")
 
-    @set_config({"cleanup_list": [".exe", ".nzb"]})
+    @pytest.mark.config({"cleanup_list": [".exe", ".nzb"]})
     def test_on_cleanup_list(self):
         assert misc.on_cleanup_list("test.exe")
         assert misc.on_cleanup_list("TEST.EXE")
@@ -621,8 +643,12 @@ class TestMisc:
             ("1.2.3.4", "1.2.3.5/32, 9.8.7.6", False),
         ],
     )
+    @pytest.mark.config(
+        lambda params: {
+            "local_ranges": params["local_ranges"],
+        }
+    )
     def test_is_local_addr(self, value, local_ranges, result):
-        @set_config({"local_ranges": local_ranges})
         def _func():
             assert misc.is_local_addr(value) is result
 
@@ -739,6 +765,23 @@ class TestMisc:
     @pytest.mark.parametrize("movie_enabled", [True, False])
     @pytest.mark.parametrize("movie_str", ["", "foobar movie"])
     @pytest.mark.parametrize("movie_cats", [[], ["movie"], ["movie", "horror", "docu"]])
+    @pytest.mark.config(
+        lambda params: {
+            "movie_rename_limit": params["movie_limit"],
+            "episode_rename_limit": params["episode_limit"],
+            "movie_sort_extra": params["movie_sort_extra"],
+            "enable_tv_sorting": params["tv_enabled"],
+            "tv_sort_string": params["tv_str"],
+            "tv_categories": params["tv_cats"],
+            "enable_movie_sorting": params["movie_enabled"],
+            "movie_sort_string": params["movie_str"],
+            "movie_categories": params["movie_cats"],
+            "enable_date_sorting": params["date_enabled"],
+            "date_sort_string": params["date_str"],
+            "date_categories": params["date_cats"],
+            "language": "en",  # Avoid translated sorter names in the test
+        }
+    )
     def test_convert_sorter_settings(
         self,
         movie_limit,
@@ -754,23 +797,6 @@ class TestMisc:
         movie_str,
         movie_cats,
     ):
-        @set_config(
-            {
-                "movie_rename_limit": movie_limit,
-                "episode_rename_limit": episode_limit,
-                "movie_sort_extra": movie_sort_extra,
-                "enable_tv_sorting": tv_enabled,
-                "tv_sort_string": tv_str,
-                "tv_categories": tv_cats,
-                "enable_movie_sorting": movie_enabled,
-                "movie_sort_string": movie_str,
-                "movie_categories": movie_cats,
-                "enable_date_sorting": date_enabled,
-                "date_sort_string": date_str,
-                "date_categories": date_cats,
-                "language": "en",  # Avoid translated sorter names in the test
-            }
-        )
         def _func():
             # Delete any leftover/pre-defined new-style sorters
             if existing_sorters := get_sorters():
@@ -966,8 +992,8 @@ class TestBuildAndRunCommand:
         misc.build_and_run_command([self.script_path], stderr=subprocess.DEVNULL)
         assert mock_subproc_popen.call_args[1]["stderr"] == subprocess.DEVNULL
 
-    @set_platform("linux")
-    @set_config({"nice": "--adjustment=-7", "ionice": "-t -n9 -c7"})
+    @pytest.mark.platform("linux")
+    @pytest.mark.config({"nice": "--adjustment=-7", "ionice": "-t -n9 -c7"})
     @mock.patch("sabnzbd.misc.userxbit")
     @mock.patch("subprocess.Popen")
     def test_linux_features(self, mock_subproc_popen, userxbit):

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -31,7 +31,7 @@ class TestNotifier(TestCase):
 
     @classmethod
     def setUpClass(self):
-        # hack since test_misc uses @set_config decorator eliminating all of the default configuration
+        # hack since test_misc uses @pytest.mark.config fixture eliminating all of the default configuration
         # We want to test with the default configuration in place; This safely resets all fields and
         # replaces them correctly in memory
         reload(cfg)

--- a/tests/test_nzbfile.py
+++ b/tests/test_nzbfile.py
@@ -28,7 +28,7 @@ from tests.testhelper import *
 
 @pytest.mark.usefixtures("clean_cache_dir")
 class TestNzbFile:
-    @set_config({"download_dir": SAB_CACHE_DIR})
+    @pytest.mark.config({"download_dir": SAB_CACHE_DIR})
     @pytest.mark.parametrize(
         "filenames",
         [

--- a/tests/test_nzbobject.py
+++ b/tests/test_nzbobject.py
@@ -29,7 +29,7 @@ from tests.testhelper import *
 
 @pytest.mark.usefixtures("clean_cache_dir")
 class TestNZO:
-    @set_config({"download_dir": SAB_CACHE_DIR})
+    @pytest.mark.config({"download_dir": SAB_CACHE_DIR})
     def test_nzo_basic(self):
         # Need to create the Default category, as we would in normal instance
         # Otherwise it will try to save the config

--- a/tests/test_nzbparser.py
+++ b/tests/test_nzbparser.py
@@ -27,7 +27,7 @@ from sabnzbd.filesystem import save_compressed
 
 @pytest.mark.usefixtures("clean_cache_dir")
 class TestNzbParser:
-    @set_config({"download_dir": SAB_CACHE_DIR})
+    @pytest.mark.config({"download_dir": SAB_CACHE_DIR})
     def test_nzbparser(self):
         nzo = NzbObject("test_basic")
         # Create test file

--- a/tests/test_postproc.py
+++ b/tests/test_postproc.py
@@ -128,13 +128,21 @@ class TestPostProc:
     @pytest.mark.parametrize("sort_string", ["%sn (%r)", "%sn (%r)/file.%ext", ""])  # Identical path result
     @pytest.mark.parametrize("marker_file", [None, ".marker"])
     @pytest.mark.parametrize("do_folder_rename", [True, False])
+    @pytest.mark.config(
+        lambda params: {
+            "marker_file": params["marker_file"],
+            "folder_rename": params["do_folder_rename"],
+            "download_dir": os.path.join(SAB_CACHE_DIR, "incomplete"),
+            "complete_dir": os.path.join(SAB_CACHE_DIR, "complete"),
+        }
+    )
     def test_prepare_extraction_path(
         self, category, has_jobdir, has_catdir, has_active_sorter, sort_string, marker_file, do_folder_rename
     ):
         # Ensure global CFG_ vars are initialised
         sabnzbd.config.read_config(os.devnull)
 
-        # Define a sorter and a category (as @set_config cannot handle those)
+        # Define a sorter and a category (as @pytest.mark.config cannot handle those)
         ConfigSorter(
             "sorter__test_prepare_extraction_path",
             {
@@ -175,14 +183,6 @@ class TestPostProc:
         fake_nzo.cat = category
         fake_nzo.nzo_info = {}  # Placeholder to prevent a crash in sorting.get_titles()
 
-        @set_config(
-            {
-                "download_dir": os.path.join(SAB_CACHE_DIR, "incomplete"),
-                "complete_dir": os.path.join(SAB_CACHE_DIR, "complete"),
-                "marker_file": marker_file,
-                "folder_rename": do_folder_rename,
-            }
-        )
         def _func():
             (
                 tmp_workdir_complete,

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -117,8 +117,8 @@ class TestSortingFunctions:
             ("", False, False),
         ],
     )
+    @pytest.mark.platform(lambda params: params["platform"])
     def test_is_full_path(self, platform, path, result_unix, result_win):
-        @set_platform(platform)
         def _func():
             result = result_win if sabnzbd.WINDOWS else result_unix
             assert sorting.is_full_path(path) == result

--- a/tests/test_utils/test_diskspeed.py
+++ b/tests/test_utils/test_diskspeed.py
@@ -26,13 +26,12 @@ from sabnzbd.utils.diskspeed import diskspeedmeasure
 from tests.testhelper import SAB_CACHE_DIR
 
 
-@pytest.mark.usefixtures("clean_cache_dir")
 class TestDiskSpeed:
     """test sabnzbd.utils.diskspeed"""
 
-    def test_disk_speed(self):
+    def test_disk_speed(self, tmp_path):
         """Test the normal use case: writable directory"""
-        speed = diskspeedmeasure(SAB_CACHE_DIR)
+        speed = diskspeedmeasure(str(tmp_path))
         assert speed > 0.0
         assert isinstance(speed, float)
 

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -381,7 +381,11 @@ class SABnzbdBaseTest:
 
     def scroll_to_top(self):
         self.driver.find_element(By.TAG_NAME, "body").send_keys(Keys.CONTROL + Keys.HOME)
-        time.sleep(2)
+        try:
+            wait = WebDriverWait(self.driver, 2)
+            wait.until(lambda driver_wait: self.driver.execute_script("return window.scrollY") == 0)
+        except RemoteDisconnected:
+            pass
 
     def wait_for_ajax(self):
         # We catch common nonsense errors from Selenium

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -24,7 +24,7 @@ import os
 import time
 import uuid
 from http.client import RemoteDisconnected
-from typing import BinaryIO, Optional
+from typing import BinaryIO, Optional, Callable
 
 import pytest
 from random import choice, randint
@@ -178,6 +178,19 @@ def random_name(length: int = 16) -> str:
     return "".join(choice(ascii_lowercase + digits) for _ in range(length))
 
 
+def wait_for(
+    condition: Callable[[], bool], timeout: float = 2, interval: float = 0.05, err_msg: str = "Condition not met"
+):
+    """Polls condition every interval until timeout."""
+    deadline = time.time() + timeout
+    while True:
+        if condition():
+            return
+        if time.time() > deadline:
+            pytest.fail(err_msg)
+        time.sleep(interval)
+
+
 class FakeHistoryDB(db.HistoryDB):
     """
     HistoryDB class with added control of the db_path via an argument and the
@@ -258,6 +271,7 @@ class SABnzbdBaseTest:
         # Open a page and test for crash
         self.driver.get(url)
         self.no_page_crash()
+        self.disable_delays()
 
     def scroll_to_top(self):
         self.driver.find_element(By.TAG_NAME, "body").send_keys(Keys.CONTROL + Keys.HOME)
@@ -271,6 +285,10 @@ class SABnzbdBaseTest:
             wait.until(lambda driver_wait: self.driver.execute_script("return document.readyState") == "complete")
         except (RemoteDisconnected, ProtocolError):
             pass
+
+    def disable_delays(self):
+        """Remove delayed UI changes"""
+        self.driver.execute_script("window.config = window.config || {}; window.config.disableDelays = true")
 
     @staticmethod
     def selenium_wrapper(func, *args):

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -279,13 +279,20 @@ def random_name(length: int = 16) -> str:
 
 
 def wait_for(
-    condition: Callable[[], bool], timeout: float = 2, interval: float = 0.05, err_msg: str = "Condition not met"
+    condition: Callable,
+    timeout: float = 2,
+    interval: float = 0.05,
+    err_msg: str = "Condition not met",
+    suppress: tuple[type[Exception], ...] = (),
 ):
     """Polls condition every interval until timeout."""
     deadline = time.time() + timeout
     while True:
-        if condition():
-            return
+        try:
+            if result := condition():
+                return result
+        except suppress:
+            pass
         if time.time() > deadline:
             pytest.fail(err_msg)
         time.sleep(interval)

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -40,6 +40,9 @@ import xmltodict
 import functools
 from werkzeug import Request
 from werkzeug.utils import send_from_directory
+from pyfakefs.fake_filesystem_unittest import Patcher
+from pyfakefs.fake_filesystem import OSType
+from pyfakefs.helpers import set_uid
 
 import sabnzbd
 import sabnzbd.cfg as cfg
@@ -75,61 +78,158 @@ SAB_NEWSSERVER_HOST = "127.0.0.1"
 SAB_NEWSSERVER_PORT = 8888
 
 
-def set_config(settings_dict):
+@pytest.fixture(autouse=True)
+def config_env(monkeypatch, request):
     """Change config-values on the fly, per test"""
+    marker = request.node.get_closest_marker("config")
+    if marker is None:
+        # No config changes for this test
+        yield
+        return
 
-    def set_config_decorator(func):
-        @functools.wraps(func)
-        def wrapper_func(*args, **kwargs):
-            # Setting up as requested
-            for item, val in settings_dict.items():
-                getattr(cfg, item).set(val)
+    if marker.args:
+        config = marker.args[0]
 
-            # Perform test
-            value = func(*args, **kwargs)
+        if callable(config):
+            if not hasattr(request.node, "callspec"):
+                raise RuntimeError("Dynamic config requires parameterized test")
+            config = config(request.node.callspec.params)
+    else:
+        if not hasattr(request.node, "callspec"):
+            raise RuntimeError("@pytest.mark.config requires parameterized 'config'")
+        config = request.node.callspec.params.get("config")
+        if config is None:
+            raise RuntimeError("Missing 'config' param for @pytest.mark.config")
 
-            # Reset values
-            for item in settings_dict:
-                getattr(cfg, item).set(getattr(cfg, item).default)
-            return value
+    # Setting up as requested
+    originals = {}
+    for item, val in config.items():
+        cfg_item = getattr(cfg, item)
+        originals[item] = cfg_item.get()
+        cfg_item.set(val)
 
-        return wrapper_func
+    yield
 
-    return set_config_decorator
+    # Restore values
+    for item, val in originals.items():
+        getattr(cfg, item).set(val)
 
 
-def set_platform(platform):
-    """Change config-values on the fly, per test"""
+@pytest.mark.parametrize("config", [{"web_host": "0.0.0.0"}, {"web_host": "::1"}])
+@pytest.mark.config()
+def test_config_parametrize(config):
+    for item, val in config.items():
+        assert getattr(cfg, item)() == val
 
-    def set_platform_decorator(func):
-        def wrapper_func(*args, **kwargs):
-            # Save original values
-            is_windows = sabnzbd.WINDOWS
-            is_macos = sabnzbd.MACOS
 
-            # Set current platform
-            if platform == "win32":
-                sabnzbd.WINDOWS = True
-                sabnzbd.MACOS = False
-            elif platform == "macos":
-                sabnzbd.WINDOWS = False
-                sabnzbd.MACOS = True
-            elif platform == "linux":
-                sabnzbd.WINDOWS = False
-                sabnzbd.MACOS = False
+@pytest.mark.parametrize("web_host", ["0.0.0.0", "::1"])
+@pytest.mark.config(lambda params: {"web_host": params["web_host"]})
+def test_config_parametrize_dynamic(web_host):
+    assert cfg.web_host() == web_host
 
-            # Perform test
-            value = func(*args, **kwargs)
 
-            # Reset values
-            sabnzbd.WINDOWS = is_windows
-            sabnzbd.MACOS = is_macos
+@pytest.mark.config({"web_host": "0.0.0.0"})
+def test_config_marker():
+    assert cfg.web_host() == "0.0.0.0"
 
-            return value
 
-        return wrapper_func
+@pytest.fixture(autouse=True)
+def platform_env(monkeypatch, request):
+    """Change platform-values on the fly, per test"""
+    marker = request.node.get_closest_marker("platform")
+    if marker is None:
+        # No platform changes for this test
+        yield
+        return
 
-    return set_platform_decorator
+    if marker.args:
+        platform_name = marker.args[0]
+
+        if callable(platform_name):
+            if not hasattr(request.node, "callspec"):
+                raise RuntimeError("Dynamic platform requires parameterized test")
+            platform_name = platform_name(request.node.callspec.params)
+    else:
+        if not hasattr(request.node, "callspec"):
+            raise RuntimeError("@pytest.mark.platform requires parameterized 'platform'")
+        platform_name = request.node.callspec.params.get("platform")
+        if platform_name is None:
+            raise RuntimeError("Missing 'platform' param for @pytest.mark.platform")
+
+    if platform_name == "win32":
+        monkeypatch.setattr(sabnzbd, "WINDOWS", True)
+        monkeypatch.setattr(sabnzbd, "MACOS", False)
+    elif platform_name == "macos":
+        monkeypatch.setattr(sabnzbd, "WINDOWS", False)
+        monkeypatch.setattr(sabnzbd, "MACOS", True)
+    elif platform_name == "linux":
+        monkeypatch.setattr(sabnzbd, "WINDOWS", False)
+        monkeypatch.setattr(sabnzbd, "MACOS", False)
+    else:
+        raise ValueError(f"Unknown platform: {platform_name}")
+
+    yield platform_name
+
+
+@pytest.mark.parametrize("platform", ["win32", "macos", "linux"])
+@pytest.mark.platform()
+def test_platform_parametrize(platform):
+    if platform == "win32":
+        assert sabnzbd.WINDOWS
+        assert not sabnzbd.MACOS
+    elif platform == "macos":
+        assert sabnzbd.MACOS
+        assert not sabnzbd.WINDOWS
+    elif platform == "linux":
+        assert not sabnzbd.WINDOWS
+        assert not sabnzbd.MACOS
+
+
+@pytest.mark.platform("win32")
+def test_platform_marker_win32():
+    assert sabnzbd.WINDOWS
+    assert not sabnzbd.MACOS
+
+
+@pytest.mark.platform("macos")
+def test_platform_marker_macos():
+    assert sabnzbd.MACOS
+    assert not sabnzbd.WINDOWS
+
+
+@pytest.mark.platform("linux")
+def test_platform_marker_linux():
+    assert not sabnzbd.WINDOWS
+    assert not sabnzbd.MACOS
+
+
+@pytest.fixture()
+def fake_fs(request):
+    """Create fake filesystem"""
+    fake_fs_marker = request.node.get_closest_marker("fake_fs")
+    platform_marker = request.node.get_closest_marker("platform")
+
+    with Patcher() as patcher:
+        if platform_marker:
+            os_map = {"win32": OSType.WINDOWS, "macos": OSType.MACOS, "linux": OSType.LINUX}
+            patcher.fs.os = os_map.get(platform_marker.args[0], patcher.fs.os)
+
+        if fake_fs_marker:
+            options = fake_fs_marker.args[0] if fake_fs_marker.args else {}
+
+            for key, val in options.items():
+                if key == "create_dirs":
+                    # Special case: create directories
+                    for dir_path in val:
+                        patcher.fs.makedirs(dir_path, mode=755, exist_ok=True)
+                        # Verify the fake filesystem does its thing
+                        assert os.path.exists(dir_path) is True
+                elif hasattr(patcher.fs, key):
+                    setattr(patcher.fs, key, val)
+                else:
+                    raise AttributeError(f"fake_fs has no attribute '{key}'")
+
+        yield patcher.fs
 
 
 def get_url_result(url="", host=SAB_HOST, port=SAB_PORT):
@@ -189,6 +289,12 @@ def wait_for(
         if time.time() > deadline:
             pytest.fail(err_msg)
         time.sleep(interval)
+
+
+@pytest.fixture
+def sleepless(monkeypatch):
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+    yield
 
 
 class FakeHistoryDB(db.HistoryDB):


### PR DESCRIPTION
Locally on macOS and Linux `CI=1 pytest -q` I can run the tests in approximately 1m40s saving about 1m.
The benefit in GitHub runners is much more variable, some runs are at best maybe 30-45 seconds faster on Linux runners, macOS/Windows less so due to fewer resources, so the overall time is not usually significantly better but you do see the failures from Linux runners quicker. I run the tests a lot locally so see a pretty big difference.

Replaces some test decorators with fixtures, primarily to resolve an issue where you can't use both but also allows some things like dynamic config without needing nested functions.

The main change is removing a lot of long sleeping which really adds up, it also fixes a few cases where the tests do try/except, but don't xfail if the expected value is never seen and just carry on.

The remaining slow tests are mostly due to `run_sabnzbd` I'm not sure I can do anything with them, maybe in the future making it works with `pytest-xdist` with multiple instances running would give a benefit but it requires quite a few changes such as making the tests deterministic.

edit: overall runtime on GitHub runners is probably around 30m vs 35m