### PR TITLE
DirectUnpack: reading output no longer blocks assembly, dropped aborts, slow failure on missing volumes

### DIFF
--- a/sabnzbd/directunpacker.py
+++ b/sabnzbd/directunpacker.py
@@ -40,9 +40,10 @@ from sabnzbd.postproc import prepare_extraction_path
 from sabnzbd.misc import SABRarFile
 from sabnzbd.utils.diskspeed import diskspeedmeasure
 
-# Only ever appended to from add(), which runs on the single Assembler thread, and only
-# removed by the unpacker itself. So the direct_unpack_threads limit needs no extra lock,
-# at worst a slot is freed just after we decided we had to wait for one.
+# Unpackers that have a live unrar instance. Held while checking the direct_unpack_threads
+# limit and claiming a slot, so that two callers of add() can never take the same one.
+# Always taken after the lock of an individual unpacker, never before it.
+ACTIVE_UNPACKERS_LOCK = threading.RLock()
 ACTIVE_UNPACKERS = []
 
 RAR_NR = re.compile(r"(.*?)(\.part(\d*).rar|\.r(\d*))$", re.IGNORECASE)
@@ -154,13 +155,18 @@ class DirectUnpacker(threading.Thread):
             logging.debug("DirectUnpack queued %s for %s", nzf.filename, self.cur_setname)
             # Is this the first one of the first set?
             if not self.active_instance and not self.is_alive() and self.have_next_volume():
-                # Too many runners already?
-                if len(ACTIVE_UNPACKERS) >= cfg.direct_unpack_threads():
-                    logging.info("Too many DirectUnpackers currently to start %s", self.cur_setname)
-                    return
+                # Claim a slot and create the instance in one go, so we can never hand the
+                # same slot to another caller of add()
+                with ACTIVE_UNPACKERS_LOCK:
+                    # Too many runners already?
+                    if len(ACTIVE_UNPACKERS) >= cfg.direct_unpack_threads():
+                        logging.info("Too many DirectUnpackers currently to start %s", self.cur_setname)
+                        return
 
-                # Start the unrar command and the loop
-                self.create_unrar_instance()
+                    # Start the unrar command
+                    self.create_unrar_instance()
+
+                # Start the loop
                 self.start()
         elif not any(test_nzf.setname == nzf.setname for test_nzf in self.next_sets):
             # Need to store this for the future, only once per set!
@@ -272,7 +278,10 @@ class DirectUnpacker(threading.Thread):
                     # Did we reach the end?
                     # Stop timer and finish
                     self.unpack_time += time.time() - start_time
-                    ACTIVE_UNPACKERS.remove(self)
+
+                    # Free the slot, there is no instance running until we start the next set
+                    with ACTIVE_UNPACKERS_LOCK:
+                        ACTIVE_UNPACKERS.remove(self)
 
                     # Take note of the correct password
                     if self.nzo.password and not self.nzo.correct_password:
@@ -397,8 +406,9 @@ class DirectUnpacker(threading.Thread):
             self.killed = True
             # Make more space
             self.reset_active()
-            if self in ACTIVE_UNPACKERS:
-                ACTIVE_UNPACKERS.remove(self)
+            with ACTIVE_UNPACKERS_LOCK:
+                if self in ACTIVE_UNPACKERS:
+                    ACTIVE_UNPACKERS.remove(self)
             logging.debug("Closing DirectUnpack for %s", self.nzo.final_name)
 
     def have_next_volume(self):
@@ -502,7 +512,8 @@ class DirectUnpacker(threading.Thread):
         ).start()
 
         # Add to runners
-        ACTIVE_UNPACKERS.append(self)
+        with ACTIVE_UNPACKERS_LOCK:
+            ACTIVE_UNPACKERS.append(self)
 
         # Doing the first
         logging.info("DirectUnpacked volume %s for %s", self.cur_volume, self.cur_setname)
@@ -603,7 +614,10 @@ def analyze_rar_filename(filename):
 def abort_all():
     """Abort all running DirectUnpackers"""
     logging.info("Aborting all DirectUnpackers")
-    for direct_unpacker in ACTIVE_UNPACKERS:
+    # Abort outside the lock, since abort() needs the lock of the unpacker itself
+    with ACTIVE_UNPACKERS_LOCK:
+        active_unpackers = ACTIVE_UNPACKERS.copy()
+    for direct_unpacker in active_unpackers:
         direct_unpacker.abort()
 
 

--- a/sabnzbd/directunpacker.py
+++ b/sabnzbd/directunpacker.py
@@ -42,7 +42,6 @@ from sabnzbd.utils.diskspeed import diskspeedmeasure
 
 if sabnzbd.WINDOWS:
     import msvcrt
-    import pywintypes
     import win32pipe
 
 # Unpackers that have a live unrar instance. Held while checking the direct_unpack_threads

--- a/sabnzbd/directunpacker.py
+++ b/sabnzbd/directunpacker.py
@@ -20,6 +20,7 @@ sabnzbd.directunpacker
 """
 
 import os
+import queue
 import re
 import subprocess
 import time
@@ -56,6 +57,7 @@ class DirectUnpacker(threading.Thread):
         self.active_instance: Optional[subprocess.Popen] = None
         self.killed: bool = False
         self.next_file_lock = threading.Condition(threading.RLock())
+        self.output_queue: queue.Queue[Optional[bytes]] = queue.Queue()
 
         self.unpack_dir_info = None
         self.rarfile_nzf: Optional[NzbFile] = None
@@ -78,10 +80,10 @@ class DirectUnpacker(threading.Thread):
         pass
 
     def reset_active(self):
-        # make sure the process and file handlers are closed nicely:
+        # make sure the process and file handlers are closed nicely.
+        # stdout is left to read_output(), closing it here could block until it stops reading
         try:
             if self.active_instance:
-                self.active_instance.stdout.close()
                 self.active_instance.stdin.close()
                 self.active_instance.wait(timeout=2)
         except Exception:
@@ -168,6 +170,47 @@ class DirectUnpacker(threading.Thread):
         with self.next_file_lock:
             self.next_file_lock.notify()
 
+    def read_output(self, instance: subprocess.Popen, output_queue: queue.Queue[Optional[bytes]]):
+        """Read the output of a single unrar instance and pass it on in chunks that end on
+        a space or a newline. This runs in its own thread, so that a silent or stalled
+        unrar can never block the callers of add() and abort(), which both need
+        START_STOP_LOCK. Ends by putting None in the queue.
+        """
+        chunk = b""
+        try:
+            # Need to read char-by-char because there's no newline after new-disk message
+            while char := instance.stdout.read(1):
+                chunk += char
+
+                # Hand over whole words, so we don't queue every single character
+                if char in (b" ", b"\n"):
+                    output_queue.put(chunk)
+                    chunk = b""
+        except (OSError, ValueError):
+            # The instance was killed and its pipes closed while we were reading
+            logging.debug("Exception in read_output()", exc_info=True)
+        finally:
+            try:
+                instance.stdout.close()
+            except Exception:
+                logging.debug("Exception closing DirectUnpack output", exc_info=True)
+            if chunk:
+                output_queue.put(chunk)
+            output_queue.put(None)
+
+    def get_output_chunk(self) -> Optional[bytes]:
+        """Wait for the next chunk of output of the active instance, None when there is
+        nothing left to read. The timeout makes sure we also notice an instance that was
+        killed without its output ever reaching end-of-file.
+        """
+        while self.active_instance:
+            try:
+                return self.output_queue.get(timeout=5)
+            except queue.Empty:
+                if self.killed:
+                    break
+        return None
+
     def run(self):
         # Input and output
         linebuf = b""
@@ -177,25 +220,20 @@ class DirectUnpacker(threading.Thread):
         extracted = []
         start_time = time.time()
 
-        # Need to read char-by-char because there's no newline after new-disk message
         while 1:
-            # We need to lock, so we don't crash if unpacker is deleted while we read
-            with START_STOP_LOCK:
-                if not self.active_instance or not self.active_instance.stdout:
-                    break
-
-                while 1:
-                    # Keep reading until reaching space or end of line
-                    # to prevent continuous locking and unlocking
-                    char = self.active_instance.stdout.read(1)
-                    linebuf += char
-
-                    if char in (b" ", b"\n", b""):
-                        break
+            chunk = self.get_output_chunk()
 
             # End of program
-            if not char:
+            if chunk is None:
                 break
+
+            linebuf += chunk
+            char = chunk[-1:]
+
+            # Trailing output that has no space or newline after it, so there is nothing
+            # to handle yet. Only happens right before the instance ends.
+            if char not in (b" ", b"\n"):
+                continue
 
             # Handle whole lines
             if char == b"\n":
@@ -452,6 +490,16 @@ class DirectUnpacker(threading.Thread):
         self.active_instance = build_and_run_command(
             command, windows_unrar_command=True, text_mode=False, stdin=subprocess.PIPE
         )
+
+        # Every instance gets its own queue and reader, so that output of a previous
+        # instance can never end up in what we read next
+        self.output_queue = output_queue = queue.Queue()
+        threading.Thread(
+            target=self.read_output,
+            args=(self.active_instance, output_queue),
+            name="DirectUnpackReader",
+            daemon=True,
+        ).start()
 
         # Add to runners
         ACTIVE_UNPACKERS.append(self)

--- a/sabnzbd/directunpacker.py
+++ b/sabnzbd/directunpacker.py
@@ -521,8 +521,10 @@ class DirectUnpacker(threading.Thread):
     @synchronized()
     def abort(self, abort_input: bytes = b"Q"):
         """Abort running instance and delete generated files"""
-        if not self.killed and self.cur_setname:
-            logging.info("Aborting DirectUnpack for %s", self.cur_setname)
+        # Also abort when there is no cur_setname, which is the case while run() is between
+        # two sets. Skipping it there would let run() start the set it was preparing.
+        if not self.killed:
+            logging.info("Aborting DirectUnpack for %s", self.cur_setname or self.nzo.final_name)
             self.killed = True
 
             # Save reference to the first rarfile
@@ -558,7 +560,8 @@ class DirectUnpacker(threading.Thread):
                 extraction_path, _, _, one_folder, _ = self.unpack_dir_info
                 # In case of flat-unpack we need to remove the files manually
                 if one_folder:
-                    # RarFile can fail for mysterious reasons
+                    # RarFile can fail for mysterious reasons. Without a rarfile we cannot
+                    # tell which files in the shared folder were ours, so we leave them.
                     try:
                         rar_contents = SABRarFile(
                             os.path.join(self.nzo.download_path, rarfile_nzf.filename), part_only=True
@@ -570,7 +573,9 @@ class DirectUnpacker(threading.Thread):
                     except Exception:
                         # The user will have to remove it themselves
                         logging.info(
-                            "Failed to clean Direct Unpack after aborting %s", rarfile_nzf.filename, exc_info=True
+                            "Failed to clean Direct Unpack after aborting %s",
+                            rarfile_nzf.filename if rarfile_nzf else self.nzo.final_name,
+                            exc_info=True,
                         )
                 else:
                     # We can just remove the whole path

--- a/sabnzbd/directunpacker.py
+++ b/sabnzbd/directunpacker.py
@@ -20,8 +20,8 @@ sabnzbd.directunpacker
 """
 
 import os
-import queue
 import re
+import select
 import subprocess
 import time
 import threading
@@ -40,6 +40,11 @@ from sabnzbd.postproc import prepare_extraction_path
 from sabnzbd.misc import SABRarFile
 from sabnzbd.utils.diskspeed import diskspeedmeasure
 
+if sabnzbd.WINDOWS:
+    import msvcrt
+    import pywintypes
+    import win32pipe
+
 # Unpackers that have a live unrar instance. Held while checking the direct_unpack_threads
 # limit and claiming a slot, so that two callers of add() can never take the same one.
 # Always taken after the lock of an individual unpacker, never before it.
@@ -47,6 +52,13 @@ ACTIVE_UNPACKERS_LOCK = threading.RLock()
 ACTIVE_UNPACKERS = []
 
 RAR_NR = re.compile(r"(.*?)(\.part(\d*).rar|\.r(\d*))$", re.IGNORECASE)
+
+# Waiting for output returns as soon as there is any, these only limit how long we can sit
+# there before checking whether we were killed in the meantime. Windows cannot select on a
+# pipe, so there we poll it and the interval is also the delay on the output itself.
+OUTPUT_TIMEOUT = 1
+WINDOWS_POLL_INTERVAL = 0.05
+OUTPUT_CHUNK_SIZE = 4096
 
 
 class DirectUnpacker(threading.Thread):
@@ -60,7 +72,6 @@ class DirectUnpacker(threading.Thread):
         self.no_more_files: bool = False
         self.lock: threading.RLock = threading.RLock()
         self.next_file_lock = threading.Condition(threading.RLock())
-        self.output_queue: queue.Queue[Optional[bytes]] = queue.Queue()
 
         self.unpack_dir_info = None
         self.rarfile_nzf: Optional[NzbFile] = None
@@ -83,10 +94,10 @@ class DirectUnpacker(threading.Thread):
         pass
 
     def reset_active(self):
-        # make sure the process and file handlers are closed nicely.
-        # stdout is left to read_output(), closing it here could block until it stops reading
+        # make sure the process and file handlers are closed nicely:
         try:
             if self.active_instance:
+                self.active_instance.stdout.close()
                 self.active_instance.stdin.close()
                 self.active_instance.wait(timeout=2)
         except Exception:
@@ -178,46 +189,27 @@ class DirectUnpacker(threading.Thread):
         with self.next_file_lock:
             self.next_file_lock.notify()
 
-    def read_output(self, instance: subprocess.Popen, output_queue: queue.Queue[Optional[bytes]]):
-        """Read the output of a single unrar instance and pass it on in chunks that end on
-        a space or a newline. This runs in its own thread, so that a silent or stalled
-        unrar can never block the callers of add() and abort(), which both need
-        self.lock. Ends by putting None in the queue.
+    def get_output_chunk(self) -> bytes:
+        """Read what the active instance has produced so far, empty when there is nothing
+        left to read. Only ever reads what is already available, so a silent or stalled
+        unrar can never block us while a caller of add() or abort() waits for our lock.
         """
-        chunk = b""
-        try:
-            # Need to read char-by-char because there's no newline after new-disk message
-            while char := instance.stdout.read(1):
-                chunk += char
-
-                # Hand over whole words, so we don't queue every single character
-                if char in (b" ", b"\n"):
-                    output_queue.put(chunk)
-                    chunk = b""
-        except (OSError, ValueError):
-            # The instance was killed and its pipes closed while we were reading
-            logging.debug("Exception in read_output()", exc_info=True)
-        finally:
+        while not self.killed and self.active_instance:
             try:
-                instance.stdout.close()
+                if sabnzbd.WINDOWS:
+                    # Only sockets can be selected on Windows, so we ask the pipe itself
+                    handle = msvcrt.get_osfhandle(self.active_instance.stdout.fileno())
+                    if available := win32pipe.PeekNamedPipe(handle, 0)[1]:
+                        return self.active_instance.stdout.read(available)
+                    time.sleep(WINDOWS_POLL_INTERVAL)
+                elif select.select([self.active_instance.stdout], [], [], OUTPUT_TIMEOUT)[0]:
+                    # Empty means end of file, so the instance is done
+                    return self.active_instance.stdout.read(OUTPUT_CHUNK_SIZE)
             except Exception:
-                logging.debug("Exception closing DirectUnpack output", exc_info=True)
-            if chunk:
-                output_queue.put(chunk)
-            output_queue.put(None)
-
-    def get_output_chunk(self) -> Optional[bytes]:
-        """Wait for the next chunk of output of the active instance, None when there is
-        nothing left to read. The timeout makes sure we also notice an instance that was
-        killed without its output ever reaching end-of-file.
-        """
-        while self.active_instance:
-            try:
-                return self.output_queue.get(timeout=5)
-            except queue.Empty:
-                if self.killed:
-                    break
-        return None
+                # Instance was killed and its pipes closed while we were reading
+                logging.debug("Exception in get_output_chunk()", exc_info=True)
+                break
+        return b""
 
     def run(self):
         # Input and output
@@ -228,26 +220,17 @@ class DirectUnpacker(threading.Thread):
         extracted = []
         start_time = time.time()
 
-        while 1:
-            chunk = self.get_output_chunk()
-
-            # End of program
-            if chunk is None:
-                break
-
+        # The new-disk message has no newline after it, so whatever is left in the buffer
+        # after taking out the whole lines is checked for the prompts below
+        while chunk := self.get_output_chunk():
             linebuf += chunk
-            char = chunk[-1:]
-
-            # Trailing output that has no space or newline after it, so there is nothing
-            # to handle yet. Only happens right before the instance ends.
-            if char not in (b" ", b"\n"):
-                continue
 
             # Handle whole lines
-            if char == b"\n":
-                # When reaching end-of-line, we can safely convert and add to the log
-                linebuf_encoded = platform_btou(linebuf.strip())
-                linebuf = b""
+            while not self.killed and b"\n" in linebuf:
+                line, linebuf = linebuf.split(b"\n", 1)
+
+                # Now we can safely convert and add to the log
+                linebuf_encoded = platform_btou(line.strip())
 
                 # Skip empty lines
                 if not linebuf_encoded:
@@ -516,16 +499,6 @@ class DirectUnpacker(threading.Thread):
         self.active_instance = build_and_run_command(
             command, windows_unrar_command=True, text_mode=False, stdin=subprocess.PIPE
         )
-
-        # Every instance gets its own queue and reader, so that output of a previous
-        # instance can never end up in what we read next
-        self.output_queue = output_queue = queue.Queue()
-        threading.Thread(
-            target=self.read_output,
-            args=(self.active_instance, output_queue),
-            name="DirectUnpackReader",
-            daemon=True,
-        ).start()
 
         # Add to runners
         with ACTIVE_UNPACKERS_LOCK:

--- a/sabnzbd/directunpacker.py
+++ b/sabnzbd/directunpacker.py
@@ -56,6 +56,8 @@ class DirectUnpacker(threading.Thread):
         self.nzo: NzbObject = nzo
         self.active_instance: Optional[subprocess.Popen] = None
         self.killed: bool = False
+        # Set by post-processing once repair is done and no new files can arrive anymore
+        self.no_more_files: bool = False
         self.lock: threading.RLock = threading.RLock()
         self.next_file_lock = threading.Condition(threading.RLock())
         self.output_queue: queue.Queue[Optional[bytes]] = queue.Queue()
@@ -355,6 +357,11 @@ class DirectUnpacker(threading.Thread):
                 # Wait for the next one..
                 self.wait_for_next_volume()
 
+                # Nothing is coming anymore, so a volume we don't have is missing for good
+                if self.no_more_files and not self.have_next_volume():
+                    logging.info("DirectUnpack failed due to missing files %s", self.cur_setname)
+                    self.abort()
+
                 # Possible that the instance was deleted while locked
                 if not self.killed:
                     # Sometimes the assembler is still working on the file, resulting in "Unexpected end of archive".
@@ -425,12 +432,21 @@ class DirectUnpacker(threading.Thread):
                 return nzf_search
         return False
 
+    def set_no_more_files(self):
+        """Called by post-processing once repair is finished. Whatever is on disk now is
+        all we are going to get, so a volume we do not have by now is never coming.
+        """
+        logging.debug("No more files will arrive for %s", self.nzo.final_name)
+        with self.next_file_lock:
+            self.no_more_files = True
+            self.next_file_lock.notify()
+
     def wait_for_next_volume(self):
-        """Wait for the correct volume to appear but stop if it was killed
-        or the NZB is in post-processing and no new files will be downloaded.
+        """Wait for the correct volume to appear but stop if it was killed or if
+        post-processing told us that no new files will be downloaded.
         """
         with self.next_file_lock:
-            self.next_file_lock.wait_for(lambda: self.have_next_volume() or self.killed or self.nzo.pp_active)
+            self.next_file_lock.wait_for(lambda: self.have_next_volume() or self.killed or self.no_more_files)
 
     @synchronized()
     def create_unrar_instance(self):

--- a/sabnzbd/directunpacker.py
+++ b/sabnzbd/directunpacker.py
@@ -132,7 +132,10 @@ class DirectUnpacker(threading.Thread):
         if not cfg.direct_unpack_tested():
             test_disk_performance()
 
-        # Stop if something is wrong or we shouldn't start yet
+        # Stop if something is wrong, or we shouldn't start yet.
+        # A running instance is deliberately left waiting on the volume it needs, so that
+        # rar_unpack() can resume it once par2 repaired the damage. Waking it up now would
+        # feed unrar a damaged volume and throw away everything unpacked so far.
         if not self.check_requirements():
             return
 

--- a/sabnzbd/directunpacker.py
+++ b/sabnzbd/directunpacker.py
@@ -40,10 +40,9 @@ from sabnzbd.postproc import prepare_extraction_path
 from sabnzbd.misc import SABRarFile
 from sabnzbd.utils.diskspeed import diskspeedmeasure
 
-# Need a lock to make sure start and stop is handled correctly
-# Otherwise we could stop while the thread was still starting
-START_STOP_LOCK = threading.RLock()
-
+# Only ever appended to from add(), which runs on the single Assembler thread, and only
+# removed by the unpacker itself. So the direct_unpack_threads limit needs no extra lock,
+# at worst a slot is freed just after we decided we had to wait for one.
 ACTIVE_UNPACKERS = []
 
 RAR_NR = re.compile(r"(.*?)(\.part(\d*).rar|\.r(\d*))$", re.IGNORECASE)
@@ -56,6 +55,7 @@ class DirectUnpacker(threading.Thread):
         self.nzo: NzbObject = nzo
         self.active_instance: Optional[subprocess.Popen] = None
         self.killed: bool = False
+        self.lock: threading.RLock = threading.RLock()
         self.next_file_lock = threading.Condition(threading.RLock())
         self.output_queue: queue.Queue[Optional[bytes]] = queue.Queue()
 
@@ -128,7 +128,7 @@ class DirectUnpacker(threading.Thread):
         if none_counter > found_counter:
             self.total_volumes = {}
 
-    @synchronized(START_STOP_LOCK)
+    @synchronized()
     def add(self, nzf: NzbFile):
         """Add jobs and start instance of DirectUnpack"""
         if not cfg.direct_unpack_tested():
@@ -174,7 +174,7 @@ class DirectUnpacker(threading.Thread):
         """Read the output of a single unrar instance and pass it on in chunks that end on
         a space or a newline. This runs in its own thread, so that a silent or stalled
         unrar can never block the callers of add() and abort(), which both need
-        START_STOP_LOCK. Ends by putting None in the queue.
+        self.lock. Ends by putting None in the queue.
         """
         chunk = b""
         try:
@@ -392,7 +392,7 @@ class DirectUnpacker(threading.Thread):
         if unrar_log:
             logging.debug("DirectUnpack Unrar output: \n%s", "\n".join(unrar_log))
 
-        with START_STOP_LOCK:
+        with self.lock:
             # Set the thread to killed so it never gets restarted by accident
             self.killed = True
             # Make more space
@@ -422,7 +422,7 @@ class DirectUnpacker(threading.Thread):
         with self.next_file_lock:
             self.next_file_lock.wait_for(lambda: self.have_next_volume() or self.killed or self.nzo.pp_active)
 
-    @synchronized(START_STOP_LOCK)
+    @synchronized()
     def create_unrar_instance(self):
         """Start the unrar instance using the user's options"""
         # Generate extraction path and save for post-proc
@@ -507,7 +507,7 @@ class DirectUnpacker(threading.Thread):
         # Doing the first
         logging.info("DirectUnpacked volume %s for %s", self.cur_volume, self.cur_setname)
 
-    @synchronized(START_STOP_LOCK)
+    @synchronized()
     def abort(self, abort_input: bytes = b"Q"):
         """Abort running instance and delete generated files"""
         if not self.killed and self.cur_setname:

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -557,7 +557,10 @@ def rar_unpack(nzo: NzbObject, workdir_complete: str, one_folder: bool, rars: li
             while nzo.direct_unpacker.is_alive():
                 logging.debug("DirectUnpacker still alive for %s: %s", nzo.final_name, last_stats)
 
-                # Bump the file-lock in case it's stuck
+                # Resume the unpacker. DirectUnpacker.add() leaves it waiting when the
+                # download was damaged, so this is the notification that lets it pick up
+                # the volumes that par2 has repaired by now. Also covers a wait that got
+                # stuck for any other reason.
                 with nzo.direct_unpacker.next_file_lock:
                     nzo.direct_unpacker.next_file_lock.notify()
                 time.sleep(2)

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -552,15 +552,18 @@ def rar_unpack(nzo: NzbObject, workdir_complete: str, one_folder: bool, rars: li
 
         # Is the direct-unpacker still running? We wait for it
         if nzo.direct_unpacker:
+            # Repair is long done by the time we get here, so this only repeats what
+            # post-processing already told the unpacker when it finished parring
+            nzo.direct_unpacker.set_no_more_files()
+
             wait_count = 0
             last_stats = nzo.direct_unpacker.get_formatted_stats()
             while nzo.direct_unpacker.is_alive():
                 logging.debug("DirectUnpacker still alive for %s: %s", nzo.final_name, last_stats)
 
-                # Repair is long done by the time we get here, so this only repeats what
-                # post-processing already told the unpacker when it finished parring
-                nzo.direct_unpacker.set_no_more_files()
-                time.sleep(2)
+                # Returns as soon as it is done, so we only ever wait the full interval
+                # when it still has work to do
+                nzo.direct_unpacker.join(timeout=2)
 
                 # Did something change? Might be stuck
                 if last_stats == nzo.direct_unpacker.get_formatted_stats():

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -557,12 +557,9 @@ def rar_unpack(nzo: NzbObject, workdir_complete: str, one_folder: bool, rars: li
             while nzo.direct_unpacker.is_alive():
                 logging.debug("DirectUnpacker still alive for %s: %s", nzo.final_name, last_stats)
 
-                # Resume the unpacker. DirectUnpacker.add() leaves it waiting when the
-                # download was damaged, so this is the notification that lets it pick up
-                # the volumes that par2 has repaired by now. Also covers a wait that got
-                # stuck for any other reason.
-                with nzo.direct_unpacker.next_file_lock:
-                    nzo.direct_unpacker.next_file_lock.notify()
+                # Repair is long done by the time we get here, so this only repeats what
+                # post-processing already told the unpacker when it finished parring
+                nzo.direct_unpacker.set_no_more_files()
                 time.sleep(2)
 
                 # Did something change? Might be stuck

--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -561,6 +561,10 @@ def rar_unpack(nzo: NzbObject, workdir_complete: str, one_folder: bool, rars: li
             while nzo.direct_unpacker.is_alive():
                 logging.debug("DirectUnpacker still alive for %s: %s", nzo.final_name, last_stats)
 
+                # Bump the file-lock in case it's stuck
+                with nzo.direct_unpacker.next_file_lock:
+                    nzo.direct_unpacker.next_file_lock.notify()
+
                 # Returns as soon as it is done, so we only ever wait the full interval
                 # when it still has work to do
                 nzo.direct_unpacker.join(timeout=2)

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -459,6 +459,11 @@ def process_job(nzo: NzbObject) -> bool:
                 # Try to get more par files
                 return False
 
+        # Repair is done, so whatever is on disk now is all Direct Unpack is ever going to
+        # get. Only after this it is safe for it to continue with the remaining volumes.
+        if nzo.direct_unpacker:
+            nzo.direct_unpacker.set_no_more_files()
+
         # If we don't need extra par2, we can disconnect
         if not sabnzbd.NzbQueue.actives(grabs=False) and cfg.autodisconnect():
             # This was the last job, close server connections

--- a/tests/test_directunpacker.py
+++ b/tests/test_directunpacker.py
@@ -196,9 +196,9 @@ class TestDirectUnpackerResume:
 
 class TestDirectUnpackerOutput:
     def test_reading_output_does_not_block_add(self, startable_unpacker):
-        """Reading unrar's output may not hold START_STOP_LOCK. add() needs that same
-        lock and is called from the single Assembler thread, so a quiet or stalled unrar
-        would otherwise stop assembly for every job in the queue.
+        """Reading unrar's output may not hold the lock that add() needs. add() is called
+        from the single Assembler thread, so a quiet or stalled unrar would otherwise stop
+        assembly for the whole job.
         """
         unpacker = startable_unpacker
         unpacker.add(make_nzf("test.part01.rar", "test", 1))
@@ -244,3 +244,22 @@ class TestDirectUnpackerOutput:
 
         assert unpacker.output_queue is not first_queue
         assert unpacker.output_queue.empty()
+
+
+class TestDirectUnpackerLock:
+    def test_unpackers_do_not_share_a_lock(self, unpacker, startable_unpacker):
+        """abort() holds the lock while it kills unrar and removes the extracted files,
+        which can take seconds. That may not hold up add() for another job, because all
+        jobs are added from the single Assembler thread.
+        """
+        assert unpacker.lock is not startable_unpacker.lock
+
+        # As held by a slow abort() of another job
+        with unpacker.lock:
+            adding = threading.Thread(
+                target=startable_unpacker.add, args=(make_nzf("test.part01.rar", "test", 1),), daemon=True
+            )
+            adding.start()
+            adding.join(timeout=5)
+
+            assert not adding.is_alive(), "add() waited for an unrelated job"

--- a/tests/test_directunpacker.py
+++ b/tests/test_directunpacker.py
@@ -1,0 +1,144 @@
+#!/usr/bin/python3 -OO
+# Copyright 2007-2026 by The SABnzbd-Team (sabnzbd.org)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+tests.test_directunpacker - Testing functions in directunpacker.py
+"""
+
+import threading
+from unittest import mock
+
+import pytest
+
+import sabnzbd.cfg as cfg
+from sabnzbd.directunpacker import DirectUnpacker
+from sabnzbd.newsunpack import rar_unpack
+from sabnzbd.nzb import NzbFile, NzbObject
+
+
+def make_nzf(filename: str, setname: str, vol: int) -> NzbFile:
+    nzf = mock.MagicMock(spec=NzbFile)
+    nzf.filename = filename
+    nzf.setname = setname
+    nzf.vol = vol
+    nzf.assembled = True
+    return nzf
+
+
+@pytest.fixture
+def unpacker(tmp_path):
+    """A DirectUnpacker with an active unrar instance that finished volume 1 of the
+    set "test", positioned as if unrar is waiting for volume 2 to appear.
+    """
+    nzo = mock.MagicMock(spec=NzbObject)
+    nzo.first_articles = []
+    nzo.unpack = True
+    nzo.bad_articles = 0
+    nzo.pp_active = False
+    nzo.removed_from_queue = False
+    nzo.files = []
+    nzo.finished_files = []
+    nzo.download_path = str(tmp_path)
+    nzo.final_name = "test.job"
+    nzo.delete = False
+
+    with mock.patch.multiple(
+        cfg,
+        direct_unpack_tested=mock.Mock(return_value=True),
+        direct_unpack=mock.Mock(return_value=True),
+        enable_unrar=mock.Mock(return_value=True),
+    ):
+        unpacker = DirectUnpacker(nzo)
+        unpacker.cur_setname = "test"
+        unpacker.cur_volume = 1
+        # Pretend unrar is running, so add() will not try to start a real one
+        unpacker.active_instance = mock.MagicMock()
+        yield unpacker
+
+
+def park_in_wait_for_next_volume(unpacker: DirectUnpacker) -> threading.Thread:
+    """Start a thread in wait_for_next_volume() and return once it is really waiting,
+    so that only a notification can release it again.
+    """
+    predicate_called = threading.Event()
+    have_next_volume = unpacker.have_next_volume
+
+    def wrapped_have_next_volume():
+        predicate_called.set()
+        return have_next_volume()
+
+    unpacker.have_next_volume = wrapped_have_next_volume
+
+    waiting = threading.Thread(target=unpacker.wait_for_next_volume, daemon=True)
+    waiting.start()
+
+    # The predicate is evaluated while holding the lock, so once it ran we only have to
+    # wait for the lock to be released by Condition.wait() to know the thread is parked
+    assert predicate_called.wait(timeout=10)
+    with unpacker.next_file_lock:
+        pass
+    return waiting
+
+
+class TestDirectUnpackerAdd:
+    def test_notifies_waiting_thread(self, unpacker):
+        """The notification at the end of add() is the only thing that releases a thread
+        parked in wait_for_next_volume() while the job is still downloading.
+        """
+        waiting = park_in_wait_for_next_volume(unpacker)
+        nzf = make_nzf("test.part02.rar", "test", 2)
+        unpacker.nzo.finished_files.append(nzf)
+
+        unpacker.add(nzf)
+
+        waiting.join(timeout=10)
+        assert not waiting.is_alive(), "wait_for_next_volume() was never woken up by add()"
+
+    def test_damaged_download_keeps_unpacker_parked(self, unpacker):
+        """Damaged articles have to be repaired by par2 first, so the unpacker is left
+        waiting instead of being fed a volume unrar would choke on.
+        """
+        waiting = park_in_wait_for_next_volume(unpacker)
+        nzf = make_nzf("test.part02.rar", "test", 2)
+        unpacker.nzo.finished_files.append(nzf)
+        unpacker.nzo.bad_articles = 1
+
+        unpacker.add(nzf)
+
+        waiting.join(timeout=2)
+        assert waiting.is_alive(), "unpacker should stay parked until par2 repaired the damage"
+
+
+class TestDirectUnpackerResume:
+    def test_rar_unpack_resumes_parked_unpacker(self, unpacker):
+        """Post-processing has to release an unpacker that add() left parked, otherwise
+        the job keeps a stalled unrar around indefinitely.
+        """
+        waiting = park_in_wait_for_next_volume(unpacker)
+        unpacker.nzo.bad_articles = 1
+
+        # No more volumes are coming, so only rar_unpack() can release it
+        unpacker.add(make_nzf("test.part02.rar", "test", 2))
+        assert waiting.is_alive()
+
+        # Post-processing repaired the set and now waits for direct unpack to finish
+        unpacker.nzo.pp_active = True
+        unpacker.success_sets["test"] = (["test.part01.rar"], [])
+        with mock.patch.object(DirectUnpacker, "is_alive", side_effect=waiting.is_alive):
+            rar_unpack(unpacker.nzo, str(unpacker.nzo.download_path), False, ["test.part01.rar"])
+
+        assert not waiting.is_alive(), "rar_unpack() did not resume the parked unpacker"

--- a/tests/test_directunpacker.py
+++ b/tests/test_directunpacker.py
@@ -189,10 +189,16 @@ class TestDirectUnpackerResume:
 
         # Post-processing repaired the set and now waits for direct unpack to finish
         unpacker.success_sets["test"] = (["test.part01.rar"], [])
-        with mock.patch.object(DirectUnpacker, "is_alive", side_effect=waiting.is_alive):
+        start = time.time()
+        with (
+            mock.patch.object(DirectUnpacker, "is_alive", side_effect=waiting.is_alive),
+            mock.patch.object(DirectUnpacker, "join", side_effect=waiting.join),
+        ):
             rar_unpack(unpacker.nzo, str(unpacker.nzo.download_path), False, ["test.part01.rar"])
 
         assert not waiting.is_alive(), "rar_unpack() did not resume the parked unpacker"
+        # Picked up the moment it finished, instead of sitting out the poll interval
+        assert time.time() - start < 1
 
 
 class TestDirectUnpackerOutput:

--- a/tests/test_directunpacker.py
+++ b/tests/test_directunpacker.py
@@ -161,18 +161,18 @@ class TestDirectUnpackerAdd:
         assert not waiting.is_alive(), "wait_for_next_volume() was never woken up by add()"
 
     def test_damaged_download_keeps_unpacker_parked(self, unpacker):
-        """Damaged articles have to be repaired by par2 first, so the unpacker is left
-        waiting instead of being fed a volume unrar would choke on.
+        """Damaged articles have to be repaired by par2 first. A notification is the only
+        thing that gets a running unpacker going, so this one may not send one.
         """
-        waiting = park_in_wait_for_next_volume(unpacker)
         nzf = make_nzf("test.part02.rar", "test", 2)
         unpacker.nzo.finished_files.append(nzf)
         unpacker.nzo.bad_articles = 1
 
-        unpacker.add(nzf)
+        with mock.patch.object(unpacker, "next_file_lock") as next_file_lock:
+            unpacker.add(nzf)
 
-        waiting.join(timeout=2)
-        assert waiting.is_alive(), "unpacker should stay parked until par2 repaired the damage"
+        next_file_lock.notify.assert_not_called()
+        next_file_lock.notify_all.assert_not_called()
 
 
 class TestDirectUnpackerResume:
@@ -363,7 +363,7 @@ class TestDirectUnpackerLock:
             assert spawning.wait(timeout=10), "unrar was never started"
 
             # Nobody else gets to look at the slots while we are claiming one
-            assert not ACTIVE_UNPACKERS_LOCK.acquire(timeout=1), "the slots were readable mid-claim"
+            assert not ACTIVE_UNPACKERS_LOCK.acquire(blocking=False), "the slots were readable mid-claim"
 
             release.set()
             adding.join(timeout=10)

--- a/tests/test_directunpacker.py
+++ b/tests/test_directunpacker.py
@@ -20,6 +20,7 @@ tests.test_directunpacker - Testing functions in directunpacker.py
 """
 
 import threading
+import time
 from unittest import mock
 
 import pytest
@@ -29,6 +30,7 @@ import sabnzbd.directunpacker
 from sabnzbd.directunpacker import ACTIVE_UNPACKERS, ACTIVE_UNPACKERS_LOCK, DirectUnpacker
 from sabnzbd.newsunpack import rar_unpack
 from sabnzbd.nzb import NzbFile, NzbObject
+from tests.testhelper import wait_for
 
 
 def make_nzf(filename: str, setname: str, vol: int) -> NzbFile:
@@ -186,7 +188,6 @@ class TestDirectUnpackerResume:
         assert waiting.is_alive()
 
         # Post-processing repaired the set and now waits for direct unpack to finish
-        unpacker.nzo.pp_active = True
         unpacker.success_sets["test"] = (["test.part01.rar"], [])
         with mock.patch.object(DirectUnpacker, "is_alive", side_effect=waiting.is_alive):
             rar_unpack(unpacker.nzo, str(unpacker.nzo.download_path), False, ["test.part01.rar"])
@@ -230,16 +231,13 @@ class TestDirectUnpackerOutput:
         unpacker.fake_unrar.instance.stdin.write.assert_called_once_with(b"C\n")
 
     @pytest.mark.parametrize("later_volume", [False, True], ids=["nothing_left", "later_volume_arrived"])
-    def test_missing_volume_ends_the_unpack(self, startable_unpacker, later_volume):
-        """Volume 2 never arrives. unrar keeps asking for the same one, so the repeating
-        prompt has to end the unpack instead of asking forever.
+    def test_missing_volume_aborts_once_repair_is_done(self, startable_unpacker, later_volume):
+        """Volume 2 never arrives. Once post-processing tells us nothing is coming anymore
+        we have to give up right away, also when a later volume did arrive.
         """
         unpacker = startable_unpacker
         if later_volume:
             unpacker.nzo.finished_files.append(make_nzf("test.part03.rar", "test", 3))
-
-        # Post-processing is running, so we know no more volumes are coming
-        unpacker.nzo.pp_active = True
 
         prompt = b"\nExtracting from test.part01.rar\n\nInsert disk with test.part02.rar [C]ontinue, [Q]uit "
         chars = (prompt[i : i + 1] for _ in iter(int, 1) for i in range(len(prompt)))
@@ -251,17 +249,31 @@ class TestDirectUnpackerOutput:
         unpacker.fake_unrar.instance.stdout.read.side_effect = read_char
 
         unpacker.add(make_nzf("test.part01.rar", "test", 1))
-        unpacker.join(timeout=60)
+        wait_for(
+            lambda: unpacker.cur_volume == 1 and unpacker.active_instance,
+            timeout=10,
+            interval=0.02,
+            err_msg="Timed out waiting for the DirectUnpacker",
+        )
+        assert unpacker.is_alive(), "gave up before post-processing said so"
+
+        unpacker.set_no_more_files()
+        unpacker.join(timeout=30)
 
         assert not unpacker.is_alive(), "kept asking for a volume that is never coming"
         assert unpacker.killed
+        # Straight to the abort, no rounds of repeating output first
+        assert not unpacker.duplicate_lines
+        assert unpacker.fake_unrar.instance.stdin.write.call_args_list == [mock.call(b"Q\n")]
 
-        # A later volume makes have_next_volume() true again once cur_volume moves on,
-        # so the repeat counter is what ends it instead of the missing volume itself
-        if later_volume:
-            assert unpacker.duplicate_lines
-        else:
-            assert not unpacker.duplicate_lines
+    def test_no_more_files_releases_the_wait(self, unpacker):
+        """The wait is only released by a notification, so post-processing has to send one"""
+        waiting = park_in_wait_for_next_volume(unpacker)
+
+        unpacker.set_no_more_files()
+
+        waiting.join(timeout=10)
+        assert not waiting.is_alive(), "set_no_more_files() did not wake the unpacker"
 
     def test_each_instance_reads_its_own_output(self, startable_unpacker):
         """Output that a previous instance left behind may not leak into the next set"""

--- a/tests/test_directunpacker.py
+++ b/tests/test_directunpacker.py
@@ -229,6 +229,40 @@ class TestDirectUnpackerOutput:
         wait_for_next_volume.assert_called_once()
         unpacker.fake_unrar.instance.stdin.write.assert_called_once_with(b"C\n")
 
+    @pytest.mark.parametrize("later_volume", [False, True], ids=["nothing_left", "later_volume_arrived"])
+    def test_missing_volume_ends_the_unpack(self, startable_unpacker, later_volume):
+        """Volume 2 never arrives. unrar keeps asking for the same one, so the repeating
+        prompt has to end the unpack instead of asking forever.
+        """
+        unpacker = startable_unpacker
+        if later_volume:
+            unpacker.nzo.finished_files.append(make_nzf("test.part03.rar", "test", 3))
+
+        # Post-processing is running, so we know no more volumes are coming
+        unpacker.nzo.pp_active = True
+
+        prompt = b"\nExtracting from test.part01.rar\n\nInsert disk with test.part02.rar [C]ontinue, [Q]uit "
+        chars = (prompt[i : i + 1] for _ in iter(int, 1) for i in range(len(prompt)))
+
+        def read_char(_size: int) -> bytes:
+            # Killing the instance closes the pipe
+            return b"" if unpacker.killed else next(chars)
+
+        unpacker.fake_unrar.instance.stdout.read.side_effect = read_char
+
+        unpacker.add(make_nzf("test.part01.rar", "test", 1))
+        unpacker.join(timeout=60)
+
+        assert not unpacker.is_alive(), "kept asking for a volume that is never coming"
+        assert unpacker.killed
+
+        # A later volume makes have_next_volume() true again once cur_volume moves on,
+        # so the repeat counter is what ends it instead of the missing volume itself
+        if later_volume:
+            assert unpacker.duplicate_lines
+        else:
+            assert not unpacker.duplicate_lines
+
     def test_each_instance_reads_its_own_output(self, startable_unpacker):
         """Output that a previous instance left behind may not leak into the next set"""
         unpacker = startable_unpacker

--- a/tests/test_directunpacker.py
+++ b/tests/test_directunpacker.py
@@ -25,7 +25,8 @@ from unittest import mock
 import pytest
 
 import sabnzbd.cfg as cfg
-from sabnzbd.directunpacker import DirectUnpacker
+import sabnzbd.directunpacker
+from sabnzbd.directunpacker import ACTIVE_UNPACKERS, DirectUnpacker
 from sabnzbd.newsunpack import rar_unpack
 from sabnzbd.nzb import NzbFile, NzbObject
 
@@ -39,11 +40,7 @@ def make_nzf(filename: str, setname: str, vol: int) -> NzbFile:
     return nzf
 
 
-@pytest.fixture
-def unpacker(tmp_path):
-    """A DirectUnpacker with an active unrar instance that finished volume 1 of the
-    set "test", positioned as if unrar is waiting for volume 2 to appear.
-    """
+def make_nzo(tmp_path) -> NzbObject:
     nzo = mock.MagicMock(spec=NzbObject)
     nzo.first_articles = []
     nzo.unpack = True
@@ -55,19 +52,72 @@ def unpacker(tmp_path):
     nzo.download_path = str(tmp_path)
     nzo.final_name = "test.job"
     nzo.delete = False
+    nzo.password = None
+    nzo.correct_password = None
+    return nzo
 
+
+@pytest.fixture
+def patched_cfg():
     with mock.patch.multiple(
         cfg,
         direct_unpack_tested=mock.Mock(return_value=True),
         direct_unpack=mock.Mock(return_value=True),
         enable_unrar=mock.Mock(return_value=True),
     ):
-        unpacker = DirectUnpacker(nzo)
-        unpacker.cur_setname = "test"
-        unpacker.cur_volume = 1
-        # Pretend unrar is running, so add() will not try to start a real one
-        unpacker.active_instance = mock.MagicMock()
+        yield
+
+
+@pytest.fixture
+def unpacker(tmp_path, patched_cfg):
+    """A DirectUnpacker with an active unrar instance that finished volume 1 of the
+    set "test", positioned as if unrar is waiting for volume 2 to appear.
+    """
+    unpacker = DirectUnpacker(make_nzo(tmp_path))
+    unpacker.cur_setname = "test"
+    unpacker.cur_volume = 1
+    # Pretend unrar is running, so add() will not try to start a real one
+    unpacker.active_instance = mock.MagicMock()
+    yield unpacker
+
+
+class FakeUnrar:
+    """An unrar process that produces no output until it is released"""
+
+    def __init__(self):
+        self.reading = threading.Event()
+        self.release = threading.Event()
+        self.instance = mock.MagicMock()
+        self.instance.poll.return_value = None
+        self.instance.stdout.read.side_effect = self.read
+
+    def read(self, _size: int) -> bytes:
+        self.reading.set()
+        assert self.release.wait(timeout=60)
+        return b""
+
+
+@pytest.fixture
+def startable_unpacker(tmp_path, patched_cfg):
+    """A DirectUnpacker that has not started yet, with volume 1 of the set "test" ready
+    on disk and a fake unrar that stays silent, so add() will start the real code path.
+    """
+    nzo = make_nzo(tmp_path)
+    nzo.finished_files.append(make_nzf("test.part01.rar", "test", 1))
+
+    unpacker = DirectUnpacker(nzo)
+    unpacker.unpack_dir_info = (str(tmp_path), str(tmp_path), None, False, None)
+    unpacker.fake_unrar = FakeUnrar()
+
+    with mock.patch.object(sabnzbd.directunpacker, "build_and_run_command", return_value=unpacker.fake_unrar.instance):
         yield unpacker
+
+    unpacker.fake_unrar.release.set()
+    unpacker.killed = True
+    if unpacker.is_alive():
+        unpacker.join(timeout=10)
+    while unpacker in ACTIVE_UNPACKERS:
+        ACTIVE_UNPACKERS.remove(unpacker)
 
 
 def park_in_wait_for_next_volume(unpacker: DirectUnpacker) -> threading.Thread:
@@ -142,3 +192,55 @@ class TestDirectUnpackerResume:
             rar_unpack(unpacker.nzo, str(unpacker.nzo.download_path), False, ["test.part01.rar"])
 
         assert not waiting.is_alive(), "rar_unpack() did not resume the parked unpacker"
+
+
+class TestDirectUnpackerOutput:
+    def test_reading_output_does_not_block_add(self, startable_unpacker):
+        """Reading unrar's output may not hold START_STOP_LOCK. add() needs that same
+        lock and is called from the single Assembler thread, so a quiet or stalled unrar
+        would otherwise stop assembly for every job in the queue.
+        """
+        unpacker = startable_unpacker
+        unpacker.add(make_nzf("test.part01.rar", "test", 1))
+        assert unpacker.is_alive(), "add() did not start the unpacker"
+        assert unpacker.fake_unrar.reading.wait(timeout=10), "unrar output was never read"
+
+        # The Assembler thread hands us the next volume while unrar produces nothing
+        adding = threading.Thread(target=unpacker.add, args=(make_nzf("test.part02.rar", "test", 2),), daemon=True)
+        adding.start()
+        adding.join(timeout=5)
+
+        assert not adding.is_alive(), "add() was blocked by a silent unrar"
+
+    def test_reads_all_output_of_the_instance(self, startable_unpacker):
+        """Whole lines, the prompt that has no newline after it and any trailing output
+        all have to survive the move off the main loop.
+        """
+        unpacker = startable_unpacker
+        output = b"\nUNRAR 6.11 freeware\n\nExtracting from test.part01.rar\n\nInsert disk with test.part02.rar [C]ontinue, [Q]uit "
+        unpacker.fake_unrar.instance.stdout.read.side_effect = [output[i : i + 1] for i in range(len(output))] + [b""]
+
+        with mock.patch.object(DirectUnpacker, "wait_for_next_volume") as wait_for_next_volume:
+            unpacker.add(make_nzf("test.part01.rar", "test", 1))
+            unpacker.join(timeout=10)
+
+        assert not unpacker.is_alive(), "unpacker did not stop at the end of the output"
+        # The prompt has no newline after it, so it is only recognized if partial output arrives
+        wait_for_next_volume.assert_called_once()
+        unpacker.fake_unrar.instance.stdin.write.assert_called_once_with(b"C\n")
+
+    def test_each_instance_reads_its_own_output(self, startable_unpacker):
+        """Output that a previous instance left behind may not leak into the next set"""
+        unpacker = startable_unpacker
+        unpacker.cur_setname = "test"
+        unpacker.create_unrar_instance()
+        first_queue = unpacker.output_queue
+        first_queue.put(b"stale ")
+
+        # This is how run() moves on to the next set
+        unpacker.reset_active()
+        unpacker.cur_setname = "test"
+        unpacker.create_unrar_instance()
+
+        assert unpacker.output_queue is not first_queue
+        assert unpacker.output_queue.empty()

--- a/tests/test_directunpacker.py
+++ b/tests/test_directunpacker.py
@@ -246,6 +246,34 @@ class TestDirectUnpackerOutput:
         assert unpacker.output_queue.empty()
 
 
+class TestDirectUnpackerAbort:
+    def test_aborts_between_sets(self, unpacker):
+        """run() clears cur_setname while it moves on to the next set, and reset_active()
+        can sit there for two seconds waiting for the old instance. An abort landing in
+        that window still has to stop us, or the next set gets unpacked anyway.
+        """
+        unpacker.cur_setname = None
+
+        unpacker.abort()
+
+        assert unpacker.killed
+        assert not unpacker.check_requirements()
+
+    def test_aborts_without_a_rarfile(self, unpacker, tmp_path):
+        """The one-folder cleanup needs the rarfile to know what to remove. Without it the
+        files are left alone, the shared folder may hold files that are not ours.
+        """
+        shared_file = tmp_path / "not-ours.mkv"
+        shared_file.touch()
+        unpacker.rarfile_nzf = None
+        unpacker.unpack_dir_info = (str(tmp_path), str(tmp_path), None, True, None)
+
+        unpacker.abort()
+
+        assert unpacker.killed
+        assert shared_file.exists(), "abort() removed files it did not unpack"
+
+
 class TestDirectUnpackerLock:
     def test_unpackers_do_not_share_a_lock(self, unpacker, startable_unpacker):
         """abort() holds the lock while it kills unrar and removes the extracted files,

--- a/tests/test_directunpacker.py
+++ b/tests/test_directunpacker.py
@@ -26,7 +26,7 @@ import pytest
 
 import sabnzbd.cfg as cfg
 import sabnzbd.directunpacker
-from sabnzbd.directunpacker import ACTIVE_UNPACKERS, DirectUnpacker
+from sabnzbd.directunpacker import ACTIVE_UNPACKERS, ACTIVE_UNPACKERS_LOCK, DirectUnpacker
 from sabnzbd.newsunpack import rar_unpack
 from sabnzbd.nzb import NzbFile, NzbObject
 
@@ -263,3 +263,29 @@ class TestDirectUnpackerLock:
             adding.join(timeout=5)
 
             assert not adding.is_alive(), "add() waited for an unrelated job"
+
+    def test_claiming_a_slot_is_atomic(self, startable_unpacker):
+        """Checking the direct_unpack_threads limit and taking one of the slots have to
+        happen together, or two callers of add() could both claim the last one.
+        """
+        unpacker = startable_unpacker
+        spawning = threading.Event()
+        release = threading.Event()
+
+        def slow_spawn(*args, **kwargs):
+            spawning.set()
+            assert release.wait(timeout=60)
+            return unpacker.fake_unrar.instance
+
+        with mock.patch.object(sabnzbd.directunpacker, "build_and_run_command", side_effect=slow_spawn):
+            adding = threading.Thread(target=unpacker.add, args=(make_nzf("test.part01.rar", "test", 1),), daemon=True)
+            adding.start()
+            assert spawning.wait(timeout=10), "unrar was never started"
+
+            # Nobody else gets to look at the slots while we are claiming one
+            assert not ACTIVE_UNPACKERS_LOCK.acquire(timeout=1), "the slots were readable mid-claim"
+
+            release.set()
+            adding.join(timeout=10)
+
+        assert unpacker in ACTIVE_UNPACKERS

--- a/tests/test_directunpacker.py
+++ b/tests/test_directunpacker.py
@@ -19,8 +19,10 @@
 tests.test_directunpacker - Testing functions in directunpacker.py
 """
 
+import os
 import threading
 import time
+from contextlib import suppress
 from unittest import mock
 
 import pytest
@@ -84,19 +86,22 @@ def unpacker(tmp_path, patched_cfg):
 
 
 class FakeUnrar:
-    """An unrar process that produces no output until it is released"""
+    """An unrar process on a real pipe, so it can be polled like the real thing.
+    Stays silent until something is written to it.
+    """
 
     def __init__(self):
-        self.reading = threading.Event()
-        self.release = threading.Event()
+        read_fd, self.write_fd = os.pipe()
         self.instance = mock.MagicMock()
         self.instance.poll.return_value = None
-        self.instance.stdout.read.side_effect = self.read
+        self.instance.stdout = open(read_fd, "rb", buffering=0)
 
-    def read(self, _size: int) -> bytes:
-        self.reading.set()
-        assert self.release.wait(timeout=60)
-        return b""
+    def write(self, output: bytes):
+        os.write(self.write_fd, output)
+
+    def close(self):
+        with suppress(OSError):
+            os.close(self.write_fd)
 
 
 @pytest.fixture
@@ -114,8 +119,8 @@ def startable_unpacker(tmp_path, patched_cfg):
     with mock.patch.object(sabnzbd.directunpacker, "build_and_run_command", return_value=unpacker.fake_unrar.instance):
         yield unpacker
 
-    unpacker.fake_unrar.release.set()
     unpacker.killed = True
+    unpacker.fake_unrar.close()
     if unpacker.is_alive():
         unpacker.join(timeout=10)
     while unpacker in ACTIVE_UNPACKERS:
@@ -210,7 +215,6 @@ class TestDirectUnpackerOutput:
         unpacker = startable_unpacker
         unpacker.add(make_nzf("test.part01.rar", "test", 1))
         assert unpacker.is_alive(), "add() did not start the unpacker"
-        assert unpacker.fake_unrar.reading.wait(timeout=10), "unrar output was never read"
 
         # The Assembler thread hands us the next volume while unrar produces nothing
         adding = threading.Thread(target=unpacker.add, args=(make_nzf("test.part02.rar", "test", 2),), daemon=True)
@@ -219,20 +223,27 @@ class TestDirectUnpackerOutput:
 
         assert not adding.is_alive(), "add() was blocked by a silent unrar"
 
-    def test_reads_all_output_of_the_instance(self, startable_unpacker):
-        """Whole lines, the prompt that has no newline after it and any trailing output
-        all have to survive the move off the main loop.
+    @pytest.mark.parametrize("chunked", [False, True], ids=["char_by_char", "all_at_once"])
+    def test_reads_all_output_of_the_instance(self, startable_unpacker, chunked):
+        """Whole lines and the prompt that has no newline after it both have to be picked
+        up, no matter how the output is spread over the reads.
         """
         unpacker = startable_unpacker
         output = b"\nUNRAR 6.11 freeware\n\nExtracting from test.part01.rar\n\nInsert disk with test.part02.rar [C]ontinue, [Q]uit "
-        unpacker.fake_unrar.instance.stdout.read.side_effect = [output[i : i + 1] for i in range(len(output))] + [b""]
 
         with mock.patch.object(DirectUnpacker, "wait_for_next_volume") as wait_for_next_volume:
             unpacker.add(make_nzf("test.part01.rar", "test", 1))
+            if chunked:
+                unpacker.fake_unrar.write(output)
+            else:
+                for index in range(len(output)):
+                    unpacker.fake_unrar.write(output[index : index + 1])
+            wait_for(lambda: unpacker.fake_unrar.instance.stdin.write.called, timeout=10)
+            unpacker.fake_unrar.close()
             unpacker.join(timeout=10)
 
         assert not unpacker.is_alive(), "unpacker did not stop at the end of the output"
-        # The prompt has no newline after it, so it is only recognized if partial output arrives
+        # The prompt has no newline after it, so it is only found in the leftover buffer
         wait_for_next_volume.assert_called_once()
         unpacker.fake_unrar.instance.stdin.write.assert_called_once_with(b"C\n")
 
@@ -245,22 +256,11 @@ class TestDirectUnpackerOutput:
         if later_volume:
             unpacker.nzo.finished_files.append(make_nzf("test.part03.rar", "test", 3))
 
-        prompt = b"\nExtracting from test.part01.rar\n\nInsert disk with test.part02.rar [C]ontinue, [Q]uit "
-        chars = (prompt[i : i + 1] for _ in iter(int, 1) for i in range(len(prompt)))
-
-        def read_char(_size: int) -> bytes:
-            # Killing the instance closes the pipe
-            return b"" if unpacker.killed else next(chars)
-
-        unpacker.fake_unrar.instance.stdout.read.side_effect = read_char
-
         unpacker.add(make_nzf("test.part01.rar", "test", 1))
-        wait_for(
-            lambda: unpacker.cur_volume == 1 and unpacker.active_instance,
-            timeout=10,
-            interval=0.02,
-            err_msg="Timed out waiting for the DirectUnpacker",
+        unpacker.fake_unrar.write(
+            b"\nExtracting from test.part01.rar\n\nInsert disk with test.part02.rar [C]ontinue, [Q]uit "
         )
+        wait_for(lambda: unpacker.cur_volume == 1 and unpacker.active_instance, timeout=10)
         assert unpacker.is_alive(), "gave up before post-processing said so"
 
         unpacker.set_no_more_files()
@@ -280,22 +280,6 @@ class TestDirectUnpackerOutput:
 
         waiting.join(timeout=10)
         assert not waiting.is_alive(), "set_no_more_files() did not wake the unpacker"
-
-    def test_each_instance_reads_its_own_output(self, startable_unpacker):
-        """Output that a previous instance left behind may not leak into the next set"""
-        unpacker = startable_unpacker
-        unpacker.cur_setname = "test"
-        unpacker.create_unrar_instance()
-        first_queue = unpacker.output_queue
-        first_queue.put(b"stale ")
-
-        # This is how run() moves on to the next set
-        unpacker.reset_active()
-        unpacker.cur_setname = "test"
-        unpacker.create_unrar_instance()
-
-        assert unpacker.output_queue is not first_queue
-        assert unpacker.output_queue.empty()
 
 
 class TestDirectUnpackerAbort:


### PR DESCRIPTION
Possibly related to #3507 but I don't think it explains their symptoms (need dump or at least logs) most of the changes are in tests or comments explaining what's going on.

Claude incoming.

Investigation started from a report of DirectUnpack occasionally leaving a job stuck: the `unrar -vp` process stays alive but stops making progress, and the job sits in the queue without ever completing or failing.

**That report is not explained by anything here.** The state it describes — unrar alive, output directory not growing — is what `unrar -vp` looks like while parked at its `[C]ontinue, [Q]uit ` prompt, and reaching that prompt means unrar produced output, which `run()` read and acted on outside the lock. So the unpacker holds nothing while it waits, and the job staying in the *queue* rather than moving to history points at the download not finishing, with the parked unrar as a symptom rather than the cause. Diagnosing it properly needs a thread dump from a running instance (`py-spy dump`) and confirmation of whether other jobs kept downloading at the same time.

What the investigation did turn up is the set of real defects below, found by reading the code around the reported behaviour. (1) can produce exactly this symptom, but only in a narrower situation than the report describes, and is worth fixing on its own merits either way.

---

## 1. Reading unrar's output blocked the Assembler thread

**When it happens.** `run()` held the module-wide `START_STOP_LOCK` across a blocking `stdout.read(1)`. `add()` is `@synchronized` on that same lock and is called from the single Assembler thread, so no job in the queue could assemble for as long as unrar produced no output. With `-idp` unrar is silent for the whole of each volume it decompresses, so this is a continuous throughput drag proportional to the number of active unpackers, not a rare event.

It becomes a permanent freeze only if unrar stays alive and never produces output again — wedged in uninterruptible I/O on an unresponsive disk, rather than merely idle. Then assembly never resumes for any job, no job reaches post-processing, and neither of the two things that can release a DirectUnpacker (`rar_unpack()` or `purge_data()` → `abort_direct_unpacker()`) is reached. `abort()` and `create_unrar_instance()` need the same lock, so the 2-minute watchdog in `rar_unpack()` cannot help either. That case is the whole queue stalling at once, not one job.

**Why this fixes it.** The read never blocks, so no caller ever waits behind it. `build_and_run_command` already sets `bufsize=0`, so `stdout` is a raw `FileIO` and both platforms can read exactly what is already available, leaving the stream in blocking mode:

```python
if sabnzbd.WINDOWS:
    handle = msvcrt.get_osfhandle(self.active_instance.stdout.fileno())
    if available := win32pipe.PeekNamedPipe(handle, 0)[1]:
        return self.active_instance.stdout.read(available)
    time.sleep(WINDOWS_POLL_INTERVAL)
elif select.select([self.active_instance.stdout], [], [], OUTPUT_TIMEOUT)[0]:
    return self.active_instance.stdout.read(OUTPUT_CHUNK_SIZE)
```

`select` cannot take a pipe on Windows and `os.set_blocking()` only supports Windows pipes from 3.12, so Windows peeks the pipe through pywin32, which is already a dependency there. Both branches also re-check `killed`, so an instance that was killed without its pipe reaching end-of-file no longer leaves `run()` waiting.

That also allows the char-by-char loop to go: `run()` appends each chunk to the buffer, takes whole lines off it with `split(b"\n", 1)`, and checks whatever is left for the prompts, which is where the newline-less new-disk message lives.

## 2. Slow DirectUnpack work blocked unrelated jobs

**When it happens.** `START_STOP_LOCK` was module-level and shared by every `DirectUnpacker`, while everything it guards is per-instance state. `abort()` holds it across `kill()`, two 0.2s sleeps and `remove_all(extraction_path, recursive=True)` — seconds on a slow or network disk. `reset_active()` holds it across `wait(timeout=2)`. With `direct_unpack_threads` defaulting to 3, all of that serialised against the Assembler thread.

**Why this fixes it.** The lock becomes `self.lock`, using the existing no-argument `@synchronized()` convention (`NzbObject`/`NzbFile` already do this). `ACTIVE_UNPACKERS` keeps a small dedicated `ACTIVE_UNPACKERS_LOCK`, held across the `direct_unpack_threads` check *and* `create_unrar_instance()` so two callers can never claim the same slot — a plain lock around `append`/`remove` would add nothing, since those are already atomic. Lock order is instance lock → `ACTIVE_UNPACKERS_LOCK`, never the reverse; `abort_all()` therefore iterates a copy taken under the lock, which also fixes it silently skipping entries when the list mutates mid-iteration.

## 3. `abort()` was ignored between sets

**When it happens.** `abort()` required `self.cur_setname`, but `run()` clears it in `reset_active()` before starting the next set, and `reset_active()` can sit in `active_instance.wait(timeout=2)`. An abort arriving in that window returned having done nothing — `killed` stayed `False`, unrar was not killed, files were not removed — and `run()` then went on to unpack the next set of a job being purged or removed from the queue.

**Why this fixes it.** `abort()` now keys only on `self.killed`, so it is effective in that window, and logs the job name when there is no set name yet.

## 4. `abort()` could raise `AttributeError` at the caller

**When it happens.** In the `one_folder` cleanup the `except` handler itself dereferenced `rarfile_nzf.filename`, so with no rarfile the error escaped `abort()` into callers such as `NzbQueue.remove()` → `purge_data()`, where nothing catches it. Reachable today: `run()`'s next-set path sets `cur_setname` and then waits in `wait_for_next_volume()` before `create_unrar_instance()` assigns `rarfile_nzf`.

**Why this fixes it.** Both the call and the handler are guarded. The files are left in place rather than falling through to `remove_all()` — with `one_folder` the extraction path is shared with the user's other files.

## 5. A missing volume failed slowly and reported a volume that was never unpacked

**When it happens.** With volume 2 missing but 3 present, the unpack waited until post-processing, then `run()` incremented `cur_volume` speculatively before checking anything. That made `have_next_volume()` match volume *3*, disarming the `not have_next_volume()` half of the repeating-prompt guard, so it took 11 identical prompts to give up and the UI showed `02/NN` for a volume that never existed.

**Why this fixes it.** Post-processing now tells the unpacker explicitly, via `set_no_more_files()`, immediately after `parring()` — the point where repair is done and nothing new can arrive. `run()` acts on it directly after the wait:

```python
if self.no_more_files and not self.have_next_volume():
    logging.info("DirectUnpack failed due to missing files %s", self.cur_setname)
    self.abort()
```

`cur_volume` is still correct at that point, so the check looks for the volume actually being waited on. `wait_for_next_volume()` now waits on `no_more_files` instead of `nzo.pp_active`, which was never a safe signal: `pp_active` is set at the start of post-processing, *before* `parring()`, so acting on it would feed unrar an unrepaired volume. `rar_unpack()` calls `set_no_more_files()` too, as an idempotent fallback that states the same thing.

Trade-off: `have_next_volume()` is now the authority once repair finishes, so a volume par2 rebuilt that has no matching assembled `NzbFile` aborts rather than continuing. That was already the behaviour whenever no later volume existed; it only survived by accident when a later volume made the check pass after the phantom increment. Renames are covered, since `verify_all_filenames_and_resort()` re-runs `set_volumes_for_nzo()`.

## 6. Minor: post-processing noticed completion up to 2s late

`rar_unpack()` polled with `time.sleep(2)`. `DirectUnpacker` is a `Thread`, so it now uses `join(timeout=2)` and returns the moment the unpack is done. The `wait_count > 60` stuck-detection and the periodic bump of the file-lock are both unchanged — iterations where the thread is alive still take the full 2s. `set_no_more_files()` is sent once before the loop, since it is a state change rather than a nudge.

---

## Deliberately not changed

- **`add()` still returns without notifying when the download is damaged.** This looks like a lost wakeup but is load-bearing: it parks the unpacker on the volume it needs so `rar_unpack()` can resume it after par2 repaired the damage. Waking it would feed unrar a damaged volume, and the resulting `abort()` would `remove_all()` everything unpacked so far. Comments added at both ends to record this.
- **No timeout on `wait_for_next_volume()`.** For the same reason — a periodic re-check would release the wait before repair. Every exit is covered: `add()`'s notify, `set_no_more_files()`, and `purge_data()` → `abort_direct_unpacker()`, which runs on every terminal outcome of `process_job()`.

## Still open

`rar_unpack()`'s watchdog aborts after two minutes without progress but then keeps looping on `while nzo.direct_unpacker.is_alive():`, calling `abort()` every two seconds — and `abort()` is a no-op once `killed` is set. An unpacker that will not stop therefore holds the single post-processing thread forever. Left alone here because stopping the wait means deciding what to do next, and extracting into a directory a surviving unrar may still be writing to is worse than waiting.

## Testing

New `tests/test_directunpacker.py`, 13 tests, using a real `os.pipe()` for unrar's output so the polling and `select` paths are actually exercised. Each fix has a test verified to fail against the pre-change implementation:

- reading output does not block `add()`
- all output is picked up whether it arrives a byte at a time or in one chunk, including the prompt that has no newline after it
- claiming a `direct_unpack_threads` slot is atomic, and unpackers do not share a lock
- abort works between sets, and without a rarfile leaves the shared folder alone
- a missing volume aborts as soon as repair is done, with and without a later volume present
- `add()` sends no notification while the download is damaged, and does send one otherwise
