### PR TITLE
Improve Add NZB form accessibility

### DIFF
--- a/interfaces/Glitter/templates/include_overlays.tmpl
+++ b/interfaces/Glitter/templates/include_overlays.tmpl
@@ -524,29 +524,29 @@
                 <div class="clearfix"></div>
                 <hr />
                 <div class="form-group">
-                    <label class="col-sm-4 control-label">$T('name')</label>
+                    <label class="col-sm-4 control-label" for="nzbname">$T('name')</label>
                     <div class="col-sm-6">
                         <input type="text" name="nzbname" id="nzbname" placeholder="$T('Glitter-addnzbFilename')" class="form-control" />
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-sm-4 control-label">$T('srv-password')</label>
+                    <label class="col-sm-4 control-label" for="password">$T('srv-password')</label>
                     <div class="col-sm-6">
                         <input type="text" name="password" id="password" placeholder="$T('srv-optional')" class="form-control" />
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-sm-4 control-label">$T('category')</label>
+                    <label class="col-sm-4 control-label" for="add-nzb-category">$T('category')</label>
                     <div class="col-sm-6">
-                        <select name="Category" class="form-control" data-bind="options: queue.categoriesList, optionsValue: 'catValue', optionsText: 'catText', optionsCaption: ''"></select>
+                        <select name="Category" id="add-nzb-category" class="form-control" data-bind="options: queue.categoriesList, optionsValue: 'catValue', optionsText: 'catText', optionsCaption: ''"></select>
                         <span class="glyphicon glyphicon-tag"></span>
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-sm-4 control-label">$T('priority')</label>
+                    <label class="col-sm-4 control-label" for="add-nzb-priority">$T('priority')</label>
                     <div class="col-sm-6">
                         <!-- This list is different from the one during download! -->
-                        <select name="Priority" class="form-control">
+                        <select name="Priority" id="add-nzb-priority" class="form-control">
                             <option value=""></option>
                             <option value="2">$T('pr-force')</option>
                             <option value="1">$T('pr-high')</option>
@@ -558,16 +558,16 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-sm-4 control-label">$T('swtag-pp')</label>
+                    <label class="col-sm-4 control-label" for="add-nzb-processing">$T('swtag-pp')</label>
                     <div class="col-sm-6">
-                        <select name="Processing" class="form-control" data-bind="options: queue.processingOptions, optionsValue: 'value', optionsText: 'name', optionsCaption: ''"></select>
+                        <select name="Processing" id="add-nzb-processing" class="form-control" data-bind="options: queue.processingOptions, optionsValue: 'value', optionsText: 'name', optionsCaption: ''"></select>
                         <span class="glyphicon glyphicon-check"></span>
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-sm-4 control-label">$T('eoq-scripts')</label>
+                    <label class="col-sm-4 control-label" for="add-nzb-script">$T('eoq-scripts')</label>
                     <div class="col-sm-6">
-                        <select name="Post-processing" class="form-control" data-bind="options: queue.scriptsList, optionsCaption: '', optionsValue: 'scriptValue', optionsText: 'scriptText', enable: (queue.scriptsList().length > 1)"></select>
+                        <select name="Post-processing" id="add-nzb-script" class="form-control" data-bind="options: queue.scriptsList, optionsCaption: '', optionsValue: 'scriptValue', optionsText: 'scriptText', enable: (queue.scriptsList().length > 1)"></select>
                         <span class="glyphicon glyphicon-flash"></span>
                     </div>
                 </div>


### PR DESCRIPTION
The visible labels in the Add NZB dialog were not associated with their form controls, so screen readers could announce some fields without a useful name.

This associates the existing translated labels with the name, password, category, priority, processing, and script fields. It does not change the dialog's layout, translations, or existing mouse and keyboard behavior.

Testing:
- Verified each label points to the intended form control.
- Verified the new control IDs are unique.
- Confirmed the existing field names and bindings remain unchanged.