### PR TITLE
feat: add 'Sort by Remaining Size' queue sort option

### DIFF
--- a/interfaces/Config/templates/config_switches.tmpl
+++ b/interfaces/Config/templates/config_switches.tmpl
@@ -152,6 +152,8 @@
                         <select name="auto_sort" id="auto_sort">
                             <option value="">$T('default')</option>
                             <option value="remaining asc" <!--#if $auto_sort == "remaining asc" then 'selected="selected"' else ""#--> >$T('Glitter-sortRemaining')</option>
+                            <option value="remaining_bytes asc" <!--#if $auto_sort == "remaining_bytes asc" then 'selected="selected"' else ""#--> >$T('Glitter-sortRemainingBytesAsc')</option>
+                            <option value="remaining_bytes desc" <!--#if $auto_sort == "remaining_bytes desc" then 'selected="selected"' else ""#--> >$T('Glitter-sortRemainingBytesDesc')</option>
                             <option value="avg_age desc" <!--#if $auto_sort == "avg_age desc" then 'selected="selected"' else ""#--> >$T('Glitter-sortAgeAsc')</option>
                             <option value="avg_age asc" <!--#if $auto_sort == "avg_age asc" then 'selected="selected"' else ""#--> >$T('Glitter-sortAgeDesc')</option>
                             <option value="name asc" <!--#if $auto_sort == "name asc" then 'selected="selected"' else ""#--> >$T('Glitter-sortNameAsc')</option>

--- a/interfaces/Config/templates/config_switches.tmpl
+++ b/interfaces/Config/templates/config_switches.tmpl
@@ -153,7 +153,6 @@
                             <option value="">$T('default')</option>
                             <option value="remaining asc" <!--#if $auto_sort == "remaining asc" then 'selected="selected"' else ""#--> >$T('Glitter-sortRemaining')</option>
                             <option value="remaining_bytes asc" <!--#if $auto_sort == "remaining_bytes asc" then 'selected="selected"' else ""#--> >$T('Glitter-sortRemainingBytesAsc')</option>
-                            <option value="remaining_bytes desc" <!--#if $auto_sort == "remaining_bytes desc" then 'selected="selected"' else ""#--> >$T('Glitter-sortRemainingBytesDesc')</option>
                             <option value="avg_age desc" <!--#if $auto_sort == "avg_age desc" then 'selected="selected"' else ""#--> >$T('Glitter-sortAgeAsc')</option>
                             <option value="avg_age asc" <!--#if $auto_sort == "avg_age asc" then 'selected="selected"' else ""#--> >$T('Glitter-sortAgeDesc')</option>
                             <option value="name asc" <!--#if $auto_sort == "name asc" then 'selected="selected"' else ""#--> >$T('Glitter-sortNameAsc')</option>

--- a/interfaces/Glitter/templates/include_queue.tmpl
+++ b/interfaces/Glitter/templates/include_queue.tmpl
@@ -47,6 +47,8 @@
             </a>
             <ul class="dropdown-menu">
                 <li><a href="#" data-action="sortRemainingAsc" data-bind="click: queue.queueSorting">$T('Glitter-sortRemaining')</a></li>
+                <li><a href="#" data-action="sortRemainingBytesAsc" data-bind="click: queue.queueSorting">$T('Glitter-sortRemainingBytesAsc')</a></li>
+                <li><a href="#" data-action="sortRemainingBytesDesc" data-bind="click: queue.queueSorting">$T('Glitter-sortRemainingBytesDesc')</a></li>
                 <li><a href="#" data-action="sortAgeAsc" data-bind="click: queue.queueSorting">$T('Glitter-sortAgeAsc')</a></li>
                 <li><a href="#" data-action="sortAgeDesc" data-bind="click: queue.queueSorting">$T('Glitter-sortAgeDesc')</a></li>
                 <li><a href="#" data-action="sortNameAsc" data-bind="click: queue.queueSorting">$T('Glitter-sortNameAsc')</a></li>

--- a/interfaces/Glitter/templates/include_queue.tmpl
+++ b/interfaces/Glitter/templates/include_queue.tmpl
@@ -48,7 +48,6 @@
             <ul class="dropdown-menu">
                 <li><a href="#" data-action="sortRemainingAsc" data-bind="click: queue.queueSorting">$T('Glitter-sortRemaining')</a></li>
                 <li><a href="#" data-action="sortRemainingBytesAsc" data-bind="click: queue.queueSorting">$T('Glitter-sortRemainingBytesAsc')</a></li>
-                <li><a href="#" data-action="sortRemainingBytesDesc" data-bind="click: queue.queueSorting">$T('Glitter-sortRemainingBytesDesc')</a></li>
                 <li><a href="#" data-action="sortAgeAsc" data-bind="click: queue.queueSorting">$T('Glitter-sortAgeAsc')</a></li>
                 <li><a href="#" data-action="sortAgeDesc" data-bind="click: queue.queueSorting">$T('Glitter-sortAgeDesc')</a></li>
                 <li><a href="#" data-action="sortNameAsc" data-bind="click: queue.queueSorting">$T('Glitter-sortNameAsc')</a></li>

--- a/interfaces/Glitter/templates/static/javascripts/glitter.queue.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.queue.js
@@ -228,6 +228,14 @@ function QueueListModel(parent) {
                 sort = 'remaining';
                 dir = 'asc';
                 break;
+            case 'sortRemainingBytesAsc':
+                sort = 'remaining_bytes';
+                dir = 'asc';
+                break;
+            case 'sortRemainingBytesDesc':
+                sort = 'remaining_bytes';
+                dir = 'desc';
+                break;
             case 'sortAgeAsc':
                 sort = 'avg_age';
                 dir = 'desc';

--- a/interfaces/Glitter/templates/static/javascripts/glitter.queue.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.queue.js
@@ -232,10 +232,6 @@ function QueueListModel(parent) {
                 sort = 'remaining_bytes';
                 dir = 'asc';
                 break;
-            case 'sortRemainingBytesDesc':
-                sort = 'remaining_bytes';
-                dir = 'desc';
-                break;
             case 'sortAgeAsc':
                 sort = 'avg_age';
                 dir = 'desc';

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -591,7 +591,8 @@ class NzbQueue:
                 logging.debug("Sorting by percentage downloaded...")
             sort_function = lambda nzo: nzo.remaining / nzo.bytes if nzo.bytes else 1
         elif field == "remaining_bytes":
-            logging.info("Sorting by remaining size (reversed: %s)", reverse)
+            if self.__nzo_list:
+                logging.debug("Sorting by remaining size...")
             sort_function = lambda nzo: nzo.remaining
         else:
             logging.debug("Sort: %s not recognized", field)
@@ -604,9 +605,10 @@ class NzbQueue:
     def update_sort_order(self):
         """Resorts the queue if it is useful for the selected sort method"""
         auto_sort = cfg.auto_sort()
-        if auto_sort and auto_sort.startswith("remaining"):
-            field, direction = auto_sort.split()
-            self.sort_queue(field, direction)
+        if auto_sort == "remaining_bytes asc":
+            self.sort_queue("remaining_bytes")
+        elif auto_sort and auto_sort.startswith("remaining"):
+            self.sort_queue("remaining")
 
     @NzbQueueLocker
     def __set_priority(self, nzo_id: str, priority: int | str) -> Optional[int]:

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -568,7 +568,7 @@ class NzbQueue:
 
     @NzbQueueLocker
     def sort_queue(self, field: str, direction: Optional[str] = None):
-        """Sort queue by field: "name", "size" or "avg_age" or by percentage remaining
+        """Sort queue by field: "name", "size", "avg_age", "remaining" or "remaining_bytes"
         Direction is specified as "desc" or "asc"
         """
         field = field.lower()
@@ -590,6 +590,9 @@ class NzbQueue:
             if self.__nzo_list:
                 logging.debug("Sorting by percentage downloaded...")
             sort_function = lambda nzo: nzo.remaining / nzo.bytes if nzo.bytes else 1
+        elif field == "remaining_bytes":
+            logging.info("Sorting by remaining size (reversed: %s)", reverse)
+            sort_function = lambda nzo: nzo.remaining
         else:
             logging.debug("Sort: %s not recognized", field)
             return
@@ -602,7 +605,8 @@ class NzbQueue:
         """Resorts the queue if it is useful for the selected sort method"""
         auto_sort = cfg.auto_sort()
         if auto_sort and auto_sort.startswith("remaining"):
-            self.sort_queue("remaining")
+            field, direction = auto_sort.split()
+            self.sort_queue(field, direction)
 
     @NzbQueueLocker
     def __set_priority(self, nzo_id: str, priority: int | str) -> Optional[int]:

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -469,7 +469,9 @@ SKIN_TEXT = {
     "explain-auto_disconnect": TT("Disconnect from Usenet server(s) when queue is empty or paused."),
     "opt-auto_sort": TT("Automatically sort queue"),
     "explain-auto_sort": TT("Automatically sort jobs in the queue when a new job is added."),
-    "explain-auto_sort_remaining": TT("The queue will resort every 30 seconds if % downloaded or Remaining Size is selected."),
+    "explain-auto_sort_remaining": TT(
+        "The queue will resort every 30 seconds if % downloaded or Remaining Size is selected."
+    ),
     "opt-direct_unpack": TT("Direct Unpack"),
     "explain-direct_unpack": TT(
         "Jobs will start unpacking during the downloading to reduce post-processing time. Only works for jobs that do not need repair."

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -902,7 +902,6 @@ SKIN_TEXT = {
     ),
     "Glitter-sortRemaining": TT("Sort by % downloaded <small>Most&rarr;Least</small>"),
     "Glitter-sortRemainingBytesAsc": TT("Sort by Remaining Size <small>Smallest&rarr;Largest</small>"),
-    "Glitter-sortRemainingBytesDesc": TT("Sort by Remaining Size <small>Largest&rarr;Smallest</small>"),
     "Glitter-sortAgeAsc": TT("Sort by Age <small>Oldest&rarr;Newest</small>"),
     "Glitter-sortAgeDesc": TT("Sort by Age <small>Newest&rarr;Oldest</small>"),
     "Glitter-sortNameAsc": TT("Sort by Name <small>A&rarr;Z</small>"),

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -469,7 +469,7 @@ SKIN_TEXT = {
     "explain-auto_disconnect": TT("Disconnect from Usenet server(s) when queue is empty or paused."),
     "opt-auto_sort": TT("Automatically sort queue"),
     "explain-auto_sort": TT("Automatically sort jobs in the queue when a new job is added."),
-    "explain-auto_sort_remaining": TT("The queue will resort every 30 seconds if % downloaded is selected."),
+    "explain-auto_sort_remaining": TT("The queue will resort every 30 seconds if % downloaded or Remaining Size is selected."),
     "opt-direct_unpack": TT("Direct Unpack"),
     "explain-direct_unpack": TT(
         "Jobs will start unpacking during the downloading to reduce post-processing time. Only works for jobs that do not need repair."
@@ -899,6 +899,8 @@ SKIN_TEXT = {
         "All usernames, passwords and API-keys are automatically removed from the log and the included copy of your settings."
     ),
     "Glitter-sortRemaining": TT("Sort by % downloaded <small>Most&rarr;Least</small>"),
+    "Glitter-sortRemainingBytesAsc": TT("Sort by Remaining Size <small>Smallest&rarr;Largest</small>"),
+    "Glitter-sortRemainingBytesDesc": TT("Sort by Remaining Size <small>Largest&rarr;Smallest</small>"),
     "Glitter-sortAgeAsc": TT("Sort by Age <small>Oldest&rarr;Newest</small>"),
     "Glitter-sortAgeDesc": TT("Sort by Age <small>Newest&rarr;Oldest</small>"),
     "Glitter-sortNameAsc": TT("Sort by Name <small>A&rarr;Z</small>"),

--- a/tests/test_functional_api.py
+++ b/tests/test_functional_api.py
@@ -657,6 +657,8 @@ class TestQueueApi(ApiTestFunctions):
             ("name", "filename", "desc"),
             ("size", "size", "asc"),  # Issue #1666, incorrect (reversed) sort order for avg_age
             ("size", "size", "desc"),
+            ("remaining_bytes", "sizeleft", "asc"),
+            ("remaining_bytes", "sizeleft", "desc"),
         ],
     )
     def test_api_queue_sort(self, sort_by, slot_name, sort_order):
@@ -698,7 +700,7 @@ class TestQueueApi(ApiTestFunctions):
         key = None
         if sort_by == "avg_age":
             key = age_in_minutes
-        elif sort_by == "size":
+        elif sort_by in ("size", "remaining_bytes"):
             key = size_in_bytes
         original_order.sort(reverse=(sort_order == "desc"), key=key)
 

--- a/tests/test_functional_api.py
+++ b/tests/test_functional_api.py
@@ -658,7 +658,6 @@ class TestQueueApi(ApiTestFunctions):
             ("size", "size", "asc"),  # Issue #1666, incorrect (reversed) sort order for avg_age
             ("size", "size", "desc"),
             ("remaining_bytes", "sizeleft", "asc"),
-            ("remaining_bytes", "sizeleft", "desc"),
         ],
     )
     def test_api_queue_sort(self, sort_by, slot_name, sort_order):


### PR DESCRIPTION
## Summary

Adds a new `remaining_bytes` sort field that sorts the queue by **absolute remaining bytes** (`bytes - bytes_tried`).

This complements the existing options:
- `size` — sorts by total download size
- `remaining` — sorts by percentage downloaded

The new option lets users sort by how much data is actually left to download, which is useful when the queue contains a mix of large partially downloaded jobs and small fresh ones.

The UI and automatic-sort setting expose only ascending order (smallest to largest). Descending automatic sorting is intentionally omitted because periodic re-sorts would make actively downloading jobs flap between positions.

## Changes

| File | Change |
|------|--------|
| `sabnzbd/nzbqueue.py` | Add the `remaining_bytes` field, route `remaining_bytes asc` auto-sort without changing existing percentage-sort behavior, and log non-empty periodic sorts at debug level |
| `sabnzbd/skintext.py` | Add the ascending Remaining Size label and update the auto-sort explanation |
| `interfaces/Glitter/.../include_queue.tmpl` | Add the ascending Remaining Size dropdown entry |
| `interfaces/Glitter/.../glitter.queue.js` | Add the `sortRemainingBytesAsc` handler |
| `interfaces/Config/.../config_switches.tmpl` | Add the ascending `remaining_bytes` auto-sort option |
| `tests/test_functional_api.py` | Test ascending `remaining_bytes` sorting against the `sizeleft` slot field |

## Auto-sort behavior

`update_sort_order()` handles `remaining_bytes asc` explicitly and calls `sort_queue("remaining_bytes")` without passing a direction. Existing percentage-based `remaining` behavior remains unchanged and likewise ignores direction, preventing periodic sort flapping.

## Test Plan

- [x] Functional queue-sort test (`7 passed`)
- [x] Queue unit suite (`6 passed, 1 skipped`)
- [x] Black, Ruff, and `git diff --check`
- [ ] Manual: sort the Glitter queue by Remaining Size and confirm smallest-to-largest order
- [ ] Manual: set auto-sort to `remaining_bytes asc` and confirm the periodic resort
