### PR TITLE
Fix flaky test_api_queue_sort test and to_unit at boundaries

### DIFF
--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -653,25 +653,26 @@ def to_units(val: int | float, postfix="") -> str:
         # Limit it to 5 as the maximum defined index.
         n = min(5, math.trunc(math.log2(val) / 10))
 
-    # Now we scale our value to the appropriate power of 1024
-    # It is written as 2^10n for symmetry with the
-    # selection above.
-    val = val / 2 ** (10 * n)
-
     # Showing the single decimal per doc string
     if n > 1:
         decimals = 1
     else:
         decimals = 0
 
-    # Rounding to the displayed precision can carry the value up to the next unit,
-    # for example 1048575 would be shown as "1024 K" instead of "1.0 M". Move it to
-    # the next unit instead, unless we are already at the maximum defined index.
-    if n < 5 and float(f"{val:.{decimals}f}") >= 1024:
+    # Now we scale our value to the appropriate power of 1024
+    # It is written as 2^10n for symmetry with the
+    # selection above. Round it to the precision we are going to display, so
+    # what we check below is what ends up in the output.
+    val = round(val / 2 ** (10 * n), decimals)
+
+    # That rounding can carry the value up into the next unit, for example 1048575
+    # would be shown as "1024 K" instead of "1.0 M". Move it up a unit instead,
+    # unless we are already at the maximum defined index.
+    if n < 5 and val >= 1024:
         n += 1
-        val = val / 1024
         if n > 1:
             decimals = 1
+        val = round(val / 1024, decimals)
 
     # We might not have anything at all to append
     if n == 0 and postfix == "":

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -664,6 +664,15 @@ def to_units(val: int | float, postfix="") -> str:
     else:
         decimals = 0
 
+    # Rounding to the displayed precision can carry the value up to the next unit,
+    # for example 1048575 would be shown as "1024 K" instead of "1.0 M". Move it to
+    # the next unit instead, unless we are already at the maximum defined index.
+    if n < 5 and float(f"{val:.{decimals}f}") >= 1024:
+        n += 1
+        val = val / 1024
+        if n > 1:
+            decimals = 1
+
     # We might not have anything at all to append
     if n == 0 and postfix == "":
         units = ""

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -660,8 +660,8 @@ def to_units(val: int | float, postfix="") -> str:
         decimals = 0
 
     # Now we scale our value to the appropriate power of 1024
-    # It is written as 2^10n for symmetry with the
-    # selection above. Round it to the precision we are going to display, so
+    # It is written as 2^10n for symmetry with the selection above.
+    # Round it to the precision we are going to display, so
     # what we check below is what ends up in the output.
     val = round(val / 2 ** (10 * n), decimals)
 

--- a/tests/test_functional_api.py
+++ b/tests/test_functional_api.py
@@ -706,8 +706,14 @@ class TestQueueApi(ApiTestFunctions):
         new_order = list(filter((geriatric_entry).__ne__, new_order))
         original_order = list(filter((geriatric_entry).__ne__, original_order))
 
-        # Verify the result
-        assert new_order == original_order
+        # Verify the result. The api sorts on the exact values, while the slots only
+        # report them rounded to the nearest display unit ("1024 KB" and "1.0 MB" both
+        # mean 1MiB). Comparing at that lower resolution avoids failing on entries that
+        # are indistinguishable in the api output but not to the actual sort.
+        if key:
+            assert [key(entry) for entry in new_order] == [key(entry) for entry in original_order]
+        else:
+            assert new_order == original_order
 
     @pytest.mark.parametrize(
         "queue_size, index_from, index_to, value2_is_nzo_id",

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -185,6 +185,16 @@ class TestMisc:
         assert "9.8 G" == misc.to_units(1024 * 1024 * 10000)
         assert "1024.0 P" == misc.to_units(1024**6)
 
+        # Values that round up to the next unit should be shown in that unit
+        assert "1023 K" == misc.to_units(1024**2 - 1024)
+        assert "1.0 M" == misc.to_units(1024**2 - 1)
+        assert "-1.0 M" == misc.to_units(-(1024**2 - 1))
+        assert "1.0 MBla" == misc.to_units(1024**2 - 1, postfix="Bla")
+        assert "1023.9 M" == misc.to_units(1024**3 - 1024**2 // 8)
+        assert "1.0 G" == misc.to_units(1024**3 - 1)
+        assert "1.0 T" == misc.to_units(1024**4 - 1)
+        assert "1.0 P" == misc.to_units(1024**5 - 1)
+
     def test_unit_back_and_forth(self):
         assert 100 == misc.from_units(misc.to_units(100))
         assert 1024 == misc.from_units(misc.to_units(1024))


### PR DESCRIPTION
Fixes #3520

Verified my hypothesis, found it's two issues.

- The api sorts by `nzo.bytes` exact value, the test maps lower resolution units back to bytes. Fix is to compare at the same resolution
- `to_units` outputting `1024 KB` instead of `1.0 MB`, calculation is `trunc(log2(val)/10)` but value is then printed at reduced precision. Fixed by applying the same formatting as the output.

bytes | before | after
-- | -- | --
1048575 | 1024 K | 1.0 M
1073741823 | 1024.0 M | 1.0 G
1099511627775 | 1024.0 G | 1.0 T

