### PR TITLE
Remove unwanted extensions in postproc

### DIFF
--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -74,6 +74,7 @@ from sabnzbd.filesystem import (
     get_unique_filename,
     get_ext,
     get_filename,
+    has_unwanted_extension,
 )
 from sabnzbd.nzb import NzbObject
 from sabnzbd.sorting import Sorter
@@ -499,6 +500,9 @@ def process_job(nzo: NzbObject) -> bool:
 
                 # Sanitize the resulting files
                 newfiles = sanitize_files(filelist=newfiles)
+
+                # Check unpacked files for unwanted extensions, the download-time check can miss files hidden inside archives
+                newfiles = remove_unwanted_files(nzo, newfiles, tmp_workdir_complete)
                 logging.info("Finished unpack_magic on %s", filename)
 
             if cfg.safe_postproc():
@@ -1161,6 +1165,40 @@ def cleanup_list(filelist: list[str], base_dir: str, skip_nzb: bool) -> list[str
                 logging.error(T("Removing %s failed"), clip_path(path))
                 logging.info("Traceback: ", exc_info=True)
         remaining_files.append(path)
+
+    # Remove the directories the removed files left behind, if they are now empty
+    remove_empty_parent_directories(base_dir, removed_files)
+    return remaining_files
+
+
+def remove_unwanted_files(nzo: NzbObject, filelist: list[str], base_dir: str) -> list[str]:
+    """Remove all files of the job that match the unwanted extensions.
+    The download-time check can be bypassed, for example by files
+    hidden inside nested archives, or within PAR2 repair data,
+    so the files produced by unpacking are verified again.
+    Only the tracked files are considered, so files of other jobs
+    in a shared folder are left alone. Returns the remaining files.
+    """
+    # Skip if not configured or after an explicit user override of the unwanted extension pause
+    if not cfg.unwanted_extensions() or not cfg.action_on_unwanted_extensions() or nzo.unwanted_ext == 2:
+        return filelist
+
+    remaining_files = []
+    removed_files = []
+    for path in filelist:
+        if os.path.isfile(path) and has_unwanted_extension(get_filename(path)):
+            try:
+                logging.info("Removing unwanted file %s", path)
+                remove_file(path)
+                removed_files.append(path)
+                continue
+            except Exception:
+                logging.error(T("Removing %s failed"), clip_path(path))
+                logging.info("Traceback: ", exc_info=True)
+        remaining_files.append(path)
+
+    if removed_files:
+        nzo.set_unpack_info("Unpack", T("Removed %s files with unwanted extensions") % len(removed_files))
 
     # Remove the directories the removed files left behind, if they are now empty
     remove_empty_parent_directories(base_dir, removed_files)

--- a/tests/test_postproc.py
+++ b/tests/test_postproc.py
@@ -340,6 +340,97 @@ class TestCleanupList:
         assert os.path.exists(job_files[0])
 
 
+@pytest.mark.usefixtures("clean_cache_dir")
+class TestRemoveUnwantedFiles:
+    @staticmethod
+    def _create_file(path):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "wb") as f:
+            f.write(b"data")
+        assert os.path.exists(path)
+        return path
+
+    @staticmethod
+    def _fake_nzo(unwanted_ext=0):
+        fake_nzo = mock.Mock()
+        fake_nzo.final_name = "TestDownload"
+        fake_nzo.unwanted_ext = unwanted_ext
+        return fake_nzo
+
+    @pytest.mark.config({"unwanted_extensions": ["exe"], "action_on_unwanted_extensions": 2})
+    def test_remove_unwanted_files_only_tracked_files(self):
+        """Only files of the job may be removed, not other files in the same folder"""
+        base_dir = os.path.join(SAB_CACHE_DIR, "complete_unwanted")
+        job_files = [self._create_file(os.path.join(base_dir, f)) for f in ("job.mkv", "job.exe")]
+        # File matching the unwanted extensions, but not part of the job
+        unrelated_file = self._create_file(os.path.join(base_dir, "MyApplication", "fake.exe"))
+        # Tracked files that no longer exist shouldn't cause problems
+        gone_file = os.path.join(base_dir, "gone.exe")
+        fake_nzo = self._fake_nzo()
+
+        remaining_files = postproc.remove_unwanted_files(fake_nzo, [*job_files, gone_file], base_dir)
+
+        assert remaining_files == [job_files[0], gone_file]
+        assert os.path.exists(job_files[0])
+        assert not os.path.exists(job_files[1])
+        assert os.path.exists(unrelated_file)
+        fake_nzo.set_unpack_info.assert_called_once()
+
+    @pytest.mark.config({"unwanted_extensions": ["exe"], "action_on_unwanted_extensions": 1})
+    def test_remove_unwanted_files_removes_empty_parent_dirs(self):
+        """Directories left empty by the removed files are pruned, but never the base directory"""
+        base_dir = os.path.join(SAB_CACHE_DIR, "complete_unwanted")
+        job_file = self._create_file(os.path.join(base_dir, "sub", "deeper", "job.exe"))
+
+        assert postproc.remove_unwanted_files(self._fake_nzo(), [job_file], base_dir) == []
+        assert not os.path.exists(os.path.join(base_dir, "sub"))
+        assert os.path.exists(base_dir)
+
+    @pytest.mark.config(
+        {"unwanted_extensions": ["mkv", "srt"], "unwanted_extensions_mode": 1, "action_on_unwanted_extensions": 2}
+    )
+    def test_remove_unwanted_files_whitelist_mode(self):
+        """In whitelist mode anything not listed is removed, except files without extension"""
+        base_dir = os.path.join(SAB_CACHE_DIR, "complete_unwanted")
+        job_files = [self._create_file(os.path.join(base_dir, f)) for f in ("job.mkv", "job.exe", "no_extension")]
+
+        remaining_files = postproc.remove_unwanted_files(self._fake_nzo(), job_files, base_dir)
+
+        assert remaining_files == [job_files[0], job_files[2]]
+        assert os.path.exists(job_files[0])
+        assert not os.path.exists(job_files[1])
+        assert os.path.exists(job_files[2])
+
+    @pytest.mark.config({"unwanted_extensions": ["exe"], "action_on_unwanted_extensions": 0})
+    def test_remove_unwanted_files_no_action_configured(self):
+        """Without an action configured, nothing is removed"""
+        base_dir = os.path.join(SAB_CACHE_DIR, "complete_unwanted")
+        job_files = [self._create_file(os.path.join(base_dir, "job.exe"))]
+        fake_nzo = self._fake_nzo()
+
+        assert postproc.remove_unwanted_files(fake_nzo, job_files, base_dir) == job_files
+        assert os.path.exists(job_files[0])
+        fake_nzo.set_unpack_info.assert_not_called()
+
+    @pytest.mark.config({"unwanted_extensions": [], "action_on_unwanted_extensions": 2})
+    def test_remove_unwanted_files_no_extensions_configured(self):
+        """Without unwanted extensions configured, nothing is removed"""
+        base_dir = os.path.join(SAB_CACHE_DIR, "complete_unwanted")
+        job_files = [self._create_file(os.path.join(base_dir, "job.exe"))]
+
+        assert postproc.remove_unwanted_files(self._fake_nzo(), job_files, base_dir) == job_files
+        assert os.path.exists(job_files[0])
+
+    @pytest.mark.config({"unwanted_extensions": ["exe"], "action_on_unwanted_extensions": 2})
+    def test_remove_unwanted_files_user_override(self):
+        """Skip the check after the user resumed a job paused for an unwanted extension"""
+        base_dir = os.path.join(SAB_CACHE_DIR, "complete_unwanted")
+        job_files = [self._create_file(os.path.join(base_dir, "job.exe"))]
+
+        assert postproc.remove_unwanted_files(self._fake_nzo(unwanted_ext=2), job_files, base_dir) == job_files
+        assert os.path.exists(job_files[0])
+
+
 class TestNzbOnlyDownload:
     @mock.patch("sabnzbd.postproc.process_single_nzb")
     @mock.patch("sabnzbd.postproc.listdir_full")


### PR DESCRIPTION
Fixes #3361

The recent file tracking changes make this a lot simpler and the code for the cleanup is very similar to `cleanup_list`.

The reason for this is unwanted extensions and cleanup list serve similar but different purposes.
unwanted extensions is supposed to pause or abort downloads that trigger
cleanup is just remove files you not interested in without pausing or aborting the download

The current experience is users believe they can set unwanted extensions [TRaSH Guides: Prevent unwanted
extensions](https://trash-guides.info/Downloaders/SABnzbd/Basic-Setup/?h=extensions#prevent-unwanted-extensions) and they are more secure because such files wont end up in completed.
This is not quite true, malicious NZBs can be crafted that hide bad files in nested archives or PAR2 data that the download check misses.

My fix proposal is if unwanted extensions is enabled, didn't intervene during the download but such files ended up in the completed directory them delete them.

Note cleanup runs when action_on_unwanted_extensions is Pause or Abort, but since this is after download deletion is the only sensible action.