### PR TITLE
Check SAB_CACHE_DIR exists first and allow to already exist

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,9 +35,10 @@ from tests.testhelper import *
 def clean_cache_dir(request):
     # Remove cache if already there
     try:
-        shutil.rmtree(SAB_CACHE_DIR, ignore_errors=True)
+        if os.path.exists(SAB_CACHE_DIR):
+            shutil.rmtree(SAB_CACHE_DIR)
         # Create an empty placeholder
-        os.makedirs(SAB_CACHE_DIR)
+        os.makedirs(SAB_CACHE_DIR, exist_ok=True)
     except Exception:
         pytest.fail("Failed to freshen up cache dir %s" % SAB_CACHE_DIR)
 


### PR DESCRIPTION
This is a little closer to what it used to be.

If it continues to have errors I suggest repeated tries like teardown does.