### PR TITLE
Prevent concurrent dirscanner scans

### DIFF
--- a/sabnzbd/dirscanner.py
+++ b/sabnzbd/dirscanner.py
@@ -76,7 +76,7 @@ class DirScanner(threading.Thread):
             signal.set_wakeup_fd(-1)
 
         self.scanner_task: Optional[asyncio.Task] = None
-        self.lock: Optional[asyncio.Lock] = None  # Prevents concurrent scans
+        self.lock = asyncio.Lock()  # Prevents concurrent scans
         self.error_reported = False  # Prevents multiple reporting of missing watched folder
         self.dirscan_dir = cfg.dirscan_dir.get_path()
         self.dirscan_speed = cfg.dirscan_speed()
@@ -231,9 +231,6 @@ class DirScanner(threading.Thread):
 
     async def scan_async(self, dirscan_dir: str):
         """Do one scan of the watched folder"""
-        with DIR_SCANNER_LOCK:
-            self.lock = asyncio.Lock()
-
         async with self.lock:
             if sabnzbd.PAUSED_ALL:
                 return


### PR DESCRIPTION
Currently a new lock is created for every scan, so there is no concurrency limit.

Since Python 3.10 `asyncio.Lock()` init doesn't require a loop, when acquired it gets the running loop.

Ref b4c3a4b19f9ba7951995083c076cd18b5aca29e5 and 3ff1d4b68c472bd7d744a821eb3af739de089dde and https://bugs.python.org/issue42392