### PR TITLE
Match to previous RSS behaviour

### DIFF
--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -742,7 +742,7 @@ class RSSReader:
         download: bool,
         force: bool,
         readout: bool,
-    ) -> tuple[Optional[FeedEvaluation], Optional[bool], Optional[bool]]:
+    ) -> tuple[Optional[FeedEvaluation], bool, bool]:
         """Evaluate a normalised entry against filters
 
         Returns a tuple (evaluation, should_download, star) or None if the entry should be skipped.
@@ -752,7 +752,7 @@ class RSSReader:
         job_status = job.get("status", " ")[0] if job else "N"
 
         if job_status not in "NGB" and not (job_status == "X" and readout):
-            return None, None, None
+            return None, False, False
 
         # Match this title against all filters
         logging.debug("Trying title=%r, size=%d", feed_entry.title, feed_entry.size)
@@ -764,7 +764,7 @@ class RSSReader:
             episode=feed_entry.episode,
         )
 
-        is_starred = job and job.get("status", "").endswith("*")
+        is_starred = bool(job and job.get("status", "").endswith("*"))
         star = first or is_starred
         should_download = (download and not first and not is_starred) or force
 

--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -415,10 +415,12 @@ class FeedConfig:
             last_rule = rule
             break
 
+        rule_has_category = bool(last_rule and last_rule.category)
+
         # Category resolution
         if not rule_matched and self.default_category:
             effective_category = self.default_category
-        elif rule_matched and last_rule and last_rule.category is not None:
+        elif rule_matched and rule_has_category:
             effective_category = last_rule.category
         elif entry_cat and not self.default_category:
             effective_category = cat_convert(entry_cat)
@@ -437,22 +439,19 @@ class FeedConfig:
         # PP resolution
         if last_rule and last_rule.pp is not None:
             resolved_pp = last_rule.pp
-        elif not ((last_rule and last_rule.category) or entry_cat):
+        elif not (rule_has_category or entry_cat):
             resolved_pp = cat_pp
 
         # Script resolution
         if last_rule and last_rule.script is not None:
             resolved_script = last_rule.script
-        elif not ((last_rule and last_rule.category is not None) or entry_cat):
+        elif not (rule_has_category or entry_cat):
             resolved_script = cat_script
 
         # Priority resolution
-        if last_rule and last_rule.priority is not None and str(last_rule.priority) != str(DEFAULT_PRIORITY):
+        if last_rule and last_rule.priority is not None:
             resolved_priority = last_rule.priority
-        elif not (
-            (last_rule and last_rule.priority is not None and str(last_rule.priority) != str(DEFAULT_PRIORITY))
-            or entry_cat
-        ):
+        elif not (rule_has_category or entry_cat):
             resolved_priority = cat_prio
 
         return FeedEvaluation(

--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -449,9 +449,9 @@ class FeedConfig:
             resolved_script = cat_script
 
         # Priority resolution
-        if last_rule and last_rule.priority is not None:
+        if last_rule and last_rule.priority not in (DEFAULT_PRIORITY, None):
             resolved_priority = last_rule.priority
-        elif not (rule_has_category or entry_cat):
+        elif not ((last_rule and last_rule.priority != DEFAULT_PRIORITY) or entry_cat):
             resolved_priority = cat_prio
 
         return FeedEvaluation(

--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -120,8 +120,8 @@ class NormalisedEntry:
 
         # Maybe the newznab also provided SxxExx info
         try:
-            season = re.findall(r"\d+", entry["newznab"]["season"])[0]
-            episode = re.findall(r"\d+", entry["newznab"]["episode"])[0]
+            season = int_conv(re.findall(r"\d+", entry["newznab"]["season"])[0])
+            episode = int_conv(re.findall(r"\d+", entry["newznab"]["episode"])[0])
         except (KeyError, IndexError):
             season = episode = 0
 
@@ -390,8 +390,8 @@ class FeedConfig:
         # Fill in missing season / episode information when F/S rules exist
         if self.has_type("F", "S") and (not feed_season or not feed_episode):
             show_analysis = sabnzbd.sorting.BasicAnalyzer(title)
-            feed_season = show_analysis.info.get("season_num")
-            feed_episode = show_analysis.info.get("episode_num")
+            feed_season = int_conv(show_analysis.info.get("season_num"))
+            feed_episode = int_conv(show_analysis.info.get("episode_num"))
 
         # Match against all filters until a positive or negative match
         for idx, rule in enumerate(self.rules):
@@ -457,8 +457,8 @@ class FeedConfig:
         return FeedEvaluation(
             matched=rule_matched,
             rule_index=matching_rule_index,
-            season=int_conv(feed_season),
-            episode=int_conv(feed_episode),
+            season=feed_season,
+            episode=feed_episode,
             category=resolved_cat,
             pp=resolved_pp,
             script=resolved_script,
@@ -780,14 +780,14 @@ class RSSReader:
             "cat": resolved_entry.cat,
             "pp": resolved_entry.pp,
             "script": resolved_entry.script,
-            "prio": str(resolved_entry.priority) if resolved_entry.priority is not None else str(DEFAULT_PRIORITY),
+            "prio": resolved_entry.priority if resolved_entry.priority is not None else DEFAULT_PRIORITY,
             "orgcat": resolved_entry.orgcat,
             "size": resolved_entry.size,
             "age": resolved_entry.age,
             "time": time.time(),
-            "rule": str(resolved_entry.rule),
-            "season": str(resolved_entry.season),
-            "episode": str(resolved_entry.episode),
+            "rule": resolved_entry.rule,
+            "season": resolved_entry.season,
+            "episode": resolved_entry.episode,
             "status": resolved_entry.status,
         }
 

--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -376,8 +376,8 @@ class FeedConfig:
         """Evaluate rules for a single RSS entry."""
         entry_cat = category
         rule_matched: bool = False
-        matching_rule_index: int = 0
         last_rule: Optional[FeedRule] = None
+        last_rule_index: int = 0
         feed_season: int = season
         feed_episode: int = episode
 
@@ -410,9 +410,9 @@ class FeedConfig:
             if outcome is None:
                 continue
 
-            matching_rule_index = idx
-            rule_matched = outcome
             last_rule = rule
+            last_rule_index = idx
+            rule_matched = outcome
             break
 
         rule_has_category = bool(last_rule and last_rule.category)
@@ -456,7 +456,7 @@ class FeedConfig:
 
         return FeedEvaluation(
             matched=rule_matched,
-            rule_index=matching_rule_index,
+            rule_index=last_rule_index,
             season=feed_season,
             episode=feed_episode,
             category=resolved_cat,

--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -376,8 +376,8 @@ class FeedConfig:
         """Evaluate rules for a single RSS entry."""
         entry_cat = category
         rule_matched: bool = False
-        matching_rule: Optional[FeedRule] = None
         matching_rule_index: int = 0
+        last_rule: Optional[FeedRule] = None
         feed_season: int = season
         feed_episode: int = episode
 
@@ -386,19 +386,6 @@ class FeedConfig:
         resolved_pp: Optional[int] = self.default_pp
         resolved_script: Optional[str] = self.default_script
         resolved_priority: Optional[int] = self.default_priority
-
-        # If there are no rules; return early
-        if not self.rules:
-            return FeedEvaluation(
-                matched=rule_matched,
-                rule_index=matching_rule_index,
-                season=int_conv(feed_season),
-                episode=int_conv(feed_episode),
-                category=resolved_cat,
-                pp=resolved_pp,
-                script=resolved_script,
-                priority=resolved_priority,
-            )
 
         # Fill in missing season / episode information when F/S rules exist
         if self.has_type("F", "S") and (not feed_season or not feed_episode):
@@ -425,20 +412,48 @@ class FeedConfig:
 
             matching_rule_index = idx
             rule_matched = outcome
-            matching_rule = rule if outcome else None
+            last_rule = rule
             break
 
-        if matching_rule is None:
-            effective_category = (
-                cat_convert(entry_cat) if entry_cat and self.default_category is None else self.default_category
-            )
+        # Category resolution
+        if not rule_matched and self.default_category:
+            effective_category = self.default_category
+        elif rule_matched and last_rule and last_rule.category is not None:
+            effective_category = last_rule.category
+        elif entry_cat and not self.default_category:
+            effective_category = cat_convert(entry_cat)
         else:
-            effective_category = matching_rule.category or cat_convert(entry_cat) or self.default_category
+            effective_category = resolved_cat
 
-        resolved_cat, resolved_pp, resolved_script, resolved_priority = self._resolve_options(
-            effective_category=effective_category,
-            matching_rule=matching_rule,
-        )
+        # Category-derived defaults
+        if effective_category:
+            resolved_cat, cat_pp, cat_script, cat_prio = cat_to_opts(effective_category)
+            cat_pp = _normalise_pp(cat_pp)
+            cat_script = _normalise_str_or_none(cat_script)
+            cat_prio = _normalise_priority(cat_prio)
+        else:
+            resolved_cat = cat_pp = cat_script = cat_prio = None
+
+        # PP resolution
+        if last_rule and last_rule.pp is not None:
+            resolved_pp = last_rule.pp
+        elif not ((last_rule and last_rule.category) or entry_cat):
+            resolved_pp = cat_pp
+
+        # Script resolution
+        if last_rule and last_rule.script is not None:
+            resolved_script = last_rule.script
+        elif not ((last_rule and last_rule.category is not None) or entry_cat):
+            resolved_script = cat_script
+
+        # Priority resolution
+        if last_rule and last_rule.priority is not None and str(last_rule.priority) != str(DEFAULT_PRIORITY):
+            resolved_priority = last_rule.priority
+        elif not (
+            (last_rule and last_rule.priority is not None and str(last_rule.priority) != str(DEFAULT_PRIORITY))
+            or entry_cat
+        ):
+            resolved_priority = cat_prio
 
         return FeedEvaluation(
             matched=rule_matched,
@@ -450,38 +465,6 @@ class FeedConfig:
             script=resolved_script,
             priority=resolved_priority,
         )
-
-    def _resolve_options(
-        self,
-        *,
-        effective_category: Optional[str],
-        matching_rule: Optional[FeedRule],
-    ) -> tuple[Optional[str], Optional[int], Optional[str], Optional[int]]:
-        """Resolve options for a feed rule."""
-        if effective_category:
-            cat, cat_pp, cat_script, cat_prio = cat_to_opts(effective_category)
-            cat_pp = _normalise_pp(cat_pp)
-            cat_script = _normalise_str_or_none(cat_script)
-            cat_prio = _normalise_priority(cat_prio)
-        else:
-            cat = cat_pp = cat_script = cat_prio = None
-
-        resolved_pp = first_not_none(
-            matching_rule.pp if matching_rule else None,
-            cat_pp,
-            self.default_pp,
-        )
-        resolved_script = first_not_none(
-            matching_rule.script if matching_rule else None,
-            cat_script,
-            self.default_script,
-        )
-        resolved_priority = first_not_none(
-            matching_rule.priority if matching_rule else None,
-            cat_prio,
-            self.default_priority,
-        )
-        return cat, resolved_pp, resolved_script, resolved_priority
 
 
 class RSSReader:
@@ -992,14 +975,6 @@ def _normalise_pp(value) -> Optional[int]:
             return iv
     except (TypeError, ValueError):
         pass
-    return None
-
-
-def first_not_none(*args):
-    """Return first value which is not None"""
-    for a in args:
-        if a is not None:
-            return a
     return None
 
 

--- a/tests/data/rss_feed_category.xml
+++ b/tests/data/rss_feed_category.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+   <channel>
+      <title>RSS feed</title>
+      <description>RSS feed</description>
+      <link>https://sabnzbd.org/</link>
+      <item>
+         <title>TITLE</title>
+         <link>http://LINK</link>
+         <comments>COMMENTS</comments>
+         <pubDate>Tue, 20 May 2025 18:21:01 +0000</pubDate>
+         <guid isPermaLink="true">https://sabnzbd.org/rss_feed_category</guid>
+         <category>TV &gt; HD</category>
+      </item>
+   </channel>
+</rss>

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -316,7 +316,6 @@ class TestRSS:
             ),
             (
                 ("", "", "", PAUSED_PRIORITY),
-                # Empty filters gives wrong prio
                 [("", "", "", "A", "*", "", "")],
                 "Title",
                 "TV > HD",

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -325,7 +325,7 @@ class TestRSS:
                     category="evaluator",
                     pp=1,
                     script=None,
-                    priority=FORCE_PRIORITY,
+                    priority=None,
                 ),
             ),
             (  # category with rule overrides
@@ -344,7 +344,7 @@ class TestRSS:
                     category="evaluator",
                     pp=2,
                     script="override.py",
-                    priority=FORCE_PRIORITY,
+                    priority=None,
                 ),
             ),
         ],
@@ -467,7 +467,7 @@ class TestRSS:
             season=0,
             episode=0,
             category="tv",
-            priority=HIGH_PRIORITY,
+            priority=LOW_PRIORITY,
         )
 
     def test_feedconfig_entry_category_pp_overrides_feed_default_pp(self, httpserver: HTTPServer):
@@ -529,7 +529,7 @@ class TestRSS:
             category="evaluator",
             pp=2,
             script=None,
-            priority=FORCE_PRIORITY,
+            priority=None,
         )
 
     def test_feedconfig_rule_pp_overrides_entry_category_pp(self, httpserver: HTTPServer):

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -93,8 +93,8 @@ class TestRSS:
         assert job_data["infourl"] == "https://nzbgeek.info/geekseek.php?guid=FakeKey"
         assert job_data["orgcat"] == "TV > HD"
         assert job_data["cat"] == "tv"
-        assert job_data["episode"] == "3"
-        assert job_data["season"] == "4"
+        assert job_data["episode"] == 3
+        assert job_data["season"] == 4
         assert job_data["size"] == 1209464000
 
         # feedparser returns UTC so SABnzbd converts to locale
@@ -121,8 +121,8 @@ class TestRSS:
         assert job_data["infourl"] == "https://nzbfinder.ws/details/FakeKey"
         assert job_data["orgcat"] == "Movies > HD"
         assert job_data["cat"] == "movies"
-        assert job_data["episode"] == "720"
-        assert job_data["season"] == "2018"
+        assert job_data["episode"] == 720
+        assert job_data["season"] == 2018
         assert job_data["size"] == 5164539914
 
         # feedparser returns UTC so SABnzbd converts to locale
@@ -206,7 +206,7 @@ class TestRSS:
                 1000,
                 0,
                 0,
-                dict(rule="0", season="0", episode="0"),
+                dict(rule=0, season=0, episode=0),
             ),
             (
                 (None, None, None, None),
@@ -216,7 +216,7 @@ class TestRSS:
                 1000,
                 0,
                 0,
-                dict(rule="1", season="0", episode="0"),
+                dict(rule=1, season=0, episode=0),
             ),
             (
                 (None, None, None, None),
@@ -226,7 +226,7 @@ class TestRSS:
                 1000,
                 0,
                 0,
-                dict(rule="1", season="5", episode="2"),
+                dict(rule=1, season=5, episode=2),
             ),
             (
                 (None, None, None, None),
@@ -236,7 +236,7 @@ class TestRSS:
                 1000,
                 0,
                 0,
-                dict(rule="0", season="1", episode="2"),
+                dict(rule=0, season=1, episode=2),
             ),
             (
                 (None, None, None, LOW_PRIORITY),
@@ -246,7 +246,7 @@ class TestRSS:
                 1000,
                 0,
                 0,
-                dict(rule="0", season="0", episode="0", prio=str(LOW_PRIORITY)),
+                dict(rule=0, season=0, episode=0, prio=LOW_PRIORITY),
             ),
             (
                 (None, None, None, LOW_PRIORITY),
@@ -256,7 +256,7 @@ class TestRSS:
                 1000,
                 0,
                 0,
-                dict(rule="0", season="0", episode="0", prio=str(HIGH_PRIORITY)),
+                dict(rule=0, season=0, episode=0, prio=HIGH_PRIORITY),
             ),
             (
                 (None, 1, None, None),
@@ -266,7 +266,7 @@ class TestRSS:
                 1000,
                 0,
                 0,
-                dict(rule="0", season="0", episode="0", pp=None),
+                dict(rule=0, season=0, episode=0, pp=None),
             ),
             (
                 (None, 1, None, None),
@@ -276,7 +276,7 @@ class TestRSS:
                 1000,
                 0,
                 0,
-                dict(rule="0", season="0", episode="0", pp=3),
+                dict(rule=0, season=0, episode=0, pp=3),
             ),
             (  # category overrides
                 ("tv", 1, "", DEFAULT_PRIORITY),
@@ -287,13 +287,13 @@ class TestRSS:
                 0,
                 0,
                 dict(
-                    rule="0",
-                    season="0",
-                    episode="0",
+                    rule=0,
+                    season=0,
+                    episode=0,
                     cat="evaluator",
                     pp=1,
                     script=None,
-                    prio=str(DEFAULT_PRIORITY),
+                    prio=DEFAULT_PRIORITY,
                 ),
             ),
             (  # category with rule overrides
@@ -305,13 +305,13 @@ class TestRSS:
                 0,
                 0,
                 dict(
-                    rule="0",
-                    season="0",
-                    episode="0",
+                    rule=0,
+                    season=0,
+                    episode=0,
                     cat="evaluator",
                     pp=2,
                     script="override.py",
-                    prio=str(DEFAULT_PRIORITY),
+                    prio=DEFAULT_PRIORITY,
                 ),
             ),
             (
@@ -323,11 +323,27 @@ class TestRSS:
                 0,
                 0,
                 dict(
-                    rule="0",
-                    season="0",
-                    episode="0",
+                    rule=0,
+                    season=0,
+                    episode=0,
                     cat="tv",
-                    prio=str(PAUSED_PRIORITY),
+                    prio=PAUSED_PRIORITY,
+                ),
+            ),
+            (
+                ("", "", "", PAUSED_PRIORITY),
+                [("", "", "", "F", "", "", "")],
+                "Title",
+                "TV > HD",
+                1000,
+                3,
+                5,
+                dict(
+                    rule=0,
+                    season=3,
+                    episode=5,
+                    cat="tv",
+                    prio=PAUSED_PRIORITY,
                 ),
             ),
         ],
@@ -373,10 +389,24 @@ class TestRSS:
                 SubElement(item, "size").text = str(size)
 
             if season is not None:
-                SubElement(item, "season").text = str(season)
+                SubElement(
+                    item,
+                    "newznab:attr",
+                    {
+                        "name": "season",
+                        "value": str(season),
+                    },
+                )
 
             if episode is not None:
-                SubElement(item, "episode").text = str(episode)
+                SubElement(
+                    item,
+                    "newznab:attr",
+                    {
+                        "name": "episode",
+                        "value": str(episode),
+                    },
+                )
 
             xml_bytes = tostring(root, encoding="utf-8")
 

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -192,6 +192,39 @@ class TestRSS:
         adjusted_date = datetime.datetime(2025, 5, 20, 18, 21, 1) - datetime.timedelta(seconds=time.timezone)
         assert job_data["age"] == adjusted_date
 
+    def test_rss_entry_category(self, httpserver: HTTPServer):
+        httpserver.expect_request("/rss_feed_category.xml").respond_with_handler(httpserver_handler_data_dir)
+
+        feed_name = "TestFeedLink"
+        self.setup_rss(
+            feed_name,
+            httpserver.url_for("/rss_feed_category.xml"),
+            priority=PAUSED_PRIORITY,
+        )
+
+        sabnzbd.config.ConfigCat(
+            "tv",
+            {
+                "pp": "3",
+                "script": "tv.py",
+                "priority": FORCE_PRIORITY,
+            },
+        )
+
+        # Start the RSS reader
+        rss_obj = rss.RSSReader()
+        rss_obj.process_feed(feed_name)
+
+        # Is the feed processed?
+        assert feed_name in rss_obj.jobs
+        assert "http://LINK" in rss_obj.jobs[feed_name]
+
+        # Check some job-data
+        job_data = rss_obj.jobs[feed_name]["http://LINK"]
+        assert job_data["orgcat"] == "TV > HD"
+        assert job_data["cat"] == "tv"
+        assert job_data["prio"] == str(PAUSED_PRIORITY)  # Default feed
+
     @pytest.mark.parametrize(
         "defaults, filters, title, category, size, season, episode, expected_match",
         [
@@ -244,7 +277,7 @@ class TestRSS:
                 1000,
                 0,
                 0,
-                FeedEvaluation(matched=True, rule_index=0, season=0, episode=0, priority=LOW_PRIORITY),
+                FeedEvaluation(matched=True, rule_index=0, season=0, episode=0, priority=None),
             ),
             (
                 (None, None, None, LOW_PRIORITY),
@@ -264,7 +297,7 @@ class TestRSS:
                 1000,
                 0,
                 0,
-                FeedEvaluation(matched=True, rule_index=0, season=0, episode=0, pp=1),
+                FeedEvaluation(matched=True, rule_index=0, season=0, episode=0, pp=None),
             ),
             (
                 (None, 1, None, None),
@@ -277,7 +310,7 @@ class TestRSS:
                 FeedEvaluation(matched=True, rule_index=0, season=0, episode=0, pp=3),
             ),
             (  # category overrides
-                ("tv", 1, DEFAULT_PRIORITY, ""),
+                ("tv", 1, "", DEFAULT_PRIORITY),
                 [("evaluator", "", "", "A", "*", "", "1")],
                 "Title",
                 None,
@@ -290,13 +323,13 @@ class TestRSS:
                     season=0,
                     episode=0,
                     category="evaluator",
-                    pp=3,
-                    script="evaluator.py",
+                    pp=1,
+                    script=None,
                     priority=FORCE_PRIORITY,
                 ),
             ),
             (  # category with rule overrides
-                ("tv", 1, DEFAULT_PRIORITY, ""),
+                ("tv", 1, "", DEFAULT_PRIORITY),
                 [("evaluator", "2", "override.py", "A", "*", "", "1")],
                 "Title",
                 None,
@@ -405,9 +438,9 @@ class TestRSS:
             season=0,
             episode=0,
             category="evaluator",
-            pp=3,
-            script="evaluator.py",
-            priority=FORCE_PRIORITY,
+            pp=None,
+            script=None,
+            priority=LOW_PRIORITY,
         )
 
     def test_feedconfig_rule_category_priority_overrides_feed_default_priority(self, httpserver: HTTPServer):
@@ -442,7 +475,7 @@ class TestRSS:
         self.setup_rss(
             feed_name,
             httpserver.url_for("/evaluator.xml"),
-            pp=1,
+            pp="1",
             filters=[],
         )
         sabnzbd.config.ConfigCat(
@@ -463,9 +496,9 @@ class TestRSS:
             season=0,
             episode=0,
             category="evaluator",
-            pp=3,
-            script="evaluator.py",
-            priority=FORCE_PRIORITY,
+            pp=1,
+            script=None,
+            priority=None,
         )
 
     def test_feedconfig_rule_pp_overrides_category_pp(self, httpserver: HTTPServer):
@@ -473,7 +506,7 @@ class TestRSS:
         self.setup_rss(
             feed_name,
             httpserver.url_for("/evaluator.xml"),
-            pp=1,
+            pp="1",
             filters=[("evaluator", "2", "", "A", "*", DEFAULT_PRIORITY, "1")],
         )
         sabnzbd.config.ConfigCat(
@@ -495,7 +528,7 @@ class TestRSS:
             episode=0,
             category="evaluator",
             pp=2,
-            script="evaluator.py",
+            script=None,
             priority=FORCE_PRIORITY,
         )
 
@@ -504,7 +537,7 @@ class TestRSS:
         self.setup_rss(
             feed_name,
             httpserver.url_for("/evaluator.xml"),
-            pp=1,
+            pp="1",
             filters=[("", "2", "", "A", "*", DEFAULT_PRIORITY, "1")],
         )
         sabnzbd.config.ConfigCat(
@@ -526,6 +559,6 @@ class TestRSS:
             episode=0,
             category="evaluator",
             pp=2,
-            script="evaluator.py",
-            priority=FORCE_PRIORITY,
+            script=None,
+            priority=None,
         )

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -21,16 +21,18 @@ tests.test_misc - Testing functions in misc.py
 
 import datetime
 import time
+import uuid
 from typing import Optional
 
 import configobj
 import pytest
 from pytest_httpserver import HTTPServer
+from werkzeug import Response
+from xml.etree.ElementTree import Element, SubElement, tostring
 
 import sabnzbd.rss as rss
 import sabnzbd.config
 from sabnzbd.constants import DEFAULT_PRIORITY, LOW_PRIORITY, HIGH_PRIORITY, FORCE_PRIORITY, PAUSED_PRIORITY
-from sabnzbd.rss import FeedEvaluation, FeedConfig
 from tests.testhelper import httpserver_handler_data_dir
 
 
@@ -44,7 +46,7 @@ class TestRSS:
         pp: Optional[str] = None,
         script: Optional[str] = None,
         priority: Optional[int] = None,
-        filters: list[tuple[str, str, str, str, str, int, str]] = None,
+        filters: Optional[list[tuple[str, str, str, str, str, int, str]]] = None,
     ):
         """Setup the basic settings to get things going"""
         values: dict = {"uri": feed_url}
@@ -192,39 +194,6 @@ class TestRSS:
         adjusted_date = datetime.datetime(2025, 5, 20, 18, 21, 1) - datetime.timedelta(seconds=time.timezone)
         assert job_data["age"] == adjusted_date
 
-    def test_rss_entry_category(self, httpserver: HTTPServer):
-        httpserver.expect_request("/rss_feed_category.xml").respond_with_handler(httpserver_handler_data_dir)
-
-        feed_name = "TestFeedLink"
-        self.setup_rss(
-            feed_name,
-            httpserver.url_for("/rss_feed_category.xml"),
-            priority=PAUSED_PRIORITY,
-        )
-
-        sabnzbd.config.ConfigCat(
-            "tv",
-            {
-                "pp": "3",
-                "script": "tv.py",
-                "priority": FORCE_PRIORITY,
-            },
-        )
-
-        # Start the RSS reader
-        rss_obj = rss.RSSReader()
-        rss_obj.process_feed(feed_name)
-
-        # Is the feed processed?
-        assert feed_name in rss_obj.jobs
-        assert "http://LINK" in rss_obj.jobs[feed_name]
-
-        # Check some job-data
-        job_data = rss_obj.jobs[feed_name]["http://LINK"]
-        assert job_data["orgcat"] == "TV > HD"
-        assert job_data["cat"] == "tv"
-        assert job_data["prio"] == str(PAUSED_PRIORITY)  # Default feed
-
     @pytest.mark.parametrize(
         "defaults, filters, title, category, size, season, episode, expected_match",
         [
@@ -237,7 +206,7 @@ class TestRSS:
                 1000,
                 0,
                 0,
-                FeedEvaluation(matched=True, rule_index=0, season=0, episode=0),
+                dict(rule="0", season="0", episode="0"),
             ),
             (
                 (None, None, None, None),
@@ -247,7 +216,7 @@ class TestRSS:
                 1000,
                 0,
                 0,
-                FeedEvaluation(matched=True, rule_index=1, season=0, episode=0),
+                dict(rule="1", season="0", episode="0"),
             ),
             (
                 (None, None, None, None),
@@ -257,7 +226,7 @@ class TestRSS:
                 1000,
                 0,
                 0,
-                FeedEvaluation(matched=True, rule_index=1, season=5, episode=2),
+                dict(rule="1", season="5", episode="2"),
             ),
             (
                 (None, None, None, None),
@@ -267,17 +236,17 @@ class TestRSS:
                 1000,
                 0,
                 0,
-                FeedEvaluation(matched=False, rule_index=0, season=1, episode=2),
+                dict(rule="0", season="1", episode="2"),
             ),
             (
                 (None, None, None, LOW_PRIORITY),
-                [],
+                [("", "", "", "A", "*", "", "")],
                 "Title",
                 None,
                 1000,
                 0,
                 0,
-                FeedEvaluation(matched=True, rule_index=0, season=0, episode=0, priority=None),
+                dict(rule="0", season="0", episode="0", prio=str(LOW_PRIORITY)),
             ),
             (
                 (None, None, None, LOW_PRIORITY),
@@ -287,7 +256,7 @@ class TestRSS:
                 1000,
                 0,
                 0,
-                FeedEvaluation(matched=True, rule_index=0, season=0, episode=0, priority=HIGH_PRIORITY),
+                dict(rule="0", season="0", episode="0", prio=str(HIGH_PRIORITY)),
             ),
             (
                 (None, 1, None, None),
@@ -297,7 +266,7 @@ class TestRSS:
                 1000,
                 0,
                 0,
-                FeedEvaluation(matched=True, rule_index=0, season=0, episode=0, pp=None),
+                dict(rule="0", season="0", episode="0", pp=None),
             ),
             (
                 (None, 1, None, None),
@@ -307,7 +276,7 @@ class TestRSS:
                 1000,
                 0,
                 0,
-                FeedEvaluation(matched=True, rule_index=0, season=0, episode=0, pp=3),
+                dict(rule="0", season="0", episode="0", pp=3),
             ),
             (  # category overrides
                 ("tv", 1, "", DEFAULT_PRIORITY),
@@ -317,15 +286,14 @@ class TestRSS:
                 1000,
                 0,
                 0,
-                FeedEvaluation(
-                    matched=True,
-                    rule_index=0,
-                    season=0,
-                    episode=0,
-                    category="evaluator",
+                dict(
+                    rule="0",
+                    season="0",
+                    episode="0",
+                    cat="evaluator",
                     pp=1,
                     script=None,
-                    priority=None,
+                    prio=str(DEFAULT_PRIORITY),
                 ),
             ),
             (  # category with rule overrides
@@ -336,15 +304,31 @@ class TestRSS:
                 1000,
                 0,
                 0,
-                FeedEvaluation(
-                    matched=True,
-                    rule_index=0,
-                    season=0,
-                    episode=0,
-                    category="evaluator",
+                dict(
+                    rule="0",
+                    season="0",
+                    episode="0",
+                    cat="evaluator",
                     pp=2,
                     script="override.py",
-                    priority=None,
+                    prio=str(DEFAULT_PRIORITY),
+                ),
+            ),
+            (
+                ("", "", "", PAUSED_PRIORITY),
+                # Empty filters gives wrong prio
+                [("", "", "", "A", "*", "", "")],
+                "Title",
+                "TV > HD",
+                1000,
+                0,
+                0,
+                dict(
+                    rule="0",
+                    season="0",
+                    episode="0",
+                    cat="tv",
+                    prio=str(PAUSED_PRIORITY),
                 ),
             ),
         ],
@@ -359,8 +343,53 @@ class TestRSS:
         size: int,
         season: int,
         episode: int,
-        expected_match: FeedEvaluation,
+        expected_match: dict,
     ):
+        def build_xml_response(
+            title: str, category: Optional[str], size: Optional[int], season: Optional[int], episode: Optional[int]
+        ):
+            root = Element("rss", version="2.0")
+
+            channel = SubElement(root, "channel")
+            SubElement(channel, "title").text = "RSS feed"
+            SubElement(channel, "description").text = "RSS feed"
+            SubElement(channel, "link").text = "https://sabnzbd.org/"
+
+            item = SubElement(channel, "item")
+
+            SubElement(item, "title").text = title
+            SubElement(item, "link").text = "http://LINK"
+            SubElement(item, "comments").text = "COMMENTS"
+            SubElement(item, "pubDate").text = "Tue, 20 May 2025 18:21:01 +0000"
+
+            guid = SubElement(item, "guid")
+            guid.set("isPermaLink", "true")
+            guid.text = uuid.uuid4().hex
+
+            # optional fields
+            if category is not None:
+                SubElement(item, "category").text = category
+
+            if size is not None:
+                SubElement(item, "size").text = str(size)
+
+            if season is not None:
+                SubElement(item, "season").text = str(season)
+
+            if episode is not None:
+                SubElement(item, "episode").text = str(episode)
+
+            xml_bytes = tostring(root, encoding="utf-8")
+
+            return xml_bytes
+
+        httpserver.expect_request("/evaluator.xml").respond_with_handler(
+            lambda request: Response(
+                build_xml_response(title=title, category=category, size=size, season=season, episode=episode),
+                status=200,
+                content_type="application/rss+xml",
+            )
+        )
         default_category, default_pp, default_script, default_priority = defaults
         feed_name = "Evaluator"
         self.setup_rss(
@@ -381,184 +410,16 @@ class TestRSS:
             },
         )
 
-        feed_cfg = FeedConfig.from_config(sabnzbd.config.get_rss()[feed_name])
-        result_match = feed_cfg.evaluate(title=title, category=category, size=size, season=season, episode=episode)
+        # Start the RSS reader
+        rss_obj = rss.RSSReader()
+        rss_obj.process_feed(feed_name)
 
-        assert result_match == expected_match
+        # Is the feed processed?
+        assert feed_name in rss_obj.jobs
+        assert "http://LINK" in rss_obj.jobs[feed_name]
 
-    def test_feedconfig_default_category_priority_is_applied(self, httpserver: HTTPServer):
-        feed_name = "Evaluator"
-        self.setup_rss(
-            feed_name,
-            httpserver.url_for("/evaluator.xml"),
-            filters=[],
-        )
-        sabnzbd.config.ConfigCat(
-            "*",
-            {
-                "priority": PAUSED_PRIORITY,
-            },
-        )
-
-        feed_cfg = FeedConfig.from_config(sabnzbd.config.get_rss()[feed_name])
-        result_match = feed_cfg.evaluate(title="Title", category=None, size=1000, season=0, episode=0)
-
-        assert result_match == FeedEvaluation(
-            matched=True,
-            rule_index=0,
-            season=0,
-            episode=0,
-            category=None,
-            priority=None,
-        )
-
-    def test_feedconfig_entry_category_priority_overrides_feed_default_priority(self, httpserver: HTTPServer):
-        feed_name = "Evaluator"
-        self.setup_rss(
-            feed_name,
-            httpserver.url_for("/evaluator.xml"),
-            priority=LOW_PRIORITY,
-            filters=[],
-        )
-        sabnzbd.config.ConfigCat(
-            "evaluator",
-            {
-                "pp": "3",
-                "script": "evaluator.py",
-                "priority": FORCE_PRIORITY,
-            },
-        )
-
-        feed_cfg = FeedConfig.from_config(sabnzbd.config.get_rss()[feed_name])
-        result_match = feed_cfg.evaluate(title="Title", category="evaluator", size=1000, season=0, episode=0)
-
-        assert result_match == FeedEvaluation(
-            matched=True,
-            rule_index=0,
-            season=0,
-            episode=0,
-            category="evaluator",
-            pp=None,
-            script=None,
-            priority=LOW_PRIORITY,
-        )
-
-    def test_feedconfig_rule_category_priority_overrides_feed_default_priority(self, httpserver: HTTPServer):
-        feed_name = "Evaluator"
-        self.setup_rss(
-            feed_name,
-            httpserver.url_for("/evaluator.xml"),
-            priority=LOW_PRIORITY,
-            filters=[("tv", "", "", "A", "*", DEFAULT_PRIORITY, "1")],
-        )
-        sabnzbd.config.ConfigCat(
-            "tv",
-            {
-                "priority": HIGH_PRIORITY,
-            },
-        )
-
-        feed_cfg = FeedConfig.from_config(sabnzbd.config.get_rss()[feed_name])
-        result_match = feed_cfg.evaluate(title="Title", category=None, size=1000, season=0, episode=0)
-
-        assert result_match == FeedEvaluation(
-            matched=True,
-            rule_index=0,
-            season=0,
-            episode=0,
-            category="tv",
-            priority=LOW_PRIORITY,
-        )
-
-    def test_feedconfig_entry_category_pp_overrides_feed_default_pp(self, httpserver: HTTPServer):
-        feed_name = "Evaluator"
-        self.setup_rss(
-            feed_name,
-            httpserver.url_for("/evaluator.xml"),
-            pp="1",
-            filters=[],
-        )
-        sabnzbd.config.ConfigCat(
-            "evaluator",
-            {
-                "pp": "3",
-                "script": "evaluator.py",
-                "priority": FORCE_PRIORITY,
-            },
-        )
-
-        feed_cfg = FeedConfig.from_config(sabnzbd.config.get_rss()[feed_name])
-        result_match = feed_cfg.evaluate(title="Title", category="evaluator", size=1000, season=0, episode=0)
-
-        assert result_match == FeedEvaluation(
-            matched=True,
-            rule_index=0,
-            season=0,
-            episode=0,
-            category="evaluator",
-            pp=1,
-            script=None,
-            priority=None,
-        )
-
-    def test_feedconfig_rule_pp_overrides_category_pp(self, httpserver: HTTPServer):
-        feed_name = "Evaluator"
-        self.setup_rss(
-            feed_name,
-            httpserver.url_for("/evaluator.xml"),
-            pp="1",
-            filters=[("evaluator", "2", "", "A", "*", DEFAULT_PRIORITY, "1")],
-        )
-        sabnzbd.config.ConfigCat(
-            "evaluator",
-            {
-                "pp": "3",
-                "script": "evaluator.py",
-                "priority": FORCE_PRIORITY,
-            },
-        )
-
-        feed_cfg = FeedConfig.from_config(sabnzbd.config.get_rss()[feed_name])
-        result_match = feed_cfg.evaluate(title="Title", category=None, size=1000, season=0, episode=0)
-
-        assert result_match == FeedEvaluation(
-            matched=True,
-            rule_index=0,
-            season=0,
-            episode=0,
-            category="evaluator",
-            pp=2,
-            script=None,
-            priority=None,
-        )
-
-    def test_feedconfig_rule_pp_overrides_entry_category_pp(self, httpserver: HTTPServer):
-        feed_name = "Evaluator"
-        self.setup_rss(
-            feed_name,
-            httpserver.url_for("/evaluator.xml"),
-            pp="1",
-            filters=[("", "2", "", "A", "*", DEFAULT_PRIORITY, "1")],
-        )
-        sabnzbd.config.ConfigCat(
-            "evaluator",
-            {
-                "pp": "3",
-                "script": "evaluator.py",
-                "priority": FORCE_PRIORITY,
-            },
-        )
-
-        feed_cfg = FeedConfig.from_config(sabnzbd.config.get_rss()[feed_name])
-        result_match = feed_cfg.evaluate(title="Title", category="evaluator", size=1000, season=0, episode=0)
-
-        assert result_match == FeedEvaluation(
-            matched=True,
-            rule_index=0,
-            season=0,
-            episode=0,
-            category="evaluator",
-            pp=2,
-            script=None,
-            priority=None,
-        )
+        # Check some job-data
+        job_data = rss_obj.jobs[feed_name]["http://LINK"]
+        for k, v in expected_match.items():
+            assert k in job_data
+            assert job_data[k] == v, f"Expected {k!r}: {job_data[k]!r} == {v!r}"


### PR DESCRIPTION
Fixes #3398

The previous refactoring has changed RSS behaviour,because I missunderstood some of the stateful aspect of the rules.

The error is that the first decisive rule controls subsequent fallback behavior, rather than directly supplying the final values.
For example, where it was doing `first_not_none(rule.pp, feed.pp, category.pp)` the original is closer to:

```py
if rule.pp:
    use it
elif no rule category and no RSS category:
    use category pp
else:
    keep feed pp
```

So, the precedence/logic is:

- reject rules still matter
- RSS categories suppress category defaults
- feed defaults can beat more-specific metadata
- category defaults are not true defaults

There are several tests you added, their names now don't really reflect what the expected or actual outcome they test for is. They're very similar or the same as some of the parametrize tests, so I could just add them in there?
