### PR TITLE
Restore keyboard access to queue row actions

### DIFF
--- a/interfaces/Glitter/templates/static/stylesheets/glitter.css
+++ b/interfaces/Glitter/templates/static/stylesheets/glitter.css
@@ -685,8 +685,15 @@ td.name .row-wrap-text {
     height: 1.5em;
 }
 
-.queue-table td.name .name-options,
-.queue-table td.name:hover .queue-item-password {
+.queue-table td.name .name-options {
+    display: block;
+    opacity: 0;
+    pointer-events: none;
+    position: absolute;
+}
+
+.queue-table td.name:hover .queue-item-password,
+.queue-table td.name:focus-within .queue-item-password {
     display: none;
 }
 
@@ -704,20 +711,27 @@ td.name .row-wrap-text {
     max-width: calc(100% - 75px);
 }
 
-.queue-table td.name:hover .row-wrap-text {
+.queue-table td.name:hover .row-wrap-text,
+.queue-table td.name:focus-within .row-wrap-text {
     max-width: calc(100% - 125px);
     /* Change for each size! */
 }
 
-.queue-table td.name:hover .direct-unpack {
+.queue-table td.name:hover .direct-unpack,
+.queue-table td.name:focus-within .direct-unpack {
     display: none;
 }
 
-.queue-table td.name:hover .name-options {
+.queue-table td.name:hover .name-options,
+.queue-table td.name:focus-within .name-options {
     display: block;
+    opacity: 1;
+    pointer-events: auto;
+    position: static;
 }
 
-.queue-table td.name:hover .glyphicon-folder-open {
+.queue-table td.name:hover .glyphicon-folder-open,
+.queue-table td.name:focus-within .glyphicon-folder-open {
     width: 1.5em;
     margin-left: 1px;
 }

--- a/interfaces/Glitter/templates/static/stylesheets/glitter.mobile.css
+++ b/interfaces/Glitter/templates/static/stylesheets/glitter.mobile.css
@@ -151,6 +151,7 @@ tr.queue-item>td:first-child>a {
     display: inline-block;
     opacity: 1;
     pointer-events: auto;
+    position: static;
 }
 
 .queue-table td.name .name-options small {


### PR DESCRIPTION
This follows up on #3477 and the queue display changes made afterward.

The row action buttons work with a mouse again, but they are completely hidden until the row is hovered. This prevents keyboard and screen reader users from reaching the move, rename, and details actions.

This change keeps the existing mouse behavior while making those actions reachable again. The buttons appear when the row is hovered or when a keyboard user moves focus to them, and the mobile layout remains unchanged.

I confirmed that the actions have clear screen reader labels, appear when focused, remain clickable, and do not change the height of the queue row.