### PR TITLE
Sanitise host_whitelist and login/request public IP addresses

### DIFF
--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -728,7 +728,7 @@ def _api_showlog(name: str, kwargs: ApiParams) -> Generator[bytes, Any, None]:
 
     def sanitize_line(line: bytes) -> bytes:
         """Apply regex substitutions to a single line to remove sensitive data"""
-        line = LOG_JSON_RE.sub(b"'REMOVED': '<REMOVED>'", line)
+        line = LOG_JSON_RE.sub(b"'\\1': '<REMOVED>'", line)
         line = LOG_INI_HIDE_RE.sub(b"\\1 = <REMOVED>", line)
         line = LOG_NNTP_AUTH_RE.sub(b"\\1 <REMOVED>", line)
         line = LOG_HASH_RE.sub(b"<HASH>", line)

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -702,7 +702,6 @@ LOG_INI_HIDE_RE = re.compile(
 LOG_NNTP_AUTH_RE = re.compile(rb"(authinfo (?:user|pass)) [^\\'\'\r\n]+", re.I)
 LOG_HASH_RE = re.compile(rb"([a-zA-Z\d]{25})", re.I)
 LOG_REMOTE_LABEL_RE = re.compile(
-    rb"(?P<prefix>^.*?]\s*.*?)"
     rb"(?P<ip>(?:\d{1,3}\.){3}\d{1,3}|(?:[A-Fa-f0-9:]+:+)+[A-Fa-f0-9.]+)"
     rb"(?:\s+\(X-Forwarded-For:\s*(?P<xff>[^)]+)\))?"
     rb"\s+\[(?P<ua>[^]]+)]"
@@ -722,8 +721,8 @@ def remote_label_replacement(m: re.Match[bytes]) -> bytes:
                 xff.append(xff_ip.encode())
             else:
                 xff.append(b"<REMOVED>")
-        return b"%s%s (X-Forwarded-For: %s) [%s]" % (m.group("prefix"), ip, b", ".join(xff), m.group("ua"))
-    return b"%s%s [%s]" % (m.group("prefix"), ip, m.group("ua"))
+        return b"%s (X-Forwarded-For: %s) [%s]" % (ip, b", ".join(xff), m.group("ua"))
+    return b"%s [%s]" % (ip, m.group("ua"))
 
 
 def sanitize_line(line: bytes, cur_user_bytes: Optional[bytes] = None) -> bytes:

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -700,29 +700,12 @@ LOG_INI_HIDE_RE = re.compile(
 )
 LOG_NNTP_AUTH_RE = re.compile(rb"(authinfo (?:user|pass)) [^\\'\'\r\n]+", re.I)
 LOG_HASH_RE = re.compile(rb"([a-zA-Z\d]{25})", re.I)
-
-# https://gist.github.com/dfee/6ed3a4b05cfe7a6faf40a2102408d5d8
-# fmt: off
-IPV4SEG  = r'(?:25[0-5]|(?:2[0-4]|1{0,1}[0-9]){0,1}[0-9])'
-IPV4ADDR = r'(?:(?:' + IPV4SEG + r'\.){3,3}' + IPV4SEG + r')'
-IPV6SEG  = r'(?:(?:[0-9a-fA-F]){1,4})'
-IPV6GROUPS = (
-    r'(?:' + IPV6SEG + r':){7,7}' + IPV6SEG,                  # 1:2:3:4:5:6:7:8
-    r'(?:' + IPV6SEG + r':){1,7}:',                           # 1::                                 1:2:3:4:5:6:7::
-    r'(?:' + IPV6SEG + r':){1,6}:' + IPV6SEG,                 # 1::8               1:2:3:4:5:6::8   1:2:3:4:5:6::8
-    r'(?:' + IPV6SEG + r':){1,5}(?::' + IPV6SEG + r'){1,2}',  # 1::7:8             1:2:3:4:5::7:8   1:2:3:4:5::8
-    r'(?:' + IPV6SEG + r':){1,4}(?::' + IPV6SEG + r'){1,3}',  # 1::6:7:8           1:2:3:4::6:7:8   1:2:3:4::8
-    r'(?:' + IPV6SEG + r':){1,3}(?::' + IPV6SEG + r'){1,4}',  # 1::5:6:7:8         1:2:3::5:6:7:8   1:2:3::8
-    r'(?:' + IPV6SEG + r':){1,2}(?::' + IPV6SEG + r'){1,5}',  # 1::4:5:6:7:8       1:2::4:5:6:7:8   1:2::8
-    IPV6SEG + r':(?:(?::' + IPV6SEG + r'){1,6})',             # 1::3:4:5:6:7:8     1::3:4:5:6:7:8   1::8
-    r':(?:(?::' + IPV6SEG + r'){1,7}|:)',                     # ::2:3:4:5:6:7:8    ::2:3:4:5:6:7:8  ::8       ::
-    r'fe80:(?::' + IPV6SEG + r'){0,4}%[0-9a-zA-Z]{1,}',       # fe80::7:8%eth0     fe80::7:8%1  (link-local IPv6 addresses with zone index)
-    r'::(?:ffff(?::0{1,4}){0,1}:){0,1}[^\s:]' + IPV4ADDR,     # ::255.255.255.255  ::ffff:255.255.255.255  ::ffff:0:255.255.255.255 (IPv4-mapped IPv6 addresses and IPv4-translated addresses)
-    r'(?:' + IPV6SEG + r':){1,4}:[^\s:]' + IPV4ADDR,          # 2001:db8:3:4::192.0.2.33  64:ff9b::192.0.2.33 (IPv4-Embedded IPv6 Address)
+LOG_REMOTE_LABEL_RE = re.compile(
+    rb"(?P<prefix>^.*?]\s*.*?)"
+    rb"(?P<ip>\S+)"
+    rb"(?:\s+\(X-Forwarded-For:\s*(?P<xff>[^)]+)\))?"
+    rb"\s+\[(?P<ua>[^]]+)]"
 )
-# fmt: on
-IPV4_RE = re.compile(IPV4ADDR.encode())
-IPV6_RE = re.compile("|".join([f"(?:{g})" for g in IPV6GROUPS[::-1]]).encode())  # Reverse rows for greedy match
 
 
 def _api_showlog(name: str, kwargs: ApiParams) -> Generator[bytes, Any, None]:
@@ -749,17 +732,18 @@ def _api_showlog(name: str, kwargs: ApiParams) -> Generator[bytes, Any, None]:
     except Exception:
         pass
 
+    def remote_label_replacement(m: re.Match[bytes]) -> bytes:
+        if m.group("xff"):
+            return b"%s<REMOVED> (X-Forwarded-For: <REMOVED>) [%s]" % (m.group("prefix"), m.group("ua"))
+        return b"%s<REMOVED> [%s]" % (m.group("prefix"), m.group("ua"))
+
     def sanitize_line(line: bytes) -> bytes:
         """Apply regex substitutions to a single line to remove sensitive data"""
         line = LOG_JSON_RE.sub(b"'\\1': '<REMOVED>'", line)
         line = LOG_INI_HIDE_RE.sub(b"\\1 = <REMOVED>", line)
         line = LOG_NNTP_AUTH_RE.sub(b"\\1 <REMOVED>", line)
         line = LOG_HASH_RE.sub(b"<HASH>", line)
-        with suppress(ValueError):
-            prefix, rest = line.split(b"] ", 1)
-            rest = IPV6_RE.sub(b"<REMOVED>", rest)
-            rest = IPV4_RE.sub(b"<REMOVED>", rest)
-            line = prefix + b"] " + rest
+        line = LOG_REMOTE_LABEL_RE.sub(remote_label_replacement, line)
         if cur_user_bytes:
             line = line.replace(cur_user_bytes, b"<USERNAME>")
         return line

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -30,7 +30,6 @@ import getpass
 import cherrypy
 from threading import Thread
 from typing import Any, Callable, Generator, Optional, TypeAlias
-from contextlib import suppress
 
 # For json.dumps, orjson is magnitudes faster than ujson, but it is harder to
 # compile due to Rust dependency. Since the output is the same, we support all modules.

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -81,7 +81,7 @@ from sabnzbd.misc import (
     bool_conv,
     get_platform_description,
     is_loopback_addr,
-    is_local_addr,
+    is_lan_addr,
 )
 from sabnzbd.filesystem import diskspace, get_ext, clip_path, remove_all, list_scripts, purge_log_files, pathbrowser
 from sabnzbd.encoding import xml_name, utob
@@ -711,14 +711,14 @@ LOG_REMOTE_LABEL_RE = re.compile(
 
 def remote_label_replacement(m: re.Match[bytes]) -> bytes:
     """Apply regex substitutions to remote labels, allows local IP addresses"""
-    if (ip_str := m.group("ip").decode()) and (is_loopback_addr(ip_str) or is_local_addr(ip_str)):
+    if (ip_str := m.group("ip").decode()) and (is_loopback_addr(ip_str) or is_lan_addr(ip_str)):
         ip = m.group("ip")
     else:
         ip = b"<REMOVED>"
     if m.group("xff"):
         xff = []
         for xff_ip in m.group("xff").decode().split(", "):
-            if is_loopback_addr(xff_ip) or is_local_addr(xff_ip):
+            if is_loopback_addr(xff_ip) or is_lan_addr(xff_ip):
                 xff.append(xff_ip.encode())
             else:
                 xff.append(b"<REMOVED>")

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -80,6 +80,8 @@ from sabnzbd.misc import (
     match_str,
     bool_conv,
     get_platform_description,
+    is_loopback_addr,
+    is_local_addr,
 )
 from sabnzbd.filesystem import diskspace, get_ext, clip_path, remove_all, list_scripts, purge_log_files, pathbrowser
 from sabnzbd.encoding import xml_name, utob
@@ -701,10 +703,39 @@ LOG_NNTP_AUTH_RE = re.compile(rb"(authinfo (?:user|pass)) [^\\'\'\r\n]+", re.I)
 LOG_HASH_RE = re.compile(rb"([a-zA-Z\d]{25})", re.I)
 LOG_REMOTE_LABEL_RE = re.compile(
     rb"(?P<prefix>^.*?]\s*.*?)"
-    rb"(?P<ip>\S+)"
+    rb"(?P<ip>(?:\d{1,3}\.){3}\d{1,3}|(?:[A-Fa-f0-9:]+:+)+[A-Fa-f0-9.]+)"
     rb"(?:\s+\(X-Forwarded-For:\s*(?P<xff>[^)]+)\))?"
     rb"\s+\[(?P<ua>[^]]+)]"
 )
+
+
+def remote_label_replacement(m: re.Match[bytes]) -> bytes:
+    """Apply regex substitutions to remote labels, allows local IP addresses"""
+    if (ip_str := m.group("ip").decode()) and (is_loopback_addr(ip_str) or is_local_addr(ip_str)):
+        ip = m.group("ip")
+    else:
+        ip = b"<REMOVED>"
+    if m.group("xff"):
+        xff = []
+        for xff_ip in m.group("xff").decode().split(", "):
+            if is_loopback_addr(xff_ip) or is_local_addr(xff_ip):
+                xff.append(xff_ip.encode())
+            else:
+                xff.append(b"<REMOVED>")
+        return b"%s%s (X-Forwarded-For: %s) [%s]" % (m.group("prefix"), ip, b", ".join(xff), m.group("ua"))
+    return b"%s%s [%s]" % (m.group("prefix"), ip, m.group("ua"))
+
+
+def sanitize_line(line: bytes, cur_user_bytes: Optional[bytes] = None) -> bytes:
+    """Apply regex substitutions to a single line to remove sensitive data"""
+    line = LOG_JSON_RE.sub(b"'\\1': '<REMOVED>'", line)
+    line = LOG_INI_HIDE_RE.sub(b"\\1 = <REMOVED>", line)
+    line = LOG_NNTP_AUTH_RE.sub(b"\\1 <REMOVED>", line)
+    line = LOG_HASH_RE.sub(b"<HASH>", line)
+    line = LOG_REMOTE_LABEL_RE.sub(remote_label_replacement, line)
+    if cur_user_bytes:
+        line = line.replace(cur_user_bytes, b"<USERNAME>")
+    return line
 
 
 def _api_showlog(name: str, kwargs: ApiParams) -> Generator[bytes, Any, None]:
@@ -724,41 +755,25 @@ def _api_showlog(name: str, kwargs: ApiParams) -> Generator[bytes, Any, None]:
     yield header.encode("utf-8")
 
     # Try to replace the username
+    cur_user_bytes: Optional[bytes] = None
     try:
-        cur_user_bytes = None
         if cur_user := getpass.getuser():
             cur_user_bytes = utob(cur_user)
     except Exception:
         pass
 
-    def remote_label_replacement(m: re.Match[bytes]) -> bytes:
-        if m.group("xff"):
-            return b"%s<REMOVED> (X-Forwarded-For: <REMOVED>) [%s]" % (m.group("prefix"), m.group("ua"))
-        return b"%s<REMOVED> [%s]" % (m.group("prefix"), m.group("ua"))
-
-    def sanitize_line(line: bytes) -> bytes:
-        """Apply regex substitutions to a single line to remove sensitive data"""
-        line = LOG_JSON_RE.sub(b"'\\1': '<REMOVED>'", line)
-        line = LOG_INI_HIDE_RE.sub(b"\\1 = <REMOVED>", line)
-        line = LOG_NNTP_AUTH_RE.sub(b"\\1 <REMOVED>", line)
-        line = LOG_HASH_RE.sub(b"<HASH>", line)
-        line = LOG_REMOTE_LABEL_RE.sub(remote_label_replacement, line)
-        if cur_user_bytes:
-            line = line.replace(cur_user_bytes, b"<USERNAME>")
-        return line
-
     # Stream log file line by line
     if sabnzbd.LOGFILE and os.path.exists(sabnzbd.LOGFILE):
         with open(sabnzbd.LOGFILE, "rb") as f:
             for line in f:
-                yield sanitize_line(line)
+                yield sanitize_line(line, cur_user_bytes)
     else:
         yield b"\nFile log disabled or not found.\n\n"
 
     # Stream config file line by line
     with open(config.get_filename(), "rb") as f:
         for line in f:
-            yield sanitize_line(line)
+            yield sanitize_line(line, cur_user_bytes)
 
 
 def _api_get_cats(name: str, kwargs: ApiParams) -> bytes:

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -30,6 +30,7 @@ import getpass
 import cherrypy
 from threading import Thread
 from typing import Any, Callable, Generator, Optional, TypeAlias
+from contextlib import suppress
 
 # For json.dumps, orjson is magnitudes faster than ujson, but it is harder to
 # compile due to Rust dependency. Since the output is the same, we support all modules.
@@ -699,7 +700,29 @@ LOG_INI_HIDE_RE = re.compile(
 )
 LOG_NNTP_AUTH_RE = re.compile(rb"(authinfo (?:user|pass)) [^\\'\'\r\n]+", re.I)
 LOG_HASH_RE = re.compile(rb"([a-zA-Z\d]{25})", re.I)
-LOG_IP_RE = re.compile(rb"((?:login (?:attempt )?|request .*)from )(.*?)( \[)", re.I)
+
+# https://gist.github.com/dfee/6ed3a4b05cfe7a6faf40a2102408d5d8
+# fmt: off
+IPV4SEG  = r'(?:25[0-5]|(?:2[0-4]|1{0,1}[0-9]){0,1}[0-9])'
+IPV4ADDR = r'(?:(?:' + IPV4SEG + r'\.){3,3}' + IPV4SEG + r')'
+IPV6SEG  = r'(?:(?:[0-9a-fA-F]){1,4})'
+IPV6GROUPS = (
+    r'(?:' + IPV6SEG + r':){7,7}' + IPV6SEG,                  # 1:2:3:4:5:6:7:8
+    r'(?:' + IPV6SEG + r':){1,7}:',                           # 1::                                 1:2:3:4:5:6:7::
+    r'(?:' + IPV6SEG + r':){1,6}:' + IPV6SEG,                 # 1::8               1:2:3:4:5:6::8   1:2:3:4:5:6::8
+    r'(?:' + IPV6SEG + r':){1,5}(?::' + IPV6SEG + r'){1,2}',  # 1::7:8             1:2:3:4:5::7:8   1:2:3:4:5::8
+    r'(?:' + IPV6SEG + r':){1,4}(?::' + IPV6SEG + r'){1,3}',  # 1::6:7:8           1:2:3:4::6:7:8   1:2:3:4::8
+    r'(?:' + IPV6SEG + r':){1,3}(?::' + IPV6SEG + r'){1,4}',  # 1::5:6:7:8         1:2:3::5:6:7:8   1:2:3::8
+    r'(?:' + IPV6SEG + r':){1,2}(?::' + IPV6SEG + r'){1,5}',  # 1::4:5:6:7:8       1:2::4:5:6:7:8   1:2::8
+    IPV6SEG + r':(?:(?::' + IPV6SEG + r'){1,6})',             # 1::3:4:5:6:7:8     1::3:4:5:6:7:8   1::8
+    r':(?:(?::' + IPV6SEG + r'){1,7}|:)',                     # ::2:3:4:5:6:7:8    ::2:3:4:5:6:7:8  ::8       ::
+    r'fe80:(?::' + IPV6SEG + r'){0,4}%[0-9a-zA-Z]{1,}',       # fe80::7:8%eth0     fe80::7:8%1  (link-local IPv6 addresses with zone index)
+    r'::(?:ffff(?::0{1,4}){0,1}:){0,1}[^\s:]' + IPV4ADDR,     # ::255.255.255.255  ::ffff:255.255.255.255  ::ffff:0:255.255.255.255 (IPv4-mapped IPv6 addresses and IPv4-translated addresses)
+    r'(?:' + IPV6SEG + r':){1,4}:[^\s:]' + IPV4ADDR,          # 2001:db8:3:4::192.0.2.33  64:ff9b::192.0.2.33 (IPv4-Embedded IPv6 Address)
+)
+# fmt: on
+IPV4_RE = re.compile(IPV4ADDR.encode())
+IPV6_RE = re.compile("|".join([f"(?:{g})" for g in IPV6GROUPS[::-1]]).encode())  # Reverse rows for greedy match
 
 
 def _api_showlog(name: str, kwargs: ApiParams) -> Generator[bytes, Any, None]:
@@ -732,7 +755,11 @@ def _api_showlog(name: str, kwargs: ApiParams) -> Generator[bytes, Any, None]:
         line = LOG_INI_HIDE_RE.sub(b"\\1 = <REMOVED>", line)
         line = LOG_NNTP_AUTH_RE.sub(b"\\1 <REMOVED>", line)
         line = LOG_HASH_RE.sub(b"<HASH>", line)
-        line = LOG_IP_RE.sub(b"\\1<REMOVED>\\3", line)
+        with suppress(ValueError):
+            prefix, rest = line.split(b"] ", 1)
+            rest = IPV6_RE.sub(b"<REMOVED>", rest)
+            rest = IPV4_RE.sub(b"<REMOVED>", rest)
+            line = prefix + b"] " + rest
         if cur_user_bytes:
             line = line.replace(cur_user_bytes, b"<USERNAME>")
         return line

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -689,14 +689,17 @@ def _api_warnings(name: str, kwargs: ApiParams) -> bytes:
     return report(keyword="warnings", data=sabnzbd.GUIHANDLER.content())
 
 
-LOG_JSON_RE = re.compile(rb"'(apikey|api|username|password|email_(server|to|from|account|pwd))': '(.*?)'", re.I)
+LOG_JSON_RE = re.compile(
+    rb"'(apikey|api|username|password|email_(server|to|from|account|pwd)|host_whitelist)': '(.*?)'", re.I
+)
 LOG_INI_HIDE_RE = re.compile(
-    rb"(apikey|api|user|username|password|email_pwd|email_account|email_to|email_from|pushover_token|pushover_userkey"
+    rb"(apikey|api|user|username|password|email_pwd|email_account|email_to|email_from|pushover_token|pushover_userkey|host_whitelist"
     rb"|apprise_(target_[a-z_]+|urls)|pushbullet_apikey|prowl_apikey|growl_password|growl_server|IPv[4|6] address|Public address IPv[4|6]-only|Local IPv6 address)\s?=.*",
     re.I,
 )
 LOG_NNTP_AUTH_RE = re.compile(rb"(authinfo (?:user|pass)) [^\\'\'\r\n]+", re.I)
 LOG_HASH_RE = re.compile(rb"([a-zA-Z\d]{25})", re.I)
+LOG_IP_RE = re.compile(rb"((?:login (?:attempt )?|request .*)from )(.*?)( \[)", re.I)
 
 
 def _api_showlog(name: str, kwargs: ApiParams) -> Generator[bytes, Any, None]:
@@ -729,6 +732,7 @@ def _api_showlog(name: str, kwargs: ApiParams) -> Generator[bytes, Any, None]:
         line = LOG_INI_HIDE_RE.sub(b"\\1 = <REMOVED>", line)
         line = LOG_NNTP_AUTH_RE.sub(b"\\1 <REMOVED>", line)
         line = LOG_HASH_RE.sub(b"<HASH>", line)
+        line = LOG_IP_RE.sub(b"\\1<REMOVED>\\3", line)
         if cur_user_bytes:
             line = line.replace(cur_user_bytes, b"<USERNAME>")
         return line

--- a/tests/test_api_and_interface.py
+++ b/tests/test_api_and_interface.py
@@ -65,12 +65,22 @@ class TestApiInternals:
                 b"2026-05-19 18:35:18,271::WARNING::[interface:689] Unsuccessful login attempt from 8.8.8.8 [Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0]\n",
                 b"<REMOVED>",
             ),
+            (
+                b"2026-05-19 18:35:18,271::WARNING::[interface:689] Unsuccessful login attempt from 127.0.0.1 [Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0]\n",
+                b"127.0.0.1",
+            ),
+            (
+                b"2026-05-19 18:35:18,271::WARNING::[interface:689] Unsuccessful login attempt from fe80::1 [Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0]\n",
+                b"fe80::1",
+            ),
         ],
         ids=[
             "ipv6-local",
             "ipv4-local",
             "ipv6-removed",
             "ipv4-removed",
+            "ipv4-loopback",
+            "ipv6-linklocal",
         ],
     )
     def test_log_sanitize_remote_label(self, line, ip):
@@ -105,12 +115,24 @@ class TestApiInternals:
                 b"<REMOVED>",
                 [b"<REMOVED>"],
             ),
+            (
+                b"2026-05-19 18:35:18,271::WARNING::[interface:689] Unsuccessful login attempt from 127.0.0.1 (X-Forwarded-For: 127.1.2.3) [Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0]\n",
+                b"127.0.0.1",
+                [b"127.1.2.3"],
+            ),
+            (
+                b"2026-05-19 18:35:18,271::WARNING::[interface:689] Unsuccessful login attempt from fe80::1 (X-Forwarded-For: fe80::2) [Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0]\n",
+                b"fe80::1",
+                [b"fe80::2"],
+            ),
         ],
         ids=[
             "ipv6-local-removed-removed",
             "ipv4-local-removed-removed",
             "ipv6-removed-local-removed",
             "ipv4-removed-removed",
+            "ipv4-loopback-loopback",
+            "ipv6-linklocal-linklocal",
         ],
     )
     def test_log_sanitize_remote_label_xff(self, line, ip, xff):

--- a/tests/test_api_and_interface.py
+++ b/tests/test_api_and_interface.py
@@ -46,6 +46,83 @@ class TestApiInternals:
     def test_auth(self):
         assert "apikey" in str(api.api_handler({"mode": "auth"}))
 
+    @pytest.mark.parametrize(
+        "line,ip",
+        [
+            (
+                b"2026-05-19 18:35:18,271::INFO::[notifier:169] Sending notification: Warning - Unsuccessful login attempt from ::ffff:172.18.0.1 [Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0] (type=warning, job_cat=None)\n",
+                b"::ffff:172.18.0.1",
+            ),
+            (
+                b"2026-05-19 18:35:18,271::WARNING::[interface:689] Unsuccessful login attempt from 172.18.0.1 [Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0]\n",
+                b"172.18.0.1",
+            ),
+            (
+                b"2026-05-19 18:35:18,271::WARNING::[interface:689] Unsuccessful login attempt from 2001:4860::1 [Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0]\n",
+                b"<REMOVED>",
+            ),
+            (
+                b"2026-05-19 18:35:18,271::WARNING::[interface:689] Unsuccessful login attempt from 8.8.8.8 [Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0]\n",
+                b"<REMOVED>",
+            ),
+        ],
+        ids=[
+            "ipv6-local",
+            "ipv4-local",
+            "ipv6-removed",
+            "ipv4-removed",
+        ],
+    )
+    def test_log_sanitize_remote_label(self, line, ip):
+        sanitized = api.sanitize_line(line)
+        assert (
+            sanitized.count(
+                b"%s [Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0]" % ip
+            )
+            == 1
+        )
+
+    @pytest.mark.parametrize(
+        "line,ip,xff",
+        [
+            (
+                b"2026-05-19 18:35:18,271::INFO::[notifier:169] Sending notification: Warning - Unsuccessful login attempt from ::ffff:172.18.0.1 (X-Forwarded-For: 8.8.8.8, 1.1.1.1) [Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0] (type=warning, job_cat=None)\n",
+                b"::ffff:172.18.0.1",
+                [b"<REMOVED>", b"<REMOVED>"],
+            ),
+            (
+                b"2026-05-19 18:35:18,271::WARNING::[interface:689] Unsuccessful login attempt from 172.18.0.1 (X-Forwarded-For: 8.8.8.8, 1.1.1.1) [Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0]\n",
+                b"172.18.0.1",
+                [b"<REMOVED>", b"<REMOVED>"],
+            ),
+            (
+                b"2026-05-19 18:35:18,271::WARNING::[interface:689] Unsuccessful login attempt from 2001:4860::1 (X-Forwarded-For: 192.168.0.50, 8.8.8.8) [Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0]\n",
+                b"<REMOVED>",
+                [b"192.168.0.50", b"<REMOVED>"],
+            ),
+            (
+                b"2026-05-19 18:35:18,271::WARNING::[interface:689] Unsuccessful login attempt from 8.8.8.8 (X-Forwarded-For: 1.1.1.1) [Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0]\n",
+                b"<REMOVED>",
+                [b"<REMOVED>"],
+            ),
+        ],
+        ids=[
+            "ipv6-local-removed-removed",
+            "ipv4-local-removed-removed",
+            "ipv6-removed-local-removed",
+            "ipv4-removed-removed",
+        ],
+    )
+    def test_log_sanitize_remote_label_xff(self, line, ip, xff):
+        sanitized = api.sanitize_line(line)
+        assert (
+            sanitized.count(
+                b"%s (X-Forwarded-For: %s) [Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0]"
+                % (ip, b", ".join(xff))
+            )
+            == 1
+        )
+
 
 def set_remote_host_or_ip(hostname: str = "localhost", remote_ip: str = "127.0.0.1"):
     """Change CherryPy's "Host" and "remote.ip"-values"""


### PR DESCRIPTION
Fixes #3426

- `host_whitelist` => \<REMOVED\>
- LOG_IP_RE removed IP and X-Forwarded-For but keeps the useragent
  - "Unsuccessful login attempt from ... ["
  - "Successful login from ... ["
  - "Request ... from ..." for example "Request GET /api from ... ["

With lines from issue report:

```
2026-05-19 18:35:18,271::INFO::[notifier:169] Sending notification: Warning - Unsuccessful login attempt from <REMOVED> [Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0] (type=warning, job_cat=None)
2026-05-19 18:35:18,271::WARNING::[interface:689] Unsuccessful login attempt from <REMOVED> [Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0]
2026-05-19 18:35:22,740::INFO::[interface:681] Successful login from <REMOVED> [Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:150.0) Gecko/20100101 Firefox/150.0]
```

---

I also noticed `api_key` and `nzb_key` in the ini are picked up by `LOG_HASH_RE` but only partially masked, is this intentional? or should they be in `LOG_INI_HIDE_RE`

---

Could this one do `b"'\\1': '<REMOVED>'"` to keep the keys or is there a reason it doesn't?

https://github.com/sabnzbd/sabnzbd/blob/25d20f0f08ce2078402faf0e7b281db9ceb04643/sabnzbd/api.py#L724