### PR TITLE
Improve Glitter history row accessibility

### DIFF
--- a/interfaces/Glitter/templates/include_history.tmpl
+++ b/interfaces/Glitter/templates/include_history.tmpl
@@ -1,7 +1,7 @@
 <div class="history" id="history-tab">
     <div class="history-header">
         <h2>$T('menu-history') <small data-bind="visible: history.showArchive()">($T('archive'))</small></h2>
-        <a href="#" data-bind="click: history.showMultiEdit, visible: hasHistory()">
+        <a href="#" aria-label="$T('Glitter-multiOperations')" data-bind="click: history.showMultiEdit, visible: hasHistory()">
             <span class="glyphicon glyphicon-tasks" data-tooltip="true" data-placement="left" title="$T('Glitter-multiOperations')"></span>
         </a>
     </div>
@@ -45,12 +45,12 @@
                         <span class="glyphicon glyphicon-ok"></span>
                     </div>
                     <div data-bind="visible: failed() && canRetry()">
-                        <a class="retry-button" href="#" data-bind="click: retry">
+                        <a class="retry-button" href="#" aria-label="$T('button-retry')" data-bind="click: retry">
                             <span class="glyphicon glyphicon-exclamation-sign"></span>
                         </a>
                     </div>
                     <div data-bind="visible: failed() && !canRetry()">
-                        <span class="retry-button-inactive">
+                        <span class="retry-button-inactive" role="img" aria-label="$T('post-Failed')">
                             <span class="glyphicon glyphicon-exclamation-sign"></span>
                         </span>
                     </div>
@@ -70,10 +70,10 @@
                 <td class="history-completedon row-wrap-text" data-bind="text: completedOn(), attr: { 'data-timestamp': completed }" onclick="showDetails(this)"></td>
                 <td class="delete">
                     <label data-bind="visible: parent.isMultiEditing()">
-                        <input type="checkbox" name="multiedit" title="$T('Glitter-multiSelect')" data-bind="click: parent.addMultiEdit, attr: { 'id': 'multiedit_' + id } " />
+                        <input type="checkbox" name="multiedit" title="$T('Glitter-multiSelect')" aria-label="$T('Glitter-selectJob')" data-bind="click: parent.addMultiEdit, attr: { 'id': 'multiedit_' + id } " />
                     </label>
                     <div class="dropdown" data-bind="visible: !parent.isMultiEditing()">
-                        <a href="#" data-toggle="dropdown" data-bind="click: updateAllHistoryInfo">
+                        <a href="#" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="$T('nzoDetails')" data-bind="click: updateAllHistoryInfo">
                             <span class="caret"></span>
                         </a>
                         <!-- ko if: hasDropdown() -->
@@ -124,7 +124,7 @@
                         </div>
                         <!-- /ko -->
                     </div>
-                    <a href="#" data-bind="click: parent.triggerRemoveDownload">
+                    <a href="#" data-bind="click: parent.triggerRemoveDownload, attr: { 'aria-label': processingDownload() == 2 ? '$T('abort')' : '$T('nzo-delete')' }">
                         <span class="hover-button glyphicon glyphicon-trash" data-bind="css: { 'glyphicon-stop' : processingDownload() == 2, disabled : processingDownload() == 1 }, attr: { title: processingDownload() == 2 ? '$T('abort')' : '$T('nzo-delete')' }"></span>
                     </a>
                 </td>


### PR DESCRIPTION
Several icon-only controls in the Glitter History table currently depend on visual tooltips for their meaning.

This adds translated accessible names to the multi-operation, retry, selection, details, and remove controls. The remove control continues to switch directly between the existing Delete and Abort translations when its action changes.

The unavailable retry indicator is also identified as a failed status for screen readers. This does not change the History layout or styling.