### PR TITLE
Fix false "is not writable at all" warning from non-atomic writability self-test

### DIFF
--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -1227,19 +1227,26 @@ def purge_log_files():
 
 
 def directory_is_writable_with_file(mydir: str, myfilename: str) -> bool:
+    """Test whether a file named myfilename can be created and written in mydir.
+
+    Only creating and writing the file needs to succeed. Cleaning up the test
+    file afterwards is best-effort: if it has already been removed (for example
+    by a concurrent writability check), that is not a failure. Treating it as
+    one caused spurious "is not writable at all. This blocks downloads."
+    warnings at startup."""
     filename = os.path.join(mydir, myfilename)
-    if os.path.exists(filename):
-        try:
-            os.remove(filename)
-        except Exception:
-            return False
     try:
         with open(filename, "w") as f:
             f.write("Some random content to test directory and file permissions")
-        os.remove(filename)
-        return True
-    except Exception:
+    except Exception as e:
+        logging.info("Cannot write test file %s: %s", filename, e)
         return False
+    finally:
+        try:
+            os.remove(filename)
+        except OSError:
+            pass
+    return True
 
 
 def directory_is_writable(test_dir: str) -> bool:

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1242,6 +1242,34 @@ class TestOtherFileSystemFunctions:
         # any modern filesystem (ext3, ext4, ntfs, modern FAT) should succeed
         assert filesystem.check_filesystem_capabilities(tempfile.gettempdir())
 
+    def test_directory_is_writable_with_file_survives_lost_test_file(self, monkeypatch):
+        # Regression test: losing the temporary test file before cleanup (e.g. a
+        # concurrent writability check removed it) must NOT be reported as "not
+        # writable". This used to surface as a false "is not writable at all.
+        # This blocks downloads." warning at startup.
+        test_dir = tempfile.gettempdir()
+        real_remove = os.remove
+        leftover = os.path.join(test_dir, "sab_test.txt")
+
+        def raise_enoent(path):
+            raise FileNotFoundError("simulated race: test file already removed")
+
+        monkeypatch.setattr(os, "remove", raise_enoent)
+        try:
+            assert filesystem.directory_is_writable_with_file(test_dir, "sab_test.txt") is True
+        finally:
+            # os.remove was patched out, so the test file was left behind
+            if os.path.exists(leftover):
+                real_remove(leftover)
+
+    def test_directory_is_writable_with_file_reports_write_failure(self, monkeypatch):
+        # A genuine failure to create/write the file must still return False
+        def raise_permission(*args, **kwargs):
+            raise PermissionError("simulated read-only filesystem")
+
+        monkeypatch.setattr("builtins.open", raise_permission)
+        assert filesystem.directory_is_writable_with_file(tempfile.gettempdir(), "sab_test.txt") is False
+
     @pytest.mark.parametrize(
         "name, ext_to_remove, output",
         [


### PR DESCRIPTION
## Problem

At startup SABnzbd can log a false **"`%s is not writable at all. This blocks
downloads.`"** warning for the download/complete folders even when they are
fully writable and downloading is not actually blocked.

Fixes #3445 (full root-cause analysis and evidence there).

## Root cause

`directory_is_writable_with_file()` performs a non-atomic
`exists → remove → open → write → remove` on a **fixed-name** temp file
(`sab_test.txt`), wrapped in a blanket `except Exception: return False`. If the
test file is removed between the write and the final `os.remove` (e.g. by a
concurrent writability check), the resulting `FileNotFoundError` is swallowed
and reported as "not writable at all" — a false negative on a writable folder.
The boolean only gates an extra capability check and sets no pause state, so the
"This blocks downloads" wording is misleading as well.

Reproduction (the helper run concurrently on one dir with the shared filename):
4 threads × 3000 iterations → ~5500/12000 calls wrongly return `False`; a
single-threaded caller never fails.

## Fix

Make the result depend only on the create-and-write succeeding, and treat
cleanup of the test file as best-effort (a test file that has already been
removed is not a failure). Genuine write failures (`PermissionError`, `EROFS`,
`ENOSPC`, …) still return `False`, and the existing unicode / special-character
capability checks in `check_filesystem_capabilities()` are unchanged.

## Tests

Added two regression tests in `tests/test_filesystem.py`:

- `test_directory_is_writable_with_file_survives_lost_test_file` — returns
  `True` even when the test file vanishes before cleanup (fails on the old
  code, passes now).
- `test_directory_is_writable_with_file_reports_write_failure` — still returns
  `False` when the file cannot be created.

`black --check` (line-length 120) is clean on both changed files.
