### PR TITLE
[created by accident, ignore] Prevent shutdown deadlock when a second signal arrives during halt

### DIFF
--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -212,6 +212,7 @@ def sig_handler(signum=None, frame=None):
 # Initializing
 ##############################################################################
 INIT_LOCK = Lock()
+SHUTDOWN_LOCK = Lock()
 
 
 def get_db_connection(thread_index=0):
@@ -432,7 +433,11 @@ def notify_shutdown_loop():
 
 def shutdown_program():
     """Stop program after halting and saving"""
-    if not sabnzbd.SABSTOP:
+    # The signal handler can re-enter this function on the main thread while halt()
+    # is still running, for example when systemd delivers a second SIGTERM during
+    # shutdown. The nested call would then deadlock on the non-reentrant INIT_LOCK
+    # already held by halt(), so only the first caller gets to perform the shutdown.
+    if not sabnzbd.SABSTOP and SHUTDOWN_LOCK.acquire(blocking=False):
         logging.info("[%s] Performing SABnzbd shutdown", misc.caller_name())
         sabnzbd.halt()
         cherrypy.engine.exit()


### PR DESCRIPTION
## The bug

When a second termination signal arrives while SABnzbd is already shutting down, the process deadlocks forever and has to be SIGKILLed. Because `halt()` never gets to `save_state()`, whatever kills the process afterwards (e.g. systemd's stop timeout) discards queue changes — I lost 163 of 298 queued jobs to this before finding the cause.

This is almost certainly the long-standing sporadic hang in #2148: that report also shows the "Signal 15 caught" line twice, and the sporadic behavior matches the race window described below.

## How it happens

`sig_handler` → `shutdown_program()` → `halt()`, which is `@synchronized(INIT_LOCK)` — a non-reentrant `threading.Lock`. `sabnzbd.SABSTOP` is only set **after** `halt()` returns, and Python signal handlers run on the main thread, nested inside whatever it was executing. So if a second SIGTERM is delivered while the main thread is inside `halt()` (which takes seconds with a busy queue — thread joins plus queue save):

1. the nested `sig_handler` runs `shutdown_program()`,
2. the `if not sabnzbd.SABSTOP` guard passes (halt #1 hasn't finished),
3. the nested `halt()` blocks acquiring `INIT_LOCK`, which is held by the *interrupted frame beneath it on the same thread* — which can never resume. Deadlock.

py-spy dump of a hung production process (5.0.4, Python 3.13, NixOS/systemd):

```
Thread 3839858 (idle): "MainThread"
    call_func (sabnzbd/decorators.py:48)      <- INIT_LOCK.acquire(), blocks forever
    shutdown_program (sabnzbd/__init__.py:436)
    sig_handler (sabnzbd/__init__.py:207)     <- SIGTERM #2
    join (threading.py:1095)
    halt (sabnzbd/__init__.py:383)            <- holds INIT_LOCK
    call_func (sabnzbd/decorators.py:49)
    shutdown_program (sabnzbd/__init__.py:436)
    sig_handler (sabnzbd/__init__.py:207)     <- SIGTERM #1
    wait (threading.py:363)
    main (SABnzbd.py:1413)
    <module> (SABnzbd.py:1658)
```

Corresponding log — the shutdown lines appear twice, then nothing:

```
12:31:39 WARNING [__init__:206] Signal 15 caught, saving and exiting...
12:31:39 INFO [__init__:435] [N/A] Performing SABnzbd shutdown
12:31:39 INFO [__init__:345] SABnzbd shutting down...
12:31:39 INFO [ssdp:103] Stopping SSDP
12:31:39 WARNING [__init__:206] Signal 15 caught, saving and exiting...
12:31:39 INFO [__init__:435] [N/A] Performing SABnzbd shutdown
        ... silence until SIGKILL ...
```

Double SIGTERMs are not exotic: systemd delivers one to every process in the control group on `systemctl stop`, and if the main process is a wrapper shell that exits first (common in distro/container packaging — NixOS here), systemd immediately re-signals the survivors ("final-sigterm"). Whether the second signal lands inside `halt()`'s window is a race, which is why the hang is sporadic.

## The fix

Make `shutdown_program()` re-entry-proof: only the first caller performs the shutdown, guarded by a non-blocking `Lock.acquire()`. A plain boolean flag would still leave a several-bytecode window between test and set that a nested signal handler can hit; `acquire(blocking=False)` is a single atomic operation. Later legitimate callers (second click on Shutdown in the UI, another signal) now return immediately instead of blocking or deadlocking.

## Verification

Reproduced deterministically on 5.0.4 (identical shutdown code) by sending two SIGTERMs 0.5s apart with `halt()` slowed to simulate a large queue:

- unpatched: deadlocks every time, py-spy shows the exact stack above
- patched: second signal logs "Signal 15 caught" and is ignored; "Performing SABnzbd shutdown" appears once; queue is saved; process exits cleanly

Also verified on the production instance that a normal single-SIGTERM stop is unaffected.
