### PR TITLE
Relax disk space requirements when not unpacking and on the same device

### DIFF
--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -41,6 +41,7 @@ from sabnzbd.filesystem import (
     get_filename,
     has_unwanted_extension,
     get_basename,
+    same_device,
 )
 from sabnzbd.constants import (
     Status,
@@ -335,14 +336,19 @@ class Assembler(Thread):
         if not full_dir:
             complete_free = cfg.complete_free.get_float()
             required_space = 0
-            if cfg.direct_unpack():
+            if cfg.direct_unpack() and nzo.unpack:
                 # We unpack while we download, so we should check every time
                 # if the unpack maybe already filled up the drive
                 required_space = complete_free / GIGI
             elif nzo.bytes_tried > (nzo.bytes - nzo.bytes_par2) * 0.90:
                 # Since only at 100% unpack is started, continue
                 # downloading until 90% complete before checking
-                required_space = (complete_free + nzo.bytes) / GIGI
+                required_space = complete_free / GIGI
+                if nzo.unpack or not same_device(download_dir.path, complete_dir.path):
+                    # Unpacking writes a second copy of the data before the archives are removed
+                    # and moving to another device copies it, so both need room for the whole job.
+                    # Without unpacking on the same device the move is only a rename.
+                    required_space += nzo.bytes / GIGI
 
             if required_space and complete_dir.free < required_space:
                 full_dir = complete_dir.path

--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -341,7 +341,7 @@ class Assembler(Thread):
                 required_space = complete_free / GIGI
             elif nzo.bytes_tried > (nzo.bytes - nzo.bytes_par2) * 0.90:
                 # Since only at 100% unpack is started, continue
-                # downloading until 95% complete before checking
+                # downloading until 90% complete before checking
                 required_space = (complete_free + nzo.bytes) / GIGI
 
             if required_space and complete_dir.free < required_space:

--- a/sabnzbd/filesystem.py
+++ b/sabnzbd/filesystem.py
@@ -35,6 +35,7 @@ import stat
 import ctypes
 import random
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Any, Optional, BinaryIO
 
 try:
@@ -1033,12 +1034,18 @@ class Diskspace:
     free: float = 0.0
 
 
+def first_existing_path(path: str) -> str:
+    """Return the first folder level of the path that exists"""
+    x = "x"
+    while x and not os.path.exists(path):
+        path, x = os.path.split(path)
+    return path
+
+
 def diskspace_base(dir_to_check: str) -> Diskspace:
     """Return amount of free and used diskspace in GBytes"""
     # Find first folder level that exists in the path
-    x = "x"
-    while x and not os.path.exists(dir_to_check):
-        dir_to_check, x = os.path.split(dir_to_check)
+    dir_to_check = first_existing_path(dir_to_check)
 
     if sabnzbd.WINDOWS:
         # windows diskfree
@@ -1073,6 +1080,27 @@ def diskspace(force: bool = False, complete_dir: Optional[str] = None) -> tuple[
     if not complete_dir:
         complete_dir = sabnzbd.cfg.complete_dir.get_path()
     return diskspace_base(sabnzbd.cfg.download_dir.get_path()), diskspace_base(complete_dir)
+
+
+@lru_cache(maxsize=16)
+def same_device(path_a: str, path_b: str) -> bool:
+    """Determine if both paths are located on the same device, meaning a file can be moved
+    between them by renaming it, without requiring any additional free space.
+    The paths do not have to exist, the first existing folder level is used."""
+    path_a = first_existing_path(path_a)
+    path_b = first_existing_path(path_b)
+
+    # Different drive letters or UNC shares are never the same device. Checked separately
+    # because st_dev is not reliable for network locations on Windows
+    if os.path.splitdrive(path_a)[0].lower() != os.path.splitdrive(path_b)[0].lower():
+        return False
+
+    try:
+        return os.stat(path_a).st_dev == os.stat(path_b).st_dev
+    except OSError:
+        # Assume separate devices, so callers keep reserving space for a copy
+        logging.debug("Could not determine if %s and %s are on the same device", path_a, path_b)
+        return False
 
 
 def get_new_id(prefix: str, folder: str, check_list: Optional[list] = None) -> str:

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -21,6 +21,7 @@ tests.test_assembler - Testing functions in assembler.py
 
 import os
 from types import SimpleNamespace
+from typing import NamedTuple, Optional
 from unittest import mock
 from zlib import crc32
 
@@ -30,6 +31,7 @@ import sabnzbd
 from sabnzbd.assembler import Assembler
 from sabnzbd.constants import GIGI
 from sabnzbd.filesystem import Diskspace
+from sabnzbd.misc import pp_to_opts
 from sabnzbd.nzb import Article, NzbFile, NzbObject
 
 
@@ -431,7 +433,7 @@ class TestDiskspaceCheck:
         self.mock_scheduler.plan_diskspace_resume.assert_called_once_with("/complete", expected_required)
 
     def test_complete_dir_full_near_completion(self):
-        """Pause when complete_dir is full and download is >95% done"""
+        """Pause when complete_dir is full and download is >90% done"""
         self.nzo.bytes_tried = int(self.nzo.bytes * 0.96)
         self.nzo.bytes_par2 = 0
         self._set_diskspace(download_free_gb=50.0, complete_free_gb=1.0)
@@ -442,8 +444,8 @@ class TestDiskspaceCheck:
         self.mock_downloader.pause.assert_called_once()
         self.mock_scheduler.plan_diskspace_resume.assert_called_once_with("/complete", expected_required)
 
-    def test_complete_dir_no_check_below_95_percent(self):
-        """No complete_dir check when download is below 95% and not direct_unpack"""
+    def test_complete_dir_no_check_below_90_percent(self):
+        """No complete_dir check when download is below 90% and not direct_unpack"""
         self.nzo.bytes_tried = int(self.nzo.bytes * 0.50)
         self._set_diskspace(download_free_gb=50.0, complete_free_gb=0.1)
 
@@ -493,3 +495,218 @@ class TestDiskspaceCheck:
 
         self.mock_notifier.send_notification.assert_called_once()
         self.mock_emailer.diskfull_mail.assert_called_once()
+
+
+class DiskspaceCheckResult(NamedTuple):
+    paused: bool
+    full_dir: Optional[str]
+    required_space: Optional[float]
+
+
+class TestDiskspaceCheckScenarios:
+    """Assembler.diskspace_check across post-processing options and single/multi-device layouts."""
+
+    @pytest.fixture(autouse=True)
+    def setup_mocks(self):
+        self.mock_downloader = mock.Mock()
+        self.mock_scheduler = mock.Mock()
+
+        try:
+            sabnzbd.Downloader = self.mock_downloader
+            sabnzbd.Scheduler = self.mock_scheduler
+            sabnzbd.notifier = mock.Mock()
+            sabnzbd.emailer = mock.Mock()
+
+            with (
+                mock.patch("sabnzbd.assembler.diskspace") as self.mock_diskspace,
+                mock.patch("sabnzbd.assembler.get_complete_directory") as self.mock_get_complete_dir,
+                mock.patch("sabnzbd.assembler.cfg") as self.mock_cfg,
+            ):
+                self.mock_get_complete_dir.return_value = ("/complete", None, True)
+                self.mock_cfg.fulldisk_autoresume.return_value = True
+                self.mock_cfg.download_dir.get_path.return_value = "/download"
+                yield
+        finally:
+            del sabnzbd.Downloader
+            del sabnzbd.Scheduler
+            del sabnzbd.notifier
+            del sabnzbd.emailer
+
+    def _run_check(
+        self,
+        job_gb: float,
+        progress: float,
+        pp: int,
+        same_device: bool,
+        disk_free_gb: float = 120.0,
+        complete_disk_free_gb: Optional[float] = None,
+        complete_free_gb: float = 5.0,
+        download_free_gb: float = 1.0,
+        par2_gb: float = 0.0,
+        direct_unpack: bool = False,
+        file_gb: float = 0.05,
+    ) -> DiskspaceCheckResult:
+        """Run one check against a modeled disk layout.
+
+        disk_free_gb is the free space on the download device *before* the job started; the bytes
+        downloaded so far are subtracted from it. On a single-device layout the complete dir sees
+        that same reduced figure, because the partially downloaded job is already occupying it."""
+        nzo = mock.Mock()
+        nzo.bytes = int(job_gb * GIGI)
+        nzo.bytes_par2 = int(par2_gb * GIGI)
+        nzo.bytes_tried = int((nzo.bytes - nzo.bytes_par2) * progress)
+        nzo.repair, nzo.unpack, nzo.delete = pp_to_opts(pp)
+
+        nzf = mock.Mock()
+        nzf.bytes = int(file_gb * GIGI)
+
+        download_dir_free = disk_free_gb - nzo.bytes_tried / GIGI
+        if same_device:
+            complete_dir_free = download_dir_free
+        else:
+            complete_dir_free = disk_free_gb if complete_disk_free_gb is None else complete_disk_free_gb
+
+        self.mock_diskspace.return_value = (
+            Diskspace(path="/download", free=download_dir_free),
+            Diskspace(path="/complete" if not same_device else "/download", free=complete_dir_free),
+        )
+        self.mock_cfg.download_free.get_float.return_value = download_free_gb * GIGI
+        self.mock_cfg.complete_free.get_float.return_value = complete_free_gb * GIGI
+        self.mock_cfg.direct_unpack.return_value = direct_unpack
+
+        Assembler.diskspace_check(nzo, nzf)
+
+        paused = self.mock_downloader.pause.called
+        resume_call = self.mock_scheduler.plan_diskspace_resume.call_args
+        return DiskspaceCheckResult(
+            paused=paused,
+            full_dir=resume_call.args[0] if resume_call else None,
+            required_space=resume_call.args[1] if resume_call else None,
+        )
+
+    @pytest.mark.parametrize("pp", [0, 1, 2, 3])
+    @pytest.mark.parametrize("same_device", [True, False])
+    def test_pp_does_not_change_requirement(self, pp, same_device):
+        """The complete_dir requirement is the full job size for every pp, including Download-only
+        (pp=0) where nothing is ever unpacked. This is the complaint in #3531."""
+        result = self._run_check(
+            job_gb=61.0,
+            progress=0.95,
+            pp=pp,
+            same_device=same_device,
+            disk_free_gb=118.0,
+            complete_disk_free_gb=60.0,
+        )
+
+        assert result.paused is True
+        assert result.required_space == pytest.approx(5.0 + 61.0)
+
+    def test_single_device_pauses_despite_ample_space(self):
+        """The crux of #3531: on one device the bytes already downloaded are deducted from
+        complete_dir.free, yet the requirement asks for the full job size on top of them, so the
+        check gets harder to satisfy the closer the job is to finishing."""
+        result = self._run_check(job_gb=61.0, progress=0.91, pp=0, same_device=True, disk_free_gb=118.0)
+
+        assert result.paused is True
+        # Free space still covers the rest of the download plus the threshold, and the move to
+        # complete_dir is a rename on one device, so it consumes nothing extra
+        assert self.mock_diskspace.return_value[1].free > 61.0 * (1 - 0.91) + 5.0
+
+    @pytest.mark.parametrize(
+        "scenario, expect_full_dir, expect_required",
+        [
+            pytest.param(
+                {"job_gb": 61.0, "progress": 0.91, "pp": 0, "same_device": True, "disk_free_gb": 118.0},
+                "/download",
+                66.0,
+                id="reported_issue_single_device",
+            ),
+            pytest.param(
+                # Same job with complete_dir on its own device, where the move really does copy
+                # the whole job, so the identical requirement is justified
+                {"job_gb": 61.0, "progress": 0.91, "pp": 0, "same_device": False, "complete_disk_free_gb": 60.0},
+                "/complete",
+                66.0,
+                id="reported_issue_separate_devices",
+            ),
+            pytest.param(
+                {"job_gb": 40.0, "progress": 1.0, "pp": 0, "same_device": True, "disk_free_gb": 80.0},
+                "/download",
+                45.0,
+                id="single_device_fully_downloaded",
+            ),
+            pytest.param(
+                {"job_gb": 61.0, "progress": 0.99, "pp": 2, "same_device": False, "complete_disk_free_gb": 70.0},
+                None,
+                None,
+                id="separate_device_complete_dir_large_enough",
+            ),
+            pytest.param(
+                # 40GB of articles plus the 5GB threshold would fit in the 52GB available, but the
+                # par2 blocks are counted too even though they are usually never downloaded
+                {"job_gb": 50.0, "par2_gb": 10.0, "progress": 0.95, "pp": 1, "same_device": False, "complete_disk_free_gb": 52.0},
+                "/complete",
+                55.0,
+                id="par2_bytes_included_in_requirement",
+            ),
+            pytest.param(
+                # cfg.direct_unpack is global, but DirectUnpacker also requires nzo.unpack, so a
+                # pp=0 job never direct unpacks and yet still takes the lenient branch
+                {
+                    "job_gb": 61.0, "progress": 0.95, "pp": 0, "same_device": False, "complete_disk_free_gb": 8.0, "direct_unpack": True
+                },
+                None,
+                None,
+                id="direct_unpack_relaxes_check",
+            ),
+            pytest.param(
+                {
+                    "job_gb": 61.0, "progress": 0.95, "pp": 0, "same_device": False, "complete_disk_free_gb": 8.0, "direct_unpack": False
+                },
+                "/complete",
+                66.0,
+                id="direct_unpack_off_same_job_pauses",
+            ),
+            pytest.param(
+                # complete_free defaults to empty (0), but the check still applies because the job
+                # size alone makes required_space non-zero
+                {
+                    "job_gb": 61.0,
+                    "progress": 0.95,
+                    "pp": 0,
+                    "same_device": False,
+                    "complete_free_gb": 0.0,
+                    "complete_disk_free_gb": 60.0,
+                },
+                "/complete",
+                61.0,
+                id="complete_free_unset",
+            ),
+            pytest.param(
+                # Both dirs are short: download_dir wins and the required_space handed to the
+                # scheduler is the much smaller download_dir figure
+                {
+                    "job_gb": 61.0,
+                    "progress": 0.95,
+                    "pp": 2,
+                    "same_device": False,
+                    "disk_free_gb": 58.0,
+                    "complete_disk_free_gb": 1.0,
+                    "download_free_gb": 1.0,
+                    "file_gb": 0.05,
+                },
+                "/download",
+                1.05,
+                id="download_dir_full_takes_precedence",
+            ),
+        ],
+    )
+    def test_diskspace_scenarios(self, scenario, expect_full_dir, expect_required):
+        result = self._run_check(**scenario)
+
+        assert result.paused is (expect_full_dir is not None)
+        assert result.full_dir == expect_full_dir
+        if expect_required is None:
+            assert result.required_space is None
+        else:
+            assert result.required_space == pytest.approx(expect_required)

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -371,6 +371,7 @@ class TestDiskspaceCheck:
         self.nzo.bytes = int(2 * GIGI)
         self.nzo.bytes_tried = 0
         self.nzo.bytes_par2 = 0
+        self.nzo.unpack = True
 
         self.nzf = mock.Mock()
         self.nzf.bytes = int(0.5 * GIGI)
@@ -389,9 +390,10 @@ class TestDiskspaceCheck:
             with (
                 mock.patch("sabnzbd.assembler.diskspace") as self.mock_diskspace,
                 mock.patch("sabnzbd.assembler.get_complete_directory") as self.mock_get_complete_dir,
+                mock.patch("sabnzbd.assembler.same_device", return_value=False) as self.mock_same_device,
                 mock.patch("sabnzbd.assembler.cfg") as self.mock_cfg,
             ):
-                # Defaults: plenty of space, no direct_unpack, autoresume on
+                # Defaults: plenty of space, no direct_unpack, autoresume on, separate devices
                 self.mock_get_complete_dir.return_value = ("/complete", None, True)
                 self.mock_cfg.download_free.get_float.return_value = 1 * GIGI
                 self.mock_cfg.complete_free.get_float.return_value = 2 * GIGI
@@ -520,6 +522,7 @@ class TestDiskspaceCheckScenarios:
             with (
                 mock.patch("sabnzbd.assembler.diskspace") as self.mock_diskspace,
                 mock.patch("sabnzbd.assembler.get_complete_directory") as self.mock_get_complete_dir,
+                mock.patch("sabnzbd.assembler.same_device") as self.mock_same_device,
                 mock.patch("sabnzbd.assembler.cfg") as self.mock_cfg,
             ):
                 self.mock_get_complete_dir.return_value = ("/complete", None, True)
@@ -568,8 +571,9 @@ class TestDiskspaceCheckScenarios:
 
         self.mock_diskspace.return_value = (
             Diskspace(path="/download", free=download_dir_free),
-            Diskspace(path="/complete" if not same_device else "/download", free=complete_dir_free),
+            Diskspace(path="/download" if same_device else "/complete", free=complete_dir_free),
         )
+        self.mock_same_device.return_value = same_device
         self.mock_cfg.download_free.get_float.return_value = download_free_gb * GIGI
         self.mock_cfg.complete_free.get_float.return_value = complete_free_gb * GIGI
         self.mock_cfg.direct_unpack.return_value = direct_unpack
@@ -586,9 +590,9 @@ class TestDiskspaceCheckScenarios:
 
     @pytest.mark.parametrize("pp", [0, 1, 2, 3])
     @pytest.mark.parametrize("same_device", [True, False])
-    def test_pp_does_not_change_requirement(self, pp, same_device):
-        """The complete_dir requirement is the full job size for every pp, including Download-only
-        (pp=0) where nothing is ever unpacked. This is the complaint in #3531."""
+    def test_job_size_required_only_when_unpacking_or_crossing_devices(self, pp, same_device):
+        """Room for the whole job is needed when it gets unpacked (pp 2 and 3) or when the move to
+        complete_dir crosses devices. A Download-only or Repair-only job on one device does not."""
         result = self._run_check(
             job_gb=61.0,
             progress=0.95,
@@ -598,42 +602,44 @@ class TestDiskspaceCheckScenarios:
             complete_disk_free_gb=60.0,
         )
 
-        assert result.paused is True
-        assert result.required_space == pytest.approx(5.0 + 61.0)
+        if pp >= 2 or not same_device:
+            assert result.paused is True
+            assert result.required_space == pytest.approx(5.0 + 61.0)
+        else:
+            assert result.paused is False
 
-    def test_single_device_pauses_despite_ample_space(self):
-        """The crux of #3531: on one device the bytes already downloaded are deducted from
-        complete_dir.free, yet the requirement asks for the full job size on top of them, so the
-        check gets harder to satisfy the closer the job is to finishing."""
+    def test_reported_issue_scenario(self):
+        """#3531: 61GB job, 118GB free at the start, 5GB complete_free and all unpacking off.
+        Used to pause at ~90% because the bytes already downloaded were deducted from
+        complete_dir.free while the requirement still asked for the whole job on top of them."""
         result = self._run_check(job_gb=61.0, progress=0.91, pp=0, same_device=True, disk_free_gb=118.0)
 
-        assert result.paused is True
-        # Free space still covers the rest of the download plus the threshold, and the move to
-        # complete_dir is a rename on one device, so it consumes nothing extra
-        assert self.mock_diskspace.return_value[1].free > 61.0 * (1 - 0.91) + 5.0
+        assert result.paused is False
+        # Free space is below the old requirement, but well above the reserve it now has to meet
+        assert 5.0 < self.mock_diskspace.return_value[1].free < 5.0 + 61.0
 
     @pytest.mark.parametrize(
         "scenario, expect_full_dir, expect_required",
         [
             pytest.param(
-                {"job_gb": 61.0, "progress": 0.91, "pp": 0, "same_device": True, "disk_free_gb": 118.0},
-                "/download",
-                66.0,
-                id="reported_issue_single_device",
-            ),
-            pytest.param(
-                # Same job with complete_dir on its own device, where the move really does copy
-                # the whole job, so the identical requirement is justified
+                # Moving to another device really does copy the whole job, so it is still required
                 {"job_gb": 61.0, "progress": 0.91, "pp": 0, "same_device": False, "complete_disk_free_gb": 60.0},
                 "/complete",
                 66.0,
-                id="reported_issue_separate_devices",
+                id="download_only_separate_devices",
+            ),
+            pytest.param(
+                # Unpacking writes a second copy alongside the archives, also on one device
+                {"job_gb": 61.0, "progress": 0.95, "pp": 2, "same_device": True, "disk_free_gb": 118.0},
+                "/download",
+                66.0,
+                id="unpack_single_device",
             ),
             pytest.param(
                 {"job_gb": 40.0, "progress": 1.0, "pp": 0, "same_device": True, "disk_free_gb": 80.0},
-                "/download",
-                45.0,
-                id="single_device_fully_downloaded",
+                None,
+                None,
+                id="download_only_single_device_fully_downloaded",
             ),
             pytest.param(
                 {"job_gb": 61.0, "progress": 0.99, "pp": 2, "same_device": False, "complete_disk_free_gb": 70.0},
@@ -644,28 +650,47 @@ class TestDiskspaceCheckScenarios:
             pytest.param(
                 # 40GB of articles plus the 5GB threshold would fit in the 52GB available, but the
                 # par2 blocks are counted too even though they are usually never downloaded
-                {"job_gb": 50.0, "par2_gb": 10.0, "progress": 0.95, "pp": 1, "same_device": False, "complete_disk_free_gb": 52.0},
+                {
+                    "job_gb": 50.0,
+                    "par2_gb": 10.0,
+                    "progress": 0.95,
+                    "pp": 1,
+                    "same_device": False,
+                    "complete_disk_free_gb": 52.0,
+                },
                 "/complete",
                 55.0,
                 id="par2_bytes_included_in_requirement",
             ),
             pytest.param(
                 # cfg.direct_unpack is global, but DirectUnpacker also requires nzo.unpack, so a
-                # pp=0 job never direct unpacks and yet still takes the lenient branch
+                # pp=0 job never direct unpacks and must not take the direct_unpack branch
                 {
-                    "job_gb": 61.0, "progress": 0.95, "pp": 0, "same_device": False, "complete_disk_free_gb": 8.0, "direct_unpack": True
-                },
-                None,
-                None,
-                id="direct_unpack_relaxes_check",
-            ),
-            pytest.param(
-                {
-                    "job_gb": 61.0, "progress": 0.95, "pp": 0, "same_device": False, "complete_disk_free_gb": 8.0, "direct_unpack": False
+                    "job_gb": 61.0,
+                    "progress": 0.95,
+                    "pp": 0,
+                    "same_device": False,
+                    "complete_disk_free_gb": 8.0,
+                    "direct_unpack": True,
                 },
                 "/complete",
                 66.0,
-                id="direct_unpack_off_same_job_pauses",
+                id="direct_unpack_ignored_for_download_only_job",
+            ),
+            pytest.param(
+                # A job that does direct unpack is checked against the reserve alone, from the
+                # start of the download rather than at 90%
+                {
+                    "job_gb": 61.0,
+                    "progress": 0.10,
+                    "pp": 2,
+                    "same_device": False,
+                    "complete_disk_free_gb": 4.0,
+                    "direct_unpack": True,
+                },
+                "/complete",
+                5.0,
+                id="direct_unpack_checks_reserve_only",
             ),
             pytest.param(
                 # complete_free defaults to empty (0), but the check still applies because the job
@@ -680,7 +705,21 @@ class TestDiskspaceCheckScenarios:
                 },
                 "/complete",
                 61.0,
-                id="complete_free_unset",
+                id="complete_free_unset_separate_devices",
+            ),
+            pytest.param(
+                # Nothing left to require, so the complete_dir check is skipped entirely
+                {
+                    "job_gb": 61.0,
+                    "progress": 0.95,
+                    "pp": 0,
+                    "same_device": True,
+                    "complete_free_gb": 0.0,
+                    "disk_free_gb": 60.0,
+                },
+                None,
+                None,
+                id="complete_free_unset_single_device",
             ),
             pytest.param(
                 # Both dirs are short: download_dir wins and the required_space handed to the

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -27,6 +27,7 @@ import unicodedata
 from pathlib import Path
 import tempfile
 from random import choice, randint
+from unittest import mock
 
 import pytest
 from pyfakefs.helpers import set_uid
@@ -440,6 +441,43 @@ class TestSameDirectory:
         assert 0 == filesystem.same_directory("/test", "/Test")
         assert 0 == filesystem.same_directory("tesT", "Test")
         assert 0 == filesystem.same_directory("/test/../Home", "/home")
+
+
+class TestFirstExistingPath:
+    def test_existing_path(self, tmp_path):
+        assert filesystem.first_existing_path(str(tmp_path)) == str(tmp_path)
+
+    def test_walks_up_to_existing_parent(self, tmp_path):
+        assert filesystem.first_existing_path(str(tmp_path / "not" / "created" / "yet")) == str(tmp_path)
+
+
+class TestSameDevice:
+    def test_same_path(self, tmp_path):
+        assert filesystem.same_device(str(tmp_path), str(tmp_path)) is True
+
+    def test_sibling_folders(self, tmp_path):
+        download_dir = tmp_path / "download"
+        complete_dir = tmp_path / "complete"
+        download_dir.mkdir()
+        complete_dir.mkdir()
+        assert filesystem.same_device(str(download_dir), str(complete_dir)) is True
+
+    def test_folders_not_created_yet(self, tmp_path):
+        """Falls back on the first existing parent, so both resolve to tmp_path"""
+        assert filesystem.same_device(str(tmp_path / "download"), str(tmp_path / "complete" / "sub")) is True
+
+    @pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Relies on /proc being its own filesystem")
+    def test_separate_devices(self, tmp_path):
+        assert filesystem.same_device(str(tmp_path), "/proc") is False
+
+    @pytest.mark.skipif(not sys.platform.startswith("win"), reason="Windows only has drive letters")
+    def test_different_drives_win(self):
+        assert filesystem.same_device("C:\\downloads", "D:\\complete") is False
+
+    def test_undeterminable_path(self, tmp_path):
+        """Fall back on separate devices, so the caller keeps reserving space for a copy"""
+        with mock.patch("os.stat", side_effect=OSError):
+            assert filesystem.same_device(str(tmp_path / "a"), str(tmp_path / "b")) is False
 
 
 class TestClipLongPath:


### PR DESCRIPTION
Fixes #3531

Past 90%, `diskspace_check()` required `complete_free + nzo.bytes` in the complete folder for every job. In the users 61GB Download-only job paused with 60GB still free, and re-paused on every following file.

Post-processing moves the data to the complete folder, so that space is genuinely needed across devices. On a *single* device it is not: the downloaded bytes are already deducted from the free space the check reads, and the move is a rename, so the job size was counted twice.

The job size is now only added when the data really is duplicated, either because the job unpacks or because the folders are on different devices. `same_device()` compares `st_dev`, guarded by a `splitdrive` check for Windows drives and shares, and assumes separate devices when it cannot tell.

Also fixed `cfg.direct_unpack()` took effect for jobs that never direct unpack, skipping the size check entirely. Tests were written against the old code first, so the ones that change are the ones the fix intends to change.

---

There is another existing issue with `+Unpack` since it keeps the archives, when they are different devices it should reserve 2x the space. I can add that fix to this PR if you'd like?