### PR TITLE
Reduce BPS allocations and fix scale

### DIFF
--- a/sabnzbd/bpsmeter.py
+++ b/sabnzbd/bpsmeter.py
@@ -22,6 +22,8 @@ sabnzbd.bpsmeter - bpsmeter
 import time
 import logging
 import re
+from collections import deque
+from itertools import islice, repeat
 from typing import Optional
 
 import sabnzbd
@@ -132,7 +134,7 @@ class BPSMeter:
         self.speed_log_time = t
         self.last_update = t
         self.bps = 0.0
-        self.bps_list: list[int] = []
+        self.bps_list: deque[int] = deque(maxlen=BPS_LIST_MAX)
 
         self.server_bps: dict[str, float] = {}
         self.cached_amount: dict[str, int] = {}
@@ -382,11 +384,8 @@ class BPSMeter:
         # Extra zeros, but never more than the maximum!
         nr_diffs = min(int(time.time() - self.speed_log_time), BPS_LIST_MAX)
         if nr_diffs > 1:
-            self.bps_list.extend([0] * nr_diffs)
-
-        # Always trim the list to the max-length
-        if len(self.bps_list) > BPS_LIST_MAX:
-            self.bps_list = self.bps_list[-BPS_LIST_MAX:]
+            # The deque trims itself to the max-length, dropping the oldest entries
+            self.bps_list.extend(repeat(0, nr_diffs))
 
     def get_sums(self):
         """return tuple of grand, month, week, day totals"""
@@ -432,7 +431,7 @@ class BPSMeter:
         refresh_rate = int(cfg.refresh_rate()) if cfg.refresh_rate() else 1
         self.add_empty_time()
         # We record every second, but display at the user's refresh-rate
-        return self.bps_list[::refresh_rate]
+        return list(islice(self.bps_list, 0, None, refresh_rate))
 
     def check_quota(self):
         """Pause the queue when all quota is spent

--- a/sabnzbd/bpsmeter.py
+++ b/sabnzbd/bpsmeter.py
@@ -134,7 +134,7 @@ class BPSMeter:
         self.speed_log_time = t
         self.last_update = t
         self.bps = 0.0
-        self.bps_list: deque[int] = deque(maxlen=BPS_LIST_MAX)
+        self.bps_list: deque[int] = deque(repeat(0, BPS_LIST_MAX), maxlen=BPS_LIST_MAX)
 
         self.server_bps: dict[str, float] = {}
         self.cached_amount: dict[str, int] = {}

--- a/sabnzbd/bpsmeter.py
+++ b/sabnzbd/bpsmeter.py
@@ -382,10 +382,12 @@ class BPSMeter:
 
     def add_empty_time(self):
         # Extra zeros, but never more than the maximum!
-        nr_diffs = min(int(time.time() - self.speed_log_time), BPS_LIST_MAX)
+        t = time.time()
+        nr_diffs = min(int(t - self.speed_log_time), BPS_LIST_MAX)
         if nr_diffs > 1:
             # The deque trims itself to the max-length, dropping the oldest entries
             self.bps_list.extend(repeat(0, nr_diffs))
+            self.speed_log_time = t
 
     def get_sums(self):
         """return tuple of grand, month, week, day totals"""


### PR DESCRIPTION
Noticed this while tracing allocations and I love a good deque.

`self.bps_list[-BPS_LIST_MAX:]`allocates a new 275 element list every second
`extend([0] * nr_diffs)` creates a temporary list to extend

Deque can do the 275 limited append in C without allocating.

---

The other changes are to initially populate the bps_list with 275 zeros, this fixes the x-axis scale where before SAB has been running for 275 seconds the speed is stretched over the whole sparkline.

Before:

https://github.com/user-attachments/assets/9387d835-c1c6-422b-9226-e229c02dc78b

After:

https://github.com/user-attachments/assets/7c2b77d4-1427-4dec-bda8-bc35b877b2a7

---

Set `self.speed_log_time = t` in `add_empty_time` fixes an issue that the graph moves left too quick if the page is refreshed lots while idle; download a job, hold F5 to refresh a bunch of times and it quickly jumps.

Before:

https://github.com/user-attachments/assets/ebdb39d5-1c99-4565-9763-fa376393d9ca

After:

https://github.com/user-attachments/assets/807d2b79-5b92-43b9-a601-ae5d17209fe3
