### PR TITLE
Fix crc32 may be being combined out-of-order

### DIFF
--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -510,7 +510,6 @@ class Assembler(Thread):
             while written < len(data):
                 written += Assembler._write(fd, nzf, mv[written:], pos + written)
 
-        nzf.update_crc32(article.crc32, len(data))
         article.on_disk = True
         sabnzbd.Assembler.update_ready_bytes(nzf, -len(data))
         with nzf.lock:

--- a/sabnzbd/nzb/file.py
+++ b/sabnzbd/nzb/file.py
@@ -107,7 +107,7 @@ class NzbFile(TryList):
         self.deleted = False
         self.import_finished = False
 
-        self.crc32: Optional[int] = 0
+        self.crc32: Optional[int] = None
         self.assembled: bool = False
         self.md5of16k: Optional[bytes] = None
         self.assembler_next_index: int = 0
@@ -192,11 +192,15 @@ class NzbFile(TryList):
         self.blocks = int_conv(blocks)
 
     @synchronized()
-    def update_crc32(self, crc32: Optional[int], length: int) -> None:
-        if self.crc32 is None or crc32 is None:
-            self.crc32 = None
-        else:
-            self.crc32 = sabctools.crc32_combine(self.crc32, crc32, length)
+    def finalize_crc32(self) -> None:
+        """Compute the whole-file crc32 by combining the per-article crc32s in decodetable order"""
+        crc = 0
+        for article in self.decodetable:
+            if article.crc32 is None or article.decoded_size is None:
+                self.crc32 = None
+                return
+            crc = sabctools.crc32_combine(crc, article.crc32, article.decoded_size)
+        self.crc32 = crc
 
     @synchronized()
     def get_articles(self, server: Server, servers: list[Server], fetch_limit: int):

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -826,6 +826,12 @@ def parring(nzo: NzbObject) -> tuple[bool, bool]:
         logging.info("Skipping verification and repair, all sets previously verified: %s", verified)
         return par_error, re_add
 
+    # Combine the per-article crc32s into a whole-file crc32 for the quick-check and SFV-check below
+    # Done here rather than while assembling because crc32_combine is order-dependent and articles can
+    # be written to disk out of order
+    for nzf in nzo.finished_files:
+        nzf.finalize_crc32()
+
     if nzo.extrapars:
         # Need to make a copy because it can change during iteration
         for setname in list(nzo.extrapars):

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -126,6 +126,10 @@ class TestAssembler:
         assert content == expected
         assert nzf.assembler_next_index == len(nzf.decodetable)
         assert nzf.contiguous_offset() == nzf.decodetable[0].file_size
+        # crc32 is finalized in post-processing, not during assembly. Once combined in decodetable
+        # order it must match the file regardless of the order articles were written to disk
+        nzf.finalize_crc32()
+        assert nzf.crc32 == crc32(expected)
 
     def test_assemble_direct_write(self, assembler):
         """Pure direct write mode"""
@@ -319,6 +323,41 @@ class TestAssembler:
         Assembler.assemble(self.nzo, self.nzf, file_done=True, allow_non_contiguous=False, direct_write=True)
         assert assembler.call_count == 3
         self._assert_expected_content(self.nzf, expected)
+
+    def test_crc32_correct_when_gap_filled_out_of_order(self, assembler):
+        """Pausing flushes the cache non-contiguously, so later articles are written before an earlier gap article.
+        The finalized crc32 must still match the file, which is combined in decodetable order."""
+        _data, expected = self._make_request(
+            self.nzf,
+            [
+                self._make_article(self.nzf, offset=0, data=bytearray(b"hello")),
+                self._make_article(self.nzf, offset=5, data=bytearray(b"world"), decoded=False),
+                self._make_article(self.nzf, offset=10, data=bytearray(b"12345")),
+            ],
+        )
+        # Forced flush writes [0] and [2], skipping the not-yet-decoded gap [1]
+        Assembler.assemble(self.nzo, self.nzf, file_done=False, allow_non_contiguous=True, direct_write=True)
+        assert self.nzf.crc32 is None  # not finalized until file_done
+        # Gap article arrives last and the file completes
+        self.nzf.decodetable[1].decoded = True
+        Assembler.assemble(self.nzo, self.nzf, file_done=True, allow_non_contiguous=False, direct_write=True)
+        self._assert_expected_content(self.nzf, expected)
+
+    def test_finalize_crc32_none_when_article_missing(self, assembler):
+        """A file with a missing article crc cannot be verified, so crc32 is None."""
+        _data, expected = self._make_request(
+            self.nzf,
+            [
+                self._make_article(self.nzf, offset=0, data=bytearray(b"hello")),
+                self._make_article(self.nzf, offset=5, data=bytearray(b"world")),
+            ],
+        )
+        Assembler.assemble(self.nzo, self.nzf, file_done=True, allow_non_contiguous=False, direct_write=True)
+        self._assert_expected_content(self.nzf, expected)
+        # A missing per-article crc (e.g. article never decoded) makes the whole-file crc unverifiable
+        self.nzf.decodetable[1].crc32 = None
+        self.nzf.finalize_crc32()
+        assert self.nzf.crc32 is None
 
 
 class TestDiskspaceCheck:


### PR DESCRIPTION
Fixes #3501

crc32 need to be combined in order so I've moved that out of the assembler and after each write (which may out-of-order) and into postproc.

Combining is not expensive, but it's better not to be part of the assembler delaying assembly of the next file.
Postproc is the more appropriate place anyway since it is what needs to use the crc32 values.