### PR TITLE
Extend Cleanup List with filename and path pattern matching

### DIFF
--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -25,7 +25,7 @@ import re
 import argparse
 import socket
 import ipaddress
-from typing import Union, Optional
+from typing import Union
 
 import sabnzbd
 from sabnzbd.config import (

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -25,7 +25,7 @@ import re
 import argparse
 import socket
 import ipaddress
-from typing import Union
+from typing import Union, Optional
 
 import sabnzbd
 from sabnzbd.config import (
@@ -136,6 +136,28 @@ def lower_case_ext(value: Union[str, list]) -> tuple[None, Union[str, list]]:
     if isinstance(value, list):
         return None, [item.lower().strip(" .") for item in value]
     return None, value.lower().strip(" .")
+
+
+def cleanup_list_validator(value: Union[str, list]) -> tuple[None, Union[str, list]]:
+    """Validate cleanup list entries
+    Accepts extensions (exe, nfo), filenames (Thumbs.db), patterns (*.tmp), and paths (images/*)
+    Rejects entries containing .. to prevent directory traversal
+    """
+
+    def validate_entry(entry: str) -> str:
+        # Always lowercase and clean
+        entry = entry.lower().strip()
+
+        # For pure extensions (no slash, single or no dot), strip leading dots
+        # For filenames/patterns/paths, keep structure as-is
+        if "/" not in entry and "\\" not in entry:
+            # Strip leading/trailing dots and spaces only if it's a pure extension
+            entry = entry.strip(" .")
+        return entry
+
+    if isinstance(value, list):
+        return None, [validate_entry(item) for item in value]
+    return None, validate_entry(value)
 
 
 def validate_single_tag(value: list[str]) -> tuple[None, list[str]]:
@@ -436,7 +458,7 @@ safe_postproc = OptionBool("misc", "safe_postproc", True)
 pause_on_post_processing = OptionBool("misc", "pause_on_post_processing", False)
 enable_all_par = OptionBool("misc", "enable_all_par", False)
 sanitize_safe = OptionBool("misc", "sanitize_safe", False)
-cleanup_list = OptionList("misc", "cleanup_list", validation=lower_case_ext)
+cleanup_list = OptionList("misc", "cleanup_list", validation=cleanup_list_validator)
 unwanted_extensions = OptionList("misc", "unwanted_extensions", validation=lower_case_ext)
 action_on_unwanted_extensions = OptionNumber("misc", "action_on_unwanted_extensions", 0)
 unwanted_extensions_mode = OptionNumber("misc", "unwanted_extensions_mode", 0)

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -141,7 +141,6 @@ def lower_case_ext(value: Union[str, list]) -> tuple[None, Union[str, list]]:
 def cleanup_list_validator(value: Union[str, list]) -> tuple[None, Union[str, list]]:
     """Validate cleanup list entries
     Accepts extensions (exe, nfo), filenames (Thumbs.db), patterns (*.tmp), and paths (images/*)
-    Rejects entries containing .. to prevent directory traversal
     """
 
     def validate_entry(entry: str) -> str:

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -862,14 +862,16 @@ def on_cleanup_list(filename: str, skip_nzb: bool = False, relative_path: Option
     - Path patterns (with slashes): images/*, */test.jpg -> matches relative paths
     """
     if cleanup_list := cfg.cleanup_list():
+        filename = filename.lower()
         name, ext = os.path.splitext(filename)
-        ext = ext.strip().lower()
-        name = name.strip().lower()
-        filename_lower = filename.lower()
+        ext = ext.strip()
+        name = name.strip()
+        if relative_path:
+            relative_path = relative_path.lower().replace("\\", "/")
 
         for entry in cleanup_list:
-            # Skip empty entries or entries that end with nzb
-            if not entry or (skip_nzb and entry.endswith("nzb")):
+            # Skip empty entries, entries with ".." in it or entries that end with nzb
+            if not entry or ".." in entry or (skip_nzb and entry.endswith("nzb")):
                 continue
 
             # Type 1: Pure extension (no dots or slashes) - backwards compatible
@@ -880,14 +882,15 @@ def on_cleanup_list(filename: str, skip_nzb: bool = False, relative_path: Option
 
             # Type 2: Filename/wildcard pattern (has dots, no slashes)
             elif "." in entry and "/" not in entry and "\\" not in entry:
-                if safe_fnmatch(filename_lower, entry):
+                if safe_fnmatch(filename, entry):
                     return True
 
             # Type 3: Path pattern (has slashes)
             elif "/" in entry or "\\" in entry:
                 if relative_path:
-                    relative_path_lower = relative_path.lower().replace("\\", "/")
-                    if safe_fnmatch(relative_path_lower, entry):
+                    # Normalize both to forward slashes for cross-platform matching
+                    entry_normalized = entry.replace("\\", "/")
+                    if safe_fnmatch(relative_path, entry_normalized):
                         return True
 
     return False

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -56,7 +56,7 @@ import sabnzbd.config as config
 import sabnzbd.cfg as cfg
 from sabnzbd.decorators import conditional_cache, synchronized
 from sabnzbd.encoding import ubtou, platform_btou
-from sabnzbd.filesystem import userxbit, make_script_path, remove_file, strip_extensions
+from sabnzbd.filesystem import userxbit, make_script_path, remove_file, strip_extensions, safe_fnmatch
 
 if sabnzbd.WINDOWS:
     try:
@@ -853,17 +853,43 @@ def get_platform_description() -> str:
     return sabnzbd.PLATFORM
 
 
-def on_cleanup_list(filename: str, skip_nzb: bool = False) -> bool:
-    """Return True if a filename matches the clean-up list"""
-    cleanup_list = cfg.cleanup_list()
-    if cleanup_list:
+def on_cleanup_list(filename: str, skip_nzb: bool = False, relative_path: Optional[str] = None) -> bool:
+    """Return True if a filename matches the clean-up list
+
+    Supports three match types:
+    - Extensions (no dots): exe, nfo -> matches file.exe, file.nfo
+    - Filename patterns (with dots): *.tmp, Thumbs.db -> matches file.tmp, Thumbs.db
+    - Path patterns (with slashes): images/*, */test.jpg -> matches relative paths
+    """
+    if cleanup_list := cfg.cleanup_list():
         name, ext = os.path.splitext(filename)
         ext = ext.strip().lower()
-        name = name.strip()
-        for cleanup_ext in cleanup_list:
-            cleanup_ext = "." + cleanup_ext
-            if (cleanup_ext == ext or (ext == "" and cleanup_ext == name)) and not (skip_nzb and cleanup_ext == ".nzb"):
-                return True
+        name = name.strip().lower()
+        filename_lower = filename.lower()
+
+        for entry in cleanup_list:
+            # Skip empty entries or entries that end with nzb
+            if not entry or (skip_nzb and entry.endswith("nzb")):
+                continue
+
+            # Type 1: Pure extension (no dots or slashes) - backwards compatible
+            if "." not in entry and "/" not in entry and "\\" not in entry:
+                cleanup_ext = "." + entry
+                if cleanup_ext == ext or (ext == "" and cleanup_ext == name):
+                    return True
+
+            # Type 2: Filename/wildcard pattern (has dots, no slashes)
+            elif "." in entry and "/" not in entry and "\\" not in entry:
+                if safe_fnmatch(filename_lower, entry):
+                    return True
+
+            # Type 3: Path pattern (has slashes)
+            elif "/" in entry or "\\" in entry:
+                if relative_path:
+                    relative_path_lower = relative_path.lower().replace("\\", "/")
+                    if safe_fnmatch(relative_path_lower, entry):
+                        return True
+
     return False
 
 

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -1148,19 +1148,22 @@ def handle_empty_queue():
             sabnzbd.LIBC.malloc_trim(0)
 
 
-def cleanup_list(wdir: str, skip_nzb: bool):
+def cleanup_list(wdir: str, skip_nzb: bool, base_dir: Optional[str] = None):
     """Remove all files whose extension matches the cleanup list,
     optionally ignoring the nzb extension
     """
     if cfg.cleanup_list():
+        if base_dir is None:
+            base_dir = wdir
         try:
             with os.scandir(wdir) as files:
                 for entry in files:
                     if entry.is_dir():
-                        cleanup_list(entry.path, skip_nzb)
+                        cleanup_list(entry.path, skip_nzb, base_dir)
                         cleanup_empty_directories(entry.path)
                     else:
-                        if on_cleanup_list(entry.name, skip_nzb):
+                        relative_path = os.path.relpath(entry.path, base_dir)
+                        if on_cleanup_list(entry.name, skip_nzb, relative_path):
                             try:
                                 logging.info("Removing unwanted file %s", entry.path)
                                 remove_file(entry.path)

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -314,7 +314,8 @@ SKIN_TEXT = {
     ),
     "opt-cleanup_list": TT("Cleanup List"),
     "explain-cleanup_list": TT(
-        "List of file extensions that should be deleted after download.<br />For example: <b>nfo</b> or <b>nfo, sfv</b>"
+        "List of file extensions, filenames or patterns that should be deleted after download.<br />"
+        "Examples: <b>nfo, sfv</b> (extensions) or <b>thumbs.db</b> (filenames) or <b>*.tmp, images/*, */test.jpg</b> (patterns)."
     ),
     "opt-history_retention": TT("History Retention"),
     "history_retention-all": TT("Keep all jobs"),

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -215,6 +215,23 @@ class TestValidators:
         assert cfg.lower_case_ext([".foo", ".bar"]) == (None, ["foo", "bar"])
         assert cfg.lower_case_ext([".foo ", " .bar"]) == (None, ["foo", "bar"])
 
+    def test_cleanup_list_validator(self):
+        # Extensions (with or without leading dot)
+        assert cfg.cleanup_list_validator(".exe") == (None, "exe")
+        assert cfg.cleanup_list_validator("nfo") == (None, "nfo")
+        assert cfg.cleanup_list_validator([".exe", "nfo"]) == (None, ["exe", "nfo"])
+
+        # Filenames (with dots, not stripped)
+        assert cfg.cleanup_list_validator("Thumbs.db") == (None, "thumbs.db")
+        assert cfg.cleanup_list_validator(["Thumbs.db", "*.tmp"]) == (None, ["thumbs.db", "*.tmp"])
+
+        # Path patterns (with slashes, not stripped)
+        assert cfg.cleanup_list_validator("images/*") == (None, "images/*")
+        assert cfg.cleanup_list_validator(["images/*", "*/test.jpg"]) == (None, ["images/*", "*/test.jpg"])
+
+        # Case insensitivity
+        assert cfg.cleanup_list_validator("CLEANUP.LOG") == (None, "cleanup.log")
+
     def test_validate_safedir(self):
         assert cfg.validate_safedir("", "", "def") == (None, "def")
         assert cfg.validate_safedir("", "C:\\", "") == (None, "C:\\")

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -237,6 +237,51 @@ class TestMisc:
         assert not misc.on_cleanup_list("test.nzb", skip_nzb=True)
         assert not misc.on_cleanup_list("test.exe.lnk")
 
+    @pytest.mark.config({"cleanup_list": ["Thumbs.db"]})
+    def test_on_cleanup_list_exact_filenames(self):
+        # Exact filename matching (case-insensitive)
+        assert misc.on_cleanup_list("Thumbs.db")
+        assert misc.on_cleanup_list("thumbs.db")
+        assert misc.on_cleanup_list("THUMBS.DB")
+        assert not misc.on_cleanup_list("Thumbs.db.bak")
+        assert not misc.on_cleanup_list("not_thumbs.db")
+
+    @pytest.mark.config({"cleanup_list": ["*.tmp", "cleanup.*"]})
+    def test_on_cleanup_list_wildcard_patterns(self):
+        # Wildcard filename patterns
+        assert misc.on_cleanup_list("file.tmp")
+        assert misc.on_cleanup_list("temp.tmp")
+        assert misc.on_cleanup_list("FILE.TMP")
+        assert not misc.on_cleanup_list("file.tmp.bak")
+        assert misc.on_cleanup_list("cleanup.log")
+        assert misc.on_cleanup_list("cleanup.txt")
+        assert misc.on_cleanup_list("CLEANUP.LOG")
+        assert not misc.on_cleanup_list("cleanup")
+
+    # cleanup_list is always lowercased by validator
+    @pytest.mark.config({"cleanup_list": ["images/*", "*/test.jpg", "cache/*.log"]})
+    def test_on_cleanup_list_path_patterns(self):
+        # Path patterns with relative paths
+        assert misc.on_cleanup_list("file.jpg", relative_path="images/file.jpg")
+        assert misc.on_cleanup_list("pic.png", relative_path="images/pic.png")
+        assert not misc.on_cleanup_list("file.jpg", relative_path="file.jpg")
+        assert misc.on_cleanup_list("test.jpg", relative_path="subfolder/test.jpg")
+        assert misc.on_cleanup_list("test.jpg", relative_path="deep/nested/test.jpg")
+        assert not misc.on_cleanup_list("other.jpg", relative_path="subfolder/other.jpg")
+        assert misc.on_cleanup_list("error.log", relative_path="cache/error.log")
+        assert not misc.on_cleanup_list("error.log", relative_path="logs/error.log")
+        # Case-insensitive path matching
+        assert misc.on_cleanup_list("file.jpg", relative_path="IMAGES/file.jpg")
+
+    # cleanup_list is always lowercased by validator
+    @pytest.mark.config({"cleanup_list": ["exe", "thumbs.db", "*.tmp"]})
+    def test_on_cleanup_list_mixed(self):
+        # Mixed list of extensions, filenames, and patterns
+        assert misc.on_cleanup_list("test.exe")
+        assert misc.on_cleanup_list("Thumbs.db")
+        assert misc.on_cleanup_list("temp.tmp")
+        assert not misc.on_cleanup_list("test.txt")
+
     def test_format_time_string(self):
         assert "0 seconds" == misc.format_time_string(None)
         assert "0 seconds" == misc.format_time_string("Test")

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -259,7 +259,7 @@ class TestMisc:
         assert not misc.on_cleanup_list("cleanup")
 
     # cleanup_list is always lowercased by validator
-    @pytest.mark.config({"cleanup_list": ["images/*", "*/test.jpg", "cache/*.log"]})
+    @pytest.mark.config({"cleanup_list": ["images/*", "*/test.jpg", "cache/*.log", "deep/*/pic.png", "temp\\*.tmp"]})
     def test_on_cleanup_list_path_patterns(self):
         # Path patterns with relative paths
         assert misc.on_cleanup_list("file.jpg", relative_path="images/file.jpg")
@@ -272,6 +272,15 @@ class TestMisc:
         assert not misc.on_cleanup_list("error.log", relative_path="logs/error.log")
         # Case-insensitive path matching
         assert misc.on_cleanup_list("file.jpg", relative_path="IMAGES/file.jpg")
+        # Wildcard with paths: deep/*/pic.png uses fnmatch which treats * as matching any chars including /
+        assert misc.on_cleanup_list("pic.png", relative_path="deep/nested/pic.png")
+        assert misc.on_cleanup_list("pic.png", relative_path="deep/nested/subfolder/pic.png")
+        # Cross-platform: patterns with backslashes in config are normalized at match time
+        # temp\*.tmp pattern should match temp/file.tmp
+        assert misc.on_cleanup_list("file.tmp", relative_path="temp/file.tmp")
+        # Cross-platform: relative paths with backslashes (from os.path.relpath on Windows)
+        # should also work with forward slash patterns
+        assert misc.on_cleanup_list("pic.png", relative_path="deep\\nested\\pic.png")
 
     # cleanup_list is always lowercased by validator
     @pytest.mark.config({"cleanup_list": ["exe", "thumbs.db", "*.tmp"]})


### PR DESCRIPTION
Previously limited to cleaning up files based only on their extensions, the 'Cleanup List' now supports more flexible matching. Users can specify:
- Exact filenames (e.g., `Thumbs.db`)
- Wildcard filename patterns (e.g., `*.tmp`, `cleanup.*`)
- Relative path patterns (e.g., `images/*`, `*/test.jpg`)

This enhancement provides greater control and flexibility for automated post-processing cleanup.

Based on request in https://forums.sabnzbd.org/viewtopic.php?t=27245