### PR TITLE
feat: add Authentik proxy-header SSO authentication

### DIFF
--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -160,6 +160,18 @@ def cleanup_list_validator(value: str | list) -> tuple[None, str | list]:
     return None, validate_entry(value)
 
 
+def validate_trusted_proxy_addresses(value: list[str]) -> tuple[None, list[str]]:
+    """Accept only exact IP addresses for trusted Authentik proxy peers."""
+    normalized = []
+    for entry in value:
+        try:
+            address = ipaddress.ip_address(entry.strip())
+        except ValueError:
+            return "Invalid trusted proxy address: %s" % entry, None
+        normalized.append(str(address))
+    return None, normalized
+
+
 def validate_single_tag(value: list[str]) -> tuple[None, list[str]]:
     """Don't split single indexer tags like "TV > HD"
     into ['TV', '>', 'HD']
@@ -552,6 +564,9 @@ ipv6_servers = OptionBool("misc", "ipv6_servers", True)
 url_base = OptionStr("misc", "url_base", "", validation=validate_url_base)
 host_whitelist = OptionList("misc", "host_whitelist", validation=all_lowercase)
 local_ranges = OptionList("misc", "local_ranges", protect=True)
+authentik_proxy_trusted_proxies = OptionList(
+    "misc", "authentik_proxy_trusted_proxies", validation=validate_trusted_proxy_addresses, protect=True, public=False
+)
 max_url_retries = OptionNumber("misc", "max_url_retries", 10, minval=1)
 downloader_sleep_time = OptionNumber("misc", "downloader_sleep_time", 10, minval=0)
 receive_threads = OptionNumber("misc", "receive_threads", 2, minval=1)

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -32,6 +32,7 @@ from sabnzbd.config import (
     OptionBool,
     OptionNumber,
     OptionPassword,
+    OptionPasswordHash,
     OptionDir,
     OptionStr,
     OptionList,
@@ -372,7 +373,10 @@ web_host = OptionStr("misc", "host", DEF_HOST, validation=validate_host)
 web_port = OptionStr("misc", "port", DEF_PORT)
 https_port = OptionStr("misc", "https_port")
 username = OptionStr("misc", "username")
+# password is retained only as a read-once migration source for existing web credentials.
+# New web passwords are persisted as one-way PBKDF2 hashes in password_hash.
 password = OptionPassword("misc", "password")
+password_hash = OptionPasswordHash("misc", "password_hash")
 bandwidth_max = OptionStr("misc", "bandwidth_max")
 cache_limit = OptionStr("misc", "cache_limit")
 web_dir = OptionStr("misc", "web_dir", DEF_STD_WEB_DIR)

--- a/sabnzbd/config.py
+++ b/sabnzbd/config.py
@@ -19,10 +19,14 @@
 sabnzbd.config - Configuration Support
 """
 
+import base64
+import hashlib
+import hmac
 import logging
 import os
 import re
 import shutil
+import tempfile
 import threading
 import time
 import uuid
@@ -425,6 +429,55 @@ class OptionPassword(Option):
     def __call__(self) -> str:
         """get() replacement"""
         return self.get()
+
+
+class OptionPasswordHash(Option):
+    """One-way password hash for credentials that never need recovery."""
+
+    prefix = "pbkdf2_sha256"
+    iterations = 600000
+
+    def __init__(self, section: str, keyword: str, default_val: str = "", add: bool = True):
+        self.get_string = self.get_stars
+        super().__init__(section, keyword, default_val, add=add)
+
+    def get_stars(self) -> str:
+        return "*" * 10 if self.get() else ""
+
+    def get_dict(self, for_public_api: bool = False) -> dict[str, str]:
+        return {self.keyword: self.get_stars()}
+
+    def set(self, value: str):
+        """Set a persisted hash, or hash a newly supplied plaintext password."""
+        if value is None or (value and not value.strip("*")):
+            return
+        if value == "":
+            super().set("")
+        elif value.startswith(self.prefix + "$"):
+            super().set(value)
+        else:
+            super().set(self.hash_password(value))
+
+    @classmethod
+    def hash_password(cls, password: str) -> str:
+        salt = base64.b64encode(os.urandom(16)).decode("ascii")
+        digest = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt.encode("ascii"), cls.iterations)
+        encoded_digest = base64.b64encode(digest).decode("ascii")
+        return "%s$%s$%s$%s" % (cls.prefix, cls.iterations, salt, encoded_digest)
+
+    def verify(self, password: str) -> bool:
+        """Verify a plaintext password using a timing-safe comparison."""
+        try:
+            algorithm, iterations, salt, expected_digest = self.get().split("$", 3)
+            if algorithm != self.prefix:
+                return False
+            digest = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt.encode("ascii"), int(iterations))
+            return hmac.compare_digest(base64.b64encode(digest).decode("ascii"), expected_digest)
+        except (AttributeError, TypeError, ValueError):
+            return False
+
+    def __call__(self) -> str:
+        return self.get() or ""
 
 
 class ConfigServer:
@@ -834,7 +887,13 @@ def get_config(section: str, keyword: str) -> Optional[AllConfigTypes]:
 
 @synchronized(CONFIG_LOCK)
 def set_config(kwargs):
-    """Set a config item, using values in dictionary"""
+    """Set a config item, using values in dictionary."""
+    # Keep the historical API password setting functional without allowing it
+    # to repopulate the legacy reversible web-password field.
+    if kwargs.get("section") == "misc" and kwargs.get("keyword") == "password":
+        sabnzbd.cfg.password_hash.set(kwargs.get("value", ""))
+        sabnzbd.cfg.password.set("")
+        return True
     try:
         item = CFG_DATABASE[kwargs.get("section")][kwargs.get("keyword")]
     except KeyError:
@@ -949,6 +1008,66 @@ def save_config(force=False):
     global CFG_OBJ, CFG_DATABASE, CFG_MODIFIED
 
     if not (CFG_MODIFIED or force):
+        return True
+
+    # Migrate only the historical web-interface password. Server and other
+    # outbound passwords must remain recoverable OptionPassword values.
+    migrated_web_password = bool(sabnzbd.cfg.password() and not sabnzbd.cfg.password_hash())
+    if migrated_web_password and sabnzbd.cfg.configlock():
+        logging.warning("Cannot migrate the web interface password while configuration is locked")
+        return False
+    if migrated_web_password:
+        # Render the complete migrated configuration before touching either
+        # persistent file, then atomically replace both copies. This prevents a
+        # failed backup cleanup from leaving a plaintext credential behind.
+        sabnzbd.cfg.password_hash.set(sabnzbd.cfg.password())
+        sabnzbd.cfg.password.set("")
+        logging.info("Migrated the web interface password to a one-way hash")
+
+        for section in CFG_DATABASE:
+            if section in ("sorters", "servers", "categories", "rss"):
+                if section not in CFG_OBJ:
+                    CFG_OBJ[section] = {}
+                for subsection in CFG_DATABASE[section]:
+                    if subsection not in CFG_OBJ[section]:
+                        CFG_OBJ[section][subsection] = {}
+                    CFG_OBJ[section][subsection] = CFG_DATABASE[section][subsection].get_dict()
+            else:
+                for option in CFG_DATABASE[section]:
+                    config_option = CFG_DATABASE[section][option]
+                    if config_option.section not in CFG_OBJ:
+                        CFG_OBJ[config_option.section] = {}
+                    CFG_OBJ[config_option.section][config_option.keyword] = CFG_DATABASE[section][option]()
+
+        backup_directory = os.path.dirname(CFG_OBJ.filename) or "."
+        sanitized_config = ""
+        sanitized_backup = ""
+        try:
+            config_fd, sanitized_config = tempfile.mkstemp(prefix=".sabnzbd-", dir=backup_directory)
+            with os.fdopen(config_fd, "wb") as fp:
+                CFG_OBJ.write(fp)
+                fp.flush()
+                os.fsync(fp.fileno())
+            shutil.copymode(CFG_OBJ.filename, sanitized_config)
+
+            backup_fd, sanitized_backup = tempfile.mkstemp(prefix=".sabnzbd-", dir=backup_directory)
+            with os.fdopen(backup_fd, "wb") as fp, open(sanitized_config, "rb") as source:
+                shutil.copyfileobj(source, fp)
+                fp.flush()
+                os.fsync(fp.fileno())
+            shutil.copymode(CFG_OBJ.filename, sanitized_backup)
+
+            os.replace(sanitized_backup, CFG_OBJ.filename + ".bak")
+            os.replace(sanitized_config, CFG_OBJ.filename)
+            CFG_MODIFIED = False
+        except IOError:
+            for temporary_file in (sanitized_config, sanitized_backup):
+                if temporary_file and os.path.exists(temporary_file):
+                    try:
+                        os.unlink(temporary_file)
+                    except OSError:
+                        pass
+            return False
         return True
 
     if sabnzbd.cfg.configlock():

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -232,7 +232,7 @@ def check_hostname():
     if only allowed to be accessed via localhost.
     """
     # If login is enabled, no API-key can be deducted
-    if cfg.username() and cfg.password():
+    if cfg.username() and (cfg.password_hash() or cfg.password()):
         return True
 
     # Don't allow requests without Host
@@ -333,7 +333,7 @@ def check_login_cookie():
 
 def check_login():
     # Not when no authentication required or basic-auth is on
-    if not cfg.html_login() or not cfg.username() or not cfg.password():
+    if not cfg.html_login() or not cfg.username() or not (cfg.password_hash() or cfg.password()):
         return True
 
     # If we show login for external IP, by using access_type=6 we can check if IP match
@@ -346,12 +346,14 @@ def check_login():
 
 def check_basic_auth(_, username, password):
     """CherryPy basic authentication validation"""
+    if cfg.password_hash():
+        return username == cfg.username() and cfg.password_hash.verify(password)
     return username == cfg.username() and password == cfg.password()
 
 
 def set_auth(conf):
     """Set the authentication for CherryPy"""
-    if cfg.username() and cfg.password() and not cfg.html_login():
+    if cfg.username() and (cfg.password_hash() or cfg.password()) and not cfg.html_login():
         conf.update(
             {
                 "tools.auth_basic.on": True,
@@ -467,7 +469,7 @@ class MainPage:
             # Have logout only with HTML and if inet=5, only when we are external
             info["have_logout"] = (
                 cfg.username()
-                and cfg.password()
+                and (cfg.password_hash() or cfg.password())
                 and (
                     cfg.html_login()
                     and (cfg.inet_exposure() < 5 or (cfg.inet_exposure() == 5 and not check_access(access_type=6)))
@@ -675,7 +677,11 @@ class LoginPage:
             raise Raiser("/")
 
         # Check login info
-        if kwargs.get("username") == cfg.username() and kwargs.get("password") == cfg.password():
+        if cfg.password_hash():
+            password_ok = cfg.password_hash.verify(kwargs.get("password", ""))
+        else:
+            password_ok = kwargs.get("password") == cfg.password()
+        if kwargs.get("username") == cfg.username() and password_ok:
             # Save login cookie
             set_login_cookie(remember_me=kwargs.get("remember_me", False))
             # Log the success
@@ -1005,7 +1011,7 @@ class ConfigGeneral:
 
         conf["web_list"] = web_list
         conf["web_dir"] = "%s - %s" % (cfg.web_dir(), cfg.web_color())
-        conf["password"] = cfg.password.get_stars()
+        conf["password"] = cfg.password_hash.get_stars()
 
         conf["language"] = cfg.language()
         conf["lang_list"] = list_languages()
@@ -1030,7 +1036,7 @@ class ConfigGeneral:
                 return badParameterResponse(msg, ajax=kwargs.get("ajax"))
 
         # Handle special options
-        cfg.password.set(kwargs.get("password"))
+        cfg.password_hash.set(kwargs.get("password", ""))
 
         web_dir = kwargs.get("web_dir")
         change_web_dir(web_dir)

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -53,6 +53,7 @@ from sabnzbd.misc import (
     is_none,
     get_cpu_name,
     clean_comma_separated_list,
+    strip_ipv4_mapped_notation,
 )
 from sabnzbd.get_addrinfo import get_fastest_addrinfo
 from sabnzbd.filesystem import (
@@ -331,7 +332,31 @@ def check_login_cookie():
     return cherrypy.request.cookie["login_cookie"].value == hashlib.sha1(cookie_str).hexdigest()
 
 
+def authentik_proxy_sso_enabled() -> bool:
+    """Return whether strict Authentik proxy-header SSO is enabled."""
+    return bool(cfg.authentik_proxy_trusted_proxies())
+
+
+def check_authentik_proxy_sso() -> bool:
+    """Trust Authentik's identity header only from an explicit TCP peer.
+
+    The direct CherryPy peer address is deliberately used instead of
+    X-Forwarded-For, which must never determine whether an identity header is
+    trusted.
+    """
+    peer_ip = strip_ipv4_mapped_notation(cherrypy.request.remote.ip)
+    if peer_ip not in cfg.authentik_proxy_trusted_proxies():
+        return False
+    username = cherrypy.request.headers.get("X-authentik-username")
+    return bool(username and username.strip())
+
+
 def check_login():
+    # A configured trusted-proxy list selects strict SSO. Never fall back to
+    # cookies or local credentials, otherwise a direct client could bypass it.
+    if authentik_proxy_sso_enabled():
+        return check_authentik_proxy_sso()
+
     # Not when no authentication required or basic-auth is on
     if not cfg.html_login() or not cfg.username() or not (cfg.password_hash() or cfg.password()):
         return True
@@ -346,6 +371,8 @@ def check_login():
 
 def check_basic_auth(_, username, password):
     """CherryPy basic authentication validation"""
+    if authentik_proxy_sso_enabled():
+        return False
     if cfg.password_hash():
         return username == cfg.username() and cfg.password_hash.verify(password)
     return username == cfg.username() and password == cfg.password()
@@ -353,7 +380,9 @@ def check_basic_auth(_, username, password):
 
 def set_auth(conf):
     """Set the authentication for CherryPy"""
-    if cfg.username() and (cfg.password_hash() or cfg.password()) and not cfg.html_login():
+    if authentik_proxy_sso_enabled():
+        conf.update({"tools.auth_basic.on": False})
+    elif cfg.username() and (cfg.password_hash() or cfg.password()) and not cfg.html_login():
         conf.update(
             {
                 "tools.auth_basic.on": True,
@@ -468,7 +497,8 @@ class MainPage:
 
             # Have logout only with HTML and if inet=5, only when we are external
             info["have_logout"] = (
-                cfg.username()
+                not authentik_proxy_sso_enabled()
+                and cfg.username()
                 and (cfg.password_hash() or cfg.password())
                 and (
                     cfg.html_login()
@@ -663,6 +693,12 @@ def get_access_info():
 class LoginPage:
     @secured_expose(check_for_login=False)
     def index(self, **kwargs):
+        # Authentik SSO is strictly proxy-header based; SAB's local login
+        # cookie cannot log an Authentik session in or out.
+        if authentik_proxy_sso_enabled():
+            cherrypy.response.status = 401
+            return _MSG_MISSING_AUTH
+
         # Base output var
         info = build_header(sabnzbd.WEB_DIR_CONFIG)
         info["error"] = ""

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -332,30 +332,47 @@ def check_login_cookie():
     return cherrypy.request.cookie["login_cookie"].value == hashlib.sha1(cookie_str).hexdigest()
 
 
-def authentik_proxy_sso_enabled() -> bool:
-    """Return whether strict Authentik proxy-header SSO is enabled."""
-    return bool(cfg.authentik_proxy_trusted_proxies())
-
-
-def check_authentik_proxy_sso() -> bool:
-    """Trust Authentik's identity header only from an explicit TCP peer.
+def _request_from_trusted_proxy() -> bool:
+    """Check whether the TCP peer of the current request is a trusted Authentik proxy.
 
     The direct CherryPy peer address is deliberately used instead of
     X-Forwarded-For, which must never determine whether an identity header is
     trusted.
     """
     peer_ip = strip_ipv4_mapped_notation(cherrypy.request.remote.ip)
-    if peer_ip not in cfg.authentik_proxy_trusted_proxies():
-        return False
+    return peer_ip in cfg.authentik_proxy_trusted_proxies()
+
+
+def check_authentik_proxy_sso() -> bool | None:
+    """Validate Authentik proxy-header SSO for the current request.
+
+    Returns:
+        True  - the request is authenticated via SSO
+        False - the request arrived from a trusted proxy but lacks a valid
+                SSO header; it must be rejected
+        None  - the request did not come from a trusted proxy; the caller
+                should fall back to normal authentication
+    """
+    if not _request_from_trusted_proxy():
+        return None
     username = cherrypy.request.headers.get("X-authentik-username")
-    return bool(username and username.strip())
+    if username and username.strip():
+        return True
+    return False
 
 
 def check_login():
-    # A configured trusted-proxy list selects strict SSO. Never fall back to
-    # cookies or local credentials, otherwise a direct client could bypass it.
-    if authentik_proxy_sso_enabled():
-        return check_authentik_proxy_sso()
+    # If SSO is configured, check for Authentik proxy auth. Requests from a
+    # trusted proxy presenting a valid header are authenticated; requests from
+    # a trusted proxy without a valid header are rejected. Requests that did
+    # not come through the proxy fall through to normal password/cookie auth.
+    if cfg.authentik_proxy_trusted_proxies():
+        result = check_authentik_proxy_sso()
+        if result is True:
+            return True
+        if result is False:
+            return False
+        # result is None - not from proxy, fall through to normal auth
 
     # Not when no authentication required or basic-auth is on
     if not cfg.html_login() or not cfg.username() or not (cfg.password_hash() or cfg.password()):
@@ -371,8 +388,14 @@ def check_login():
 
 def check_basic_auth(_, username, password):
     """CherryPy basic authentication validation"""
-    if authentik_proxy_sso_enabled():
-        return False
+    if cfg.authentik_proxy_trusted_proxies():
+        result = check_authentik_proxy_sso()
+        if result is True:
+            return True
+        if result is False:
+            return False
+        # None - not from proxy, fall through to normal basic auth
+
     if cfg.password_hash():
         return username == cfg.username() and cfg.password_hash.verify(password)
     return username == cfg.username() and password == cfg.password()
@@ -380,9 +403,7 @@ def check_basic_auth(_, username, password):
 
 def set_auth(conf):
     """Set the authentication for CherryPy"""
-    if authentik_proxy_sso_enabled():
-        conf.update({"tools.auth_basic.on": False})
-    elif cfg.username() and (cfg.password_hash() or cfg.password()) and not cfg.html_login():
+    if cfg.username() and (cfg.password_hash() or cfg.password()) and not cfg.html_login():
         conf.update(
             {
                 "tools.auth_basic.on": True,
@@ -496,8 +517,14 @@ class MainPage:
             info["platform"] = sabnzbd.PLATFORM
 
             # Have logout only with HTML and if inet=5, only when we are external
+            # Hide logout for SSO-authenticated requests (cannot invalidate an
+            # Authentik proxy session from within SABnzbd).
             info["have_logout"] = (
-                not authentik_proxy_sso_enabled()
+                not (
+                    cfg.authentik_proxy_trusted_proxies()
+                    and _request_from_trusted_proxy()
+                    and cherrypy.request.headers.get("X-authentik-username", "").strip()
+                )
                 and cfg.username()
                 and (cfg.password_hash() or cfg.password())
                 and (
@@ -693,9 +720,9 @@ def get_access_info():
 class LoginPage:
     @secured_expose(check_for_login=False)
     def index(self, **kwargs):
-        # Authentik SSO is strictly proxy-header based; SAB's local login
-        # cookie cannot log an Authentik session in or out.
-        if authentik_proxy_sso_enabled():
+        # Authentik SSO users cannot use local login - if the request arrived
+        # through the trusted proxy, it must carry a valid SSO header.
+        if cfg.authentik_proxy_trusted_proxies() and _request_from_trusted_proxy():
             cherrypy.response.status = 401
             return _MSG_MISSING_AUTH
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -28,6 +28,64 @@ from sabnzbd.misc import is_local_addr, is_loopback_addr
 
 class TestInterfaceFunctions:
     @pytest.mark.parametrize(
+        "remote_ip, authentik_username, expected",
+        [
+            ("10.4.1.20", "harry", True),  # from trusted proxy + header → authenticated
+            ("10.4.1.20", "harry", True),  # with XFF → still authenticated
+            ("10.4.1.21", "harry", None),  # not from proxy → fall through
+            ("10.4.1.21", "someuser", None),  # not from proxy → fall through
+            ("10.4.1.20", None, False),  # from proxy, no header → reject
+            ("10.4.1.20", "   ", False),  # from proxy, blank header → reject
+        ],
+    )
+    @pytest.mark.config({"authentik_proxy_trusted_proxies": ["10.4.1.20"]})
+    def test_authentik_proxy_sso(self, remote_ip, authentik_username, expected):
+        cherrypy.request.remote.ip = remote_ip
+        if authentik_username is not None:
+            cherrypy.request.headers["X-Authentik-Username"] = authentik_username
+        else:
+            cherrypy.request.headers.pop("X-Authentik-Username", None)
+        assert interface.check_authentik_proxy_sso() is expected
+
+    @pytest.mark.config(
+        {
+            "authentik_proxy_trusted_proxies": ["10.4.1.20"],
+            "html_login": True,
+            "username": "testuser",
+            "password_hash": "pbkdf2_sha256$600000$c2FsdHlzYWx0$fakesignature",
+        }
+    )
+    def test_authentik_proxy_sso_check_login_hybrid(self):
+        """SSO users authenticate; direct users fall through to cookie/password auth."""
+        # Request from trusted proxy with valid header → authenticated
+        cherrypy.request.remote.ip = "10.4.1.20"
+        cherrypy.request.headers["X-Authentik-Username"] = "harry"
+        assert interface.check_login() is True
+
+        # Request from trusted proxy without header → rejected
+        cherrypy.request.headers.pop("X-Authentik-Username", None)
+        assert interface.check_login() is False
+
+        # Request from non-proxy → falls through to cookie check
+        cherrypy.request.remote.ip = "192.168.1.50"
+        # No cookie set → not authenticated
+        assert interface.check_login() is False
+
+    @pytest.mark.config(
+        {
+            "authentik_proxy_trusted_proxies": ["10.4.1.20"],
+            "html_login": False,
+            "username": "testuser",
+            "password_hash": "pbkdf2_sha256$600000$c2FsdHlzYWx0$fakesignature",
+        }
+    )
+    def test_authentik_proxy_sso_basic_auth_hybrid(self):
+        """Basic auth is available when SSO is configured and local creds exist."""
+        conf = {}
+        interface.set_auth(conf)
+        assert conf.get("tools.auth_basic.on") is True
+
+    @pytest.mark.parametrize(
         "remote_ip, local_ranges, xff_header, result_with_xff",
         [
             ("10.11.12.13", None, None, True),


### PR DESCRIPTION
Add support for Authentik (and compatible) forward-auth proxies that set the `X-Authentik-Username` header.

The feature is configured by adding trusted proxy IP(s) to the new `authentik_proxy_trusted_proxies` config option (a protected, API-hidden list under `[misc]`).

### How it works (hybrid mode)
- Requests from a **trusted proxy** with a valid `X-Authentik-Username` header → authenticated via SSO
- Requests from a **trusted proxy without the header** → rejected (cannot bypass the proxy)
- Requests **not from the proxy** → fall through to normal password/cookie/basic auth

This means existing local/direct access continues to work even when SSO is configured — useful for mixed-access environments.

### Design decisions
- The TCP peer address (`cherrypy.request.remote.ip`) is used for trust, not `X-Forwarded-For` — prevents header spoofing from untrusted clients
- When a request is authenticated via SSO, the logout button is hidden (SSO logout is handled at the proxy level, not within SAB)
- The login page returns 401 for requests that arrived through the proxy (they must have a valid Authentik session)
- Config is `protect=True` and `public=False` — not exposed in the web UI or API

### Testing
- New parametrized test covering all three-state return values (True/False/None)
- Integration tests for `check_login()` and `set_auth()` in hybrid mode
- All 7,326 unit tests pass (including 8 new SSO-specific tests)
- Black and Ruff clean