### PR TITLE
Improve Glitter search and pagination accessibility

### DIFF
--- a/interfaces/Glitter/templates/include_history.tmpl
+++ b/interfaces/Glitter/templates/include_history.tmpl
@@ -135,15 +135,20 @@
     <div class="history-footer">
 
     <div class="input-group search-box">
-        <input type="text" class="form-control" placeholder="$T('Glitter-search')" required data-bind="textInput: history.searchTerm, event: { keydown: history.clearSearchTerm }" />
-        <a data-bind="event: { mousedown: history.clearSearchTerm }">
+        <input type="text" class="form-control" placeholder="$T('Glitter-search')" aria-label="$T('Glitter-search')" required data-bind="textInput: history.searchTerm, event: { keydown: history.clearSearchTerm }" />
+        <a href="#" data-bind="click: history.clearSearchTerm, attr: { 'aria-label': history.searchTerm() ? '$T('Glitter-clearSearch')' : '$T('Glitter-search')' }">
             <span class="glyphicon" data-bind="css: { 'glyphicon-search' : !history.searchTerm(), 'glyphicon-remove' : history.searchTerm() }"></span>
         </a>
     </div>
 
     <ul class="pagination" data-bind="foreach: history.pagination.allpages(), visible: history.pagination.hasPagination" style="display: none;">
-        <li data-bind="css: { active: isCurrent, disabled: isDots }, click: onclick">
-            <span data-bind="text: page"></span>
+        <li data-bind="css: { active: isCurrent, disabled: isDots }">
+            <!-- ko ifnot: isDots -->
+            <a href="#" data-bind="text: page, click: onclick, attr: { 'aria-current': isCurrent ? 'page' : null }"></a>
+            <!-- /ko -->
+            <!-- ko if: isDots -->
+            <span aria-hidden="true" data-bind="text: page"></span>
+            <!-- /ko -->
         </li>
     </ul>
 

--- a/interfaces/Glitter/templates/include_queue.tmpl
+++ b/interfaces/Glitter/templates/include_queue.tmpl
@@ -230,15 +230,20 @@
     </form>
 
     <div class="input-group search-box" data-bind="visible: queue.hasQueueSearch" style="display: none;">
-        <input type="text" class="form-control" placeholder="$T('Glitter-search')" required data-bind="textInput: queue.searchTerm, event: { keydown: queue.clearSearchTerm }" />
-        <a data-bind="event: { mousedown: queue.clearSearchTerm }">
+        <input type="text" class="form-control" placeholder="$T('Glitter-search')" aria-label="$T('Glitter-search')" required data-bind="textInput: queue.searchTerm, event: { keydown: queue.clearSearchTerm }" />
+        <a href="#" data-bind="click: queue.clearSearchTerm, attr: { 'aria-label': queue.searchTerm() ? '$T('Glitter-clearSearch')' : '$T('Glitter-search')' }">
             <span class="glyphicon" data-bind="css: { 'glyphicon-search' : !queue.searchTerm(), 'glyphicon-remove' : queue.searchTerm() }"></span>
         </a>
     </div>
 
     <ul class="pagination" data-bind="foreach: queue.pagination.allpages, visible: queue.pagination.hasPagination" style="display: none;">
-        <li data-bind="css: { active: isCurrent, disabled: isDots }, click: onclick">
-            <span data-bind="text: page"></span>
+        <li data-bind="css: { active: isCurrent, disabled: isDots }">
+            <!-- ko ifnot: isDots -->
+            <a href="#" data-bind="text: page, click: onclick, attr: { 'aria-current': isCurrent ? 'page' : null }"></a>
+            <!-- /ko -->
+            <!-- ko if: isDots -->
+            <span aria-hidden="true" data-bind="text: page"></span>
+            <!-- /ko -->
         </li>
     </ul>
 

--- a/interfaces/Glitter/templates/static/javascripts/glitter.history.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.history.js
@@ -184,15 +184,15 @@ function HistoryListModel(parent) {
     // Clear searchterm
     self.clearSearchTerm = function(data, event) {
         // Was it escape key or click?
-        if(event.type === 'mousedown' || (event.keyCode && event.keyCode === 27)) {
+        if(event.type === 'click' || (event.keyCode && event.keyCode === 27)) {
             // Set the loader so it doesn't flicker and then switch
             self.isLoading(true)
             self.searchTerm('');
         }
         // Was it click and the field is empty? Then we focus on the field
-        if(event.type === 'mousedown' && self.searchTerm() === '') {
+        if(event.type === 'click' && self.searchTerm() === '') {
             $(event.target).parents('.search-box').find('input[type="text"]').focus()
-            return;
+            return false;
         }
         // Need to return true to allow typing
         return true;

--- a/interfaces/Glitter/templates/static/javascripts/glitter.main.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.main.js
@@ -1236,41 +1236,41 @@ function ViewModel() {
         });
         $(document).bind('keydown', 'shift+left', function(e) {
             if($("body").hasClass("container-tabbed")) {
-                $('#history-tab.active > ul.pagination li.active').prev().click();
-                $('#queue-tab.active > ul.pagination li.active').prev().click();
+                $('#history-tab.active > ul.pagination li.active').prev().children('a').click();
+                $('#queue-tab.active > ul.pagination li.active').prev().children('a').click();
             } else {
-                $('#history-tab > ul.pagination li.active').prev().click();
-                $('#queue-tab > ul.pagination li.active').prev().click();
+                $('#history-tab > ul.pagination li.active').prev().children('a').click();
+                $('#queue-tab > ul.pagination li.active').prev().children('a').click();
             }
             e.preventDefault();
         });
         $(document).bind('keydown', 'shift+right', function(e) {
             if($("body").hasClass("container-tabbed")) {
-                $('#history-tab.active > ul.pagination li.active').next().click();
-                $('#queue-tab.active > ul.pagination li.active').next().click();
+                $('#history-tab.active > ul.pagination li.active').next().children('a').click();
+                $('#queue-tab.active > ul.pagination li.active').next().children('a').click();
             } else {
-                $('#history-tab > ul.pagination li.active').next().click();
-                $('#queue-tab > ul.pagination li.active').next().click();
+                $('#history-tab > ul.pagination li.active').next().children('a').click();
+                $('#queue-tab > ul.pagination li.active').next().children('a').click();
             }
             e.preventDefault();
         });
         $(document).bind('keydown', 'shift+up', function(e) {
             if($("body").hasClass("container-tabbed")) {
-                $('#history-tab.active > ul.pagination li').first().click();
-                $('#queue-tab.active > ul.pagination li').first().click();
+                $('#history-tab.active > ul.pagination li').first().children('a').click();
+                $('#queue-tab.active > ul.pagination li').first().children('a').click();
             } else {
-                $('#history-tab > ul.pagination li').first().click();
-                $('#queue-tab > ul.pagination li').first().click();
+                $('#history-tab > ul.pagination li').first().children('a').click();
+                $('#queue-tab > ul.pagination li').first().children('a').click();
             }
             e.preventDefault();
         });
         $(document).bind('keydown', 'shift+down', function(e) {
             if($("body").hasClass("container-tabbed")) {
-                $('#history-tab.active > ul.pagination li').last().click();
-                $('#queue-tab.active > ul.pagination li').last().click();
+                $('#history-tab.active > ul.pagination li').last().children('a').click();
+                $('#queue-tab.active > ul.pagination li').last().children('a').click();
             } else {
-                $('#history-tab > ul.pagination li').last().click();
-                $('#queue-tab > ul.pagination li').last().click();
+                $('#history-tab > ul.pagination li').last().children('a').click();
+                $('#queue-tab > ul.pagination li').last().children('a').click();
             }
             e.preventDefault();
         });

--- a/interfaces/Glitter/templates/static/javascripts/glitter.queue.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.queue.js
@@ -204,14 +204,14 @@ function QueueListModel(parent) {
     // Clear searchterm
     self.clearSearchTerm = function(data, event) {
         // Was it escape key or click?
-        if(event.type === 'mousedown' || (event.keyCode && event.keyCode === 27)) {
+        if(event.type === 'click' || (event.keyCode && event.keyCode === 27)) {
             self.isLoading(true)
             self.searchTerm('');
         }
         // Was it click and the field is empty? Then we focus on the field
-        if(event.type === 'mousedown' && self.searchTerm() === '') {
+        if(event.type === 'click' && self.searchTerm() === '') {
             $(event.target).parents('.search-box').find('input[type="text"]').focus()
-            return;
+            return false;
         }
         // Need to return true to allow typing
         return true;

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -819,6 +819,7 @@ SKIN_TEXT = {
     "Glitter-free": TT("Free Space"),
     "Glitter-freeTemp": TT("Temp Folder"),
     "Glitter-search": TT("Search"),
+    "Glitter-clearSearch": TT("Clear search"),
     "Glitter-multiOperations": TT("Multi-Operations"),
     "Glitter-multiSelect": TT("Hold shift key to select a range"),
     "Glitter-selectJob": TT("Select job"),


### PR DESCRIPTION
The Queue and History search fields and pagination controls are difficult to use from a keyboard or screen reader.

This gives both search fields accessible names and makes their search and clear controls normal keyboard-focusable links. The accessible name changes directly from Search to Clear search when text is entered, and clearing the search returns focus to the field.

Pagination page numbers are now keyboard-focusable links, the current page is exposed to assistive technology, and separator dots are skipped.