### PR TITLE
Fix test for flagging has_header_encryption after a failed password attempt

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1219,7 +1219,7 @@ class TestSABRarFile:
             with SABRarFile(os.path.join(test_dir, rar_file), part_only=True) as zf:
                 with expected:
                     zf.setpassword(password)
-                if zf._file_parser.has_header_encryption():
+                if zf._file_parser.has_header_encryption() and expected_correct:
                     assert zf.namelist()
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
https://github.com/markokr/rarfile/commit/e2c0d6ef2b4b35ea20e10a76613b2aa79cdf784e fixes this behaviour, so when there is next a release this test will fail.

Prior to that commit:

```py
with SABRarFile(...) as zf:
  # has_header_encryption() is True
  suppress(...):
    zf.setpassword("wrong")
  # has_header_encryption() is False - which is wrong
```
