### PR TITLE
Purge downloaded items from the rss history

### DIFF
--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -528,14 +528,14 @@ class RSSRepository:
     def __init__(self, db: HistoryDB):
         self.db = db
 
-    def remove_obsolete(self, feed: str, new_urls: Optional[Iterable[str]] = None):
+    def remove_obsolete(self, feed: str, new_urls: Optional[Iterable[str]] = None, purge_downloaded: bool = False):
         """
         Expire G/B links that are not in new_jobs (mark them 'X')
 
         Expired links older than 3 days are removed
         """
-        now = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
-        limit = now - 3 * 24 * 3600  # 3 days in seconds
+        now = datetime.datetime.now(datetime.timezone.utc)
+        limit = int((now - datetime.timedelta(days=3)).timestamp())
 
         if new_urls:
             # Create temporary table for all new URLs
@@ -567,25 +567,32 @@ class RSSRepository:
             self.db.execute("DROP TABLE temp_urls")
 
         # Purge
+        if purge_downloaded:
+            states = (RSSState.EXPIRED, RSSState.DOWNLOADED)
+        else:
+            states = (RSSState.EXPIRED,)
+        placeholders = ", ".join("?" for _ in states)
         if not self.db.execute(
-            """
+            f"""
             SELECT url FROM rss
             WHERE feed = ?
-              AND state = ?
+              AND state in ({placeholders})
               AND seen_at < ?
         """,
             (
                 feed,
-                RSSState.EXPIRED,
+                *states,
                 limit,
             ),
         ):
             return
 
         expired_urls = [row["url"] for row in self.db.cursor]
-        for url in expired_urls:
-            logging.debug("Purging link %s", url)
-            self.db.execute("DELETE FROM rss WHERE feed = ? AND url = ?", (feed, url))
+        for batch in batched(expired_urls, 500):
+            for url in batch:
+                logging.debug("Purging link %s", url)
+            placeholders = ",".join("?" * len(batch))
+            self.db.execute(f"DELETE FROM rss WHERE feed = ? AND url IN ({placeholders})", (feed, *batch))
 
     def get_feed_jobs(
         self,
@@ -901,7 +908,7 @@ class RSSReader:
             if new_downloads and cfg.email_rss() and not force:
                 emailer.rss_mail(feed, new_downloads)
 
-            repo.remove_obsolete(feed, new_links)
+            repo.remove_obsolete(feed, new_links, purge_downloaded=True)
 
         return ""
 

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -619,7 +619,7 @@ class TestRSS:
                 title="keep",
                 infourl=None,
                 size=10,
-                age=old_seen_at,
+                age=age,
                 seen_at=old_seen_at,
                 season=1,
                 episode=1,
@@ -637,7 +637,7 @@ class TestRSS:
                 title="old-g",
                 infourl=None,
                 size=20,
-                age=old_seen_at,
+                age=age,
                 seen_at=old_seen_at,
                 season=1,
                 episode=1,
@@ -655,12 +655,30 @@ class TestRSS:
                 title="old-x",
                 infourl=None,
                 size=30,
-                age=old_seen_at,
+                age=age,
                 seen_at=old_seen_at,
                 season=1,
                 episode=1,
                 category=None,
                 state=RSSState.EXPIRED,
+            )
+        )
+
+        # Old D item should be purged directly
+        purge_old_d_url = "http://example.test/purge-old-d"
+        repo.upsert(
+            ResolvedEntry(
+                feed=feed,
+                link=purge_old_d_url,
+                title="old-d",
+                infourl=None,
+                size=30,
+                age=age,
+                seen_at=old_seen_at,
+                season=1,
+                episode=1,
+                category=None,
+                state=RSSState.DOWNLOADED,
             )
         )
 
@@ -682,8 +700,26 @@ class TestRSS:
             )
         )
 
+        # Recent D item should be kept
+        keep_d_url = "http://example.test/keep-young-d"
+        repo.upsert(
+            ResolvedEntry(
+                feed=feed,
+                link=keep_d_url,
+                title="young-d",
+                infourl=None,
+                size=40,
+                age=age,
+                seen_at=new_seen_at,
+                season=1,
+                episode=1,
+                category=None,
+                state=RSSState.DOWNLOADED,
+            )
+        )
+
         # Run remove_obsolete with only keep_url as the set of current URLs
-        repo.remove_obsolete(feed, {keep_url})
+        repo.remove_obsolete(feed, {keep_url}, purge_downloaded=True)
 
         jobs = {e.link: e for e in repo.get_feed_jobs(feed=feed)}
 
@@ -697,9 +733,16 @@ class TestRSS:
         # Old X should have been purged
         assert purge_old_x_url not in jobs
 
+        # Old D should have been purged
+        assert purge_old_d_url not in jobs
+
         # Young X should still exist
         assert keep_x_url in jobs
         assert jobs[keep_x_url].state is RSSState.EXPIRED
+
+        # Young D should still exist
+        assert keep_d_url in jobs
+        assert jobs[keep_d_url].state is RSSState.DOWNLOADED
 
     def test_rss_is_starred_persists_and_affects_later_runs(self, httpserver: HTTPServer, tmp_rss, mocker):
         """Initial scan should mark GOOD entries as starred and persist this across runs.


### PR DESCRIPTION
Fixes #3451

Main purge query changed from `age` to `seen_at` a bugfix for the SQLite changes, `age` is usually when it was posted or indexed, `seen_at` is when it was last seen in an RSS fetch.

The purge change is it currently when it reads a feed it changes any G or B status to X then removes them after 3 days.
But it also needs to purge items that have been downloaded (D) but are no longer in the feed after 3 days.
Since the user could have just not ran SAB for 3 days and a purge occurs at startup, it only purges downloaded items when the feed is read.