### PR TITLE
Add accessible names to Glitter connections and orphaned jobs tables

### DIFF
--- a/interfaces/Glitter/templates/include_overlays.tmpl
+++ b/interfaces/Glitter/templates/include_overlays.tmpl
@@ -274,7 +274,7 @@
                                 </div>
 
                                 <!-- ko if: serverconnections().length > 0 -->
-                                <table class="table table-hover table-server-connections" data-bind="visible: \$root.showActiveConnections()">
+                                <table class="table table-hover table-server-connections" aria-label="$T('connections')" data-bind="visible: \$root.showActiveConnections()">
                                     <thead>
                                         <tr>
                                             <th><strong>$T('article-id')</strong></th>
@@ -304,7 +304,7 @@
                         <a href="#" class="hover-button process-all-orphaned" data-bind="click: removeAllOrphaned">$T('Glitter-purgeOrphaned') <span class="glyphicon glyphicon-trash"></span></a>
                         <a href="#" class="hover-button process-all-orphaned" data-bind="click: addAllOrphaned">$T('Glitter-retryAllOrphaned') <span class="glyphicon glyphicon-plus-sign"></span></a>
                         <div class="clearfix"></div>
-                        <table class="table table-hover table-striped">
+                        <table class="table table-hover table-striped" aria-label="$T('Glitter-orphanedJobs')">
                             <thead>
                                 <tr>
                                     <th style="width: 30px;"></th>


### PR DESCRIPTION
The active server connections and orphaned jobs tables in the Glitter Status dialog did not have accessible names, so screen reader users navigating by table could not identify them.

This names both tables using the existing translated Connections and Orphaned jobs text. It does not change the existing layout or behavior.

Testing:
- Verified both tables have the intended translated accessible names.
- Ran the interface test suite: 7,318 passed.
