### PR TITLE
Improve Config search accessibility

### DIFF
--- a/interfaces/Config/templates/_inc_header_uc.tmpl
+++ b/interfaces/Config/templates/_inc_header_uc.tmpl
@@ -170,14 +170,14 @@
                     </a>
                 </li>
                 <li class="dropdown" id="search-menu">
-                    <a data-toggle="dropdown" href="#">
+                    <a data-toggle="dropdown" href="#" aria-label="$T('cmenu-search')" aria-controls="search-dropdown" aria-haspopup="true" aria-expanded="false">
                         <span class="glyphicon glyphicon-search"></span>
                         <strong><span class="glyphicon glyphicon-search"></span></strong>
                     </a>
                     <ul class="dropdown-menu" id="search-dropdown">
                         <li>
                             <form onsubmit="return false">
-                                <input type="text" name="config-search" id="search-box" placeholder="$T('cmenu-search')" onkeyup="doConfigSearch(this)">
+                                <input type="text" name="config-search" id="search-box" placeholder="$T('cmenu-search')" aria-label="$T('cmenu-search')" aria-controls="search-dropdown" onkeyup="doConfigSearch(this)">
                             </form>
                         </li>
                     </ul>

--- a/interfaces/Config/templates/staticcfg/js/script.js
+++ b/interfaces/Config/templates/staticcfg/js/script.js
@@ -501,6 +501,7 @@ var pagesContainer = new Array(arrPages.length);
 // Add trigger to focus on the field and load the results
 $(document).ready(function() {
     $('#search-menu').on('shown.bs.dropdown', function(event) {
+        setConfigSearchExpanded(true)
         // Focus so easy typing
         $('#search-box').focus()
         // Load things to search if we haven't yet
@@ -511,6 +512,45 @@ $(document).ready(function() {
                 });
             });
         }
+    }).on('hidden.bs.dropdown', function(event) {
+        setConfigSearchExpanded(false)
+    });
+
+    $('#search-box').on('keydown', function(event) {
+        var key = event.key || event.which;
+        var isArrowDown = key === 'ArrowDown' || key === 40;
+        var isArrowUp = key === 'ArrowUp' || key === 38;
+        var isEscape = key === 'Escape' || key === 'Esc' || key === 27;
+
+        if(isArrowDown || isArrowUp) {
+            event.preventDefault();
+            event.stopPropagation();
+            focusConfigSearchResult(isArrowDown ? 1 : -1)
+        } else if(isEscape) {
+            event.preventDefault();
+            event.stopPropagation();
+            closeConfigSearch()
+        }
+    });
+
+    $('#search-dropdown').on('keydown', 'a.config-search-result', function(event) {
+        var key = event.key || event.which;
+        var isArrowDown = key === 'ArrowDown' || key === 40;
+        var isArrowUp = key === 'ArrowUp' || key === 38;
+        var isEscape = key === 'Escape' || key === 'Esc' || key === 27;
+
+        if(isArrowDown || isArrowUp) {
+            event.preventDefault();
+            event.stopPropagation();
+            focusConfigSearchResult(isArrowDown ? 1 : -1)
+        } else if(isEscape) {
+            event.preventDefault();
+            event.stopPropagation();
+            closeConfigSearch()
+        }
+    }).on('mouseenter focus', 'a.config-search-result', function() {
+        getConfigSearchResults().parent().removeClass('active')
+        $(this).parent().addClass('active')
     });
 
     // For the scrolling
@@ -536,11 +576,46 @@ $(document).ready(function() {
 
 // Don't go too fast
 var searchTimeout
+
+function getConfigSearchResults() {
+    return $('#search-dropdown').find('a.config-search-result')
+}
+
+function setConfigSearchExpanded(expanded) {
+    $('#search-menu > a[data-toggle="dropdown"]').attr('aria-expanded', expanded ? 'true' : 'false')
+}
+
+function closeConfigSearch() {
+    $('#search-menu').removeClass('open')
+    setConfigSearchExpanded(false)
+    $('#search-box').focus()
+}
+
+function focusConfigSearchResult(offset) {
+    var $results = getConfigSearchResults()
+    var activeIndex = $results.index(document.activeElement)
+    var nextIndex
+
+    if(!$results.length) return
+
+    if(activeIndex < 0) {
+        nextIndex = offset > 0 ? 0 : $results.length - 1
+    } else {
+        nextIndex = activeIndex + offset
+        if(nextIndex >= $results.length) nextIndex = 0
+        if(nextIndex < 0) nextIndex = $results.length - 1
+    }
+
+    getConfigSearchResults().parent().removeClass('active')
+    $results.eq(nextIndex).parent().addClass('active')
+    $results.eq(nextIndex).focus()
+}
+
 function doConfigSearch(value) {
     // Cancel previous
     clearTimeout(searchTimeout)
     // Build new search
-    var searchTerm = $(value).val().replace('"', '\"')
+    var searchTerm = $.trim($(value).val())
     var searchOutput = $('#search-dropdown')
 
     // Build new search
@@ -551,14 +626,24 @@ function doConfigSearch(value) {
         if (searchTerm.length < 2) return
         // Find some results!
         $.each(pagesContainer, function(page_index, results) {
+            if(!results) return
             // Get the matches
-            var subResults = results.filter(':contains("'+searchTerm+'")')
+            var subResults = results.filter(function() {
+                return $(this).text().toUpperCase().indexOf(searchTerm.toUpperCase()) >= 0
+            })
             if(subResults.length > 0) {
                 // Add the section
-                searchOutput.append('<li class="divider"></li>')
-                searchOutput.append('<li class="dropdown-header">'+configTranslate.searchPages[page_index]+'</li>')
+                searchOutput.append($('<li class="divider"></li>'))
+                searchOutput.append($('<li class="dropdown-header"></li>').text(configTranslate.searchPages[page_index]))
                 $.each(subResults, function(index, result) {
-                    searchOutput.append('<li><a href="'+rootURL + 'config/' + arrPages[page_index] +  '/#' + $(result).attr('for') +'">'+$(result).text()+'</a></li>')
+                    var resultUrl = rootURL + 'config/' + arrPages[page_index] +  '/#' + $(result).attr('for')
+                    searchOutput.append(
+                        $('<li></li>').append(
+                            $('<a class="config-search-result"></a>')
+                                .attr('href', resultUrl)
+                                .text($(result).text())
+                        )
+                    )
                 })
             }
         })


### PR DESCRIPTION
This improves the Config search dropdown for keyboard and screen reader users.

What changed:
- Gives the icon-only search trigger and search field translated accessible names using the existing Search text.
- Keeps the dropdown expanded state in sync with the Bootstrap open and close events.
- Lets Arrow keys move from the search field into the generated results, and lets Escape close the dropdown from the search field or results.
- Builds search results with DOM helpers instead of inserting raw HTML strings.

Checked:
- git diff --check
- node --check interfaces/Config/templates/staticcfg/js/script.js
- Local Playwright harness for Config search keyboard behavior
- Local mobile and tablet viewport smoke checks for Config search