### PR TITLE
[Enhancement] Adding Search Bar to Queue

### DIFF
--- a/interfaces/Glitter/templates/include_queue.tmpl
+++ b/interfaces/Glitter/templates/include_queue.tmpl
@@ -55,6 +55,12 @@
                 <li><a href="#" data-action="sortSizeDesc" data-bind="click: queue.queueSorting">$T('Glitter-sortSizeDesc')</a></li>
             </ul>
         </div>
+        <div class="input-group search-box" data-bind="visible: queue.hasQueueSearch" style="display: none;">
+            <input type="text" class="form-control" placeholder="$T('Glitter-search')" required data-bind="textInput: queue.searchTerm, event: { keydown: queue.clearSearchTerm }" />
+            <a data-bind="event: { mousedown: queue.clearSearchTerm }">
+                <span class="glyphicon" data-bind="css: { 'glyphicon-search' : !queue.searchTerm(), 'glyphicon-remove' : queue.searchTerm() }"></span>
+            </a>
+        </div>
     </div>
     <div class="clearfix"></div>
     <table class="table table-striped table-hover queue-table">
@@ -228,13 +234,6 @@
         </div>
         <div class="clearfix"></div>
     </form>
-
-    <div class="input-group search-box" data-bind="visible: queue.hasQueueSearch" style="display: none;">
-        <input type="text" class="form-control" placeholder="$T('Glitter-search')" required data-bind="textInput: queue.searchTerm, event: { keydown: queue.clearSearchTerm }" />
-        <a data-bind="event: { mousedown: queue.clearSearchTerm }">
-            <span class="glyphicon" data-bind="css: { 'glyphicon-search' : !queue.searchTerm(), 'glyphicon-remove' : queue.searchTerm() }"></span>
-        </a>
-    </div>
 
     <ul class="pagination" data-bind="foreach: queue.pagination.allpages, visible: queue.pagination.hasPagination" style="display: none;">
         <li data-bind="css: { active: isCurrent, disabled: isDots }, click: onclick">

--- a/tests/test_nzbqueue.py
+++ b/tests/test_nzbqueue.py
@@ -149,6 +149,29 @@ class TestNzbQueue:
         # Try list restored
         assert sabnzbd.Downloader.servers[0] in next(iter(joba.files[0].articles)).try_list
 
+    def test_queue_info_search_filters_download_queue(self):
+        q = NzbQueue()
+
+        alpha = make_dummy_nzo("alpha")
+        alpha.final_name = "Alpha Release"
+        beta = make_dummy_nzo("beta")
+        beta.final_name = "Beta Release"
+
+        q.add(alpha)
+        q.add(beta)
+
+        _, _, _, queued_items, _, matched_items = q.queue_info(search="alpha")
+
+        assert matched_items == 1
+        assert len(queued_items) == 1
+        assert queued_items[0].final_name == "Alpha Release"
+
+        _, _, _, queued_items_casefold, _, matched_items_casefold = q.queue_info(search="ALPHA")
+
+        assert matched_items_casefold == 1
+        assert len(queued_items_casefold) == 1
+        assert queued_items_casefold[0].final_name == "Alpha Release"
+
     def test_stop_idle_jobs_no_crash_on_exhausted_articles(self):
         """Regression test: stop_idle_jobs must not raise RuntimeError when
         register_article removes an article from nzf.articles (a dict) while


### PR DESCRIPTION
Task:
- Add the ability to filter the queue in scenarios where you have queues longer than a few pages.

Purpose:
- The ability to see where something is in the queue.  Ease of finding so you could move it up or down in the overall list.

What Happens:
- There currently is no search or filter mechanism to understand what is where for longer queues.

What Should Happen
- When a user supplies a query param, it will be used to filter the existing queue to confirm it is in the list.  The desired end state exists the same, where you could move it to the top or bottom, or conduct all normal actions.