### PR TITLE
Fix RuntimeError: dictionary changed size during iteration in stop_idle_jobs

### DIFF
--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -906,15 +906,23 @@ class NzbQueue:
                         break
 
                     if nzf.all_servers_in_try_list(active_servers):
-                        # Check for articles where all active servers have already been tried
+                        # Collect articles where all active servers have already been tried.
+                        # Snapshot under lock to avoid RuntimeError from dict mutation when
+                        # register_article later calls nzf.remove_article (see #3431).
                         with nzf.lock:
-                            for article in nzf.articles:
-                                if article.all_servers_in_try_list(active_servers):
-                                    logging.debug(
-                                        "Removing article %s with bad trylist in file %s", article, nzf.filename
-                                    )
-                                    nzo.increase_bad_articles_counter("missing_articles")
-                                    sabnzbd.NzbQueue.register_article(article, success=False)
+                            articles_to_remove = [
+                                article for article in nzf.articles
+                                if article.all_servers_in_try_list(active_servers)
+                            ]
+                        # Act outside the iteration; register_article is intentionally
+                        # not locked ("not locked for performance") and must not be
+                        # called while nzf.lock is held by the same thread.
+                        for article in articles_to_remove:
+                            logging.debug(
+                                "Removing article %s with bad trylist in file %s", article, nzf.filename
+                            )
+                            nzo.increase_bad_articles_counter("missing_articles")
+                            sabnzbd.NzbQueue.register_article(article, success=False)
 
                         if not nzf.assembled and not nzf.articles:
                             logging.debug("Not assembled but no remaining articles for file %s", nzf.filename)

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -913,9 +913,6 @@ class NzbQueue:
                             articles_to_remove = [
                                 article for article in nzf.articles if article.all_servers_in_try_list(active_servers)
                             ]
-                        # Act outside the iteration; register_article is intentionally
-                        # not locked ("not locked for performance") and must not be
-                        # called while nzf.lock is held by the same thread.
                         for article in articles_to_remove:
                             logging.debug("Removing article %s with bad trylist in file %s", article, nzf.filename)
                             nzo.increase_bad_articles_counter("missing_articles")

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -911,16 +911,13 @@ class NzbQueue:
                         # register_article later calls nzf.remove_article (see #3431).
                         with nzf.lock:
                             articles_to_remove = [
-                                article for article in nzf.articles
-                                if article.all_servers_in_try_list(active_servers)
+                                article for article in nzf.articles if article.all_servers_in_try_list(active_servers)
                             ]
                         # Act outside the iteration; register_article is intentionally
                         # not locked ("not locked for performance") and must not be
                         # called while nzf.lock is held by the same thread.
                         for article in articles_to_remove:
-                            logging.debug(
-                                "Removing article %s with bad trylist in file %s", article, nzf.filename
-                            )
+                            logging.debug("Removing article %s with bad trylist in file %s", article, nzf.filename)
                             nzo.increase_bad_articles_counter("missing_articles")
                             sabnzbd.NzbQueue.register_article(article, success=False)
 

--- a/tests/test_nzbqueue.py
+++ b/tests/test_nzbqueue.py
@@ -112,6 +112,34 @@ class TestNzbQueue:
         # Try list restored
         assert sabnzbd.Downloader.servers[0] in list(joba.files[0].articles)[0].try_list
 
+    def test_stop_idle_jobs_no_crash_on_exhausted_articles(self):
+        """Regression test: stop_idle_jobs must not raise RuntimeError when
+        register_article removes an article from nzf.articles (a dict) while
+        the same dict is being iterated.  Introduced by commit 44d94226e when
+        nzf.articles was changed from list to dict but the protective [:] copy
+        was dropped from the iteration in stop_idle_jobs."""
+        server = sabnzbd.Downloader.servers[0]
+
+        nzo = make_dummy_nzo("stall-test", files=1, articles=3)
+        nzf = nzo.files[0]
+
+        # Load all articles into memory (only first is loaded at NzbFile init)
+        nzf.finish_import()
+
+        q = NzbQueue()
+        # add() resets try lists, so saturate them after adding
+        q.add(nzo)
+        sabnzbd.NzbQueue = q
+
+        # Saturate all try-lists so stop_idle_jobs enters the article-removal branch
+        nzo.add_to_try_list(server)
+        nzf.add_to_try_list(server)
+        for article in list(nzf.articles):
+            article.add_to_try_list(server)
+
+        # Must not raise RuntimeError: dictionary changed size during iteration
+        q.stop_idle_jobs()
+
     @pytest.mark.skipif(not sabnzbd.WINDOWS, reason="Legacy 3.0.0 queue fixture contains Windows-specific paths")
     def test_restore_legacy_queue_format_3_0_0(self, tmp_path, monkeypatch):
         fixture_path = Path(SAB_DATA_DIR) / "test_3_0_0_queue_format"


### PR DESCRIPTION
## Summary

- Fixes #3431 — SABnzbd crashes with `RuntimeError: dictionary changed size during iteration` in `stop_idle_jobs`
- Collects exhausted articles into a snapshot list while holding `nzf.lock`, then calls `register_article` outside the iteration
- Adds a regression test that reproduces the crash without the fix

## Root Cause

`stop_idle_jobs` iterated over `nzf.articles` (a `dict`) and called `register_article(article, success=False)` inside the loop. That call chains to `nzf.remove_article` → `self.articles.pop(article)`, mutating the dict mid-iteration.

The `with nzf.lock:` provided no protection because `nzf.lock` is an `RLock` — the same thread re-acquires it freely when `nzf.remove_article` (`@synchronized()`) is called deeper in the stack.

This was originally safe when `nzf.articles` was a `list` (commit `fd3ece31c` used `nzf.articles[:]`). Commit `44d94226e` changed `articles` to a `dict` for O(1) lookups but the protective copy was dropped.

## Changes

**`sabnzbd/nzbqueue.py`** — collect-then-act pattern in `stop_idle_jobs`:
```python
# Before (broken — mutates dict mid-iteration)
with nzf.lock:
    for article in nzf.articles:
        if article.all_servers_in_try_list(active_servers):
            ...
            sabnzbd.NzbQueue.register_article(article, success=False)

# After — snapshot under lock, act outside iteration
with nzf.lock:
    articles_to_remove = [
        article for article in nzf.articles
        if article.all_servers_in_try_list(active_servers)
    ]
for article in articles_to_remove:
    ...
    sabnzbd.NzbQueue.register_article(article, success=False)
```

**`tests/test_nzbqueue.py`** — regression test that crashes on the unfixed code and passes after the fix.

## Test plan

- [ ] `python -m pytest tests/test_nzbqueue.py` — all pass
- [ ] Verify `test_stop_idle_jobs_no_crash_on_exhausted_articles` fails on `develop` without this fix and passes with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)