### PR TITLE
Improve wait for direct unpacker to finish

### DIFF
--- a/sabnzbd/newsunpack.py
+++ b/sabnzbd/newsunpack.py
@@ -560,7 +560,9 @@ def rar_unpack(nzo: NzbObject, workdir_complete: str, one_folder: bool, rars: li
                 # Bump the file-lock in case it's stuck
                 with nzo.direct_unpacker.next_file_lock:
                     nzo.direct_unpacker.next_file_lock.notify()
-                time.sleep(2)
+
+                # Returns as soon as it is done
+                nzo.direct_unpacker.join(timeout=2)
 
                 # Did something change? Might be stuck
                 if last_stats == nzo.direct_unpacker.get_formatted_stats():


### PR DESCRIPTION
Pulled this change out of #3521

This loop is polling the direct unpacker every 2 seconds, sending it a `next_file_lock.notify()` and eventually timing it out.

However, since direct unpackers are threads that we are waiting to finish `join(timeout=2)` is more appropriate way to wait for either 2 seconds or until the thread finishes.