### PR TITLE
Use media duration for accurate sample detection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ rarfile==4.2
 guessit==3.8.0
 babelfish==0.6.1
 rebulk==3.2.0
+hachoir==3.3.0
 
 # Recent cryptography versions require Rust. If you run into issues compiling this
 # SABnzbd will also work with older pre-Rust versions such as cryptography==3.3.2

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -1085,19 +1085,23 @@ def get_all_passwords(nzo) -> list[str]:
     return unique_passwords
 
 
-def is_sample(filename: str, filepath: Optional[str] = None) -> bool:
-    """Try to determine if filename is (most likely) a sample.
-    When filepath points to the actual file on disk, the media duration is used
+def is_sample(filename_or_filepath: str) -> bool:
+    """Try to determine if the file is (most likely) a sample.
+    When given a path to an actual file on disk, the media duration is used
     to rule out false-positives on titles that merely contain "sample" or
     "proof" (e.g. "The.Moment.of.Proof.S01E01")."""
-    if not re.search(RE_SAMPLE, filename):
+    if not re.search(RE_SAMPLE, os.path.basename(filename_or_filepath)):
         return False
 
     # Long media files are never a sample, no matter what its name suggests
-    if filepath:
-        if duration := get_media_duration(filepath):
-            logging.debug("Media duration of %s is %s seconds", filepath, duration)
+    if os.path.isfile(filename_or_filepath):
+        if duration := get_media_duration(filename_or_filepath):
+            logging.debug("Media duration of %s is %s seconds", filename_or_filepath, duration)
             return duration <= SAMPLE_MAX_DURATION
+        logging.debug(
+            "Could not determine media duration of %s, using filename-based sample detection",
+            filename_or_filepath,
+        )
     return True
 
 

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -43,6 +43,13 @@ from threading import Thread, RLock
 from collections.abc import Iterable
 from typing import Any, AnyStr, Optional, Collection
 
+from hachoir.parser import createParser as hachoir_create_parser
+from hachoir.metadata import extractMetadata as hachoir_extract_metadata
+from hachoir.core.log import log as hachoir_log
+
+# Keep hachoir from printing parser warnings straight to the console
+hachoir_log.use_print = False
+
 import sabnzbd
 import sabnzbd.getipaddress
 from sabnzbd.constants import (
@@ -79,12 +86,17 @@ if sabnzbd.WINDOWS:
 if sabnzbd.MACOS:
     from sabnzbd.utils import sleepless
 
+
 TAB_UNITS = ("", "K", "M", "G", "T", "P")
 RE_UNITS = re.compile(r"(\d+\.*\d*)\s*([KMGTP]?)", re.I)
 RE_VERSION = re.compile(r"(\d+)\.(\d+)\.(\d+)([a-zA-Z]*)(\d*)")
-RE_SAMPLE = re.compile(r"((^|[\W_])(sample|proof))", re.I)  # something-sample or something-proof
 RE_IP4 = re.compile(r"inet\s+(addr:\s*)?(\d+\.\d+\.\d+\.\d+)")
 RE_IP6 = re.compile(r"inet6\s+(addr:\s*)?([0-9a-f:]+)", re.I)
+
+# Media shorter than this (in seconds) can be an actual sample; anything longer
+# is considered real content even when its name matches the sample pattern
+RE_SAMPLE = re.compile(r"((^|[\W_])(sample|proof))", re.I)  # something-sample or something-proof
+SAMPLE_MAX_DURATION = 2 * 60
 
 # Name patterns for NZB parsing
 RE_SUBJECT_FILENAME_QUOTES = re.compile(r'"([^"]*)"')
@@ -1073,9 +1085,38 @@ def get_all_passwords(nzo) -> list[str]:
     return unique_passwords
 
 
-def is_sample(filename: str) -> bool:
-    """Try to determine if filename is (most likely) a sample"""
-    return bool(re.search(RE_SAMPLE, filename))
+def is_sample(filename: str, filepath: Optional[str] = None) -> bool:
+    """Try to determine if filename is (most likely) a sample.
+    When filepath points to the actual file on disk, the media duration is used
+    to rule out false-positives on titles that merely contain "sample" or
+    "proof" (e.g. "The.Moment.of.Proof.S01E01")."""
+    if not re.search(RE_SAMPLE, filename):
+        return False
+
+    # Long media files are never a sample, no matter what its name suggests
+    if filepath:
+        if duration := get_media_duration(filepath):
+            logging.debug("Media duration of %s is %s seconds", filepath, duration)
+            return duration <= SAMPLE_MAX_DURATION
+    return True
+
+
+def get_media_duration(filepath: str) -> Optional[float]:
+    """Return the duration of a media file in seconds using the pure-Python
+    hachoir parser (no external tools required), or None when it cannot be
+    determined (not a media file, unreadable, or missing duration metadata)."""
+    if not os.path.isfile(filepath):
+        return None
+    try:
+        parser = hachoir_create_parser(filepath)
+        if not parser:
+            return None
+        with parser:
+            if duration := hachoir_extract_metadata(parser).get("duration", 0):
+                return duration.total_seconds()
+    except Exception:
+        logging.debug("Failed to read media duration of %s", filepath, exc_info=True)
+    return None
 
 
 def find_on_path(targets: str | tuple[str, ...]) -> Optional[str]:

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -1263,8 +1263,9 @@ def remove_samples(path: str):
     for root, _dirs, files in os.walk(path):
         for file_to_match in files:
             nr_files += 1
-            if is_sample(file_to_match):
-                files_to_delete.append(os.path.join(root, file_to_match))
+            full_path = os.path.join(root, file_to_match)
+            if is_sample(file_to_match, full_path):
+                files_to_delete.append(full_path)
 
     # Make sure we skip false-positives
     if len(files_to_delete) < nr_files:

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -1264,7 +1264,7 @@ def remove_samples(path: str):
         for file_to_match in files:
             nr_files += 1
             full_path = os.path.join(root, file_to_match)
-            if is_sample(file_to_match, full_path):
+            if is_sample(full_path):
                 files_to_delete.append(full_path)
 
     # Make sure we skip false-positives

--- a/sabnzbd/sorting.py
+++ b/sabnzbd/sorting.py
@@ -514,11 +514,13 @@ class Sorter:
 
     def _filter_files(self, f: str, base_path: str) -> bool:
         filepath = self._to_filepath(f, base_path)
+        # Cheap checks first; the media-duration sample check
+        # only runs for files that are otherwise kept
         return (
-            not is_sample(f)
-            and get_ext(f) not in EXCLUDED_FILE_EXTS
+            get_ext(f) not in EXCLUDED_FILE_EXTS
             and os.path.exists(filepath)
             and os.stat(filepath).st_size >= self.rename_limit
+            and not is_sample(f, filepath)
         )
 
     def rename(self, files: list[str], base_path: str) -> tuple[str, bool, list[str]]:

--- a/sabnzbd/sorting.py
+++ b/sabnzbd/sorting.py
@@ -520,7 +520,7 @@ class Sorter:
             get_ext(f) not in EXCLUDED_FILE_EXTS
             and os.path.exists(filepath)
             and os.stat(filepath).st_size >= self.rename_limit
-            and not is_sample(f, filepath)
+            and not is_sample(filepath)
         )
 
     def rename(self, files: list[str], base_path: str) -> tuple[str, bool, list[str]]:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -25,6 +25,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import wave
 from random import randint, sample
 from unittest import mock
 
@@ -457,8 +458,67 @@ class TestMisc:
         ],
     )
     def test_is_sample_known_false_positives(self, name, result):
-        """We know these fail, but don't have a better solution for them at the moment."""
+        """These cannot be resolved by name alone; they are handled by inspecting
+        the actual media duration when the file is available (see #2083 tests below)."""
         assert misc.is_sample(name) != result
+
+    @staticmethod
+    def _write_wav(path: str, seconds: float):
+        """Create a real WAV file of the given length (pure Python, no external tools)"""
+        framerate = 8000
+        with wave.open(path, "wb") as wav:
+            wav.setnchannels(1)
+            wav.setsampwidth(2)
+            wav.setframerate(framerate)
+            wav.writeframes(b"\x00\x00" * int(framerate * seconds))
+
+    def test_get_media_duration(self, tmp_path):
+        wav_file = os.path.join(tmp_path, "tone.wav")
+        self._write_wav(wav_file, 2.5)
+        assert misc.get_media_duration(wav_file) == pytest.approx(2.5, abs=0.1)
+
+        # Not a media file and a non-existent file both yield no duration
+        not_media = os.path.join(tmp_path, "notmedia.bin")
+        with open(not_media, "wb") as fp:
+            fp.write(b"this is not a media file")
+        assert misc.get_media_duration(not_media) is None
+        assert misc.get_media_duration(os.path.join(tmp_path, "does_not_exist.mkv")) is None
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Not Death Proof (2022) 1080p x264 (DD5.1) BE Subs.mkv",
+            "Proof.of.Everything.(2042).4320p.x266-4U.mkv",
+            "Crime_Scene_S01E13_Free_Sample_For_Sale_480p-OhDear.mp4",
+            "Sample That 2011 480p WEB-DL.H265-aMiGo.avi",
+        ],
+    )
+    def test_is_sample_long_media_not_a_sample(self, name, tmp_path, monkeypatch):
+        """Real content whose title contains 'sample'/'proof' must not be flagged as
+        a sample once the actual (long) media file is available on disk (#2083)."""
+        media_file = os.path.join(tmp_path, name)
+        self._write_wav(media_file, 2.0)
+        # Treat anything over 1s as "long" so the short test file counts as real content
+        monkeypatch.setattr(misc, "SAMPLE_MAX_DURATION", 1)
+        # The name alone still trips the detector...
+        assert misc.is_sample(name) is True
+        # ...but with the real (long) file on disk it is correctly kept
+        assert misc.is_sample(name, media_file) is False
+
+    def test_is_sample_short_media_still_a_sample(self, tmp_path):
+        """A genuinely short media file matching the sample pattern stays a sample"""
+        media_file = os.path.join(tmp_path, "Something.1080p.H264-EMRG-sample.avi")
+        self._write_wav(media_file, 2.0)
+        assert misc.is_sample(os.path.basename(media_file), media_file) is True
+
+    def test_is_sample_unanalysable_file_falls_back_to_name(self, tmp_path):
+        """When the file cannot be analysed, fall back to the name-based result"""
+        non_media = os.path.join(tmp_path, "file-sample.mkv")
+        with open(non_media, "wb") as fp:
+            fp.write(b"not really an mkv")
+        assert misc.is_sample("file-sample.mkv", non_media) is True
+        # A non-sample name is never a sample, regardless of the file on disk
+        assert misc.is_sample("regular-movie.mkv", non_media) is False
 
     @pytest.mark.parametrize(
         "test_input, expected_output",

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -503,22 +503,22 @@ class TestMisc:
         # The name alone still trips the detector...
         assert misc.is_sample(name) is True
         # ...but with the real (long) file on disk it is correctly kept
-        assert misc.is_sample(name, media_file) is False
+        assert misc.is_sample(media_file) is False
 
     def test_is_sample_short_media_still_a_sample(self, tmp_path):
         """A genuinely short media file matching the sample pattern stays a sample"""
         media_file = os.path.join(tmp_path, "Something.1080p.H264-EMRG-sample.avi")
         self._write_wav(media_file, 2.0)
-        assert misc.is_sample(os.path.basename(media_file), media_file) is True
+        assert misc.is_sample(media_file) is True
 
     def test_is_sample_unanalysable_file_falls_back_to_name(self, tmp_path):
         """When the file cannot be analysed, fall back to the name-based result"""
         non_media = os.path.join(tmp_path, "file-sample.mkv")
         with open(non_media, "wb") as fp:
             fp.write(b"not really an mkv")
-        assert misc.is_sample("file-sample.mkv", non_media) is True
+        assert misc.is_sample(non_media) is True
         # A non-sample name is never a sample, regardless of the file on disk
-        assert misc.is_sample("regular-movie.mkv", non_media) is False
+        assert misc.is_sample(os.path.join(tmp_path, "regular-movie.mkv")) is False
 
     @pytest.mark.parametrize(
         "test_input, expected_output",


### PR DESCRIPTION
Enhances the `is_sample()` logic to reduce false positives for files whose names contain "sample" or "proof" but are actually full-length content.

Integrates the `hachoir` library to parse media files and extract their duration. Files are only considered samples if their duration is less than or equal to `SAMPLE_MAX_DURATION` (default 2 minutes).

If media duration cannot be determined (e.g., not a media file or parsing fails), the detection falls back to the name-based approach.

Closes #2083