### PR TITLE
Improve Glitter message accessibility

### DIFF
--- a/interfaces/Glitter/templates/include_messages.tmpl
+++ b/interfaces/Glitter/templates/include_messages.tmpl
@@ -1,8 +1,8 @@
 <div id="queue-messages" class="queue-messages" data-bind="visible: hasMessages() || displayTabbed()" style="display: none;">
-    <table class="table table-hover table-messages">
+    <table class="table table-hover table-messages" aria-label="$T('warnings')">
         <thead>
             <tr>
-                <th class="table-messages-header-label"></th>
+                <th class="table-messages-header-label"><span class="sr-only">$T('warnings')</span></th>
                 <th style="width: 30px;"></th>
             </tr>
         </thead>
@@ -11,7 +11,7 @@
                 <tr>
                     <td class="table-messages-hide"></td>
                     <td data-bind="attr: { 'rowspan': parseInt(nrWarnings())+1 }, click: clearWarnings" class="table-messages-remove">
-                        <a href="#" class="hover-button"><span class="glyphicon glyphicon-remove"></span></a>
+                        <a href="#" class="hover-button" aria-label="$T('button-clear')"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
                     </td>
                 </tr>
                 <!-- ko foreach: allWarnings -->
@@ -32,7 +32,7 @@
                     </td>
                     <!-- ko if: \$data.hasOwnProperty("clear") -->
                     <td class="table-messages-remove">
-                        <a href="#" data-bind="click: clear"  class="hover-button"><span class="glyphicon glyphicon-remove"></span></a>
+                        <a href="#" data-bind="click: clear" class="hover-button" aria-label="$T('button-clear')"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
                     </td>
                     <!-- /ko -->
                 </tr>


### PR DESCRIPTION
The warnings and messages table did not have an accessible name, and its icon-only clear actions were unlabeled.

This names the table and message column using the existing Warnings translation, labels both clear actions using the existing Clear translation, and hides their decorative icons from assistive technology. It does not change the existing layout or behavior.

Testing:
- Verified the warnings table, message heading, and both clear actions have the intended accessible names.
- Ran the interface test suite: 7,318 passed.