### PR TITLE
Add Ayatana AppIndicator tray support on GNOME

### DIFF
--- a/sabnzbd/sabtraylinux.py
+++ b/sabnzbd/sabtraylinux.py
@@ -23,6 +23,9 @@ import gi
 from gi.repository import Gtk, GLib
 import logging
 
+HAVE_APPINDICATOR = False
+HAVE_XAPP = False
+
 try:
     gi.require_version("AyatanaAppIndicator3", "0.1")
     from gi.repository import AyatanaAppIndicator3
@@ -30,20 +33,19 @@ try:
     HAVE_APPINDICATOR = True
     logging.debug("AyatanaAppIndicator3 found: %s", AyatanaAppIndicator3)
 except Exception:
-    HAVE_APPINDICATOR = False
     logging.debug("AyatanaAppIndicator3 not available")
 
-try:
-    gi.require_version("XApp", "1.0")
-    from gi.repository import XApp
+if not HAVE_APPINDICATOR:
+    try:
+        gi.require_version("XApp", "1.0")
+        from gi.repository import XApp
 
-    if not hasattr(XApp, "StatusIcon"):
-        raise ImportError
-    HAVE_XAPP = True
-    logging.debug("XApp found: %s" % XApp)
-except Exception:
-    HAVE_XAPP = False
-    logging.debug("XApp not available, falling back to Gtk.StatusIcon")
+        if not hasattr(XApp, "StatusIcon"):
+            raise ImportError
+        HAVE_XAPP = True
+        logging.debug("XApp found: %s", XApp)
+    except Exception:
+        logging.debug("XApp not available, falling back to Gtk.StatusIcon")
 from time import sleep
 import subprocess
 from threading import Thread

--- a/sabnzbd/sabtraylinux.py
+++ b/sabnzbd/sabtraylinux.py
@@ -24,6 +24,16 @@ from gi.repository import Gtk, GLib
 import logging
 
 try:
+    gi.require_version("AyatanaAppIndicator3", "0.1")
+    from gi.repository import AyatanaAppIndicator3
+
+    HAVE_APPINDICATOR = True
+    logging.debug("AyatanaAppIndicator3 found: %s", AyatanaAppIndicator3)
+except Exception:
+    HAVE_APPINDICATOR = False
+    logging.debug("AyatanaAppIndicator3 not available")
+
+try:
     gi.require_version("XApp", "1.0")
     from gi.repository import XApp
 
@@ -66,17 +76,31 @@ class StatusIcon(Thread):
             logging.debug("language file not loaded, waiting")
 
         self.sabpaused = False
-        if HAVE_XAPP:
+        if HAVE_APPINDICATOR:
+            self.statusicon = AyatanaAppIndicator3.Indicator.new(
+                "sabnzbd",
+                self.sabicons["default"],
+                AyatanaAppIndicator3.IndicatorCategory.APPLICATION_STATUS,
+            )
+            self.statusicon.set_status(AyatanaAppIndicator3.IndicatorStatus.ACTIVE)
+        elif HAVE_XAPP:
             self.statusicon = XApp.StatusIcon()
         else:
             self.statusicon = Gtk.StatusIcon()
-        self.statusicon.set_name("SABnzbd")
-        self.statusicon.set_visible(True)
+
+        if not HAVE_APPINDICATOR:
+            self.statusicon.set_name("SABnzbd")
+            self.statusicon.set_visible(True)
+
         self.icon = self.sabicons["default"]
         self.refresh_icon()
         self.tooltip = "SABnzbd %s" % sabnzbd.__version__
         self.refresh_tooltip()
-        if HAVE_XAPP:
+
+        if HAVE_APPINDICATOR:
+            self.menu = self.create_menu()
+            self.statusicon.set_menu(self.menu)
+        elif HAVE_XAPP:
             self.statusicon.connect("activate", self.right_click_event)
         else:
             self.statusicon.connect("popup-menu", self.right_click_event)
@@ -85,14 +109,19 @@ class StatusIcon(Thread):
         Gtk.main()
 
     def refresh_icon(self):
-        if HAVE_XAPP:
+        if HAVE_APPINDICATOR:
+            self.statusicon.set_icon_full(self.icon, "SABnzbd")
+        elif HAVE_XAPP:
             # icon path must be absolute in XApp
             self.statusicon.set_icon_name(self.icon)
         else:
             self.statusicon.set_from_file(self.icon)
 
     def refresh_tooltip(self):
-        self.statusicon.set_tooltip_text(self.tooltip)
+        if HAVE_APPINDICATOR:
+            self.statusicon.set_title(self.tooltip)
+        else:
+            self.statusicon.set_tooltip_text(self.tooltip)
 
     # run this every updatefreq ms
     def run(self):
@@ -115,8 +144,7 @@ class StatusIcon(Thread):
         self.refresh_tooltip()
         return 1
 
-    def right_click_event(self, icon, button, time):
-        """menu"""
+    def create_menu(self):
         menu = Gtk.Menu()
 
         maddnzb = Gtk.MenuItem(label=T("Add NZB"))
@@ -148,6 +176,11 @@ class StatusIcon(Thread):
         menu.append(mshutdown)
 
         menu.show_all()
+        return menu
+
+    def right_click_event(self, icon, button, time):
+        """menu"""
+        menu = self.create_menu()
         menu.popup(None, None, None, self.statusicon, button, time)
 
     def addnzb(self, icon):


### PR DESCRIPTION
## Summary

Adds an Ayatana AppIndicator backend for the Linux tray icon.

On current GNOME/Wayland environments, both `Gtk.StatusIcon` and
`XApp.StatusIcon` may fail to produce a visible tray icon. This adds
`AyatanaAppIndicator3` as the preferred backend when available, while
retaining the existing XApp and Gtk fallbacks.

## Tested on

- Ubuntu 26.04 LTS
- GNOME / Wayland
- SABnzbd develop, 5.1.0RC1
- Python 3.14
- `gir1.2-ayatanaappindicator3-0.1`
- Ubuntu AppIndicators extension

## Result

The SABnzbd tray icon appears correctly and exposes the existing menu.
The icon also updates for idle, downloading, and paused states.

## Notes

The Ayatana typelib is optional. Systems without it continue to use
the existing XApp or Gtk implementation.

Proposed fix for #3506.