### PR TITLE
Fix warnings with repair job and missing renamed files

### DIFF
--- a/sabnzbd/nzb/file.py
+++ b/sabnzbd/nzb/file.py
@@ -226,10 +226,10 @@ class NzbFile(TryList):
             if not self.first_article_processed():
                 return None
 
-            self.nzo.verify_nzf_filename(self)
-            filename = sanitize_filename(self.filename)
             with self.nzo.lock:
                 if not self.filepath:
+                    self.nzo.verify_nzf_filename(self)
+                    filename = sanitize_filename(self.filename)
                     self.filepath = self.nzo.get_unique_filepath(filename)
                     self.filename = get_filename(self.filepath)
         return self.filepath

--- a/sabnzbd/nzb/object.py
+++ b/sabnzbd/nzb/object.py
@@ -829,12 +829,13 @@ class NzbObject(TryList):
 
         # Substitute renamed files
         if renames := load_data(RENAMES_FILE, self.admin_path, remove=True):
-            for name in renames:
-                if name in existing_files or renames[name] in existing_files:
+            for name, old_name in renames.items():
+                if name in existing_files or old_name in existing_files:
                     if name in existing_files:
                         existing_files.remove(name)
-                    existing_files.append(renames[name])
-            self.renames = renames
+                    if os.path.exists(os.path.join(wdir, old_name)):
+                        existing_files.append(old_name)
+                self.renamed_file(name, old_name)
 
         # Looking for the longest name first, minimizes the chance on a mismatch
         existing_files.sort(key=len)
@@ -1380,15 +1381,17 @@ class NzbObject(TryList):
             self.direct_unpacker.set_volumes_for_nzo()
 
     @synchronized()
-    def renamed_file(self, name_set, old_name=None):
+    def renamed_file(self, renames_or_name: Union[dict[str, str], str], old_name: Optional[str] = None):
         """Save renames at various stages (Download/PP)
         to be used on Retry. Accepts strings and dicts.
         """
-        if not old_name:
+        if isinstance(renames_or_name, dict):
             # Add to dict
-            self.renames.update(name_set)
-        else:
-            self.renames[name_set] = old_name
+            for name, old_name in renames_or_name.items():
+                if old_name is not None:
+                    self.renames[name] = self.renames.pop(old_name, old_name)
+        elif old_name is not None:
+            self.renames[renames_or_name] = self.renames.pop(old_name, old_name)
 
     @synchronized()
     def get_unique_filepath(self, filename: str) -> str:

--- a/tests/test_nzbobject.py
+++ b/tests/test_nzbobject.py
@@ -40,6 +40,13 @@ class TestNZO:
         assert nzo.work_name == "test_basic"
         assert not nzo.files
 
+        # Renaming a file twice should remove the redundant entry
+        nzo.renamed_file("YENC NAME", "NZF NAME")
+        assert nzo.renames["YENC NAME"] == "NZF NAME"
+        nzo.renamed_file("PAR2 NAME", "YENC NAME")
+        assert nzo.renames["PAR2 NAME"] == "NZF NAME"
+        assert len(nzo.renames) == 1
+
         # Create NZB-file to import
         nzb_fp = create_and_read_nzb_fp("basic_rar5")
 


### PR DESCRIPTION
Fixes #3423 - just the warnings it won't be able to fix the job, will probably address separately.

`verify_nzf_filename` under lock so less chance of racing and adding a rename before par2 is processed.

`renamed_file` added typing and handles multiple renames avoiding leaving stale entries, not strictly required since `check_existing_files` now only adds paths which exist but avoids storing invalid state.