### PR TITLE
Fix assembler ready bytes accounting

### DIFF
--- a/sabnzbd/articlecache.py
+++ b/sabnzbd/articlecache.py
@@ -167,6 +167,10 @@ class ArticleCache(threading.Thread):
                 return
             nzo.saved_articles.add(article)
 
+        # Count the decoded bytes before they can be written, so the assembler always
+        # removes bytes that were added, even when we write straight to disk below
+        sabnzbd.Assembler.add_ready_bytes(article)
+
         if article.lowest_partnum and not (article.nzf.import_finished or article.nzf.filename_checked):
             # Write the first-fetched articles to temporary file unless downloading
             # of the rest of the parts has started or filename is verified.

--- a/sabnzbd/assembler.py
+++ b/sabnzbd/assembler.py
@@ -125,14 +125,30 @@ class Assembler(Thread):
         with self.ready_bytes_lock:
             return sum(self.ready_bytes.values())
 
-    def update_ready_bytes(self, nzf: NzbFile, delta: int) -> int:
+    def file_ready_bytes(self, nzf: NzbFile) -> int:
+        """Decoded bytes of this file that still have to be written to disk"""
         with self.ready_bytes_lock:
-            cur = self.ready_bytes.get(nzf.nzf_id, 0) + delta
-            if cur <= 0:
-                self.ready_bytes.pop(nzf.nzf_id, None)
+            return self.ready_bytes.get(nzf.nzf_id, 0)
+
+    def add_ready_bytes(self, article: Article) -> None:
+        """Start tracking the decoded bytes of an article that still have to be written to disk.
+        Called when the data enters the article cache, so it is always counted before the cache
+        can write it to disk, keeping it symmetrical with remove_ready_bytes"""
+        if not article.decoded_size:
+            return
+        nzf_id = article.nzf.nzf_id
+        with self.ready_bytes_lock:
+            self.ready_bytes[nzf_id] = self.ready_bytes.get(nzf_id, 0) + article.decoded_size
+
+    def remove_ready_bytes(self, article: Article) -> None:
+        """Stop tracking an article, its data is now on disk"""
+        nzf_id = article.nzf.nzf_id
+        with self.ready_bytes_lock:
+            # Could already be gone, for example when the file was finished or the job was removed
+            if (cur := self.ready_bytes.get(nzf_id, 0) - article.decoded_size) > 0:
+                self.ready_bytes[nzf_id] = cur
             else:
-                self.ready_bytes[nzf.nzf_id] = cur
-            return cur
+                self.ready_bytes.pop(nzf_id, None)
 
     def clear_ready_bytes(self, *nzfs: NzbFile) -> None:
         with self.ready_bytes_lock:
@@ -153,11 +169,8 @@ class Assembler(Thread):
             self.queue.put(AssemblerTask(nzo))
             return
 
-        # Track bytes pending being written for this nzf
-        if self.should_track_ready_bytes(article, allow_non_contiguous):
-            ready_bytes = self.update_ready_bytes(nzf, article.decoded_size)
-        else:
-            ready_bytes = 0
+        # Bytes pending being written for this nzf
+        ready_bytes = self.file_ready_bytes(nzf)
 
         article_has_first_part = bool(article and article.lowest_partnum)
         if article_has_first_part:
@@ -227,11 +240,6 @@ class Assembler(Thread):
         if next_ready and ready_bytes >= self.assembler_trigger:
             return True
         return False
-
-    @staticmethod
-    def should_track_ready_bytes(article: Optional[Article], allow_non_contiguous: bool) -> bool:
-        """"""
-        return article and not allow_non_contiguous and article.decoded_size
 
     def delay(self) -> float:
         """Calculate how long if at all the downloader thread should sleep to allow the assembler to catch up"""
@@ -511,7 +519,7 @@ class Assembler(Thread):
                 written += Assembler._write(fd, nzf, mv[written:], pos + written)
 
         article.on_disk = True
-        sabnzbd.Assembler.update_ready_bytes(nzf, -len(data))
+        sabnzbd.Assembler.remove_ready_bytes(article)
         with nzf.lock:
             # assembler_next_index is the lowest index that has not yet been written sequentially from the start of the file.
             # If this was the next required index to remain sequential, it can be incremented which allows the assembler to


### PR DESCRIPTION
`ArticleCache.save_article` > `_flush_article_to_disk` > `Assembler.assemble_article` > `Assembler.write` subtracts ready bytes before they are added via `NzbQueue.register_article`, results in incorrect tracking and higher memory usage - assembler thinks it has little to do meanwhile it keeps hitting the out-of-order write path.

Fix is to record the bytes in the article cache before we decide how they will be written, then it doesn't matter if all assembler paths subtract.