### PR TITLE
Label SABnzbd login fields and help link for screen readers

### DIFF
--- a/interfaces/Config/templates/login/main.tmpl
+++ b/interfaces/Config/templates/login/main.tmpl
@@ -37,10 +37,8 @@
                 <div class="alert alert-danger" role="alert">$error</div>
                 <!--#end if#-->
 
-                <label class="sr-only" for="login-username">$T('srv-username')</label>
-                <input type="text" class="form-control" id="login-username" name="username" placeholder="$T('srv-username')" autocomplete="username" required autofocus>
-                <label class="sr-only" for="login-password">$T('srv-password')</label>
-                <input type="password" class="form-control" id="login-password" name="password" placeholder="$T('srv-password')" autocomplete="current-password" required>
+                <input type="text" class="form-control" name="username" placeholder="$T('srv-username')" aria-label="$T('srv-username')" autocomplete="username" required autofocus>
+                <input type="password" class="form-control" name="password" placeholder="$T('srv-password')" aria-label="$T('srv-password')" autocomplete="current-password" required>
 
                 <button class="btn btn-default"><span class="glyphicon glyphicon-circle-arrow-right"></span> $T('login') </button>
 

--- a/interfaces/Config/templates/login/main.tmpl
+++ b/interfaces/Config/templates/login/main.tmpl
@@ -28,8 +28,8 @@
         <div class="account-wall">
             <div class="text-center logo-header">
                 <!--#include $webdir + "/staticcfg/images/logo-full.svg"#-->
-                <a href="https://sabnzbd.org/wiki/faq#why-login" target="_blank">
-                    <span class="glyphicon glyphicon-question-sign"></span>
+                <a href="https://sabnzbd.org/wiki/faq#why-login" target="_blank" aria-label="$T('menu-help')">
+                    <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
                 </a>
             </div>
             <form class="form-signin" action="./" method="post">
@@ -37,8 +37,10 @@
                 <div class="alert alert-danger" role="alert">$error</div>
                 <!--#end if#-->
 
-                <input type="text" class="form-control" name="username" placeholder="$T('srv-username')" autocomplete="username" required autofocus>
-                <input type="password" class="form-control" name="password" placeholder="$T('srv-password')" autocomplete="current-password" required>
+                <label class="sr-only" for="login-username">$T('srv-username')</label>
+                <input type="text" class="form-control" id="login-username" name="username" placeholder="$T('srv-username')" autocomplete="username" required autofocus>
+                <label class="sr-only" for="login-password">$T('srv-password')</label>
+                <input type="password" class="form-control" id="login-password" name="password" placeholder="$T('srv-password')" autocomplete="current-password" required>
 
                 <button class="btn btn-default"><span class="glyphicon glyphicon-circle-arrow-right"></span> $T('login') </button>
 


### PR DESCRIPTION
The login form relied on placeholder text to identify the username and password fields, and its icon-only help link did not have an accessible name.

This adds visually hidden labels associated with both login fields and names the help link using the existing Help translation. The decorative help icon is hidden from assistive technology. It does not change the existing layout or behavior.

Testing:
- Verified both labels are associated with their intended fields and the help link has the translated accessible name.
- Ran the interface test suite: 7,318 passed.
