### PR TITLE
Remove disableDelays because config is not defined

### DIFF
--- a/interfaces/Config/templates/staticcfg/js/script.js
+++ b/interfaces/Config/templates/staticcfg/js/script.js
@@ -415,11 +415,11 @@ $(document).ready(function () {
                     do_restart();
                 } else {
                     $('#config_err_msg').text(" ");
-                    setTimeout(config_success, config.disableDelays ? 0 : 1000);
+                    setTimeout(config_success, 1000);
                 }
             } else {
                $('#config_err_msg').text(" ");
-               setTimeout(config_success, config.disableDelays ? 0 : 1000);
+               setTimeout(config_success, 1000);
             }
         },
         error: function () {

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -384,7 +384,6 @@ class SABnzbdBaseTest:
         # Open a page and test for crash
         self.driver.get(url)
         self.no_page_crash()
-        self.disable_delays()
 
     def scroll_to_top(self):
         self.driver.find_element(By.TAG_NAME, "body").send_keys(Keys.CONTROL + Keys.HOME)
@@ -402,10 +401,6 @@ class SABnzbdBaseTest:
             wait.until(lambda driver_wait: self.driver.execute_script("return document.readyState") == "complete")
         except (RemoteDisconnected, ProtocolError):
             pass
-
-    def disable_delays(self):
-        """Remove delayed UI changes"""
-        self.driver.execute_script("window.config = window.config || {}; window.config.disableDelays = true")
 
     @staticmethod
     def selenium_wrapper(func, *args):


### PR DESCRIPTION
I should have added a variable to the main template set by `bool(os.environ.get("CI", False))` [i did try a branch like this](https://github.com/sabnzbd/sabnzbd/compare/develop...mnightingale:sabnzbd:bugfix/fixdisableconfigdelays?expand=1)

But I think the impact is pretty low <5 seconds (at least locally) so we should just remove it.