### PR TITLE
Optimise scanning for orphan jobs and retry all

### DIFF
--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1930,8 +1930,8 @@ def build_header(webdir: str = "", for_template: bool = True, trans_functions: b
 
 
 def build_history(
-    start: int = 0,
-    limit: int = 1000000,
+    start: int,
+    limit: int,
     archive: bool = False,
     search: Optional[str] = None,
     categories: Optional[list[str]] = None,

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -868,11 +868,7 @@ def _api_rss_now(name: str, kwargs: ApiParams) -> bytes:
 
 def _api_retry_all(name: str, kwargs: ApiParams) -> bytes:
     """API: Retry all failed items in History"""
-    items = sabnzbd.api.build_history()[0]
-    nzo_ids = []
-    for item in items:
-        if item["retry"]:
-            nzo_ids.append(retry_job(item["nzo_id"]))
+    nzo_ids = [retry_job(job["nzo_id"]) for job in sabnzbd.get_db_connection().get_retryable_jobs()]
     return report(keyword="status", data=nzo_ids)
 
 

--- a/sabnzbd/database.py
+++ b/sabnzbd/database.py
@@ -443,6 +443,20 @@ class HistoryDB:
 
         return items, total_items
 
+    def get_retryable_jobs(self) -> list[dict[str, Any]]:
+        """Return the nzo_id and path of all history items that can be retried,
+        failed jobs whose incomplete folder still exists and failed URL-fetches
+        """
+        jobs = []
+        if self.execute(
+            "SELECT nzo_id, path, report FROM history WHERE archive IS NULL AND (status = ? OR report = 'future')",
+            (Status.FAILED,),
+        ):
+            for item in self.cursor:
+                if item["report"] == "future" or (item["path"] and os.path.exists(item["path"])):
+                    jobs.append({"nzo_id": item["nzo_id"], "path": item["path"]})
+        return jobs
+
     def have_duplicate_key(self, duplicate_key: str) -> bool:
         """Check whether History contains this duplicate key"""
         if self.execute(

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -33,6 +33,7 @@ from sabnzbd.filesystem import get_admin_path, remove_all, globber_full, remove_
 from sabnzbd.nzbparser import process_single_nzb
 from sabnzbd.panic import panic_queue
 from sabnzbd.decorators import NzbQueueLocker
+from sabnzbd.database import HistoryDB
 from sabnzbd.constants import (
     QUEUE_FILE_NAME,
     QUEUE_VERSION,
@@ -144,20 +145,16 @@ class NzbQueue:
         result = []
         # Folders from the download queue
         if all_jobs:
-            registered = []
+            registered = set()
         else:
-            registered = [nzo.work_name for nzo in self.__nzo_list]
+            registered = {nzo.work_name for nzo in self.__nzo_list}
 
         # Retryable folders from History
-        items = sabnzbd.api.build_history()[0]
-        # Anything waiting or active or retryable is a known item
-        registered.extend(
-            [
-                os.path.basename(item["path"])
-                for item in items
-                if item["retry"] or item["loaded"] or item["status"] == Status.QUEUED
-            ]
-        )
+        with HistoryDB() as history_db:
+            registered.update(os.path.basename(job["path"]) for job in history_db.get_retryable_jobs())
+
+        # Anything waiting or active in post-processing is also a known item
+        registered.update(os.path.basename(nzo.download_path) for nzo in sabnzbd.PostProcessor.get_queue())
 
         # Repair unregistered folders
         for folder in globber_full(cfg.download_dir.get_path()):

--- a/tests/test_nzbqueue.py
+++ b/tests/test_nzbqueue.py
@@ -25,16 +25,24 @@ import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Optional
+from unittest import mock
 
 import pytest
 
 import sabnzbd
-from sabnzbd.constants import NORMAL_PRIORITY, JOB_ADMIN, ONDISK_VERSION, ONDISK_FILE, RENAMES_FILE
+from sabnzbd.constants import NORMAL_PRIORITY, JOB_ADMIN, ONDISK_VERSION, ONDISK_FILE, RENAMES_FILE, Status
+from sabnzbd.database import HistoryDB
 from sabnzbd.downloader import Server
 from sabnzbd.filesystem import save_compressed, save_data
 from sabnzbd.nzb import NzbFile, NzbObject
 from sabnzbd.nzbqueue import NzbQueue
-from tests.testhelper import SAB_DATA_DIR, SAB_NEWSSERVER_HOST, SAB_NEWSSERVER_PORT, create_and_read_nzb_fp
+from tests.testhelper import (
+    FakeHistoryDB,
+    SAB_DATA_DIR,
+    SAB_NEWSSERVER_HOST,
+    SAB_NEWSSERVER_PORT,
+    create_and_read_nzb_fp,
+)
 
 
 @pytest.fixture()
@@ -92,6 +100,31 @@ def make_dummy_nzo(name: str, priority: int = NORMAL_PRIORITY, files: int = 50, 
         for file in range(files)
     ]
 
+    return nzo
+
+
+def make_dummy_postproc_nzo(name: str, download_path: str, status: str = Status.QUEUED, pp_active: bool = False):
+    """Mock NzbObject in the post-processing queue, with all the attributes
+    add_active_history() needs so it can pass through build_history()"""
+    nzo = mock.Mock()
+    nzo.nzo_id = f"SABnzbd_nzo_{name}"
+    nzo.final_name = name
+    nzo.filename = f"{name}.nzb"
+    nzo.cat = "*"
+    nzo.script = "none"
+    nzo.url = ""
+    nzo.status = status
+    nzo.pp_active = pp_active
+    nzo.repair = nzo.unpack = nzo.delete = True
+    nzo.nzo_info = {}
+    nzo.unpack_info = {}
+    nzo.bytes_downloaded = 1024
+    nzo.fail_msg = ""
+    nzo.correct_password = ""
+    nzo.action_line = ""
+    nzo.duplicate_key = ""
+    nzo.time_added = 0
+    nzo.download_path = download_path
     return nzo
 
 
@@ -260,3 +293,56 @@ class TestNzbQueue:
         # renamed.rar is on disk, but it has missing articles
         assert nzo.files
         assert not nzo.finished_files
+
+    def test_scan_jobs_known_jobs(self, mocker, monkeypatch, tmp_path):
+        """Folders belonging to jobs in the download queue, the post-processing
+        queue, or retryable from History must not be treated as orphans.
+        Anything else in the incomplete folder is an orphan."""
+        monkeypatch.setattr(HistoryDB, "db_path", str(tmp_path / "history1.db"))
+        monkeypatch.setattr(HistoryDB, "startup_done", False)
+
+        def make_job_folder(name: str) -> str:
+            path = os.path.join(sabnzbd.cfg.download_dir.get_path(), name)
+            os.makedirs(path, exist_ok=True)
+            return path
+
+        # Job in the download queue
+        queued_nzo = make_dummy_nzo("queued", files=1, articles=1)
+        sabnzbd.NzbQueue.add(queued_nzo, save=False)
+        make_job_folder(queued_nzo.work_name)
+
+        # Job waiting in the post-processing queue
+        postproc_path = make_job_folder("job-postproc")
+        pp_nzo = make_dummy_postproc_nzo("job-postproc", postproc_path)
+        mocker.patch.object(sabnzbd, "PostProcessor", create=True)
+        sabnzbd.PostProcessor.get_queue.return_value = [pp_nzo]
+
+        with FakeHistoryDB(str(tmp_path / "history1.db")) as history_db:
+            # The postproc job is also already in the history database, which briefly happens at the end of post-processing
+            history_db.add_fake_history_job("job-postproc", Status.COMPLETED, path=postproc_path)
+            # Failed job with the incomplete folder still on disk: retryable
+            history_db.add_fake_history_job("job-failed", Status.FAILED, path=make_job_folder("job-failed"))
+            # Failed job whose recorded incomplete folder no longer exists is not retryable, so a same-named folder is an orphan
+            make_job_folder("job-gone")
+            history_db.add_fake_history_job("job-gone", Status.FAILED, path=str(tmp_path / "elsewhere" / "job-gone"))
+            # A failed URL-fetch (report = 'future') is always retryable, regardless of status or whether the folder exists
+            history_db.add_fake_history_job(
+                "job-future", Status.COMPLETED, path=make_job_folder("job-future"), futuretype=True
+            )
+            # Completed job: its folder should no longer exist, so treat leftovers as orphans
+            history_db.add_fake_history_job("job-completed", Status.COMPLETED, path=make_job_folder("job-completed"))
+            # Archived jobs are not visible to queue repair, even when they would
+            # otherwise be retryable, so the folder is treated as an orphan
+            history_db.add_fake_history_job(
+                "job-archived", Status.FAILED, path=make_job_folder("job-archived"), archive=True
+            )
+
+        # Folder not known anywhere
+        make_job_folder("job-orphan")
+
+        orphans = sabnzbd.NzbQueue.scan_jobs(action=False)
+        assert sorted(orphans) == ["job-archived", "job-completed", "job-gone", "job-orphan"]
+
+        # With all_jobs=True the download queue itself is not considered registered
+        orphans_all = sabnzbd.NzbQueue.scan_jobs(all_jobs=True, action=False)
+        assert queued_nzo.work_name in orphans_all

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -316,49 +316,66 @@ class FakeHistoryDB(db.HistoryDB):
         db.HistoryDB.db_path = db_path
         super().__init__()
 
+    def add_fake_history_job(
+        self,
+        name: str,
+        status: str = Status.COMPLETED,
+        category: str = "*",
+        password: str = "",
+        path: Optional[str] = None,
+        futuretype: bool = False,
+        archive: bool = False,
+        completed: Optional[float] = None,
+    ) -> str:
+        """Add a single history entry, with random values for anything not specified"""
+        nzo = mock.Mock()
+
+        nzo.password = password
+        nzo.correct_password = "secret"
+        nzo.final_name = name
+        nzo.filename = "%s%s.nzb" % (name, "{{" + password + "}}" if password else "")
+        nzo.cat = category
+        nzo.script = "placeholder_script"
+        nzo.url = "placeholder_url"
+        nzo.status = status
+        nzo.fail_msg = "Failure" if status == Status.FAILED else ""
+        nzo.nzo_id = str(uuid.uuid4())
+        nzo.bytes_downloaded = randint(1024, 1024**4)
+        nzo.md5sum = "".join(choice("abcdef" + digits) for i in range(32))
+        nzo.repair, nzo.unpack, nzo.delete = pp_to_opts(choice(list(PP_LOOKUP.keys())))  # for "pp"
+        nzo.nzo_info = {"download_time": randint(1, 10**4)}
+        nzo.unpack_info = {"unpack_info": "placeholder unpack_info line\r\n" * 3}
+        nzo.duplicate_key = "show/season/episode"
+        nzo.time_added = int(time.time())
+        nzo.futuretype = futuretype  # for "report", only True when fetching an URL
+        if path is None:
+            path = os.path.join(os.path.dirname(db.HistoryDB.db_path), "placeholder_downpath")
+        nzo.download_path = path
+
+        # Mock time when calling add_history_db() to randomize completion times
+        almost_time = mock.Mock(return_value=completed if completed is not None else time.time() - randint(0, 10**8))
+        with mock.patch("time.time", almost_time):
+            self.add_history_db(
+                nzo,
+                storage=os.path.join(os.path.dirname(db.HistoryDB.db_path), "placeholder_workdir"),
+                postproc_time=randint(1, 10**3),
+                script_output="",
+                script_line="",
+            )
+        if archive:
+            self.archive(nzo.nzo_id)
+
+        return nzo.nzo_id
+
     def add_fake_history_jobs(self, number_of_entries=1):
         """Generate a history db with any number of fake entries"""
-
         for _ in range(0, number_of_entries):
-            nzo = mock.Mock()
-
-            # Mock all input build_history_info() needs
-            distro_choice = choice(self.distro_names)
-            distro_random = random_name()
-            nzo.password = choice(["secret", ""])
-            nzo.correct_password = "secret"
-            nzo.final_name = "%s.%s.Linux.ISO-Usenet" % (distro_choice, distro_random)
-            nzo.filename = "%s.%s.Linux-Usenet%s.nzb" % (
-                (distro_choice, distro_random, "{{" + nzo.password + "}}")
-                if nzo.password
-                else (distro_choice, distro_random, "")
+            self.add_fake_history_job(
+                name="%s.%s.Linux.ISO-Usenet" % (choice(self.distro_names), random_name()),
+                status=choice([Status.COMPLETED, choice(self.status_options)]),
+                category=choice(self.category_options),
+                password=choice(["secret", ""]),
             )
-            nzo.cat = choice(self.category_options)
-            nzo.script = "placeholder_script"
-            nzo.url = "placeholder_url"
-            nzo.status = choice([Status.COMPLETED, choice(self.status_options)])
-            nzo.fail_msg = "¡Fracaso absoluto!" if nzo.status == Status.FAILED else ""
-            nzo.nzo_id = str(uuid.uuid4())
-            nzo.bytes_downloaded = randint(1024, 1024**4)
-            nzo.md5sum = "".join(choice("abcdef" + digits) for i in range(32))
-            nzo.repair, nzo.unpack, nzo.delete = pp_to_opts(choice(list(PP_LOOKUP.keys())))  # for "pp"
-            nzo.nzo_info = {"download_time": randint(1, 10**4)}
-            nzo.unpack_info = {"unpack_info": "placeholder unpack_info line\r\n" * 3}
-            nzo.duplicate_key = "show/season/episode"
-            nzo.time_added = int(time.time())
-            nzo.futuretype = False  # for "report", only True when fetching an URL
-            nzo.download_path = os.path.join(os.path.dirname(db.HistoryDB.db_path), "placeholder_downpath")
-
-            # Mock time when calling add_history_db() to randomize completion times
-            almost_time = mock.Mock(return_value=time.time() - randint(0, 10**8))
-            with mock.patch("time.time", almost_time):
-                self.add_history_db(
-                    nzo,
-                    storage=os.path.join(os.path.dirname(db.HistoryDB.db_path), "placeholder_workdir"),
-                    postproc_time=randint(1, 10**3),
-                    script_output="",
-                    script_line="",
-                )
 
 
 @pytest.mark.usefixtures("run_sabnzbd", "run_sabnews_and_selenium")


### PR DESCRIPTION
Fixes #3484 - n.b. I might make separate improvements to `build_history` but this PR address the issue that `scan_jobs` and `api_retry_all` load the whole database into memory and prepare all the columns for use.

`sabnzbd.api.build_history()[0]` grabs all history regardless of status with a limit of 1,000,000 records so effectively all.

It filters the history in Python with `if item["retry"] or item["loaded"] or item["status"] == Status.QUEUED`

- **retry:** only True when status = Status.Failed and path exists or report == "future"
- **loaded:** always False for DB rows, set to True when postproc starts
- **status = Status.QUEUED:** waiting to download or postproc

We can reduce how many records and columns we need to select for scan_jobs.
Registered / known paths that are not eligible for repair:

- All active items in the nzbqueue (unchanged)
- `get_retryable_jobs()` not archived and (status = 'Failed' OR report = 'future'), future or with a path that exists
- All items in postproc queue - note duplicates in pp and history do not matter

`_api_retry_all` retries anything in `get_retryable_jobs()`

The test ran without this PR also passes, so I don't think the behaviour has changed but `scan_jobs` is tested more than `_api_retry_all`

---

A few things of note:

`FakeHistoryDB` adds to history database with impossible statuses, history only stores completed and failed but it also adds records with statuses that only exist in nzbqueue or postproc. I haven't changed it because some tests appear to actually rely on this.

`build_history` start and limit are now required, removed the 1,000,000 default. It is now only used from `_api_history_default` which always provides start/limit even if 0. It might be useful to document that limit=0 means postproc only. As mentioned previously I may look at this some other time, perhaps taking the prepending of postproc out of build_history and/or simpler handling of duplicates in postproc and history.