### PR TITLE
fix active pagination for light theme

### DIFF
--- a/interfaces/Glitter/templates/static/stylesheets/glitter.css
+++ b/interfaces/Glitter/templates/static/stylesheets/glitter.css
@@ -2297,7 +2297,7 @@ legend {
 .pagination li.active a:hover,
 .pagination li.active span:hover,
 .pagination>li>span:hover {
-    background-color: var(--clr-table-row-alt);
+    background-color: var(--clr-table-bg);
     border: 1px solid var(--clr-border-subtle);
     color: var(--clr-text);
 }


### PR DESCRIPTION
before:
<img width="435" height="59" alt="image" src="https://github.com/user-attachments/assets/3a4147ef-6f8c-457d-acfd-5593382a68da" />

after:
<img width="433" height="75" alt="image" src="https://github.com/user-attachments/assets/dba2e835-f048-4e7d-9626-a99b6b9320d0" />
