### PR TITLE
Replace getopt with argparse in SABnzbd CLI

### DIFF
--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -29,7 +29,7 @@ import logging
 import logging.handlers
 import importlib.util
 import traceback
-import getopt
+import argparse
 import signal
 import socket
 import subprocess
@@ -193,60 +193,106 @@ class GUIHandler(logging.Handler):
         return self.store
 
 
-def print_help():
-    print()
-    print("Usage: %s [-f <configfile>] <other options>" % sabnzbd.MY_NAME)
-    print()
-    print("Options marked [*] are stored in the config file")
-    print()
-    print("Options:")
-    print("  -f  --config-file <ini>     Location of config file")
-    print("  -s  --server <srv:port>     Listen on server:port [*]")
-    print("  -t  --templates <templ>     Template directory [*]")
-    print()
-    print("  -l  --logging <-1..2>       Set logging level (-1=off, 0=least,2= most) [*]")
-    print("  -w  --weblogging            Enable cherrypy access logging")
-    print()
-    print("  -b  --browser <0..1>        Auto browser launch (0= off, 1= on) [*]")
+def _logging_type(value):
+    """Custom type for --logging that handles negative numbers.
+
+    argparse can't parse "-l -1" because it tokenizes "-1" as a flag.
+    This type function handles both "-l=-1" and "-l -1" after pre-processing.
+    """
+    try:
+        value = int(value)
+    except (ValueError, TypeError):
+        raise argparse.ArgumentTypeError("invalid integer value: '%s'" % value)
+    if value < -1 or value > 2:
+        raise argparse.ArgumentTypeError("invalid choice: %d (choose from -1, 0, 1, 2)" % value)
+    return value
+
+
+def build_parser():
+    """Build the argument parser for SABnzbd CLI."""
     if sabnzbd.WINDOWS:
-        print("  -d  --daemon                Use when run as a service")
+        daemon_help = "Use when run as a service"
     else:
-        print("  -d  --daemon                Fork daemon process")
-        print("      --pid <path>            Create a PID file in the given folder (full path)")
-        print("      --pidfile <path>        Create a PID file with the given name (full path)")
-    print()
-    print("  -h  --help                  Print this message")
-    print("  -v  --version               Print version information")
-    print("  -c  --clean                 Remove queue, cache and logs")
-    print("  -p  --pause                 Start in paused mode")
-    print("      --repair                Add orphaned jobs from the incomplete folder to the queue")
-    print("      --repair-all            Try to reconstruct the queue from the incomplete folder")
-    print("                              with full data reconstruction")
-    print("      --https <port>          Port to use for HTTPS server")
-    print("      --ipv6_hosting <0|1>    Listen on IPv6 address [::1] [*]")
-    print("      --inet_exposure <0..5>  Set external internet access [*]")
-    print("      --no-login              Start with username and password reset")
-    print("      --log-all               Log all article handling (for developers)")
-    print("      --disable-file-log      Logging is only written to console")
-    print("      --console               Force logging to console")
-    print("      --new                   Run a new instance of SABnzbd")
-    print()
-    print("NZB (or related) file:")
-    print("  NZB or compressed NZB file, with extension .nzb, .zip, .rar, .7z, .gz, or .bz2")
-    print()
+        daemon_help = "Fork daemon process"
 
+    parser = argparse.ArgumentParser(
+        prog=sabnzbd.MY_NAME or "SABnzbd",
+        description="Usage: %s [-f <configfile>] <other options>" % (sabnzbd.MY_NAME or "SABnzbd"),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="Options marked [*] are stored in the config file\n\n"
+        "NZB (or related) file:\n"
+        "  NZB or compressed NZB file, with extension .nzb, .zip, .rar, .7z, .gz, or .bz2",
+    )
 
-def print_version():
-    print("""
-%s-%s
+    parser.add_argument(
+        "-f", "--config", "--config-file", dest="config_file", metavar="<ini>", help="Location of config file"
+    )
+    parser.add_argument("-s", "--server", metavar="<srv:port>", help="Listen on server:port [*]")
+    parser.add_argument("-t", "--templates", metavar="<templ>", help="Template directory [*]")
+    parser.add_argument(
+        "-l", "--logging", type=_logging_type, metavar="-1..2", help="Set logging level (-1=off, 0=least, 2=most) [*]"
+    )
+    parser.add_argument("-w", "--weblogging", action="store_true", help="Enable cherrypy access logging")
+    parser.add_argument(
+        "-b", "--browser", type=int, choices=[0, 1], metavar="0..1", help="Auto browser launch (0=off, 1=on) [*]"
+    )
+    parser.add_argument("-d", "--daemon", action="store_true", help=daemon_help)
+    parser.add_argument("-v", "--version", action="version", version="%(prog)s-" + (sabnzbd.__version__ or ""))
+    parser.add_argument("-n", "--nobrowser", action="store_true", help="Disable auto browser launch")
+    parser.add_argument("-c", "--clean", action="store_true", help="Remove queue, cache and logs")
+    parser.add_argument("-p", "--pause", action="store_true", help="Start in paused mode")
+    parser.add_argument("--https", type=int, metavar="<port>", help="Port to use for HTTPS server")
+    parser.add_argument(
+        "--ipv6",
+        "--ipv6_hosting",
+        dest="ipv6_hosting",
+        type=int,
+        choices=[0, 1],
+        help="Listen on IPv6 address [::1] [*]",
+    )
+    parser.add_argument(
+        "--inet",
+        "--inet_exposure",
+        dest="inet_exposure",
+        type=int,
+        choices=range(0, 6),
+        help="Set external internet access [*]",
+    )
+    parser.add_argument("--no-login", action="store_true", help="Start with username and password reset")
+    parser.add_argument(
+        "--repair", action="store_true", help="Add orphaned jobs from the incomplete folder to the queue"
+    )
+    parser.add_argument(
+        "--repair-all", action="store_true", help="Try to reconstruct the queue from the incomplete folder"
+    )
+    parser.add_argument("--log-all", action="store_true", help="Log all article handling (for developers)")
+    parser.add_argument(
+        "--disable",
+        "--disable-file-log",
+        dest="disable_file_log",
+        action="store_true",
+        help="Logging is only written to console",
+    )
+    parser.add_argument("--console", action="store_true", help="Force logging to console")
+    parser.add_argument("--new", action="store_true", help="Run a new instance of SABnzbd")
+    if not sabnzbd.WINDOWS:
+        parser.add_argument("--pid", metavar="<path>", help="Create a PID file in the given folder")
+        parser.add_argument("--pidfile", metavar="<path>", help="Create a PID file with the given name")
 
-(C) Copyright 2007-2026 by The SABnzbd-Team (sabnzbd.org)
-SABnzbd comes with ABSOLUTELY NO WARRANTY.
-This is free software, and you are welcome to redistribute it
-under certain conditions. It is licensed under the
-GNU GENERAL PUBLIC LICENSE Version 2 or (at your option) any later version.
+    # Win32 service options (hidden from --help)
+    service_group = parser.add_argument_group("Win32 service options")
+    service_group.add_argument("--password", help=argparse.SUPPRESS)
+    service_group.add_argument("--username", help=argparse.SUPPRESS)
+    service_group.add_argument("--startup", help=argparse.SUPPRESS)
+    service_group.add_argument("--perfmonini", help=argparse.SUPPRESS)
+    service_group.add_argument("--perfmondll", help=argparse.SUPPRESS)
+    service_group.add_argument("--interactive", action="store_true", help=argparse.SUPPRESS)
+    service_group.add_argument("-2", "--wait", help=argparse.SUPPRESS)
+    service_group.add_argument("--autorestarted", action="store_true", help=argparse.SUPPRESS)
+    service_group.add_argument("--servicecall", help=argparse.SUPPRESS)
 
-""" % (sabnzbd.MY_NAME, sabnzbd.__version__))
+    parser.add_argument("args", nargs="*", help=argparse.SUPPRESS)
+    return parser
 
 
 def daemonize():
@@ -735,100 +781,61 @@ def evaluate_inipath(path):
 
 
 def commandline_handler():
-    """Split win32-service commands are true parameters
+    """Parse command-line arguments.
     Returns:
-        service, sab_opts, serv_opts, upload_nzbs
+        service, parsed, serv_opts, upload_nzbs
     """
+    parser = build_parser()
+
+    # Pre-process sys.argv: convert "-l -1" to "--logging=-1" for backward compat.
+    # argparse can't parse negative numbers as option arguments (treats them as flags).
+    raw_args = sys.argv[1:]
+    processed_args = []
+    i = 0
+    while i < len(raw_args):
+        if raw_args[i] in ("-l", "--logging") and i + 1 < len(raw_args):
+            processed_args.append("--logging=%s" % raw_args[i + 1])
+            i += 2
+        else:
+            processed_args.append(raw_args[i])
+            i += 1
+
+    parsed = parser.parse_args(processed_args)
+
     service = ""
-    sab_opts = []
     serv_opts = [os.path.normpath(os.path.abspath(sys.argv[0]))]
     upload_nzbs = []
 
-    try:
-        opts, args = getopt.getopt(
-            sys.argv[1:],
-            "phdvncwl:s:f:t:b:2:",
-            [
-                "pause",
-                "help",
-                "daemon",
-                "nobrowser",
-                "clean",
-                "logging=",
-                "weblogging",
-                "server=",
-                "templates",
-                "ipv6_hosting=",
-                "inet_exposure=",
-                "browser=",
-                "config-file=",
-                "disable-file-log",
-                "version",
-                "https=",
-                "autorestarted",
-                "repair",
-                "repair-all",
-                "log-all",
-                "no-login",
-                "pid=",
-                "new",
-                "console",
-                "pidfile=",
-                # Below Win32 Service options
-                "password=",
-                "username=",
-                "startup=",
-                "perfmonini=",
-                "perfmondll=",
-                "interactive",
-                "wait=",
-            ],
-        )
-    except getopt.GetoptError:
-        print_help()
-        exit_sab(2)
+    remaining = parsed.args
 
     # Check for Win32 service commands
-    if args and args[0] in ("install", "update", "remove", "start", "stop", "restart", "debug"):
-        service = args[0]
-        serv_opts.extend(args)
+    WIN32_SERVICE_CMDS = {"install", "update", "remove", "start", "stop", "restart", "debug"}
+    if remaining and remaining[0] in WIN32_SERVICE_CMDS:
+        service = remaining[0]
+        serv_opts.extend(remaining)
 
+    # Collect NZB files from remaining args (not service commands)
     if not service:
-        # Get and remove any NZB file names
-        for entry in args:
-            if get_ext(entry) in VALID_NZB_FILES + VALID_ARCHIVES:
+        for entry in remaining:
+            if entry not in WIN32_SERVICE_CMDS and get_ext(entry) in VALID_NZB_FILES + VALID_ARCHIVES:
                 upload_nzbs.append(os.path.abspath(entry))
 
-    for opt, arg in opts:
-        if opt in ("password", "username", "startup", "perfmonini", "perfmondll", "interactive", "wait"):
-            # Service option, just collect
-            if service:
-                serv_opts.append(opt)
-                if arg:
-                    serv_opts.append(arg)
-        else:
-            if opt == "-f":
-                arg = os.path.normpath(os.path.abspath(arg))
-            sab_opts.append((opt, arg))
+    # Win32 service options → serv_opts
+    for attr in ("password", "username", "startup", "perfmonini", "perfmondll", "wait"):
+        val = getattr(parsed, attr, None)
+        if val is not None:
+            serv_opts.append("--%s" % attr)
+            serv_opts.append(str(val))
+    if getattr(parsed, "interactive", False):
+        serv_opts.append("--interactive")
 
-    return service, sab_opts, serv_opts, upload_nzbs
-
-
-def get_f_option(opts):
-    """Return value of the -f option"""
-    for opt, arg in opts:
-        if opt == "-f":
-            return arg
-    else:
-        return None
+    return service, parsed, serv_opts, upload_nzbs
 
 
 def main():
     global LOG_FLAG
     import sabnzbd  # Due to ApplePython bug
 
-    autobrowser = None
-    autorestarted = False
     sabnzbd.MY_FULLNAME = __file__
     sabnzbd.MY_NAME = os.path.basename(sabnzbd.MY_FULLNAME)
     fork = False
@@ -851,85 +858,70 @@ def main():
     new_instance = False
     ipv6_hosting = None
     inet_exposure = None
+    autobrowser = None
+    autorestarted = False
 
-    _service, sab_opts, _serv_opts, upload_nzbs = commandline_handler()
+    _service, opts, _serv_opts, upload_nzbs = commandline_handler()
 
-    for opt, arg in sab_opts:
-        if opt == "--servicecall":
-            sabnzbd.MY_FULLNAME = arg
-        elif opt in ("-d", "--daemon"):
-            if not sabnzbd.WINDOWS:
-                fork = True
-            autobrowser = False
-            sabnzbd.DAEMON = True
-            sabnzbd.RESTART_ARGS.append(opt)
-        elif opt in ("-f", "--config-file"):
-            inifile = arg
-            sabnzbd.RESTART_ARGS.append(opt)
-            sabnzbd.RESTART_ARGS.append(arg)
-        elif opt in ("-h", "--help"):
-            print_help()
-            exit_sab(0)
-        elif opt in ("-t", "--templates"):
-            web_dir = arg
-        elif opt in ("-s", "--server"):
-            web_host, web_port = split_host(arg)
-        elif opt in ("-n", "--nobrowser"):
-            autobrowser = False
-        elif opt in ("-b", "--browser"):
-            autobrowser = sabnzbd.misc.bool_conv(arg)
-        elif opt == "--autorestarted":
-            autorestarted = True
-        elif opt in ("-c", "--clean"):
-            clean_up = True
-        elif opt in ("-w", "--weblogging"):
-            cherrypylogging = True
-        elif opt in ("-l", "--logging"):
-            try:
-                logging_level = int(arg)
-            except Exception:
-                logging_level = -2
-            if logging_level < -1 or logging_level > 2:
-                print_help()
-                exit_sab(1)
-        elif opt == "--console":
-            console_logging = True
-            sabnzbd.RESTART_ARGS.append(opt)
-        elif opt in ("-v", "--version"):
-            print_version()
-            exit_sab(0)
-        elif opt in ("-p", "--pause"):
-            pause = True
-        elif opt == "--https":
-            https_port = int(arg)
-            sabnzbd.RESTART_ARGS.append(opt)
-            sabnzbd.RESTART_ARGS.append(arg)
-        elif opt == "--repair":
-            repair = 1
-            pause = True
-        elif opt == "--repair-all":
-            repair = 2
-            pause = True
-        elif opt == "--log-all":
-            sabnzbd.LOG_ALL = True
-        elif opt == "--disable-file-log":
-            no_file_log = True
-        elif opt == "--no-login":
-            no_login = True
-        elif opt == "--pid":
-            pid_path = arg
-            sabnzbd.RESTART_ARGS.append(opt)
-            sabnzbd.RESTART_ARGS.append(arg)
-        elif opt == "--pidfile":
-            pid_file = arg
-            sabnzbd.RESTART_ARGS.append(opt)
-            sabnzbd.RESTART_ARGS.append(arg)
-        elif opt == "--new":
-            new_instance = True
-        elif opt == "--ipv6_hosting":
-            ipv6_hosting = arg
-        elif opt == "--inet_exposure":
-            inet_exposure = arg
+    if opts.servicecall:
+        sabnzbd.MY_FULLNAME = opts.servicecall
+    if opts.daemon:
+        if not sabnzbd.WINDOWS:
+            fork = True
+        autobrowser = False
+        sabnzbd.DAEMON = True
+        sabnzbd.RESTART_ARGS.append("--daemon")
+    if opts.config_file:
+        inifile = os.path.normpath(os.path.abspath(opts.config_file))
+        sabnzbd.RESTART_ARGS.extend(["--config-file", inifile])
+    if opts.templates:
+        web_dir = opts.templates
+    if opts.server:
+        web_host, web_port = split_host(opts.server)
+    if opts.nobrowser:
+        autobrowser = False
+    if opts.browser is not None:
+        autobrowser = bool(opts.browser)
+    if opts.autorestarted:
+        autorestarted = True
+    if opts.clean:
+        clean_up = True
+    if opts.weblogging:
+        cherrypylogging = True
+    if opts.logging is not None:
+        logging_level = opts.logging
+    if opts.console:
+        console_logging = True
+        sabnzbd.RESTART_ARGS.append("--console")
+    if opts.pause:
+        pause = True
+    if opts.https is not None:
+        https_port = opts.https
+        sabnzbd.RESTART_ARGS.extend(["--https", str(https_port)])
+    if opts.repair:
+        repair = 1
+        pause = True
+    if opts.repair_all:
+        repair = 2
+        pause = True
+    if opts.log_all:
+        sabnzbd.LOG_ALL = True
+    if opts.disable_file_log:
+        no_file_log = True
+    if opts.no_login:
+        no_login = True
+    if opts.pid:
+        pid_path = opts.pid
+        sabnzbd.RESTART_ARGS.extend(["--pid", pid_path])
+    if opts.pidfile:
+        pid_file = opts.pidfile
+        sabnzbd.RESTART_ARGS.extend(["--pidfile", pid_file])
+    if opts.new:
+        new_instance = True
+    if opts.ipv6_hosting is not None:
+        ipv6_hosting = opts.ipv6_hosting
+    if opts.inet_exposure is not None:
+        inet_exposure = opts.inet_exposure
 
     sabnzbd.MY_FULLNAME = os.path.normpath(os.path.abspath(sabnzbd.MY_FULLNAME))
     sabnzbd.MY_NAME = os.path.basename(sabnzbd.MY_FULLNAME)
@@ -1592,12 +1584,12 @@ def handle_windows_service():
         return True
 
     # Handle installation and other options
-    service, sab_opts, serv_opts, _upload_nzbs = commandline_handler()
+    service, opts, serv_opts, _upload_nzbs = commandline_handler()
 
     if service:
         if service in ("install", "update"):
             # In this case check for required parameters
-            path = get_f_option(sab_opts)
+            path = opts.config_file
             if not path:
                 print("The -f <path> parameter is required.\n" "Use: -f <path> %s" % service)
                 return True
@@ -1605,6 +1597,41 @@ def handle_windows_service():
             # First run the service installed, because this will
             # set the service key in the Registry
             win32serviceutil.HandleCommandLine(SABnzbd, argv=serv_opts)
+
+            # Convert parsed args to tuples for set_serv_parms
+            sab_opts = []
+            _OPTION_MAP = [
+                ("config_file", "-f"),
+                ("daemon", "--daemon"),
+                ("templates", "--templates"),
+                ("server", "--server"),
+                ("logging", "--logging"),
+                ("browser", "--browser"),
+                ("https", "--https"),
+                ("ipv6_hosting", "--ipv6_hosting"),
+                ("inet_exposure", "--inet_exposure"),
+                ("pid", "--pid"),
+                ("pidfile", "--pidfile"),
+                ("pause", "--pause"),
+                ("clean", "--clean"),
+                ("weblogging", "--weblogging"),
+                ("console", "--console"),
+                ("no_login", "--no-login"),
+                ("log_all", "--log-all"),
+                ("disable_file_log", "--disable-file-log"),
+                ("repair", "--repair"),
+                ("repair_all", "--repair-all"),
+                ("new", "--new"),
+                ("autorestarted", "--autorestarted"),
+                ("nobrowser", "--nobrowser"),
+                ("servicecall", "--servicecall"),
+            ]
+            for attr, flag in _OPTION_MAP:
+                val = getattr(opts, attr, None)
+                if val is True:
+                    sab_opts.append((flag, ""))
+                elif val is not None and val is not False:
+                    sab_opts.append((flag, str(val)))
 
             # Add our own parameter to the Registry
             if set_serv_parms(SABnzbd._svc_name_, sab_opts):

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -208,6 +208,16 @@ def _logging_type(value):
     return value
 
 
+_COPYRIGHT_TEMPLATE = (
+    "\n%(prog)s-%(version)s\n\n"
+    "(C) Copyright 2007-2026 by The SABnzbd-Team (sabnzbd.org)\n"
+    "SABnzbd comes with ABSOLUTELY NO WARRANTY.\n"
+    "This is free software, and you are welcome to redistribute it\n"
+    "under certain conditions. It is licensed under the\n"
+    "GNU GENERAL PUBLIC LICENSE Version 2 or (at your option) any later version.\n"
+)
+
+
 def build_parser():
     """Build the argument parser for SABnzbd CLI."""
     if sabnzbd.WINDOWS:
@@ -237,7 +247,13 @@ def build_parser():
         "-b", "--browser", type=int, choices=[0, 1], metavar="0..1", help="Auto browser launch (0=off, 1=on) [*]"
     )
     parser.add_argument("-d", "--daemon", action="store_true", help=daemon_help)
-    parser.add_argument("-v", "--version", action="version", version="%(prog)s-" + (sabnzbd.__version__ or ""))
+    parser.add_argument(
+        "-v", "--version", action="version",
+        version=_COPYRIGHT_TEMPLATE % {
+            "prog": sabnzbd.MY_NAME or "SABnzbd",
+            "version": sabnzbd.__version__ or "",
+        },
+    )
     parser.add_argument("-n", "--nobrowser", action="store_true", help="Disable auto browser launch")
     parser.add_argument("-c", "--clean", action="store_true", help="Remove queue, cache and logs")
     parser.add_argument("-p", "--pause", action="store_true", help="Start in paused mode")
@@ -861,7 +877,10 @@ def main():
     autobrowser = None
     autorestarted = False
 
-    _service, opts, _serv_opts, upload_nzbs = commandline_handler()
+    try:
+        _service, opts, _serv_opts, upload_nzbs = commandline_handler()
+    except SystemExit as e:
+        exit_sab(e.code)
 
     if opts.servicecall:
         sabnzbd.MY_FULLNAME = opts.servicecall

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -248,8 +248,11 @@ def build_parser():
     )
     parser.add_argument("-d", "--daemon", action="store_true", help=daemon_help)
     parser.add_argument(
-        "-v", "--version", action="version",
-        version=_COPYRIGHT_TEMPLATE % {
+        "-v",
+        "--version",
+        action="version",
+        version=_COPYRIGHT_TEMPLATE
+        % {
             "prog": sabnzbd.MY_NAME or "SABnzbd",
             "version": sabnzbd.__version__ or "",
         },

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -910,10 +910,10 @@ def main():
         no_file_log = True
     if opts.no_login:
         no_login = True
-    if opts.pid:
+    if getattr(opts, "pid", None):
         pid_path = opts.pid
         sabnzbd.RESTART_ARGS.extend(["--pid", pid_path])
-    if opts.pidfile:
+    if getattr(opts, "pidfile", None):
         pid_file = opts.pidfile
         sabnzbd.RESTART_ARGS.extend(["--pidfile", pid_file])
     if opts.new:

--- a/tests/test_cli_argparse.py
+++ b/tests/test_cli_argparse.py
@@ -19,14 +19,16 @@
 
 from unittest import mock
 
+import argparse
 import pytest
+
+import sabnzbd
+from SABnzbd import build_parser
 
 
 @pytest.fixture(autouse=True)
 def _mock_sabnzbd_env(monkeypatch):
     """Set sabnzbd module state for CLI tests."""
-    import sabnzbd
-
     monkeypatch.setattr(sabnzbd, "MY_NAME", "SABnzbd")
     monkeypatch.setattr(sabnzbd, "__version__", "4.0.0")
     monkeypatch.setattr(sabnzbd, "WINDOWS", False)
@@ -35,22 +37,12 @@ def _mock_sabnzbd_env(monkeypatch):
 class TestBuildParser:
     """Tests for build_parser()."""
 
-    def _build(self, windows=False):
-        import sabnzbd
-        from SABnzbd import build_parser
-
-        if windows:
-            sabnzbd.WINDOWS = windows
-        return build_parser()
-
     def test_parser_returns_argument_parser(self):
-        import argparse
-
-        parser = self._build()
+        parser = build_parser()
         assert isinstance(parser, argparse.ArgumentParser)
 
     def test_boolean_flags(self):
-        parser = self._build()
+        parser = build_parser()
         for flag in [
             "--daemon",
             "--nobrowser",
@@ -71,7 +63,7 @@ class TestBuildParser:
             assert getattr(opts, attr) is True, f"{flag} should be True"
 
     def test_short_boolean_flags(self):
-        parser = self._build()
+        parser = build_parser()
         for short, attr in [
             ("-d", "daemon"),
             ("-n", "nobrowser"),
@@ -83,139 +75,141 @@ class TestBuildParser:
             assert getattr(opts, attr) is True, f"{short} should set {attr}"
 
     def test_config_file_option(self):
-        parser = self._build()
+        parser = build_parser()
         opts = parser.parse_args(["-f", "/tmp/test.ini"])
         assert opts.config_file == "/tmp/test.ini"
 
     def test_config_file_long_option(self):
-        parser = self._build()
+        parser = build_parser()
         opts = parser.parse_args(["--config-file", "/tmp/test.ini"])
         assert opts.config_file == "/tmp/test.ini"
 
     def test_config_file_alias(self):
-        parser = self._build()
+        parser = build_parser()
         opts = parser.parse_args(["--config", "/tmp/test.ini"])
         assert opts.config_file == "/tmp/test.ini"
 
     def test_server_option(self):
-        parser = self._build()
+        parser = build_parser()
         opts = parser.parse_args(["-s", "0.0.0.0:8080"])
         assert opts.server == "0.0.0.0:8080"
 
     def test_templates_option(self):
-        parser = self._build()
+        parser = build_parser()
         opts = parser.parse_args(["-t", "/my/templates"])
         assert opts.templates == "/my/templates"
 
     def test_logging_valid_range(self):
-        parser = self._build()
+        parser = build_parser()
         for level in (-1, 0, 1, 2):
             processed = ["--logging=%d" % level]
             opts = parser.parse_args(processed)
             assert opts.logging == level
 
     def test_logging_invalid_range(self):
-        parser = self._build()
+        parser = build_parser()
         with pytest.raises(SystemExit):
             parser.parse_args(["--logging=3"])
 
     def test_logging_invalid_negative(self):
-        parser = self._build()
+        parser = build_parser()
         with pytest.raises(SystemExit):
             parser.parse_args(["--logging=-5"])
 
     def test_browser_option(self):
-        parser = self._build()
+        parser = build_parser()
         opts = parser.parse_args(["-b", "1"])
         assert opts.browser == 1
 
     def test_browser_off(self):
-        parser = self._build()
+        parser = build_parser()
         opts = parser.parse_args(["-b", "0"])
         assert opts.browser == 0
 
     def test_https_port(self):
-        parser = self._build()
+        parser = build_parser()
         opts = parser.parse_args(["--https", "9090"])
         assert opts.https == 9090
 
     def test_ipv6_hosting(self):
-        parser = self._build()
+        parser = build_parser()
         opts = parser.parse_args(["--ipv6_hosting", "1"])
         assert opts.ipv6_hosting == 1
 
     def test_ipv6_alias(self):
-        parser = self._build()
+        parser = build_parser()
         opts = parser.parse_args(["--ipv6", "1"])
         assert opts.ipv6_hosting == 1
 
     def test_inet_exposure_valid(self):
-        parser = self._build()
+        parser = build_parser()
         for level in range(6):
             opts = parser.parse_args(["--inet_exposure", str(level)])
             assert opts.inet_exposure == level
 
     def test_inet_exposure_invalid(self):
-        parser = self._build()
+        parser = build_parser()
         with pytest.raises(SystemExit):
             parser.parse_args(["--inet_exposure", "6"])
 
     def test_inet_alias(self):
-        parser = self._build()
+        parser = build_parser()
         opts = parser.parse_args(["--inet", "3"])
         assert opts.inet_exposure == 3
 
     def test_disable_file_log_alias(self):
-        parser = self._build()
+        parser = build_parser()
         opts = parser.parse_args(["--disable"])
         assert opts.disable_file_log is True
 
     def test_pid_option(self):
-        parser = self._build(windows=False)
+        parser = build_parser()
         opts = parser.parse_args(["--pid", "/var/run/sabnzbd.pid"])
         assert opts.pid == "/var/run/sabnzbd.pid"
 
     def test_pidfile_option(self):
-        parser = self._build(windows=False)
+        parser = build_parser()
         opts = parser.parse_args(["--pidfile", "/var/run/sabnzbd.pid"])
         assert opts.pidfile == "/var/run/sabnzbd.pid"
 
-    def test_pid_not_on_windows(self):
-        parser = self._build(windows=True)
+    def test_pid_not_on_windows(self, monkeypatch):
+        monkeypatch.setattr(sabnzbd, "WINDOWS", True)
+        parser = build_parser()
         with pytest.raises(SystemExit):
             parser.parse_args(["--pid", "/tmp/pid"])
 
-    def test_pidfile_not_on_windows(self):
-        parser = self._build(windows=True)
+    def test_pidfile_not_on_windows(self, monkeypatch):
+        monkeypatch.setattr(sabnzbd, "WINDOWS", True)
+        parser = build_parser()
         with pytest.raises(SystemExit):
             parser.parse_args(["--pidfile", "/tmp/pid"])
 
     def test_nzb_files_as_remaining_args(self):
-        parser = self._build()
+        parser = build_parser()
         opts = parser.parse_args(["movie.nzb", "album.nzb"])
         assert opts.args == ["movie.nzb", "album.nzb"]
 
     def test_mixed_flags_and_nzb_files(self):
-        parser = self._build()
+        parser = build_parser()
         opts = parser.parse_args(["-d", "-c", "movie.nzb"])
         assert opts.daemon is True
         assert opts.clean is True
         assert opts.args == ["movie.nzb"]
 
     def test_win32_service_options_hidden(self):
-        parser = self._build()
+        parser = build_parser()
         opts = parser.parse_args(["--password", "secret", "--username", "admin"])
         assert opts.password == "secret"
         assert opts.username == "admin"
 
     def test_version_flag(self):
-        parser = self._build()
+        parser = build_parser()
         with pytest.raises(SystemExit) as exc_info:
             parser.parse_args(["--version"])
         assert exc_info.value.code == 0
 
     def test_help_flag(self, capsys):
-        parser = self._build()
+        parser = build_parser()
         with pytest.raises(SystemExit) as exc_info:
             parser.parse_args(["--help"])
         assert exc_info.value.code == 0
@@ -223,7 +217,7 @@ class TestBuildParser:
         assert "config-file" in captured.out.lower() or "config" in captured.out.lower()
 
     def test_no_args_defaults(self):
-        parser = self._build()
+        parser = build_parser()
         opts = parser.parse_args([])
         assert opts.config_file is None
         assert opts.server is None

--- a/tests/test_cli_argparse.py
+++ b/tests/test_cli_argparse.py
@@ -1,0 +1,382 @@
+#!/usr/bin/python3 -OO
+# Copyright 2007-2026 by The SABnzbd-Team (sabnzbd.org)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""Tests for SABnzbd CLI argument parsing (argparse migration)."""
+
+import sys
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_sabnzbd_env():
+    """Ensure SABnzbd module state doesn't leak between tests."""
+    import sabnzbd
+
+    orig_windows = sabnzbd.WINDOWS
+    yield
+    sabnzbd.WINDOWS = orig_windows
+
+
+class TestBuildParser:
+    """Tests for build_parser()."""
+
+    def _build(self, windows=False):
+        import sabnzbd
+
+        sabnzbd.WINDOWS = windows
+        sabnzbd.MY_NAME = "SABnzbd"
+        sabnzbd.__version__ = "4.0.0"
+        from SABnzbd import build_parser
+
+        return build_parser()
+
+    def test_parser_returns_argument_parser(self):
+        import argparse
+
+        parser = self._build()
+        assert isinstance(parser, argparse.ArgumentParser)
+
+    def test_boolean_flags(self):
+        parser = self._build()
+        for flag in [
+            "--daemon",
+            "--nobrowser",
+            "--clean",
+            "--weblogging",
+            "--pause",
+            "--no-login",
+            "--log-all",
+            "--disable-file-log",
+            "--console",
+            "--new",
+            "--autorestarted",
+            "--repair",
+            "--repair-all",
+        ]:
+            opts = parser.parse_args([flag])
+            attr = flag.lstrip("-").replace("-", "_")
+            assert getattr(opts, attr) is True, f"{flag} should be True"
+
+    def test_short_boolean_flags(self):
+        parser = self._build()
+        for short, attr in [
+            ("-d", "daemon"),
+            ("-n", "nobrowser"),
+            ("-c", "clean"),
+            ("-w", "weblogging"),
+            ("-p", "pause"),
+        ]:
+            opts = parser.parse_args([short])
+            assert getattr(opts, attr) is True, f"{short} should set {attr}"
+
+    def test_config_file_option(self):
+        parser = self._build()
+        opts = parser.parse_args(["-f", "/tmp/test.ini"])
+        assert opts.config_file == "/tmp/test.ini"
+
+    def test_config_file_long_option(self):
+        parser = self._build()
+        opts = parser.parse_args(["--config-file", "/tmp/test.ini"])
+        assert opts.config_file == "/tmp/test.ini"
+
+    def test_config_file_alias(self):
+        parser = self._build()
+        opts = parser.parse_args(["--config", "/tmp/test.ini"])
+        assert opts.config_file == "/tmp/test.ini"
+
+    def test_server_option(self):
+        parser = self._build()
+        opts = parser.parse_args(["-s", "0.0.0.0:8080"])
+        assert opts.server == "0.0.0.0:8080"
+
+    def test_templates_option(self):
+        parser = self._build()
+        opts = parser.parse_args(["-t", "/my/templates"])
+        assert opts.templates == "/my/templates"
+
+    def test_logging_valid_range(self):
+        parser = self._build()
+        for level in (-1, 0, 1, 2):
+            processed = ["--logging=%d" % level]
+            opts = parser.parse_args(processed)
+            assert opts.logging == level
+
+    def test_logging_invalid_range(self):
+        parser = self._build()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--logging=3"])
+
+    def test_logging_invalid_negative(self):
+        parser = self._build()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--logging=-5"])
+
+    def test_browser_option(self):
+        parser = self._build()
+        opts = parser.parse_args(["-b", "1"])
+        assert opts.browser == 1
+
+    def test_browser_off(self):
+        parser = self._build()
+        opts = parser.parse_args(["-b", "0"])
+        assert opts.browser == 0
+
+    def test_https_port(self):
+        parser = self._build()
+        opts = parser.parse_args(["--https", "9090"])
+        assert opts.https == 9090
+
+    def test_ipv6_hosting(self):
+        parser = self._build()
+        opts = parser.parse_args(["--ipv6_hosting", "1"])
+        assert opts.ipv6_hosting == 1
+
+    def test_ipv6_alias(self):
+        parser = self._build()
+        opts = parser.parse_args(["--ipv6", "1"])
+        assert opts.ipv6_hosting == 1
+
+    def test_inet_exposure_valid(self):
+        parser = self._build()
+        for level in range(6):
+            opts = parser.parse_args(["--inet_exposure", str(level)])
+            assert opts.inet_exposure == level
+
+    def test_inet_exposure_invalid(self):
+        parser = self._build()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--inet_exposure", "6"])
+
+    def test_inet_alias(self):
+        parser = self._build()
+        opts = parser.parse_args(["--inet", "3"])
+        assert opts.inet_exposure == 3
+
+    def test_disable_file_log_alias(self):
+        parser = self._build()
+        opts = parser.parse_args(["--disable"])
+        assert opts.disable_file_log is True
+
+    def test_pid_option(self):
+        parser = self._build(windows=False)
+        opts = parser.parse_args(["--pid", "/var/run/sabnzbd.pid"])
+        assert opts.pid == "/var/run/sabnzbd.pid"
+
+    def test_pidfile_option(self):
+        parser = self._build(windows=False)
+        opts = parser.parse_args(["--pidfile", "/var/run/sabnzbd.pid"])
+        assert opts.pidfile == "/var/run/sabnzbd.pid"
+
+    def test_pid_not_on_windows(self):
+        parser = self._build(windows=True)
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--pid", "/tmp/pid"])
+
+    def test_pidfile_not_on_windows(self):
+        parser = self._build(windows=True)
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--pidfile", "/tmp/pid"])
+
+    def test_nzb_files_as_remaining_args(self):
+        parser = self._build()
+        opts = parser.parse_args(["movie.nzb", "album.nzb"])
+        assert opts.args == ["movie.nzb", "album.nzb"]
+
+    def test_mixed_flags_and_nzb_files(self):
+        parser = self._build()
+        opts = parser.parse_args(["-d", "-c", "movie.nzb"])
+        assert opts.daemon is True
+        assert opts.clean is True
+        assert opts.args == ["movie.nzb"]
+
+    def test_win32_service_options_hidden(self):
+        parser = self._build()
+        opts = parser.parse_args(["--password", "secret", "--username", "admin"])
+        assert opts.password == "secret"
+        assert opts.username == "admin"
+
+    def test_version_flag(self, capsys):
+        parser = self._build()
+        with pytest.raises(SystemExit) as exc_info:
+            parser.parse_args(["--version"])
+        assert exc_info.value.code == 0
+
+    def test_help_flag(self, capsys):
+        parser = self._build()
+        with pytest.raises(SystemExit) as exc_info:
+            parser.parse_args(["--help"])
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        assert "config-file" in captured.out.lower() or "config" in captured.out.lower()
+
+    def test_no_args_defaults(self):
+        parser = self._build()
+        opts = parser.parse_args([])
+        assert opts.config_file is None
+        assert opts.server is None
+        assert opts.logging is None
+        assert opts.https is None
+        assert opts.daemon is False
+        assert opts.clean is False
+
+
+class TestCommandlineHandler:
+    """Tests for commandline_handler()."""
+
+    def _run_handler(self, args):
+        import sabnzbd
+
+        sabnzbd.MY_NAME = "SABnzbd"
+        sabnzbd.__version__ = "4.0.0"
+        sabnzbd.WINDOWS = False
+        with mock.patch("sys.argv", ["SABnzbd"] + args):
+            from SABnzbd import commandline_handler
+
+            return commandline_handler()
+
+    def test_simple_flags(self):
+        service, opts, serv_opts, upload_nzbs = self._run_handler(["-d", "-c", "-p"])
+        assert opts.daemon is True
+        assert opts.clean is True
+        assert opts.pause is True
+        assert service == ""
+
+    def test_config_file(self):
+        service, opts, serv_opts, upload_nzbs = self._run_handler(["-f", "/tmp/test.ini"])
+        assert opts.config_file == "/tmp/test.ini"
+
+    def test_server_option(self):
+        service, opts, serv_opts, upload_nzbs = self._run_handler(["-s", "0.0.0.0:8080"])
+        assert opts.server == "0.0.0.0:8080"
+
+    def test_nzb_files_collected(self):
+        service, opts, serv_opts, upload_nzbs = self._run_handler(["movie.nzb", "album.nzb"])
+        assert len(upload_nzbs) == 2
+        assert any("movie.nzb" in f for f in upload_nzbs)
+        assert any("album.nzb" in f for f in upload_nzbs)
+
+    def test_nzb_with_flags(self):
+        service, opts, serv_opts, upload_nzbs = self._run_handler(["-d", "movie.nzb"])
+        assert opts.daemon is True
+        assert len(upload_nzbs) == 1
+
+    def test_invalid_logging_exits(self):
+        with pytest.raises(SystemExit):
+            self._run_handler(["-l", "5"])
+
+    def test_logging_negative_works(self):
+        """Verify -l -1 is handled by pre-processing."""
+        service, opts, serv_opts, upload_nzbs = self._run_handler(["-l", "-1"])
+        assert opts.logging == -1
+
+    def test_logging_positive_works(self):
+        service, opts, serv_opts, upload_nzbs = self._run_handler(["-l", "2"])
+        assert opts.logging == 2
+
+    def test_invalid_inet_exposure_exits(self):
+        with pytest.raises(SystemExit):
+            self._run_handler(["--inet_exposure", "10"])
+
+    def test_help_exits(self):
+        with pytest.raises(SystemExit):
+            self._run_handler(["--help"])
+
+    def test_version_exits(self):
+        with pytest.raises(SystemExit):
+            self._run_handler(["--version"])
+
+    def test_all_boolean_flags(self):
+        args = [
+            "--daemon",
+            "--nobrowser",
+            "--clean",
+            "--weblogging",
+            "--pause",
+            "--no-login",
+            "--log-all",
+            "--disable-file-log",
+            "--console",
+            "--new",
+            "--repair",
+            "--repair-all",
+        ]
+        service, opts, serv_opts, upload_nzbs = self._run_handler(args)
+        for attr in [
+            "daemon",
+            "nobrowser",
+            "clean",
+            "weblogging",
+            "pause",
+            "no_login",
+            "log_all",
+            "disable_file_log",
+            "console",
+            "new",
+            "repair",
+            "repair_all",
+        ]:
+            assert getattr(opts, attr) is True, f"{attr} should be True"
+
+    def test_backward_compat_short_flags(self):
+        service, opts, serv_opts, upload_nzbs = self._run_handler(["-d", "-c", "-p", "-w", "-n"])
+        assert opts.daemon is True
+        assert opts.clean is True
+        assert opts.pause is True
+        assert opts.weblogging is True
+        assert opts.nobrowser is True
+
+    def test_backward_compat_config_file_alias(self):
+        """--config should work as backward compat for --config-file."""
+        service, opts, serv_opts, upload_nzbs = self._run_handler(["--config", "/tmp/test.ini"])
+        assert opts.config_file == "/tmp/test.ini"
+
+    def test_backward_compat_ipv6_alias(self):
+        service, opts, serv_opts, upload_nzbs = self._run_handler(["--ipv6", "1"])
+        assert opts.ipv6_hosting == 1
+
+    def test_backward_compat_inet_alias(self):
+        service, opts, serv_opts, upload_nzbs = self._run_handler(["--inet", "3"])
+        assert opts.inet_exposure == 3
+
+    def test_backward_compat_disable_alias(self):
+        service, opts, serv_opts, upload_nzbs = self._run_handler(["--disable"])
+        assert opts.disable_file_log is True
+
+    def test_complex_mix(self):
+        args = ["-f", "/tmp/test.ini", "-d", "-l", "2", "--https", "9090", "--inet_exposure", "3", "movie.nzb"]
+        service, opts, serv_opts, upload_nzbs = self._run_handler(args)
+        assert opts.config_file == "/tmp/test.ini"
+        assert opts.daemon is True
+        assert opts.logging == 2
+        assert opts.https == 9090
+        assert opts.inet_exposure == 3
+        assert len(upload_nzbs) == 1
+
+    def test_archives_also_collected(self):
+        service, opts, serv_opts, upload_nzbs = self._run_handler(["movie.rar", "album.7z"])
+        assert len(upload_nzbs) == 2
+
+    def test_non_nzb_files_not_collected(self):
+        service, opts, serv_opts, upload_nzbs = self._run_handler(["readme.txt", "movie.nzb"])
+        assert len(upload_nzbs) == 1
+        assert any("movie.nzb" in f for f in upload_nzbs)
+
+    def test_wait_option(self):
+        service, opts, serv_opts, upload_nzbs = self._run_handler(["--wait", "30"])
+        assert opts.wait == "30"

--- a/tests/test_cli_argparse.py
+++ b/tests/test_cli_argparse.py
@@ -23,13 +23,13 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def _reset_sabnzbd_env():
-    """Ensure SABnzbd module state doesn't leak between tests."""
+def _mock_sabnzbd_env(monkeypatch):
+    """Set sabnzbd module state for CLI tests."""
     import sabnzbd
 
-    orig_windows = sabnzbd.WINDOWS
-    yield
-    sabnzbd.WINDOWS = orig_windows
+    monkeypatch.setattr(sabnzbd, "MY_NAME", "SABnzbd")
+    monkeypatch.setattr(sabnzbd, "__version__", "4.0.0")
+    monkeypatch.setattr(sabnzbd, "WINDOWS", False)
 
 
 class TestBuildParser:
@@ -37,12 +37,10 @@ class TestBuildParser:
 
     def _build(self, windows=False):
         import sabnzbd
-
-        sabnzbd.WINDOWS = windows
-        sabnzbd.MY_NAME = "SABnzbd"
-        sabnzbd.__version__ = "4.0.0"
         from SABnzbd import build_parser
 
+        if windows:
+            sabnzbd.WINDOWS = windows
         return build_parser()
 
     def test_parser_returns_argument_parser(self):
@@ -239,14 +237,9 @@ class TestCommandlineHandler:
     """Tests for commandline_handler()."""
 
     def _run_handler(self, args):
-        import sabnzbd
+        from SABnzbd import commandline_handler
 
-        sabnzbd.MY_NAME = "SABnzbd"
-        sabnzbd.__version__ = "4.0.0"
-        sabnzbd.WINDOWS = False
         with mock.patch("sys.argv", ["SABnzbd", *args]):
-            from SABnzbd import commandline_handler
-
             return commandline_handler()
 
     def test_simple_flags(self):

--- a/tests/test_cli_argparse.py
+++ b/tests/test_cli_argparse.py
@@ -17,7 +17,6 @@
 
 """Tests for SABnzbd CLI argument parsing (argparse migration)."""
 
-import sys
 from unittest import mock
 
 import pytest
@@ -211,7 +210,7 @@ class TestBuildParser:
         assert opts.password == "secret"
         assert opts.username == "admin"
 
-    def test_version_flag(self, capsys):
+    def test_version_flag(self):
         parser = self._build()
         with pytest.raises(SystemExit) as exc_info:
             parser.parse_args(["--version"])
@@ -245,34 +244,33 @@ class TestCommandlineHandler:
         sabnzbd.MY_NAME = "SABnzbd"
         sabnzbd.__version__ = "4.0.0"
         sabnzbd.WINDOWS = False
-        with mock.patch("sys.argv", ["SABnzbd"] + args):
+        with mock.patch("sys.argv", ["SABnzbd", *args]):
             from SABnzbd import commandline_handler
 
             return commandline_handler()
 
     def test_simple_flags(self):
-        service, opts, serv_opts, upload_nzbs = self._run_handler(["-d", "-c", "-p"])
+        _service, opts, _serv_opts, _upload_nzbs = self._run_handler(["-d", "-c", "-p"])
         assert opts.daemon is True
         assert opts.clean is True
         assert opts.pause is True
-        assert service == ""
 
     def test_config_file(self):
-        service, opts, serv_opts, upload_nzbs = self._run_handler(["-f", "/tmp/test.ini"])
+        _service, opts, _serv_opts, _upload_nzbs = self._run_handler(["-f", "/tmp/test.ini"])
         assert opts.config_file == "/tmp/test.ini"
 
     def test_server_option(self):
-        service, opts, serv_opts, upload_nzbs = self._run_handler(["-s", "0.0.0.0:8080"])
+        _service, opts, _serv_opts, _upload_nzbs = self._run_handler(["-s", "0.0.0.0:8080"])
         assert opts.server == "0.0.0.0:8080"
 
     def test_nzb_files_collected(self):
-        service, opts, serv_opts, upload_nzbs = self._run_handler(["movie.nzb", "album.nzb"])
+        _service, _opts, _serv_opts, upload_nzbs = self._run_handler(["movie.nzb", "album.nzb"])
         assert len(upload_nzbs) == 2
         assert any("movie.nzb" in f for f in upload_nzbs)
         assert any("album.nzb" in f for f in upload_nzbs)
 
     def test_nzb_with_flags(self):
-        service, opts, serv_opts, upload_nzbs = self._run_handler(["-d", "movie.nzb"])
+        _service, opts, _serv_opts, upload_nzbs = self._run_handler(["-d", "movie.nzb"])
         assert opts.daemon is True
         assert len(upload_nzbs) == 1
 
@@ -282,11 +280,11 @@ class TestCommandlineHandler:
 
     def test_logging_negative_works(self):
         """Verify -l -1 is handled by pre-processing."""
-        service, opts, serv_opts, upload_nzbs = self._run_handler(["-l", "-1"])
+        _service, opts, _serv_opts, _upload_nzbs = self._run_handler(["-l", "-1"])
         assert opts.logging == -1
 
     def test_logging_positive_works(self):
-        service, opts, serv_opts, upload_nzbs = self._run_handler(["-l", "2"])
+        _service, opts, _serv_opts, _upload_nzbs = self._run_handler(["-l", "2"])
         assert opts.logging == 2
 
     def test_invalid_inet_exposure_exits(self):
@@ -316,7 +314,7 @@ class TestCommandlineHandler:
             "--repair",
             "--repair-all",
         ]
-        service, opts, serv_opts, upload_nzbs = self._run_handler(args)
+        _service, opts, _serv_opts, _upload_nzbs = self._run_handler(args)
         for attr in [
             "daemon",
             "nobrowser",
@@ -334,7 +332,7 @@ class TestCommandlineHandler:
             assert getattr(opts, attr) is True, f"{attr} should be True"
 
     def test_backward_compat_short_flags(self):
-        service, opts, serv_opts, upload_nzbs = self._run_handler(["-d", "-c", "-p", "-w", "-n"])
+        _service, opts, _serv_opts, _upload_nzbs = self._run_handler(["-d", "-c", "-p", "-w", "-n"])
         assert opts.daemon is True
         assert opts.clean is True
         assert opts.pause is True
@@ -343,24 +341,24 @@ class TestCommandlineHandler:
 
     def test_backward_compat_config_file_alias(self):
         """--config should work as backward compat for --config-file."""
-        service, opts, serv_opts, upload_nzbs = self._run_handler(["--config", "/tmp/test.ini"])
+        _service, opts, _serv_opts, _upload_nzbs = self._run_handler(["--config", "/tmp/test.ini"])
         assert opts.config_file == "/tmp/test.ini"
 
     def test_backward_compat_ipv6_alias(self):
-        service, opts, serv_opts, upload_nzbs = self._run_handler(["--ipv6", "1"])
+        _service, opts, _serv_opts, _upload_nzbs = self._run_handler(["--ipv6", "1"])
         assert opts.ipv6_hosting == 1
 
     def test_backward_compat_inet_alias(self):
-        service, opts, serv_opts, upload_nzbs = self._run_handler(["--inet", "3"])
+        _service, opts, _serv_opts, _upload_nzbs = self._run_handler(["--inet", "3"])
         assert opts.inet_exposure == 3
 
     def test_backward_compat_disable_alias(self):
-        service, opts, serv_opts, upload_nzbs = self._run_handler(["--disable"])
+        _service, opts, _serv_opts, _upload_nzbs = self._run_handler(["--disable"])
         assert opts.disable_file_log is True
 
     def test_complex_mix(self):
         args = ["-f", "/tmp/test.ini", "-d", "-l", "2", "--https", "9090", "--inet_exposure", "3", "movie.nzb"]
-        service, opts, serv_opts, upload_nzbs = self._run_handler(args)
+        _service, opts, _serv_opts, upload_nzbs = self._run_handler(args)
         assert opts.config_file == "/tmp/test.ini"
         assert opts.daemon is True
         assert opts.logging == 2
@@ -369,14 +367,14 @@ class TestCommandlineHandler:
         assert len(upload_nzbs) == 1
 
     def test_archives_also_collected(self):
-        service, opts, serv_opts, upload_nzbs = self._run_handler(["movie.rar", "album.7z"])
+        _service, _opts, _serv_opts, upload_nzbs = self._run_handler(["movie.rar", "album.7z"])
         assert len(upload_nzbs) == 2
 
     def test_non_nzb_files_not_collected(self):
-        service, opts, serv_opts, upload_nzbs = self._run_handler(["readme.txt", "movie.nzb"])
+        _service, _opts, _serv_opts, upload_nzbs = self._run_handler(["readme.txt", "movie.nzb"])
         assert len(upload_nzbs) == 1
         assert any("movie.nzb" in f for f in upload_nzbs)
 
     def test_wait_option(self):
-        service, opts, serv_opts, upload_nzbs = self._run_handler(["--wait", "30"])
+        _service, opts, _serv_opts, _upload_nzbs = self._run_handler(["--wait", "30"])
         assert opts.wait == "30"


### PR DESCRIPTION
## Summary

Replace the legacy `getopt`-based CLI argument parsing with `argparse.ArgumentParser`, while preserving full backward compatibility with existing options and usage patterns.

## Motivation

The current CLI parsing uses `getopt` with manual `print_help()` / `print_version()` functions, a hand-built `(opt, arg)` tuple list (`sab_opts`), and a long `if/elif` chain in `main()` to consume those tuples.

## Changes

- **`SABnzbd.py`**:
  - Replace `import getopt` with `import argparse`
  - Add `build_parser()`, single source of truth for all CLI options
  - Add `_logging_type()`, custom type that validates `--logging` range (-1..2) and handles negative numbers
  - `commandline_handler()` returns the argparse `Namespace` directly (no more tuple intermediary)
  - `main()` accesses options via `opts.attribute` instead of iterating `(opt, arg)` tuples
  - Remove dead code: `print_help()`, `print_version()`, `get_f_option()`
  - Backward-compat aliases via argparse: `--config`/`--config-file`, `--ipv6`/`--ipv6_hosting`, `--inet`/`--inet_exposure`, `--disable`/`--disable-file-log`
  - `-2` short option restored for `--wait` (Win32 service)
  - Win32 service options hidden from `--help` via `argparse.SUPPRESS`
  - Pre-processing of `sys.argv` to convert `-l -1` → `--logging=-1` (argparse limitation with negative numbers)

- **`tests/test_cli_argparse.py`** (new, 51 tests):
  - `TestBuildParser` — 30 tests: flags, options, aliases, validation, platform-specific behavior, help/version
  - `TestCommandlineHandler` — 21 tests: full integration, NZB collection, backward compat, complex flag combinations

## Backward Compatibility

All existing CLI options work unchanged:

| Before (getopt) | After (argparse) | Status |
|------------------|-------------------|--------|
| `-f`, `--config-file` | `-f`, `--config`, `--config-file` | ✅ Enhanced |
| `-l -1` | `-l -1`, `--logging=-1` | ✅ Works |
| `--ipv6_hosting 1` | `--ipv6 1`, `--ipv6_hosting 1` | ✅ Enhanced |
| `--inet_exposure 3` | `--inet 3`, `--inet_exposure 3` | ✅ Enhanced |
| `--disable-file-log` | `--disable`, `--disable-file-log` | ✅ Enhanced |
| `--help`, `--version` | `--help`, `--version` | ✅ Auto-generated |