### PR TITLE
Fix contiguous ready check article.on_disk or article.failed should skip

### DIFF
--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -219,7 +219,7 @@ class Assembler(Thread):
             return (
                 next_ready
                 and ready_bytes >= self.assembler_trigger
-                and nzf.contiguous_ready_bytes() >= self.assembler_trigger
+                and nzf.has_contiguous_ready_bytes(self.assembler_trigger)
             )
         # Direct Write
         if allow_non_contiguous:

--- a/sabnzbd/nzb/file.py
+++ b/sabnzbd/nzb/file.py
@@ -288,18 +288,19 @@ class NzbFile(TryList):
         return offset
 
     @synchronized()
-    def contiguous_ready_bytes(self) -> int:
-        """How many bytes from assembler_next_index onward are ready to write to file contiguously?"""
-        bytes_ready: int = 0
+    def has_contiguous_ready_bytes(self, bytes_ready: int) -> bool:
+        """Are there at least bytes_ready bytes from assembler_next_index onward ready to write to file contiguously?"""
         for article in self.decodetable[self.assembler_next_index :]:
             if not article.decoded:
                 break
-            if article.on_disk:
+            if article.on_disk or article.failed:
                 continue
             if article.decoded_size is None:
                 break
-            bytes_ready += article.decoded_size
-        return bytes_ready
+            bytes_ready -= article.decoded_size
+            if bytes_ready <= 0:
+                break
+        return bytes_ready <= 0
 
     def sort_key(self) -> tuple[Any, ...]:
         """Comparison function for sorting NZB files.


### PR DESCRIPTION
Small bug for append mode due to article-level retry, on_disk or failed should skip the article as part of the calculation.

```py
if article.on_disk or article.failed:
    continue
```

I also made it exit early once it reaches the trigger.