### PR TITLE
Fix postproc scripts on Windows

### DIFF
--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -214,6 +214,7 @@ def external_processing(
     extern_proc: str, nzo: NzbObject, complete_dir: str, status: int, newfiles: list[str]
 ) -> tuple[str, int]:
     """Run a user postproc script, return console output and exit value"""
+    complete_dir = clip_path(complete_dir)
     failure_url = nzo.nzo_info.get("failure", "")
     # Items can be bool or null, causing POpen to fail
     command = [

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -240,7 +240,7 @@ def external_processing(
         "avg_bps": int(nzo.avg_bps_total / nzo.avg_bps_freq) if nzo.avg_bps_freq else 0,
         "age": calc_age(nzo.avg_date),
         "orig_nzb_gz": clip_path(nzb_paths[0]) if nzb_paths else "",
-        "files": json.dumps(sorted([os.path.relpath(newfile, complete_dir) for newfile in newfiles])),
+        "files": json.dumps(sorted([os.path.relpath(clip_path(newfile), complete_dir) for newfile in newfiles])),
     }
 
     # Make sure that if we run a Python script it's output is unbuffered, so we can show it to the user

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -608,9 +608,7 @@ def process_job(nzo: NzbObject) -> bool:
                 nzo.status = Status.RUNNING
                 nzo.set_action_line(T("Running script"), nzo.script)
                 nzo.set_unpack_info("Script", T("Running user script %s") % nzo.script, unique=True)
-                script_log, script_ret = external_processing(
-                    script_path, nzo, clip_path(workdir_complete), job_result, newfiles
-                )
+                script_log, script_ret = external_processing(script_path, nzo, workdir_complete, job_result, newfiles)
 
                 # Format output depending on return status
                 script_line = get_last_line(script_log)

--- a/tests/test_newsunpack.py
+++ b/tests/test_newsunpack.py
@@ -993,7 +993,7 @@ class TestExternalProcessingEnv:
         variable exactly as the receiving script saw it.
         """
         base = long_path(os.path.join(SAB_CACHE_DIR, "sab_env"))
-        complete_dir = clip_path(os.path.join(base, "complete"))
+        complete_dir = os.path.join(base, "complete")
         admin_dir = os.path.join(base, JOB_ADMIN)
         assert create_all_dirs(complete_dir), f"Failed to create {complete_dir}"
         assert create_all_dirs(admin_dir), f"Failed to create {admin_dir}"
@@ -1008,7 +1008,7 @@ class TestExternalProcessingEnv:
         output, ret = newsunpack.external_processing(script_path, nzo, complete_dir, status, newfiles)
 
         sab_env = json.loads(output)
-        return sab_env, complete_dir, ret
+        return sab_env, clip_path(complete_dir), ret
 
     def _run_files(self, filenames):
         """SAB_FILES convenience wrapper: returns (decoded_files, expected, ret).

--- a/tests/test_newsunpack.py
+++ b/tests/test_newsunpack.py
@@ -41,7 +41,7 @@ import sabnzbd.newsunpack as newsunpack
 from sabnzbd.constants import JOB_ADMIN
 from tests.testhelper import SAB_CACHE_DIR
 from sabnzbd.misc import format_time_string, SABRarFile
-from sabnzbd.filesystem import long_path, create_all_dirs, listdir_full
+from sabnzbd.filesystem import long_path, create_all_dirs, listdir_full, clip_path
 
 
 class TestNewsUnpackFunctions:
@@ -993,7 +993,7 @@ class TestExternalProcessingEnv:
         variable exactly as the receiving script saw it.
         """
         base = long_path(os.path.join(SAB_CACHE_DIR, "sab_env"))
-        complete_dir = os.path.join(base, "complete")
+        complete_dir = clip_path(os.path.join(base, "complete"))
         admin_dir = os.path.join(base, JOB_ADMIN)
         assert create_all_dirs(complete_dir), f"Failed to create {complete_dir}"
         assert create_all_dirs(admin_dir), f"Failed to create {admin_dir}"


### PR DESCRIPTION
Fixes #3513 

Verified failure with test not matching actual input for `completed_dir` and tested fix on Windows.

```
SAB_COMPLETE_DIR=E:\Downloads\complete\test_download_100MB
SAB_FILES=["test_download_100MB-explanation.txt", "test_download_100MB.bin"]
```

Expect black to fail because of rule changes