### PR TITLE
Repair with no par2 sets and missing data should have failed status

### DIFF
--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -869,6 +869,14 @@ def parring(nzo: NzbObject) -> tuple[bool, bool]:
                 if rars:
                     par_error = not try_rar_check(nzo, rars)
 
+            # Any non-par2 files missing data
+            if not par_error and any(not f.is_par2 and f.bytes_left for f in nzo.finished_files):
+                emsg = T("Repair failed - Not on your server(s)") + " - https://sabnzbd.org/not-complete"
+                nzo.fail_msg = emsg
+                nzo.set_unpack_info("Repair", emsg)
+                nzo.status = Status.FAILED
+                par_error = True
+
             # Save that we already tried SFV/RAR-verification
             verified[""] = not par_error
 


### PR DESCRIPTION
Fixes #3430

Post processing is "+Delete" so it should try to repair, test NZB has no par2, 10 files, 1 complete, 9 each missing one or more articles.

`fail_hopeless_jobs` is disabled

I think the message may need changing, but I'm not sure how to communicate that verification failed because there are no par2 files and some articles are not available.

Path to get here is:
- No par2 files so `verified` is empty
- No sfv for sfv check
- No RARs for RAR-check
- There are non-par2 files with missing data (f.bytes.left)

So we know data is missing and we couldn't repair, so this should be a failed job.
If there was par2 data this would already be handled correctly as a failed job.

If PP mode was just "Download" it will still be marked completed as expected.