### PR TITLE
Add guards to blocking connections to prevent them processing the queue

### DIFF
--- a/sabnzbd/downloader.py
+++ b/sabnzbd/downloader.py
@@ -380,7 +380,7 @@ class Downloader(Thread):
     @synchronized(DOWNLOADER_LOCK)
     def add_socket(self, nw: NewsWrapper):
         """Add a socket to be watched for read or write availability"""
-        if nw.nntp:
+        if nw.nntp and not nw.blocking:
             nw.server.idle_threads.discard(nw)
             nw.server.busy_threads.add(nw)
             try:
@@ -402,7 +402,7 @@ class Downloader(Thread):
     @synchronized(DOWNLOADER_LOCK)
     def remove_socket(self, nw: NewsWrapper):
         """Remove a socket to be watched"""
-        if nw.nntp:
+        if nw.nntp and not nw.blocking:
             nw.server.busy_threads.discard(nw)
             nw.server.idle_threads.add(nw)
             nw.timeout = None

--- a/sabnzbd/newswrapper.py
+++ b/sabnzbd/newswrapper.py
@@ -371,7 +371,7 @@ class NewsWrapper:
         server = self.server
 
         # Do not pipeline requests until authentication is completed (connected)
-        if self.ready or not self._response_queue:
+        if not self.blocking and (self.ready or not self._response_queue):
             server_ready = (
                 server.active
                 and not server.restart


### PR DESCRIPTION
Fixes #3443

`prepare_request` could grab an article request from the queue while testing connections.
`read` and `write` could call `remove_socket` adding the socket to `idle_threads`, then downloader could call `add_socket`.

Could end up with the API blocking connection being read/written from multiple threads, breaking state.