### PR TITLE
Improve Glitter header menu labels

### DIFF
--- a/interfaces/Glitter/templates/include_menu.tmpl
+++ b/interfaces/Glitter/templates/include_menu.tmpl
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-inverse main-navbar">
     <div class="navbar-header">
-        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse" aria-label="Toggle SABnzbd navigation menu" aria-controls="navbar-collapse" aria-expanded="false">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse" aria-label="$T('Glitter-toggleNavigation')" aria-controls="navbar-collapse" aria-expanded="false">
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
@@ -13,7 +13,7 @@
                 <button type="button" class="btn btn-default navbar-btn" data-bind="click: pauseToggle, attr: { 'title': downloadsPaused() ? '$T('link-resume')' : '$T('link-pause')', 'aria-label': downloadsPaused() ? '$T('link-resume')' : '$T('link-pause')' }">
                     <span class="glyphicon" data-bind="css: { 'glyphicon-play' : downloadsPaused(), 'glyphicon-pause' : !downloadsPaused() }"></span>
                 </button>
-                <button type="button" class="btn btn-default navbar-btn dropdown-toggle" data-toggle="dropdown" aria-label="$T('pauseFor')" aria-haspopup="true">
+                <button type="button" class="btn btn-default navbar-btn dropdown-toggle" data-toggle="dropdown" aria-label="$T('pauseFor')" aria-haspopup="true" aria-expanded="false">
                     <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu">
@@ -26,7 +26,7 @@
                     <li class="divider"></li>
                     <li><a href="#" data-bind="click: openCustomPauseTime">$T('Glitter-custom')</a></li>
                 </ul>
-                <span class="btn btn-default navbar-btn navbar-timeleft" role="status" aria-live="polite" data-bind="text: timeLeft, attr: { 'aria-label': timeLeftLabel }">0:00</span>
+                <span class="btn btn-default navbar-btn navbar-timeleft" data-bind="text: timeLeft" data-toggle="dropdown">0:00</span>
             </div>
         </div>
     </div>
@@ -37,13 +37,13 @@
             <li class="speedlimit-dropdown dropdown">
                 <div class="btn-group">
                     <div class="btn-group">
-                        <button type="button" class="btn btn-default navbar-btn navbar-speed" data-toggle="dropdown" aria-haspopup="true" data-bind="attr: { 'aria-label': speedMenuLabel }">
+                        <button type="button" class="btn btn-default navbar-btn navbar-speed" data-toggle="dropdown" aria-haspopup="true">
                             <span data-bind="text: speedText">0 KB/s</span>
                         </button>
                         <button type="button" class="btn btn-default navbar-btn dropdown-toggle" data-toggle="dropdown" onclick="keepOpen(this)" aria-hidden="true" tabindex="-1">
                             <span class="caret"></span>
                         </button>
-                        <a href="#" class="max-speed-input-clear hover-button" aria-label="Clear speed limit" data-bind="click: clearSpeedLimit, visible:(speedLimit() < 100 && speedLimit() > 0)" style="display: none;">
+                        <a href="#" class="max-speed-input-clear hover-button" aria-label="$T('button-clear')" data-bind="click: clearSpeedLimit, visible:(speedLimit() < 100 && speedLimit() > 0)" style="display: none;">
                             <span class="glyphicon glyphicon-link"></span>
                         </a>
                         <div class="dropdown-menu max-speed-input">
@@ -82,7 +82,7 @@
                 <a href="./config/" aria-label="SABnzbd $T('menu-config')"><span class="glyphicon glyphicon-cog"></span></a>
             </li>
             <li class="dropdown main-menu-link" data-bind="css: { 'active-on-queue-finish-menu': finishaction()}">
-                <a href="#" data-toggle="dropdown"  onclick="keepOpen(this)" aria-label="Open SABnzbd main menu" aria-haspopup="true">
+                <a href="#" data-toggle="dropdown"  onclick="keepOpen(this)" aria-label="$T('Glitter-mainMenu')" aria-haspopup="true" aria-expanded="false">
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>

--- a/interfaces/Glitter/templates/include_menu.tmpl
+++ b/interfaces/Glitter/templates/include_menu.tmpl
@@ -1,19 +1,19 @@
 <nav class="navbar navbar-inverse main-navbar">
     <div class="navbar-header">
-        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse" aria-label="Toggle SABnzbd navigation menu" aria-controls="navbar-collapse" aria-expanded="false">
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
         </button>
-        <a class="navbar-logo" href="./">
+        <a class="navbar-logo" href="./" aria-label="SABnzbd $T('menu-queue')">
             #include $webdir + "/../../Config/templates/staticcfg/images/logo-small.svg"#
         </a>
         <div class="btn-group">
             <div class="btn-group">
-                <button type="button" class="btn btn-default navbar-btn" data-bind="click: pauseToggle, attr: { 'title': downloadsPaused() ? '$T('link-resume')' : '$T('link-pause')' }">
+                <button type="button" class="btn btn-default navbar-btn" data-bind="click: pauseToggle, attr: { 'title': downloadsPaused() ? '$T('link-resume')' : '$T('link-pause')', 'aria-label': downloadsPaused() ? '$T('link-resume')' : '$T('link-pause')' }">
                     <span class="glyphicon" data-bind="css: { 'glyphicon-play' : downloadsPaused(), 'glyphicon-pause' : !downloadsPaused() }"></span>
                 </button>
-                <button type="button" class="btn btn-default navbar-btn dropdown-toggle" data-toggle="dropdown">
+                <button type="button" class="btn btn-default navbar-btn dropdown-toggle" data-toggle="dropdown" aria-label="$T('pauseFor')" aria-haspopup="true">
                     <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu">
@@ -26,7 +26,7 @@
                     <li class="divider"></li>
                     <li><a href="#" data-bind="click: openCustomPauseTime">$T('Glitter-custom')</a></li>
                 </ul>
-                <span class="btn btn-default navbar-btn navbar-timeleft" data-bind="text: timeLeft"  data-toggle="dropdown">0:00</span>
+                <span class="btn btn-default navbar-btn navbar-timeleft" role="status" aria-live="polite" data-bind="text: timeLeft, attr: { 'aria-label': timeLeftLabel }">0:00</span>
             </div>
         </div>
     </div>
@@ -37,13 +37,13 @@
             <li class="speedlimit-dropdown dropdown">
                 <div class="btn-group">
                     <div class="btn-group">
-                        <button type="button" class="btn btn-default navbar-btn navbar-speed" data-toggle="dropdown">
+                        <button type="button" class="btn btn-default navbar-btn navbar-speed" data-toggle="dropdown" aria-haspopup="true" data-bind="attr: { 'aria-label': speedMenuLabel }">
                             <span data-bind="text: speedText">0 KB/s</span>
                         </button>
-                        <button type="button" class="btn btn-default navbar-btn dropdown-toggle" data-toggle="dropdown" onclick="keepOpen(this)">
+                        <button type="button" class="btn btn-default navbar-btn dropdown-toggle" data-toggle="dropdown" onclick="keepOpen(this)" aria-hidden="true" tabindex="-1">
                             <span class="caret"></span>
                         </button>
-                        <a href="#" class="max-speed-input-clear hover-button" data-bind="click: clearSpeedLimit, visible:(speedLimit() < 100 && speedLimit() > 0)" style="display: none;">
+                        <a href="#" class="max-speed-input-clear hover-button" aria-label="Clear speed limit" data-bind="click: clearSpeedLimit, visible:(speedLimit() < 100 && speedLimit() > 0)" style="display: none;">
                             <span class="glyphicon glyphicon-link"></span>
                         </a>
                         <div class="dropdown-menu max-speed-input">
@@ -61,14 +61,14 @@
                 </div>
             </li>
             <li data-tooltip="true" data-placement="bottom" title="$T('Glitter-addNZB')">
-                <a href="#modal-add-nzb" data-toggle="modal"><span class="glyphicon glyphicon-plus-sign"></span></a>
+                <a href="#modal-add-nzb" data-toggle="modal" aria-label="$T('Glitter-addNZB')"><span class="glyphicon glyphicon-plus-sign"></span></a>
             </li>
             <li data-tooltip="true" data-placement="bottom" title="$T('Glitter-statusInterfaceOptions')" data-bind="click: loadStatusInfo">
-                <a href="#modal-options" data-toggle="modal"><span class="glyphicon glyphicon-wrench"></span></a>
+                <a href="#modal-options" data-toggle="modal" aria-label="$T('Glitter-statusInterfaceOptions')"><span class="glyphicon glyphicon-wrench"></span></a>
             </li>
             <!--#if $have_rss_defined#-->
             <li data-tooltip="true" data-placement="bottom" title="$T('cmenu-rss')">
-                <a href="./config/rss/">
+                <a href="./config/rss/" aria-label="$T('cmenu-rss')">
                     <svg class="rss-icon-svg" viewBox="0 0 8 8">
                         <rect class="rss-button" width="8" height="8" />
                         <circle class="rss-symbol" cx="2" cy="6" r="1" />
@@ -79,10 +79,10 @@
             </li>
             <!--#end if#-->
             <li data-tooltip="true" data-placement="bottom" title="SABnzbd $T('menu-config')">
-                <a href="./config/"><span class="glyphicon glyphicon-cog"></span></a>
+                <a href="./config/" aria-label="SABnzbd $T('menu-config')"><span class="glyphicon glyphicon-cog"></span></a>
             </li>
             <li class="dropdown main-menu-link" data-bind="css: { 'active-on-queue-finish-menu': finishaction()}">
-                <a href="#" data-toggle="dropdown"  onclick="keepOpen(this)">
+                <a href="#" data-toggle="dropdown"  onclick="keepOpen(this)" aria-label="Open SABnzbd main menu" aria-haspopup="true">
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
@@ -102,7 +102,7 @@
                     <li class="divider"></li>
                     <li class="dropdown-header"><span class="glyphicon glyphicon-off"></span> $T('Glitter-onFinish'):</li>
                     <li>
-                        <select data-bind="value: finishaction, event: { change: setOnQueueFinish }" class="form-control">
+                        <select data-bind="value: finishaction, event: { change: setOnQueueFinish }" class="form-control" aria-label="$T('Glitter-onFinish')">
                             <option value=""></option>
                             <option value="shutdown_program">$T('shutdownSab')</option>
                             <!--#if $power_options#-->

--- a/interfaces/Glitter/templates/static/javascripts/glitter.main.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.main.js
@@ -105,6 +105,14 @@ function ViewModel() {
         return self.speed() + ' ' + (self.speedMetrics[self.speedMetric()] ? self.speedMetrics[self.speedMetric()] : "B/s");
     });
 
+    self.timeLeftLabel = ko.pureComputed(function() {
+        return 'Time remaining: ' + self.timeLeft();
+    });
+
+    self.speedMenuLabel = ko.pureComputed(function() {
+        return 'Download speed: ' + self.speedText() + '. Open speed limit menu';
+    });
+
     // Dynamic icon
     self.SABIcon = ko.pureComputed(function() {
         if (self.downloadsPaused()) {

--- a/interfaces/Glitter/templates/static/javascripts/glitter.main.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.main.js
@@ -105,14 +105,6 @@ function ViewModel() {
         return self.speed() + ' ' + (self.speedMetrics[self.speedMetric()] ? self.speedMetrics[self.speedMetric()] : "B/s");
     });
 
-    self.timeLeftLabel = ko.pureComputed(function() {
-        return 'Time remaining: ' + self.timeLeft();
-    });
-
-    self.speedMenuLabel = ko.pureComputed(function() {
-        return 'Download speed: ' + self.speedText() + '. Open speed limit menu';
-    });
-
     // Dynamic icon
     self.SABIcon = ko.pureComputed(function() {
         if (self.downloadsPaused()) {

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -813,6 +813,8 @@ SKIN_TEXT = {
     "Glitter-pause6h": TT("Pause for 6 hours"),
     "Glitter-setMaxLinespeed": TT("You must set a maximum bandwidth before you can set a bandwidth limit"),
     "Glitter-left": TT("left"),
+    "Glitter-toggleNavigation": TT("Toggle SABnzbd navigation menu"),
+    "Glitter-mainMenu": TT("Open SABnzbd main menu"),
     "Glitter-free": TT("Free Space"),
     "Glitter-freeTemp": TT("Temp Folder"),
     "Glitter-search": TT("Search"),


### PR DESCRIPTION
This cleans up some of the Glitter header controls for screen reader use.

I noticed several icon-only buttons were announced as just "menu" or "button", and the speed limit menu was especially confusing because the visible caret was reachable as a separate control. This adds labels to the header actions and hides the duplicate caret from keyboard/screen reader navigation.

Tested locally with NVDA.