### PR TITLE
cgroup-aware memory limits for the article cache

### DIFF
--- a/sabnzbd/articlecache.py
+++ b/sabnzbd/articlecache.py
@@ -21,7 +21,7 @@ sabnzbd.articlecache - Article cache handling
 
 import logging
 import threading
-import struct
+import sys
 import time
 from typing import Collection, Optional
 
@@ -34,7 +34,7 @@ from sabnzbd.constants import (
     ARTICLE_CACHE_NON_CONTIGUOUS_FLUSH_PERCENTAGE,
 )
 from sabnzbd.nzb import Article, NzbFile
-from sabnzbd.misc import to_units
+from sabnzbd.misc import to_units, get_memory
 
 # Operations on the article table are handled via try/except.
 # The counters need to be made atomic to ensure consistency.
@@ -56,11 +56,18 @@ class ArticleCache(threading.Thread):
         self.__last_flush: float = 0
         self.__non_contiguous_trigger: int = 0  # Force flush trigger
 
-        # On 32 bit we only allow the user to set 1GB
-        # For 64 bit we allow up to 4GB, in case somebody wants that
-        self.__cache_upper_limit = GIGI
-        if sabnzbd.MACOS or sabnzbd.WINDOWS or (struct.calcsize("P") * 8) == 64:
-            self.__cache_upper_limit = 4 * GIGI
+        # A 32 bit process runs out of address space long before it runs out of memory,
+        # so it never gets to use more than 1GB no matter how much the machine has
+        self.__cache_upper_limit: int = int(4 * GIGI) if sys.maxsize > 2**32 else int(GIGI)
+
+        # Beyond that, never claim more than a share of the memory we are allowed to use.
+        # Skipped when it could not be determined, we would end up without any cache at all
+        memory = get_memory()
+        if memory.effective:
+            # A cgroup limit also has to cover the page cache our own writes generate,
+            # so leave more headroom there than on a host that can reclaim globally
+            memory_fraction = 4 if memory.cgroup_limit else 2
+            self.__cache_upper_limit = min(self.__cache_upper_limit, memory.effective // memory_fraction)
 
     def change_direct_write(self, direct_write: bool) -> None:
         self.__direct_write = direct_write
@@ -124,7 +131,7 @@ class ArticleCache(threading.Thread):
             self.__cache_limit = self.__cache_upper_limit
         else:
             self.__cache_limit = min(limit, self.__cache_upper_limit)
-        self.__non_contiguous_trigger = self.__cache_limit * ARTICLE_CACHE_NON_CONTIGUOUS_FLUSH_PERCENTAGE
+        self.__non_contiguous_trigger = int(self.__cache_limit * ARTICLE_CACHE_NON_CONTIGUOUS_FLUSH_PERCENTAGE)
         if self.__cache_limit:
             logging.debug("Article cache trigger:%s", to_units(self.__non_contiguous_trigger))
 

--- a/sabnzbd/articlecache.py
+++ b/sabnzbd/articlecache.py
@@ -32,9 +32,10 @@ from sabnzbd.constants import (
     GIGI,
     ANFO,
     ARTICLE_CACHE_NON_CONTIGUOUS_FLUSH_PERCENTAGE,
+    ARTICLE_CACHE_RESERVED_MEMORY,
 )
 from sabnzbd.nzb import Article, NzbFile
-from sabnzbd.misc import to_units, get_memory, cgroup_memory_limit
+from sabnzbd.misc import to_units, get_memory
 
 # Operations on the article table are handled via try/except.
 # The counters need to be made atomic to ensure consistency.
@@ -60,13 +61,12 @@ class ArticleCache(threading.Thread):
         # so it never gets to use more than 1GB no matter how much the machine has
         self.__cache_upper_limit: int = int(4 * GIGI) if sys.maxsize > 2**32 else int(GIGI)
 
-        # Beyond that, never claim more than a share of the memory we are allowed to use.
-        # Skipped when it could not be determined, we would end up without any cache at all
+        # Whatever is configured also has to fit in the memory we are allowed to use,
+        # leaving room for the rest of SABnzbd and anything else sharing the limit.
+        # Skipped when memory could not be determined, we would end up without any cache
         if memory := get_memory():
-            # A cgroup limit also has to cover the page cache our own writes generate,
-            # so leave more headroom there than on a host that can reclaim globally
-            memory_fraction = 4 if cgroup_memory_limit() else 2
-            self.__cache_upper_limit = min(self.__cache_upper_limit, memory // memory_fraction)
+            available = max(0, memory - ARTICLE_CACHE_RESERVED_MEMORY)
+            self.__cache_upper_limit = min(self.__cache_upper_limit, available)
 
     def change_direct_write(self, direct_write: bool) -> None:
         self.__direct_write = direct_write

--- a/sabnzbd/articlecache.py
+++ b/sabnzbd/articlecache.py
@@ -34,7 +34,7 @@ from sabnzbd.constants import (
     ARTICLE_CACHE_NON_CONTIGUOUS_FLUSH_PERCENTAGE,
 )
 from sabnzbd.nzb import Article, NzbFile
-from sabnzbd.misc import to_units, get_memory
+from sabnzbd.misc import to_units, get_memory, cgroup_memory_limit
 
 # Operations on the article table are handled via try/except.
 # The counters need to be made atomic to ensure consistency.
@@ -62,12 +62,11 @@ class ArticleCache(threading.Thread):
 
         # Beyond that, never claim more than a share of the memory we are allowed to use.
         # Skipped when it could not be determined, we would end up without any cache at all
-        memory = get_memory()
-        if memory.effective:
+        if memory := get_memory():
             # A cgroup limit also has to cover the page cache our own writes generate,
             # so leave more headroom there than on a host that can reclaim globally
-            memory_fraction = 4 if memory.cgroup_limit else 2
-            self.__cache_upper_limit = min(self.__cache_upper_limit, memory.effective // memory_fraction)
+            memory_fraction = 4 if cgroup_memory_limit() else 2
+            self.__cache_upper_limit = min(self.__cache_upper_limit, memory // memory_fraction)
 
     def change_direct_write(self, direct_write: bool) -> None:
         self.__direct_write = direct_write

--- a/sabnzbd/articlecache.py
+++ b/sabnzbd/articlecache.py
@@ -21,7 +21,7 @@ sabnzbd.articlecache - Article cache handling
 
 import logging
 import threading
-import sys
+import struct
 import time
 from typing import Collection, Optional
 
@@ -57,9 +57,11 @@ class ArticleCache(threading.Thread):
         self.__last_flush: float = 0
         self.__non_contiguous_trigger: int = 0  # Force flush trigger
 
-        # A 32 bit process runs out of address space long before it runs out of memory,
-        # so it never gets to use more than 1GB no matter how much the machine has
-        self.__cache_upper_limit: int = int(4 * GIGI) if sys.maxsize > 2**32 else int(GIGI)
+        # On 32 bit we only allow the user to set 1GB
+        # For 64 bit we allow up to 4GB, in case somebody wants that
+        self.__cache_upper_limit = GIGI
+        if sabnzbd.MACOS or sabnzbd.WINDOWS or (struct.calcsize("P") * 8) == 64:
+            self.__cache_upper_limit = 4 * GIGI
 
         # Whatever is configured also has to fit in the memory we are allowed to use,
         # leaving room for the rest of SABnzbd and anything else sharing the limit.

--- a/sabnzbd/constants.py
+++ b/sabnzbd/constants.py
@@ -114,6 +114,8 @@ NTTP_MAX_BUFFER_SIZE = int(10 * MEBI)
 DEF_PIPELINING_REQUESTS = 2
 # Article cache capacity factor to force a non-contiguous flush to disk
 ARTICLE_CACHE_NON_CONTIGUOUS_FLUSH_PERCENTAGE = 0.9
+# Memory left to the rest of the system when capping the article cache
+ARTICLE_CACHE_RESERVED_MEMORY = int(500 * MEBI)
 
 REPAIR_PRIORITY = 3
 FORCE_PRIORITY = 2

--- a/sabnzbd/constants.py
+++ b/sabnzbd/constants.py
@@ -115,7 +115,7 @@ DEF_PIPELINING_REQUESTS = 2
 # Article cache capacity factor to force a non-contiguous flush to disk
 ARTICLE_CACHE_NON_CONTIGUOUS_FLUSH_PERCENTAGE = 0.9
 # Memory left to the rest of the system when capping the article cache
-ARTICLE_CACHE_RESERVED_MEMORY = int(500 * MEBI)
+ARTICLE_CACHE_RESERVED_MEMORY = int(512 * MEBI)
 
 REPAIR_PRIORITY = 3
 FORCE_PRIORITY = 2

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -774,6 +774,16 @@ def get_cache_limit() -> str:
 
 
 def get_memory() -> int:
+    """Memory available to this process: physical total, clamped by any
+    cgroup limit so containers size against their own budget."""
+    total = _physical_memory()
+    limit = _cgroup_memory_limit()
+    if total and limit:
+        return min(total, limit)
+    return total or limit or 0
+
+
+def _physical_memory() -> int:
     try:
         if sabnzbd.WINDOWS:
             # Use win32api to get total physical memory
@@ -794,6 +804,44 @@ def get_memory() -> int:
     except Exception:
         pass
     return 0
+
+
+def _cgroup_memory_limit() -> Optional[int]:
+    """Memory limit applied to this container, or None if unlimited/absent"""
+    if sabnzbd.WINDOWS or sabnzbd.MACOS:
+        return None
+
+    # Exceeding memory.high throttles us under heavy reclaim, exceeding memory.max
+    # invokes the OOM killer. Take the lowest limit that is set, so we size against
+    # the budget we are meant to stay within rather than the one that gets us killed.
+    limit = None
+    for path in (
+        # cgroup v2
+        "/sys/fs/cgroup/memory.high",
+        "/sys/fs/cgroup/memory.max",
+        # cgroup v1, no equivalent of memory.high
+        "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+    ):
+        value = _read_cgroup_limit(path)
+        if value and (limit is None or value < limit):
+            limit = value
+    return limit
+
+
+def _read_cgroup_limit(path: str) -> Optional[int]:
+    """Read a single cgroup limit file, returning None if absent or unlimited"""
+    try:
+        with open(path) as f:
+            raw = f.read().strip()
+        # cgroup v2 spells unlimited as "max", v1 uses a huge sentinel
+        if raw == "max":
+            return None
+        value = int(raw)
+        if value <= 0 or value >= (1 << 62):
+            return None
+        return value
+    except (OSError, ValueError):
+        return None
 
 
 @conditional_cache(cache_time=3600)

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -767,7 +767,7 @@ def get_cache_limit() -> str:
         pass
 
     # Always at least minimum on Windows/macOS
-    if sabnzbd.WINDOWS and sabnzbd.MACOS:
+    if sabnzbd.WINDOWS or sabnzbd.MACOS:
         return DEF_ARTICLE_CACHE_DEFAULT
 
     # If failed, leave empty for Linux so user needs to decide

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -778,7 +778,7 @@ def get_memory() -> int:
     any cgroup limit so containers size against their own budget rather than the
     host's. Returns 0 when neither could be determined."""
     physical = _physical_memory()
-    limit = cgroup_memory_limit()
+    limit = _cgroup_memory_limit()
     if physical and limit:
         return min(physical, limit)
     return physical or limit or 0
@@ -811,7 +811,7 @@ def _physical_memory() -> Optional[int]:
     return None
 
 
-def cgroup_memory_limit() -> Optional[int]:
+def _cgroup_memory_limit() -> Optional[int]:
     """Memory limit applied to this container, or None if unlimited/absent"""
     if sabnzbd.WINDOWS or sabnzbd.MACOS:
         return None

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -793,10 +793,11 @@ def get_memory() -> MemoryInfo:
     """Physical memory installed and any cgroup limit applied to us. Callers that
     only need a single number want MemoryInfo.effective, the rest care about the
     distinction because a cgroup limit also has to cover our own page cache."""
-    return MemoryInfo(_physical_memory() or None, _cgroup_memory_limit())
+    return MemoryInfo(_physical_memory(), _cgroup_memory_limit())
 
 
-def _physical_memory() -> int:
+def _physical_memory() -> Optional[int]:
+    """Total memory installed in the machine, or None if it could not be determined"""
     try:
         if sabnzbd.WINDOWS:
             # Use win32api to get total physical memory
@@ -813,10 +814,13 @@ def _physical_memory() -> int:
                             return int(line.split()[1]) * 1024
             except Exception:
                 pass
-            return os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
+            # sysconf reports -1 for values it does not know, which would multiply
+            # out to a plausible looking but negative amount of memory
+            if (memory := os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")) > 0:
+                return memory
     except Exception:
         pass
-    return 0
+    return None
 
 
 def _cgroup_memory_limit() -> Optional[int]:

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -42,6 +42,7 @@ import rarfile
 import hashlib
 from threading import Thread, RLock
 from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import Any, AnyStr, Optional, Collection
 from functools import lru_cache
 
@@ -750,7 +751,7 @@ def get_cache_limit() -> str:
     """
     # Calculate, if possible
     try:
-        mem_bytes = get_memory()
+        mem_bytes = get_memory().effective
 
         # Use 1/4th of available memory
         mem_bytes = mem_bytes / 4
@@ -773,14 +774,26 @@ def get_cache_limit() -> str:
     return ""
 
 
-def get_memory() -> int:
-    """Memory available to this process: physical total, clamped by any
-    cgroup limit so containers size against their own budget."""
-    total = _physical_memory()
-    limit = _cgroup_memory_limit()
-    if total and limit:
-        return min(total, limit)
-    return total or limit or 0
+@dataclass(frozen=True, slots=True)
+class MemoryInfo:
+    """Memory available to us, either value is None when it could not be determined"""
+
+    physical: Optional[int] = None
+    cgroup_limit: Optional[int] = None
+
+    @property
+    def effective(self) -> int:
+        """Lowest known bound on the memory we can use, 0 when nothing could be determined"""
+        if self.physical and self.cgroup_limit:
+            return min(self.physical, self.cgroup_limit)
+        return self.physical or self.cgroup_limit or 0
+
+
+def get_memory() -> MemoryInfo:
+    """Physical memory installed and any cgroup limit applied to us. Callers that
+    only need a single number want MemoryInfo.effective, the rest care about the
+    distinction because a cgroup limit also has to cover our own page cache."""
+    return MemoryInfo(_physical_memory() or None, _cgroup_memory_limit())
 
 
 def _physical_memory() -> int:

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -42,7 +42,6 @@ import rarfile
 import hashlib
 from threading import Thread, RLock
 from collections.abc import Iterable
-from dataclasses import dataclass
 from typing import Any, AnyStr, Optional, Collection
 from functools import lru_cache
 
@@ -751,7 +750,7 @@ def get_cache_limit() -> str:
     """
     # Calculate, if possible
     try:
-        mem_bytes = get_memory().effective
+        mem_bytes = get_memory()
 
         # Use 1/4th of available memory
         mem_bytes = mem_bytes / 4
@@ -774,26 +773,15 @@ def get_cache_limit() -> str:
     return ""
 
 
-@dataclass(frozen=True, slots=True)
-class MemoryInfo:
-    """Memory available to us, either value is None when it could not be determined"""
-
-    physical: Optional[int] = None
-    cgroup_limit: Optional[int] = None
-
-    @property
-    def effective(self) -> int:
-        """Lowest known bound on the memory we can use, 0 when nothing could be determined"""
-        if self.physical and self.cgroup_limit:
-            return min(self.physical, self.cgroup_limit)
-        return self.physical or self.cgroup_limit or 0
-
-
-def get_memory() -> MemoryInfo:
-    """Physical memory installed and any cgroup limit applied to us. Callers that
-    only need a single number want MemoryInfo.effective, the rest care about the
-    distinction because a cgroup limit also has to cover our own page cache."""
-    return MemoryInfo(_physical_memory(), _cgroup_memory_limit())
+def get_memory() -> int:
+    """Memory we are allowed to use: the memory installed in the machine, clamped by
+    any cgroup limit so containers size against their own budget rather than the
+    host's. Returns 0 when neither could be determined."""
+    physical = _physical_memory()
+    limit = cgroup_memory_limit()
+    if physical and limit:
+        return min(physical, limit)
+    return physical or limit or 0
 
 
 def _physical_memory() -> Optional[int]:
@@ -823,7 +811,7 @@ def _physical_memory() -> Optional[int]:
     return None
 
 
-def _cgroup_memory_limit() -> Optional[int]:
+def cgroup_memory_limit() -> Optional[int]:
     """Memory limit applied to this container, or None if unlimited/absent"""
     if sabnzbd.WINDOWS or sabnzbd.MACOS:
         return None

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1252,6 +1252,7 @@ class TestSABRarFile:
                 assert zf.namelist() == expected_files
 
 
+@pytest.mark.platform("linux")
 class TestCgroupMemoryLimit:
     """Container memory detection, see _cgroup_memory_limit()"""
 
@@ -1260,7 +1261,7 @@ class TestCgroupMemoryLimit:
     V2_MAX = "/sys/fs/cgroup/memory.max"
     V1_MAX = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
 
-    def patched_open(self, files):
+    def patched_open(self, files: dict[str, str]):
         real_open = open
 
         def _open(path, *args, **kwargs):
@@ -1272,49 +1273,40 @@ class TestCgroupMemoryLimit:
 
         return mock.patch("builtins.open", _open)
 
-    @pytest.mark.platform("linux")
     def test_no_cgroup_files(self):
         with self.patched_open({}):
             assert misc._cgroup_memory_limit() is None
 
-    @pytest.mark.platform("linux")
     def test_v2_max_only(self):
         with self.patched_open({self.V2_MAX: str(2 * self.GIGI)}):
             assert misc._cgroup_memory_limit() == 2 * self.GIGI
 
-    @pytest.mark.platform("linux")
     def test_v2_unlimited(self):
         with self.patched_open({self.V2_MAX: "max", self.V2_HIGH: "max"}):
             assert misc._cgroup_memory_limit() is None
 
-    @pytest.mark.platform("linux")
     def test_v2_high_below_max_wins(self):
         """memory.high throttles, so it is the budget we should size against"""
         with self.patched_open({self.V2_HIGH: str(self.GIGI), self.V2_MAX: str(4 * self.GIGI)}):
             assert misc._cgroup_memory_limit() == self.GIGI
 
-    @pytest.mark.platform("linux")
     def test_v2_high_unset_falls_back_to_max(self):
         with self.patched_open({self.V2_HIGH: "max", self.V2_MAX: str(2 * self.GIGI)}):
             assert misc._cgroup_memory_limit() == 2 * self.GIGI
 
-    @pytest.mark.platform("linux")
     def test_v1_limit(self):
         with self.patched_open({self.V1_MAX: str(512 * 1024 * 1024)}):
             assert misc._cgroup_memory_limit() == 512 * 1024 * 1024
 
-    @pytest.mark.platform("linux")
     def test_v1_unlimited_sentinel(self):
         """v1 reports a huge sentinel rather than a keyword when unlimited"""
         with self.patched_open({self.V1_MAX: "9223372036854771712"}):
             assert misc._cgroup_memory_limit() is None
 
-    @pytest.mark.platform("linux")
     def test_garbage_is_ignored(self):
         with self.patched_open({self.V2_MAX: "not-a-number"}):
             assert misc._cgroup_memory_limit() is None
 
-    @pytest.mark.platform("linux")
     def test_get_memory_reports_both_values(self):
         with self.patched_open({self.V2_MAX: str(self.GIGI)}):
             with mock.patch("sabnzbd.misc._physical_memory", return_value=64 * self.GIGI):
@@ -1322,19 +1314,16 @@ class TestCgroupMemoryLimit:
         assert memory.physical == 64 * self.GIGI
         assert memory.cgroup_limit == self.GIGI
 
-    @pytest.mark.platform("linux")
     def test_effective_clamps_to_cgroup(self):
         with self.patched_open({self.V2_MAX: str(self.GIGI)}):
             with mock.patch("sabnzbd.misc._physical_memory", return_value=64 * self.GIGI):
                 assert misc.get_memory().effective == self.GIGI
 
-    @pytest.mark.platform("linux")
     def test_effective_keeps_physical_when_lower(self):
         with self.patched_open({self.V2_MAX: str(64 * self.GIGI)}):
             with mock.patch("sabnzbd.misc._physical_memory", return_value=8 * self.GIGI):
                 assert misc.get_memory().effective == 8 * self.GIGI
 
-    @pytest.mark.platform("linux")
     def test_effective_uses_cgroup_when_physical_unknown(self):
         """_physical_memory() returns None when it cannot be determined"""
         with self.patched_open({self.V2_MAX: str(self.GIGI)}):
@@ -1343,7 +1332,6 @@ class TestCgroupMemoryLimit:
         assert memory.physical is None
         assert memory.effective == self.GIGI
 
-    @pytest.mark.platform("linux")
     def test_effective_zero_when_nothing_known(self):
         with self.patched_open({}):
             with mock.patch("sabnzbd.misc._physical_memory", return_value=None):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1336,9 +1336,9 @@ class TestCgroupMemoryLimit:
 
     @pytest.mark.platform("linux")
     def test_effective_uses_cgroup_when_physical_unknown(self):
-        """_physical_memory() returns 0 on failure"""
+        """_physical_memory() returns None when it cannot be determined"""
         with self.patched_open({self.V2_MAX: str(self.GIGI)}):
-            with mock.patch("sabnzbd.misc._physical_memory", return_value=0):
+            with mock.patch("sabnzbd.misc._physical_memory", return_value=None):
                 memory = misc.get_memory()
         assert memory.physical is None
         assert memory.effective == self.GIGI
@@ -1346,5 +1346,5 @@ class TestCgroupMemoryLimit:
     @pytest.mark.platform("linux")
     def test_effective_zero_when_nothing_known(self):
         with self.patched_open({}):
-            with mock.patch("sabnzbd.misc._physical_memory", return_value=0):
+            with mock.patch("sabnzbd.misc._physical_memory", return_value=None):
                 assert misc.get_memory().effective == 0

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1250,3 +1250,85 @@ class TestSABRarFile:
                 with pytest.raises(rarfile.RarWrongPassword):
                     zf.setpassword("WRONG_PASSWORD")
                 assert zf.namelist() == expected_files
+
+
+class TestCgroupMemoryLimit:
+    """Container memory detection, see _cgroup_memory_limit()"""
+
+    GIGI = 1024**3
+    V2_HIGH = "/sys/fs/cgroup/memory.high"
+    V2_MAX = "/sys/fs/cgroup/memory.max"
+    V1_MAX = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+
+    def patched_open(self, files):
+        real_open = open
+
+        def _open(path, *args, **kwargs):
+            if str(path).startswith("/sys/fs/cgroup"):
+                if str(path) in files:
+                    return mock.mock_open(read_data=files[str(path)])()
+                raise FileNotFoundError(path)
+            return real_open(path, *args, **kwargs)
+
+        return mock.patch("builtins.open", _open)
+
+    @pytest.mark.platform("linux")
+    def test_no_cgroup_files(self):
+        with self.patched_open({}):
+            assert misc._cgroup_memory_limit() is None
+
+    @pytest.mark.platform("linux")
+    def test_v2_max_only(self):
+        with self.patched_open({self.V2_MAX: str(2 * self.GIGI)}):
+            assert misc._cgroup_memory_limit() == 2 * self.GIGI
+
+    @pytest.mark.platform("linux")
+    def test_v2_unlimited(self):
+        with self.patched_open({self.V2_MAX: "max", self.V2_HIGH: "max"}):
+            assert misc._cgroup_memory_limit() is None
+
+    @pytest.mark.platform("linux")
+    def test_v2_high_below_max_wins(self):
+        """memory.high throttles, so it is the budget we should size against"""
+        with self.patched_open({self.V2_HIGH: str(self.GIGI), self.V2_MAX: str(4 * self.GIGI)}):
+            assert misc._cgroup_memory_limit() == self.GIGI
+
+    @pytest.mark.platform("linux")
+    def test_v2_high_unset_falls_back_to_max(self):
+        with self.patched_open({self.V2_HIGH: "max", self.V2_MAX: str(2 * self.GIGI)}):
+            assert misc._cgroup_memory_limit() == 2 * self.GIGI
+
+    @pytest.mark.platform("linux")
+    def test_v1_limit(self):
+        with self.patched_open({self.V1_MAX: str(512 * 1024 * 1024)}):
+            assert misc._cgroup_memory_limit() == 512 * 1024 * 1024
+
+    @pytest.mark.platform("linux")
+    def test_v1_unlimited_sentinel(self):
+        """v1 reports a huge sentinel rather than a keyword when unlimited"""
+        with self.patched_open({self.V1_MAX: "9223372036854771712"}):
+            assert misc._cgroup_memory_limit() is None
+
+    @pytest.mark.platform("linux")
+    def test_garbage_is_ignored(self):
+        with self.patched_open({self.V2_MAX: "not-a-number"}):
+            assert misc._cgroup_memory_limit() is None
+
+    @pytest.mark.platform("linux")
+    def test_get_memory_clamps_to_cgroup(self):
+        with self.patched_open({self.V2_MAX: str(self.GIGI)}):
+            with mock.patch("sabnzbd.misc._physical_memory", return_value=64 * self.GIGI):
+                assert misc.get_memory() == self.GIGI
+
+    @pytest.mark.platform("linux")
+    def test_get_memory_keeps_physical_when_lower(self):
+        with self.patched_open({self.V2_MAX: str(64 * self.GIGI)}):
+            with mock.patch("sabnzbd.misc._physical_memory", return_value=8 * self.GIGI):
+                assert misc.get_memory() == 8 * self.GIGI
+
+    @pytest.mark.platform("linux")
+    def test_get_memory_uses_cgroup_when_physical_unknown(self):
+        """_physical_memory() returns 0 on failure"""
+        with self.patched_open({self.V2_MAX: str(self.GIGI)}):
+            with mock.patch("sabnzbd.misc._physical_memory", return_value=0):
+                assert misc.get_memory() == self.GIGI

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1254,7 +1254,7 @@ class TestSABRarFile:
 
 @pytest.mark.platform("linux")
 class TestCgroupMemoryLimit:
-    """Container memory detection, see cgroup_memory_limit()"""
+    """Container memory detection, see _cgroup_memory_limit()"""
 
     GIGI = 1024**3
     V2_HIGH = "/sys/fs/cgroup/memory.high"
@@ -1275,37 +1275,37 @@ class TestCgroupMemoryLimit:
 
     def test_no_cgroup_files(self):
         with self.patched_open({}):
-            assert misc.cgroup_memory_limit() is None
+            assert misc._cgroup_memory_limit() is None
 
     def test_v2_max_only(self):
         with self.patched_open({self.V2_MAX: str(2 * self.GIGI)}):
-            assert misc.cgroup_memory_limit() == 2 * self.GIGI
+            assert misc._cgroup_memory_limit() == 2 * self.GIGI
 
     def test_v2_unlimited(self):
         with self.patched_open({self.V2_MAX: "max", self.V2_HIGH: "max"}):
-            assert misc.cgroup_memory_limit() is None
+            assert misc._cgroup_memory_limit() is None
 
     def test_v2_high_below_max_wins(self):
         """memory.high throttles, so it is the budget we should size against"""
         with self.patched_open({self.V2_HIGH: str(self.GIGI), self.V2_MAX: str(4 * self.GIGI)}):
-            assert misc.cgroup_memory_limit() == self.GIGI
+            assert misc._cgroup_memory_limit() == self.GIGI
 
     def test_v2_high_unset_falls_back_to_max(self):
         with self.patched_open({self.V2_HIGH: "max", self.V2_MAX: str(2 * self.GIGI)}):
-            assert misc.cgroup_memory_limit() == 2 * self.GIGI
+            assert misc._cgroup_memory_limit() == 2 * self.GIGI
 
     def test_v1_limit(self):
         with self.patched_open({self.V1_MAX: str(512 * 1024 * 1024)}):
-            assert misc.cgroup_memory_limit() == 512 * 1024 * 1024
+            assert misc._cgroup_memory_limit() == 512 * 1024 * 1024
 
     def test_v1_unlimited_sentinel(self):
         """v1 reports a huge sentinel rather than a keyword when unlimited"""
         with self.patched_open({self.V1_MAX: "9223372036854771712"}):
-            assert misc.cgroup_memory_limit() is None
+            assert misc._cgroup_memory_limit() is None
 
     def test_garbage_is_ignored(self):
         with self.patched_open({self.V2_MAX: "not-a-number"}):
-            assert misc.cgroup_memory_limit() is None
+            assert misc._cgroup_memory_limit() is None
 
     def test_get_memory_clamps_to_cgroup(self):
         with self.patched_open({self.V2_MAX: str(self.GIGI)}):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1315,20 +1315,36 @@ class TestCgroupMemoryLimit:
             assert misc._cgroup_memory_limit() is None
 
     @pytest.mark.platform("linux")
-    def test_get_memory_clamps_to_cgroup(self):
+    def test_get_memory_reports_both_values(self):
         with self.patched_open({self.V2_MAX: str(self.GIGI)}):
             with mock.patch("sabnzbd.misc._physical_memory", return_value=64 * self.GIGI):
-                assert misc.get_memory() == self.GIGI
+                memory = misc.get_memory()
+        assert memory.physical == 64 * self.GIGI
+        assert memory.cgroup_limit == self.GIGI
 
     @pytest.mark.platform("linux")
-    def test_get_memory_keeps_physical_when_lower(self):
+    def test_effective_clamps_to_cgroup(self):
+        with self.patched_open({self.V2_MAX: str(self.GIGI)}):
+            with mock.patch("sabnzbd.misc._physical_memory", return_value=64 * self.GIGI):
+                assert misc.get_memory().effective == self.GIGI
+
+    @pytest.mark.platform("linux")
+    def test_effective_keeps_physical_when_lower(self):
         with self.patched_open({self.V2_MAX: str(64 * self.GIGI)}):
             with mock.patch("sabnzbd.misc._physical_memory", return_value=8 * self.GIGI):
-                assert misc.get_memory() == 8 * self.GIGI
+                assert misc.get_memory().effective == 8 * self.GIGI
 
     @pytest.mark.platform("linux")
-    def test_get_memory_uses_cgroup_when_physical_unknown(self):
+    def test_effective_uses_cgroup_when_physical_unknown(self):
         """_physical_memory() returns 0 on failure"""
         with self.patched_open({self.V2_MAX: str(self.GIGI)}):
             with mock.patch("sabnzbd.misc._physical_memory", return_value=0):
-                assert misc.get_memory() == self.GIGI
+                memory = misc.get_memory()
+        assert memory.physical is None
+        assert memory.effective == self.GIGI
+
+    @pytest.mark.platform("linux")
+    def test_effective_zero_when_nothing_known(self):
+        with self.patched_open({}):
+            with mock.patch("sabnzbd.misc._physical_memory", return_value=0):
+                assert misc.get_memory().effective == 0

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1254,7 +1254,7 @@ class TestSABRarFile:
 
 @pytest.mark.platform("linux")
 class TestCgroupMemoryLimit:
-    """Container memory detection, see _cgroup_memory_limit()"""
+    """Container memory detection, see cgroup_memory_limit()"""
 
     GIGI = 1024**3
     V2_HIGH = "/sys/fs/cgroup/memory.high"
@@ -1275,64 +1275,55 @@ class TestCgroupMemoryLimit:
 
     def test_no_cgroup_files(self):
         with self.patched_open({}):
-            assert misc._cgroup_memory_limit() is None
+            assert misc.cgroup_memory_limit() is None
 
     def test_v2_max_only(self):
         with self.patched_open({self.V2_MAX: str(2 * self.GIGI)}):
-            assert misc._cgroup_memory_limit() == 2 * self.GIGI
+            assert misc.cgroup_memory_limit() == 2 * self.GIGI
 
     def test_v2_unlimited(self):
         with self.patched_open({self.V2_MAX: "max", self.V2_HIGH: "max"}):
-            assert misc._cgroup_memory_limit() is None
+            assert misc.cgroup_memory_limit() is None
 
     def test_v2_high_below_max_wins(self):
         """memory.high throttles, so it is the budget we should size against"""
         with self.patched_open({self.V2_HIGH: str(self.GIGI), self.V2_MAX: str(4 * self.GIGI)}):
-            assert misc._cgroup_memory_limit() == self.GIGI
+            assert misc.cgroup_memory_limit() == self.GIGI
 
     def test_v2_high_unset_falls_back_to_max(self):
         with self.patched_open({self.V2_HIGH: "max", self.V2_MAX: str(2 * self.GIGI)}):
-            assert misc._cgroup_memory_limit() == 2 * self.GIGI
+            assert misc.cgroup_memory_limit() == 2 * self.GIGI
 
     def test_v1_limit(self):
         with self.patched_open({self.V1_MAX: str(512 * 1024 * 1024)}):
-            assert misc._cgroup_memory_limit() == 512 * 1024 * 1024
+            assert misc.cgroup_memory_limit() == 512 * 1024 * 1024
 
     def test_v1_unlimited_sentinel(self):
         """v1 reports a huge sentinel rather than a keyword when unlimited"""
         with self.patched_open({self.V1_MAX: "9223372036854771712"}):
-            assert misc._cgroup_memory_limit() is None
+            assert misc.cgroup_memory_limit() is None
 
     def test_garbage_is_ignored(self):
         with self.patched_open({self.V2_MAX: "not-a-number"}):
-            assert misc._cgroup_memory_limit() is None
+            assert misc.cgroup_memory_limit() is None
 
-    def test_get_memory_reports_both_values(self):
+    def test_get_memory_clamps_to_cgroup(self):
         with self.patched_open({self.V2_MAX: str(self.GIGI)}):
             with mock.patch("sabnzbd.misc._physical_memory", return_value=64 * self.GIGI):
-                memory = misc.get_memory()
-        assert memory.physical == 64 * self.GIGI
-        assert memory.cgroup_limit == self.GIGI
+                assert misc.get_memory() == self.GIGI
 
-    def test_effective_clamps_to_cgroup(self):
-        with self.patched_open({self.V2_MAX: str(self.GIGI)}):
-            with mock.patch("sabnzbd.misc._physical_memory", return_value=64 * self.GIGI):
-                assert misc.get_memory().effective == self.GIGI
-
-    def test_effective_keeps_physical_when_lower(self):
+    def test_get_memory_keeps_physical_when_lower(self):
         with self.patched_open({self.V2_MAX: str(64 * self.GIGI)}):
             with mock.patch("sabnzbd.misc._physical_memory", return_value=8 * self.GIGI):
-                assert misc.get_memory().effective == 8 * self.GIGI
+                assert misc.get_memory() == 8 * self.GIGI
 
-    def test_effective_uses_cgroup_when_physical_unknown(self):
+    def test_get_memory_uses_cgroup_when_physical_unknown(self):
         """_physical_memory() returns None when it cannot be determined"""
         with self.patched_open({self.V2_MAX: str(self.GIGI)}):
             with mock.patch("sabnzbd.misc._physical_memory", return_value=None):
-                memory = misc.get_memory()
-        assert memory.physical is None
-        assert memory.effective == self.GIGI
+                assert misc.get_memory() == self.GIGI
 
-    def test_effective_zero_when_nothing_known(self):
+    def test_get_memory_zero_when_nothing_known(self):
         with self.patched_open({}):
             with mock.patch("sabnzbd.misc._physical_memory", return_value=None):
-                assert misc.get_memory().effective == 0
+                assert misc.get_memory() == 0


### PR DESCRIPTION
On a clean install `misc.get_cache_limit()` was `min(physical/4, 1G)`
The ceiling in `ArticleCache.__cache_upper_limit` clamps whatever the user has configured and varied by platform and 64bit.

## Summary table
 
| Scenario | Default `cache_limit` before | after | Ceiling before | after |
|---|---|---|---|---|
| 64-bit host, 64G RAM | 1G | 1G | 4G | 4G |
| 64-bit host, 16G RAM | 1G | 1G | 4G | 4G |
| 64-bit host, 4G RAM | 1G | 1G | 4G | **2G** |
| 64-bit host, 2G RAM | 512M | 512M | 4G | **1G** |
| Docker `--memory=8g` (64G host) | 1G | 1G | 4G | **2G** |
| Docker `--memory=2g` (64G host) | 1G | **512M** | 4G | **512M** |
| Docker `--memory=512m` (64G host) | 1G | **128M** | 4G | **128M** |
| k8s `memory.high=1g` (64G host) | 1G | **256M** | 4G | **256M** |
| NAS/LXC 2g limit, 8G host | 1G | **512M** | 4G | **512M** |
| 32-bit Linux (RPi OS), 8G | 1G | 1G | 1G | 1G |
| 32-bit Windows, 4G | 1G | 1G | 4G | **1G** |
| 32-bit Windows in 2g container | 1G | **512M** | 4G | **512M** |
| memory undetectable | - | - | 4G | 4G |

Bold = changed

tl;dr: **Nothing increases** - every difference is a tightening

Ordinary installs are untouched. 64-bit bare metal with ≥8G sees no change at all to either value. The changes land on containers and small machines, which is the intent. I'm saving probably drastically reducing limits for a future change.

The `--memory=512m` row is the bug being fixed: 1G default cache in a 512M container - twice the entire budget. That's the OOM kill.

## What drives each change

**Containers now see their own budget.** `get_memory()` previously read `/proc/meminfo` `MemTotal`, which is not namespaced, so a container reported the host's RAM. A 512M container therefore computed its default from 64G, sailed past the `1G` cap check, and settled on a 1G cache - twice its entire budget. This is the OOM-kill case the work exists to fix.

**The ceiling is now memory-derived, not just platform-derived.** Previously the ceiling ignored memory entirely, so a user on a 2G machine could set `cache_limit=4G` and it would be honoured. It is now `min(address_space_cap, effective_memory // fraction)`.

**Containers get a smaller fraction (1/4) than bare metal (1/2).** Under cgroup v2 the page cache generated by our own writes to `download_dir` is charged against the same limit, so a given fraction leaves less real headroom inside a container than on a host where the kernel reclaims globally.

**32-bit Windows ceiling corrected.** The old condition was `MACOS or WINDOWS or 64-bit`, so `WINDOWS` short-circuited the bitness test and a 32-bit Windows build got a 4G ceiling inside a ~2G address space. Bitness now decides the address-space cap on its own. I'm not sure it's even usable on 32-bit Windows anymore so this probably doesn't matter.

**Undetectable memory keeps a working cache.** When neither physical memory nor a cgroup limit can be determined, the memory-derived cap is skipped entirely rather than evaluating to zero. A zero ceiling would clamp `__cache_limit` to 0, making `save_article()`'s `if self.__cache_limit` guard falsy and pushing *every* article down the spill-to-disk path.

## Unrelated bug spotted nearby

`get_cache_limit()` did (WINDOWS **and** MACOS) so never true.
