### PR TITLE
Add logging of unhandled connection exceptions and wait_for result

### DIFF
--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1441,14 +1441,16 @@ def test_nntp_server_dict(kwargs: dict[str, Union[str, list[str]]]) -> tuple[boo
         # Trying SSL on non-SSL port?
         if match_str(str(err), ("unknown protocol", "wrong version number")):
             return False, T("Unknown SSL protocol: Try disabling SSL or connecting on a different port.")
-        return False, str(err)
+        logging.info("Traceback: ", exc_info=True)
+        return False, T("Could not determine connection result (%s)") % str(err)
 
     except NNTPPermanentError:
         # Handled by the code below
         pass
 
     except Exception as err:
-        return False, str(err)
+        logging.info("Traceback: ", exc_info=True)
+        return False, T("Could not determine connection result (%s)") % str(err)
 
     if not username or not password:
         nw.queue_command(b"ARTICLE <test@home>\r\n")
@@ -1457,7 +1459,8 @@ def test_nntp_server_dict(kwargs: dict[str, Union[str, list[str]]]) -> tuple[boo
             nw.read(on_response=on_response)
         except Exception as err:
             # Some internal error, not always safe to close connection
-            return False, str(err)
+            logging.info("Traceback: ", exc_info=True)
+            return False, T("Could not determine connection result (%s)") % str(err)
 
     # Parse result
     return_status = ()

--- a/tests/test_functional_config.py
+++ b/tests/test_functional_config.py
@@ -226,10 +226,13 @@ class TestConfigRSS(SABnzbdBaseTest):
             self.driver.find_element, By.XPATH, '//div[@id="rss-tab-matched"]/table/tbody//button'
         )
         download_btn.click()
-        self.wait_for_ajax()
 
         # Does the page think it's a success?
-        assert "Added NZB" in download_btn.text
+        wait_for(
+            lambda: "Added NZB" in download_btn.text,
+            timeout=5,
+            err_msg="Added NZB is not visible",
+        )
 
         # Check if the fetch-request was added to the queue
         wait_for(
@@ -275,12 +278,13 @@ class TestConfigServers(SABnzbdBaseTest):
         self.selenium_wrapper(self.driver.find_element, By.NAME, "ssl").click()
 
         # Test server-check
+        result_box = self.selenium_wrapper(self.driver.find_element, By.CSS_SELECTOR, "#addServerContent .result-box")
         self.selenium_wrapper(self.driver.find_element, By.CSS_SELECTOR, "#addServerContent .testServer").click()
-        self.wait_for_ajax()
-        check_result = self.selenium_wrapper(
-            self.driver.find_element, By.CSS_SELECTOR, "#addServerContent .result-box"
-        ).text
-        assert "Connection Successful" in check_result
+        wait_for(
+            lambda: "Connection Successful" in result_box.text,
+            timeout=5,
+            err_msg="The connection test was not successful",
+        )
 
         # Set test-servername
         self.selenium_wrapper(self.driver.find_element, By.ID, "displayname").send_keys(self.server_name)

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -450,9 +450,13 @@ class DownloadFlowBasics(SABnzbdBaseTest):
         port_inp.send_keys(SAB_NEWSSERVER_PORT)
 
         # Test server-check
+        server_response = self.selenium_wrapper(self.driver.find_element, By.ID, "serverResponse")
         self.selenium_wrapper(self.driver.find_element, By.ID, "serverTest").click()
-        self.wait_for_ajax()
-        assert "Connection Successful" in self.selenium_wrapper(self.driver.find_element, By.ID, "serverResponse").text
+        wait_for(
+            lambda: "Connection Successful" in server_response.text,
+            timeout=5,
+            err_msg="The connection test was not successful",
+        )
 
         # Final page done
         self.selenium_wrapper(self.driver.find_element, By.ID, "next-button").click()


### PR DESCRIPTION
```
assert 'Connection Successful' in "'NoneType' object has no attribute 'id'"
```

I think the error comes from `return False, str(err)`,  it's not a very helpful message to show to the user so I've changed to a message already used for unknown status, and added logging of the exception so we can find the causes with future failures.

Before the traceback should I add `logging.info(T("Could not determine connection result (%s)") ...` for context?

`wait_for_ajax` I think is a bit racy / fragile

- click
- wait_for_ajax waits for `jQuery.active == 0` but I suspect the click may have been dispatched to Selenium but the ajax request may not have started so it might return early

I've switched it to the `wait_for` helper to check multiple times and disregard what jQuery is up to.