### PR TITLE
Remove unreliable test

### DIFF
--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -101,21 +101,6 @@ class FakeNNTPServer:
 @pytest.fixture
 def fake_nntp_server(request):
     """Fixture that provides a fake NNTP server"""
-    params = getattr(request, "param", {})
-
-    # For fail_connect, don't start a server at all - use a closed port
-    if params.get("fail_connect"):
-        # Find a port and don't listen on it
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.bind(("127.0.0.1", 0))
-        port = sock.getsockname()[1]
-
-        server = FakeNNTPServer(port=port)
-        server.port = port  # Don't start, just hold the port number
-        yield server
-        sock.close()
-        return
-
     server = FakeNNTPServer()
     server.start()
     yield server
@@ -259,23 +244,3 @@ class TestConnectionStateMachine:
         assert nw.nntp is None
         assert nw.connected is False
         assert nw.ready is False
-
-    @pytest.mark.parametrize("fake_nntp_server", [{"fail_connect": True}], indirect=True)
-    @pytest.mark.parametrize("test_server", [{"timeout": 0.1}], indirect=True)
-    def test_failed_connect_allows_retry(self, fake_nntp_server, test_server, mock_downloader):
-        """Failed connect should set error_msg (and optionally clear nntp)"""
-        nw = NewsWrapper(test_server, thrdnum=1)
-        test_server.idle_threads.add(nw)
-
-        nw.init_connect()
-
-        # Wait for connect to fail (connection refused)
-        for _ in range(100):
-            if nw.nntp is None:
-                break
-            time.sleep(0.05)
-
-        # Connection should have failed and been reset
-        assert nw.ready is False
-        assert nw.connected is False
-        assert nw.nntp is None


### PR DESCRIPTION
This test often fails especially on Linux, I believe it's a combination of:

- Connect in a separate thread
- Connect can ignore the timeout and take longer than expected because of kernel TCP behaviour
- Result is that the 5 second wait in the test occurs before the connect thread has finished

The other tests such as test_hard_reset_clears_all_state adequately test most of the behaviour anyway.