### PR TITLE
Speed up tests with pytest-xdist

### DIFF
--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -68,4 +68,4 @@ jobs:
         pip install -r requirements.txt --no-dependencies
         pip install --upgrade -r tests/requirements.txt
     - name: Test SABnzbd
-      run: pytest -s -n auto --dist loadscope
+      run: pytest -s -n auto

--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -68,4 +68,4 @@ jobs:
         pip install -r requirements.txt --no-dependencies
         pip install --upgrade -r tests/requirements.txt
     - name: Test SABnzbd
-      run: pytest -s
+      run: pytest -s -n auto --dist loadscope

--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -68,4 +68,4 @@ jobs:
         pip install -r requirements.txt --no-dependencies
         pip install --upgrade -r tests/requirements.txt
     - name: Test SABnzbd
-      run: pytest -s -n auto
+      run: pytest -n auto

--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -68,4 +68,4 @@ jobs:
         pip install -r requirements.txt --no-dependencies
         pip install --upgrade -r tests/requirements.txt
     - name: Test SABnzbd
-      run: pytest -n auto
+      run: pytest -n auto --dist loadscope

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ SABnzbd-*/
 
 # Testing folders
 tests/cache
+tests/cache_gw*
 
 # General junk
 *.keep

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,9 @@ These have to be separate otherwise SABnzbd is started multiple times!
 """
 
 import os
+import random
 import shutil
+import socket
 import subprocess
 import sys
 import time
@@ -40,6 +42,8 @@ from tests.testhelper import (
     SAB_CACHE_DIR,
     SAB_DATA_DIR,
     SAB_HOST,
+    SAB_NEWSSERVER_HOST,
+    SAB_NEWSSERVER_PORT,
     SAB_PORT,
     SABnzbdBaseTest,
     get_api_result,
@@ -52,6 +56,42 @@ from tests.testhelper import (
 # fixtures (config_env, platform_env) are what apply the @pytest.mark.config
 # and @pytest.mark.platform markers, so they must be globally visible.
 from tests.testhelper import config_env, platform_env, fake_fs, sleepless  # noqa: F401
+
+
+def pytest_configure(config):
+    """Make randomized test parameters identical across pytest-xdist workers"""
+    testrunuid = None
+    workerinput = getattr(config, "workerinput", None)
+    if workerinput:
+        testrunuid = workerinput.get("testrunuid")
+    testrunuid = testrunuid or os.environ.get("PYTEST_XDIST_TESTRUNUID")
+    if testrunuid:
+        random.seed(testrunuid)
+
+
+@pytest.fixture(scope="session")
+def warm_up_guessit():
+    """Force guessit to load its bundled config before any fake filesystem is active."""
+    import guessit
+
+    guessit.api.guessit("Warm.Up.S01E01.1080p.mkv")
+
+
+def _port_is_open(host, port):
+    """Return True if something is accepting connections on host:port"""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.25)
+        return sock.connect_ex((host, port)) == 0
+
+
+def _wait_for_port_release(host, port, timeout=30):
+    """Block until nothing is listening on host:port, returns False on timeout"""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not _port_is_open(host, port):
+            return True
+        time.sleep(0.1)
+    return False
 
 
 @pytest.fixture(scope="module")
@@ -73,17 +113,11 @@ def clean_cache_dir(request):
 
     yield request
 
-    # Remove cache dir with retries in case it's still running
-    for x in range(100):
-        try:
-            shutil.rmtree(SAB_CACHE_DIR)
-            break
-        except (FileNotFoundError, PermissionError):
-            break
-        except OSError:
-            time.sleep(0.1)
-    else:
-        print("Unable to remove cache dir")
+    # Best-effort cleanup. A lingering handle on Windows (from the just-stopped
+    # instance, Defender, or the indexer) shouldn't fail teardown, and every
+    # worker uses its own isolated cache dir, so leftovers can't leak between
+    # workers. The setup phase above re-freshens the dir anyway.
+    shutil.rmtree(SAB_CACHE_DIR, ignore_errors=True)
 
 
 @pytest.fixture(scope="module")
@@ -101,6 +135,25 @@ def run_sabnzbd(clean_cache_dir, request):
             sabnzbd_process.communicate(timeout=30)
         except Exception as err:
             warn("Failed to shutdown the sabnzbd process: %s" % err)
+
+        # Wait for the process to fully exit before returning. The shutdown request
+        # returns as soon as it is accepted, but the instance keeps saving state to
+        # the shared cache dir and holds the fixed port for a moment afterwards. The
+        # next module's clean_cache_dir/start-up would otherwise race with it.
+        try:
+            sabnzbd_process.communicate(timeout=30)
+        except subprocess.TimeoutExpired:
+            sabnzbd_process.kill()
+            sabnzbd_process.communicate(timeout=30)
+
+        # The tracked PID exiting is not proof the instance is gone. Within a single
+        # worker the port and cache dir are reused by every module, so a lingering
+        # instance (slow shutdown, re-exec, orphaned worker) can keep re-saving its
+        # own config over the cache dir.
+        # Block until the port is actually free so the next module starts clean.
+        if not _wait_for_port_release(SAB_HOST, SAB_PORT):
+            sabnzbd_process.kill()
+            warn("Port %s:%s still in use after SABnzbd shutdown" % (SAB_HOST, SAB_PORT))
 
     # Allow the test file to specify what ini to load; if none given, use the basic one by default
     ini_file = getattr(request.module, "INI_FILE", "sabnzbd.basic.ini")
@@ -177,8 +230,18 @@ def run_sabnews_and_selenium(request):
     driver = webdriver.Chrome(options=driver_options)
     SABnzbdBaseTest.driver = driver
 
-    # Start SABNews
-    sabnews_process = subprocess.Popen([sys.executable, os.path.join(SAB_BASE_DIR, "sabnews.py")])
+    # Start SABNews on this worker's own host/port so parallel workers don't
+    # collide on a single fixed newsserver port.
+    sabnews_process = subprocess.Popen(
+        [
+            sys.executable,
+            os.path.join(SAB_BASE_DIR, "sabnews.py"),
+            "-s",
+            SAB_NEWSSERVER_HOST,
+            "-p",
+            str(SAB_NEWSSERVER_PORT),
+        ]
+    )
 
     # Now we run the tests
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,6 +133,9 @@ def run_sabnzbd(clean_cache_dir, request):
         except requests.ConnectionError:
             sabnzbd_process.kill()
             sabnzbd_process.communicate(timeout=30)
+        except requests.exceptions.ChunkedEncodingError:
+            # Occurs when the server disappears while responding
+            pass
         except Exception as err:
             warn("Failed to shutdown the sabnzbd process: %s" % err)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,24 @@ def warm_up_guessit():
     guessit.api.guessit("Warm.Up.S01E01.1080p.mkv")
 
 
+@pytest.fixture(scope="session")
+def compiled_language_files():
+    """Ensure the gettext .mo translation files are compiled, once per session"""
+    locale_dir = os.path.join(SAB_BASE_DIR, "..", "locale")
+    if not os.path.isdir(locale_dir):
+        try:
+            # Language files missing; let make_mo do its thing
+            make_mo = subprocess.Popen([sys.executable, os.path.join(SAB_BASE_DIR, "..", "tools", "make_mo.py")])
+            make_mo.communicate(timeout=30)
+
+            # Check the dir again, should exist now
+            if not os.path.isdir(locale_dir):
+                raise FileNotFoundError
+        except Exception:
+            pytest.fail("Failed to compile language files in %s" % locale_dir)
+    return locale_dir
+
+
 def _port_is_open(host, port):
     """Return True if something is accepting connections on host:port"""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
@@ -121,7 +139,7 @@ def clean_cache_dir(request):
 
 
 @pytest.fixture(scope="module")
-def run_sabnzbd(clean_cache_dir, request):
+def run_sabnzbd(clean_cache_dir, compiled_language_files, request):
     """Start SABnzbd (with translations). A number of key configuration parameters are defined
     in testhelper.py (SAB_* variables). Scope is set to 'module' to prevent configuration
     changes made during functional tests from causing failures in unrelated tests."""
@@ -163,20 +181,6 @@ def run_sabnzbd(clean_cache_dir, request):
 
     # Copy basic config file with API key
     shutil.copyfile(os.path.join(SAB_DATA_DIR, ini_file), os.path.join(SAB_CACHE_DIR, DEF_INI_FILE))
-
-    # Check if we have language files
-    locale_dir = os.path.join(SAB_BASE_DIR, "..", "locale")
-    if not os.path.isdir(locale_dir):
-        try:
-            # Language files missing; let make_mo do its thing
-            make_mo = subprocess.Popen([sys.executable, os.path.join(SAB_BASE_DIR, "..", "tools", "make_mo.py")])
-            make_mo.communicate(timeout=30)
-
-            # Check the dir again, should exist now
-            if not os.path.isdir(locale_dir):
-                raise FileNotFoundError
-        except Exception:
-            pytest.fail("Failed to compile language files in %s" % locale_dir)
 
     # Start SABnzbd and continue
     sabnzbd_process = subprocess.Popen(

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -17,3 +17,4 @@ lxml
 black
 pytest-mock
 pytest-asyncio
+pytest-xdist

--- a/tests/test_api_and_interface.py
+++ b/tests/test_api_and_interface.py
@@ -20,6 +20,7 @@ tests.test_api - Tests for API functions
 """
 
 import os
+from functools import cached_property
 from random import choice, randint
 from unittest import mock
 
@@ -208,7 +209,9 @@ def set_remote_host_or_ip(hostname: str = "localhost", remote_ip: str = "127.0.0
 class TestSecuredExpose:
     """Test the security handling"""
 
-    main_page = sabnzbd.interface.MainPage()
+    @cached_property
+    def main_page(self):
+        return sabnzbd.interface.MainPage()
 
     def api_wrapper(self, *args, **kwargs):
         """Wrapper to convert bytes to str"""

--- a/tests/test_api_and_interface.py
+++ b/tests/test_api_and_interface.py
@@ -213,6 +213,12 @@ class TestSecuredExpose:
     def main_page(self):
         return sabnzbd.interface.MainPage()
 
+    @pytest.fixture(autouse=True)
+    def setup(self, monkeypatch):
+        monkeypatch.setattr(cherrypy.request, "headers", {})
+        monkeypatch.setattr(cherrypy.request.remote, "ip", "127.0.0.1")
+        yield
+
     def api_wrapper(self, *args, **kwargs):
         """Wrapper to convert bytes to str"""
         if api_response := self.main_page.api(*args, **kwargs):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -47,8 +47,7 @@ class TestOptions:
     test_section = "test_section"
     test_keyword = "test_keyword"
 
-    def test_base_option(self, monkeypatch):
-        monkeypatch.setattr(config, "CONFIG", config.SABnzbdConfig())
+    def test_base_option(self):
         test_option = config.Option(self.test_section, self.test_keyword)
         assert test_option.section == self.test_section
         assert test_option.keyword == self.test_keyword
@@ -61,8 +60,7 @@ class TestOptions:
         # Need to add tests for all the relevant options
         raise NotImplementedError
 
-    def test_non_public(self, monkeypatch):
-        monkeypatch.setattr(config, "CONFIG", config.SABnzbdConfig())
+    def test_non_public(self):
         test_option = config.Option(self.test_section, self.test_keyword, public=True)
         assert test_option.get_dict() == {self.test_keyword: None}
         assert test_option.get_dict(for_public_api=False) == {self.test_keyword: None}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -47,22 +47,22 @@ class TestOptions:
     test_section = "test_section"
     test_keyword = "test_keyword"
 
-    def test_base_option(self):
+    def test_base_option(self, monkeypatch):
+        monkeypatch.setattr(config, "CONFIG", config.SABnzbdConfig())
         test_option = config.Option(self.test_section, self.test_keyword)
         assert test_option.section == self.test_section
         assert test_option.keyword == self.test_keyword
         assert test_option.section in config.CONFIG.database
         assert test_option.keyword in config.CONFIG.database[test_option.section]
         assert config.CONFIG.database[test_option.section][test_option.keyword] == test_option
-        # Reset database
-        config.CONFIG.database = {}
 
     @pytest.mark.xfail(reason="These tests should be added")
     def test_all(self):
         # Need to add tests for all the relevant options
         raise NotImplementedError
 
-    def test_non_public(self):
+    def test_non_public(self, monkeypatch):
+        monkeypatch.setattr(config, "CONFIG", config.SABnzbdConfig())
         test_option = config.Option(self.test_section, self.test_keyword, public=True)
         assert test_option.get_dict() == {self.test_keyword: None}
         assert test_option.get_dict(for_public_api=False) == {self.test_keyword: None}
@@ -75,9 +75,6 @@ class TestOptions:
         test_option = config.OptionPassword(self.test_section, self.test_keyword, default_val="test_password")
         assert test_option.get_dict() == {self.test_keyword: "test_password"}
         assert test_option.get_dict(for_public_api=True) == {self.test_keyword: "**********"}
-
-        # Reset database
-        config.CONFIG.database = {}
 
 
 @pytest.mark.usefixtures("clean_cache_dir")
@@ -181,8 +178,9 @@ class TestConfig:
             "complete_dir": os.path.join(SAB_COMPLETE_DIR, "test_config_backup"),
         }
     )
-    def test_config_backup(self):
+    def test_config_backup(self, monkeypatch):
         """Combined tests for the config.{create,validate,restore}_config_backup functions"""
+        monkeypatch.setattr(sabnzbd, "CONFIG_BACKUP_HTTPS_OK", [])
         # Prepare the basics
         admin_dir = sabnzbd.cfg.admin_dir.get_path()
         sabnzbd.cfg.set_root_folders2()

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -228,6 +228,7 @@ class TestUuDecoder:
         [
             VALID_UU_LINES[-1][:10] + bytes("ваше здоровье", encoding="utf8") + VALID_UU_LINES[-1][-10:],  # Non-ascii
         ],
+        ids=["non_ascii"],
     )
     def test_broken_uu(self, bad_data):
         mock_nzf = mock.Mock()

--- a/tests/test_functional_adding_nzbs.py
+++ b/tests/test_functional_adding_nzbs.py
@@ -24,6 +24,7 @@ import shutil
 import stat
 import sys
 import time
+from functools import cached_property
 from random import choice, randint, sample
 
 import pytest
@@ -129,10 +130,6 @@ class ModuleVars:
     PRE_QUEUE_SETUP_DONE = False
 
 
-# Shared variables at module-level
-VAR = ModuleVars()
-
-
 @pytest.fixture(scope="function")
 def pause_and_clear():
     # Pause the queue
@@ -150,6 +147,10 @@ def pause_and_clear():
 
 @pytest.mark.usefixtures("run_sabnzbd", "pause_and_clear")
 class TestAddingNZBs:
+    @cached_property
+    def config(self):
+        return ModuleVars()
+
     def _api_set_config(self, keyword, value):
         """Shorthand for the API-call to change the config settings"""
         json = get_api_result(
@@ -163,19 +164,19 @@ class TestAddingNZBs:
         assert value == json["config"]["misc"][keyword]
 
     def _setup_script_dir(self):
-        VAR.SCRIPT_DIR = os.path.join(SAB_CACHE_DIR, "scripts" + SCRIPT_RANDOM)
+        self.config.SCRIPT_DIR = os.path.join(SAB_CACHE_DIR, "scripts" + SCRIPT_RANDOM)
         try:
-            os.makedirs(VAR.SCRIPT_DIR, exist_ok=True)
+            os.makedirs(self.config.SCRIPT_DIR, exist_ok=True)
         except Exception:
-            pytest.fail("Cannot create script_dir %s" % VAR.SCRIPT_DIR)
+            pytest.fail("Cannot create script_dir %s" % self.config.SCRIPT_DIR)
 
-        self._api_set_config("script_dir", VAR.SCRIPT_DIR)
+        self._api_set_config("script_dir", self.config.SCRIPT_DIR)
 
     def _customize_pre_queue_script(self, priority, category):
         """Add a script that accepts the job and sets priority & category"""
         script_name = "SCRIPT%s.py" % SCRIPT_RANDOM
         try:
-            script_path = os.path.join(VAR.SCRIPT_DIR, script_name)
+            script_path = os.path.join(self.config.SCRIPT_DIR, script_name)
             with open(script_path, "w") as f:
                 # line 1 = accept; 4 = category; 6 = priority
                 f.write(
@@ -189,12 +190,12 @@ class TestAddingNZBs:
             if not sys.platform.startswith("win"):
                 os.chmod(script_path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
         except Exception:
-            pytest.fail("Cannot add script %s to script_dir %s" % (script_name, VAR.SCRIPT_DIR))
+            pytest.fail("Cannot add script %s to script_dir %s" % (script_name, self.config.SCRIPT_DIR))
 
-        if not VAR.PRE_QUEUE_SETUP_DONE:
+        if not self.config.PRE_QUEUE_SETUP_DONE:
             # Set as pre-queue script
             self._api_set_config("pre_script", script_name)
-            VAR.PRE_QUEUE_SETUP_DONE = True
+            self.config.PRE_QUEUE_SETUP_DONE = True
 
     def _configure_cat(self, priority, tag):
         category_name = "cat" + tag + CAT_RANDOM
@@ -345,10 +346,10 @@ class TestAddingNZBs:
         return NORMAL_PRIORITY, return_state
 
     def _prep_priority_tester(self, prio_def_cat, prio_add, prio_add_cat, prio_preq, prio_preq_cat, prio_meta_cat):
-        if not VAR.SCRIPT_DIR:
+        if not self.config.SCRIPT_DIR:
             self._setup_script_dir()
-        if not VAR.NZB_FILE:
-            VAR.NZB_FILE = self._create_random_nzb()
+        if not self.config.NZB_FILE:
+            self.config.NZB_FILE = self._create_random_nzb()
 
         # Set the priority for the Default category
         self._configure_default_category_priority(prio_def_cat)
@@ -357,8 +358,8 @@ class TestAddingNZBs:
         cat_meta = None
         if prio_meta_cat is not None:
             cat_meta = self._configure_cat(prio_meta_cat, "meta")
-            if not VAR.META_NZB_FILE:
-                VAR.META_NZB_FILE = self._create_meta_nzb(cat_meta)
+            if not self.config.META_NZB_FILE:
+                self.config.META_NZB_FILE = self._create_meta_nzb(cat_meta)
         cat_add = None
         if prio_add_cat is not None:
             cat_add = self._configure_cat(prio_add_cat, "add")
@@ -371,7 +372,7 @@ class TestAddingNZBs:
         self._customize_pre_queue_script(prio_preq, cat_preq)
 
         # Queue the job, store the nzo_id
-        extra = {"name": VAR.META_NZB_FILE if cat_meta else VAR.NZB_FILE}
+        extra = {"name": self.config.META_NZB_FILE if cat_meta else self.config.NZB_FILE}
         if cat_add:
             extra["cat"] = cat_add
         if prio_add is not None:
@@ -478,16 +479,16 @@ class TestAddingNZBs:
     def test_adding_nzbs_partial(self):
         """Test adding parts of an NZB file, cut off somewhere in the middle to simulate
         the effects of an interrupted download or bad hardware. Should fail, of course."""
-        if not VAR.NZB_FILE:
-            VAR.NZB_FILE = self._create_random_nzb()
+        if not self.config.NZB_FILE:
+            self.config.NZB_FILE = self._create_random_nzb()
 
-        nzb_basedir, nzb_basename = os.path.split(VAR.NZB_FILE)
-        nzb_size = os.stat(VAR.NZB_FILE).st_size
+        nzb_basedir, nzb_basename = os.path.split(self.config.NZB_FILE)
+        nzb_size = os.stat(self.config.NZB_FILE).st_size
         part_size = round(randint(40, 70) / 100 * nzb_size)
         first_part = os.path.join(nzb_basedir, "part1_of_" + nzb_basename)
         second_part = os.path.join(nzb_basedir, "part2_of_" + nzb_basename)
 
-        with open(VAR.NZB_FILE, "rb") as nzb_in:
+        with open(self.config.NZB_FILE, "rb") as nzb_in:
             for nzb_part, chunk in (first_part, part_size), (second_part, -1):
                 with open(nzb_part, "wb") as nzb_out:
                     nzb_out.write(nzb_in.read(chunk))
@@ -519,10 +520,10 @@ class TestAddingNZBs:
     )
     def test_adding_nzbs_malformed(self, keep_first, keep_last, strip_first, strip_last, should_work):
         """Test adding broken, empty, or otherwise malformed NZB file"""
-        if not VAR.NZB_FILE:
-            VAR.NZB_FILE = self._create_random_nzb()
+        if not self.config.NZB_FILE:
+            self.config.NZB_FILE = self._create_random_nzb()
 
-        with open(VAR.NZB_FILE, "rt") as nzb_in:
+        with open(self.config.NZB_FILE, "rt") as nzb_in:
             nzb_lines = nzb_in.readlines()
             assert len(nzb_lines) >= 9
 

--- a/tests/test_functional_sorting.py
+++ b/tests/test_functional_sorting.py
@@ -79,34 +79,41 @@ class TestDownloadSorting(DownloadFlowBasics):
         self.download_nzb(os.path.join("sorting", test_data_dir), result, True)
 
     @pytest.mark.parametrize(
-        "test_data_dir, result",
+        "testcase",
         [
-            (
-                "SINGLE_sort_s23e06_480i-SABnzbd",
-                ["Single.Sort.S23E06.mov"],
-            ),  # Single episode, no other files
-            (
-                "SINGLE_sort_s23e06_480i-SABnzbd",
-                ["Single.Sort.S23E06.1.mov"],
-            ),  # Repeat to verify a unique filename is applied
             pytest.param(
-                "single-ep_sort_s06e66_4k_uhd-SABnzbd",
-                ["Single-Ep.Sort.S06E66." + ext for ext in ("avi", "srt")],
+                [
+                    (
+                        "SINGLE_sort_s23e06_480i-SABnzbd",
+                        ["Single.Sort.S23E06.mov"],
+                    ),  # Single episode, no other files
+                    (
+                        "SINGLE_sort_s23e06_480i-SABnzbd",
+                        ["Single.Sort.S23E06.1.mov"],
+                    ),  # Repeat to verify a unique filename is applied
+                ],
+                id="SINGLE_sort_s23e06_480i-SABnzbd",
+            ),
+            pytest.param(
+                [
+                    (
+                        "single-ep_sort_s06e66_4k_uhd-SABnzbd",
+                        ["Single-Ep.Sort.S06E66." + ext for ext in ("avi", "srt")],
+                    ),  # Single episode with associated smaller file
+                    (
+                        "single-ep_sort_s06e66_4k_uhd-SABnzbd",
+                        ["Single-Ep.Sort.S06E66.1." + ext for ext in ("avi", "srt")],
+                    ),  # Repeat to verify unique filenames are applied
+                ],
                 marks=pytest.mark.xfail(
                     sabnzbd.MACOS or sabnzbd.WINDOWS,
                     reason="Unreliable on macOS and Windows",
                 ),
-            ),  # Single episode with associated smaller file
-            pytest.param(
-                "single-ep_sort_s06e66_4k_uhd-SABnzbd",
-                ["Single-Ep.Sort.S06E66.1." + ext for ext in ("avi", "srt")],
-                marks=pytest.mark.xfail(
-                    sabnzbd.MACOS or sabnzbd.WINDOWS,
-                    reason="Unreliable on macOS and Windows",
-                ),
-            ),  # Repeat to verify unique filenames are applied
+                id="single-ep_sort_s06e66_4k_uhd-SABnzbd",
+            ),
         ],
     )
-    def test_download_sorting_single(self, test_data_dir, result):
+    def test_download_sorting_single(self, testcase):
         """Test single episode file handling"""
-        self.download_nzb(os.path.join("sorting", test_data_dir), result, True)
+        for test_data_dir, result in testcase:
+            self.download_nzb(os.path.join("sorting", test_data_dir), result, True)

--- a/tests/test_getipaddress.py
+++ b/tests/test_getipaddress.py
@@ -21,14 +21,14 @@ tests.test_utils.test_check_dir - Testing SABnzbd checkdir util
 
 import socket
 
-from sabnzbd.cfg import selftest_host
+import sabnzbd.cfg as cfg
 from sabnzbd.getipaddress import addresslookup4, public_ipv4, local_ipv4, public_ipv6
 from sabnzbd.misc import is_ipv4_addr, is_ipv6_addr
 
 
 class TestGetIpAddress:
     def test_addresslookup4(self):
-        address = addresslookup4(selftest_host())
+        address = addresslookup4(cfg.selftest_host())
         assert address
         for item in address:
             assert isinstance(item[0], type(socket.AF_INET))

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -144,12 +144,20 @@ class TestInterfaceFunctions:
         }
     )
     def test_check_access(
-        self, access_type, inet_exposure, local_ranges, remote_ip, xff_header, verify_xff_header, result_with_xff
+        self,
+        access_type,
+        inet_exposure,
+        local_ranges,
+        remote_ip,
+        xff_header,
+        verify_xff_header,
+        result_with_xff,
+        monkeypatch,
     ):
         def _func():
             # Insert fake request data
-            cherrypy.request.remote.ip = remote_ip
-            cherrypy.request.headers.update({"X-Forwarded-For": xff_header})
+            monkeypatch.setitem(cherrypy.request.headers, "X-Forwarded-For", xff_header)
+            monkeypatch.setattr(cherrypy.request.remote, "ip", remote_ip)
 
             if verify_xff_header:
                 result = result_with_xff
@@ -220,10 +228,10 @@ class TestInterfaceFunctions:
             "local_ranges": params["local_ranges"],
         }
     )
-    def test_remote_ip_from_xff(self, local_ranges, xff_ips, expected_result):
+    def test_remote_ip_from_xff(self, local_ranges, xff_ips, expected_result, monkeypatch):
         def _func():
             # Insert fake request data; should *not* influence the results of the tested function
-            cherrypy.request.remote.ip = "6.6.6.6"
+            monkeypatch.setattr(cherrypy.request.remote, "ip", "6.6.6.6")
             assert xff_ips
             assert interface.remote_ip_from_xff(xff_ips) is expected_result
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -34,8 +34,6 @@ from unittest import mock
 import pytest
 import rarfile
 
-import sabnzbd
-import sabnzbd.cfg
 from sabnzbd import lang, misc, newsunpack, cfg
 from sabnzbd.config import ConfigCat, get_sorters, save_config
 from sabnzbd.constants import (
@@ -50,16 +48,14 @@ from tests.testhelper import SAB_BASE_DIR
 
 
 @pytest.fixture
-def reset_language(monkeypatch):
-    """Guarantee translation state is restored on teardown, even if an assertion fails,
-    so a non-default language can't leak into other tests on the pytest-xdist worker.
-    set_language() swaps the builtins T/TT translators and set_locale_info() sets the
-    lang module globals."""
+def reset_language(compiled_language_files, monkeypatch):
+    """Provide a compiled-translations environment for a test and guarantee the global
+    translation state is restored on teardown"""
     monkeypatch.setattr(lang, "_DOMAIN", lang._DOMAIN)
     monkeypatch.setattr(lang, "_LOCALEDIR", lang._LOCALEDIR)
     monkeypatch.setitem(builtins.__dict__, "T", builtins.__dict__.get("T"))
     monkeypatch.setitem(builtins.__dict__, "TT", builtins.__dict__.get("TT"))
-    yield
+    yield compiled_language_files
     # Reset to the default (English) translators regardless of what the test selected
     lang.set_language()
 
@@ -344,11 +340,7 @@ class TestMisc:
         assert "2 days 2 hours 2 seconds" == misc.format_time_string(2 * 86400 + 2 * 60 * 60 + 2)
 
     def test_format_time_string_locale(self, reset_language):
-        # Have to set the languages, if it was compiled
-        locale_dir = os.path.join(SAB_BASE_DIR, "..", sabnzbd.constants.DEF_LANGUAGE)
-        if not os.path.exists(locale_dir):
-            pytest.mark.skip("No language files compiled")
-
+        locale_dir = reset_language
         lang.set_locale_info("SABnzbd", locale_dir)
         lang.set_language("de")
         assert "1 Sekunde" == misc.format_time_string(1)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -19,6 +19,7 @@
 tests.test_misc - Testing functions in misc.py
 """
 
+import builtins
 import datetime
 import functools
 import os
@@ -46,6 +47,21 @@ from sabnzbd.constants import (
 )
 from sabnzbd.misc import SABRarFile
 from tests.testhelper import SAB_BASE_DIR
+
+
+@pytest.fixture
+def reset_language(monkeypatch):
+    """Guarantee translation state is restored on teardown, even if an assertion fails,
+    so a non-default language can't leak into other tests on the pytest-xdist worker.
+    set_language() swaps the builtins T/TT translators and set_locale_info() sets the
+    lang module globals."""
+    monkeypatch.setattr(lang, "_DOMAIN", lang._DOMAIN)
+    monkeypatch.setattr(lang, "_LOCALEDIR", lang._LOCALEDIR)
+    monkeypatch.setitem(builtins.__dict__, "T", builtins.__dict__.get("T"))
+    monkeypatch.setitem(builtins.__dict__, "TT", builtins.__dict__.get("TT"))
+    yield
+    # Reset to the default (English) translators regardless of what the test selected
+    lang.set_language()
 
 
 class TestMisc:
@@ -327,7 +343,7 @@ class TestMisc:
         assert "1 day 59 seconds" == misc.format_time_string(86400 + 59)
         assert "2 days 2 hours 2 seconds" == misc.format_time_string(2 * 86400 + 2 * 60 * 60 + 2)
 
-    def test_format_time_string_locale(self):
+    def test_format_time_string_locale(self, reset_language):
         # Have to set the languages, if it was compiled
         locale_dir = os.path.join(SAB_BASE_DIR, "..", sabnzbd.constants.DEF_LANGUAGE)
         if not os.path.exists(locale_dir):
@@ -341,8 +357,6 @@ class TestMisc:
         assert "1 Stunde 1 Minuten 1 Sekunde" == misc.format_time_string(60 * 60 + 60 + 1)
         assert "1 Tag 59 Sekunden" == misc.format_time_string(86400 + 59)
         assert "2 Tage 2 Stunden 2 Sekunden" == misc.format_time_string(2 * 86400 + 2 * 60 * 60 + 2)
-        # Reset language
-        lang.set_language()
 
     def test_format_time_left(self):
         assert "0:00:00" == misc.format_time_left(0)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -59,8 +59,8 @@ class TestMisc:
         assert "%H:%M" == misc.time_format("%H:%M")
 
     @pytest.mark.config({"ampm": True})
-    def test_timeformatampm(self):
-        misc.HAVE_AMPM = True
+    def test_timeformatampm(self, monkeypatch):
+        monkeypatch.setattr(misc, "HAVE_AMPM", True)
         assert "%I:%M:%S %p" == misc.time_format("%H:%M:%S")
         assert "%I:%M %p" == misc.time_format("%H:%M")
 
@@ -1127,7 +1127,10 @@ class TestBuildAndRunCommand:
     @pytest.mark.config({"nice": "--adjustment=-7", "ionice": "-t -n9 -c7"})
     @mock.patch("sabnzbd.misc.userxbit")
     @mock.patch("subprocess.Popen")
-    def test_linux_features(self, mock_subproc_popen, userxbit):
+    def test_linux_features(self, mock_subproc_popen, userxbit, monkeypatch):
+        monkeypatch.setattr(newsunpack, "NICE_COMMAND", None)
+        monkeypatch.setattr(newsunpack, "IONICE_COMMAND", None)
+
         # Should break on no-execute permissions
         userxbit.return_value = False
         with pytest.raises(IOError):
@@ -1151,8 +1154,8 @@ class TestBuildAndRunCommand:
         assert mock_subproc_popen.call_args[0][0] == test_cmd
 
         # Have to fake these for it to work
-        newsunpack.IONICE_COMMAND = "ionice"
-        newsunpack.NICE_COMMAND = "nice"
+        monkeypatch.setattr(newsunpack, "IONICE_COMMAND", "ionice")
+        monkeypatch.setattr(newsunpack, "NICE_COMMAND", "nice")
         userxbit.return_value = True
         misc.build_and_run_command([self.script_path, "input 1"])
         assert mock_subproc_popen.call_args[0][0] == [

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -28,6 +28,7 @@ import sys
 import tempfile
 import wave
 from contextlib import nullcontext
+from functools import cached_property
 from random import randint, sample
 from unittest import mock
 
@@ -1091,7 +1092,9 @@ class TestMisc:
 
 class TestBuildAndRunCommand:
     # Path should exist
-    script_path = os.path.join(SAB_BASE_DIR, "test_misc.py")
+    @cached_property
+    def script_path(self):
+        return os.path.join(SAB_BASE_DIR, "test_misc.py")
 
     def test_none_check(self):
         with pytest.raises(IOError):

--- a/tests/test_newsunpack.py
+++ b/tests/test_newsunpack.py
@@ -51,8 +51,11 @@ class TestNewsUnpackFunctions:
         assert not newsunpack.is_sfv_file("tests/data/only_comments.sfv")
         assert not newsunpack.is_sfv_file("tests/data/random.bin")
 
-    def test_is_sevenfile(self):
-        # False, because the command is not set
+    def test_is_sevenfile(self, monkeypatch):
+        # False, because the command is not set. Force it explicitly: SEVENZIP_COMMAND
+        # is a module global that another test in this class may have populated via
+        # find_programs(), and under pytest-xdist tests share no ordering guarantee.
+        monkeypatch.setattr(newsunpack, "SEVENZIP_COMMAND", None)
         assert not newsunpack.SEVENZIP_COMMAND
         assert not newsunpack.is_sevenfile("tests/data/test_7zip/testfile.7z")
 
@@ -65,6 +68,11 @@ class TestNewsUnpackFunctions:
         assert newsunpack.is_sevenfile("tests/data/test_7zip/testfile.7z")
 
     def test_sevenzip(self):
+        # Make the test self-sufficient: SEVENZIP_COMMAND is a module global and
+        # under pytest-xdist this test may land on a worker where no earlier test
+        # called find_programs(), leaving it None (SevenZip would then wrongly raise
+        # "File is not a 7zip file"). find_programs() is idempotent.
+        newsunpack.find_programs(".")
         testzip = newsunpack.SevenZip("tests/data/test_7zip/testfile.7z")
         assert testzip.namelist() == ["My_Test_Download.bin"]
         # Basic check that we can get data from the 7zip

--- a/tests/test_newsunpack.py
+++ b/tests/test_newsunpack.py
@@ -44,6 +44,23 @@ from sabnzbd.misc import format_time_string, SABRarFile
 from sabnzbd.filesystem import long_path, create_all_dirs, listdir_full, clip_path
 
 
+@pytest.fixture(autouse=True)
+def _isolate_newsunpack_globals(monkeypatch):
+    """Snapshot the module globals that these tests mutate so they can't leak into other
+    tests/modules on the same pytest-xdist worker"""
+    for name in (
+        "NICE_COMMAND",
+        "IONICE_COMMAND",
+        "PAR2_COMMAND",
+        "RAR_COMMAND",
+        "SEVENZIP_COMMAND",
+    ):
+        monkeypatch.setattr(newsunpack, name, getattr(newsunpack, name))
+    # PostProcessor is unset by default; raising=False lets monkeypatch delete it on teardown
+    monkeypatch.setattr(sabnzbd, "PostProcessor", getattr(sabnzbd, "PostProcessor", None), raising=False)
+    yield
+
+
 class TestNewsUnpackFunctions:
     def test_is_sfv_file(self):
         assert newsunpack.is_sfv_file("tests/data/good_sfv_unicode.sfv")

--- a/tests/test_newswrapper.py
+++ b/tests/test_newswrapper.py
@@ -239,9 +239,9 @@ class TestNewsWrapper:
         def mock_connect(self):
             pass
 
-        monkeypatch.setattr("sabnzbd.newswrapper.NNTP.connect", mock_connect)
-        nntp = newswrapper.NNTP(nw, nw.server.info)
-        monkeypatch.undo()
+        with monkeypatch.context() as m:
+            m.setattr("sabnzbd.newswrapper.NNTP.connect", mock_connect)
+            nntp = newswrapper.NNTP(nw, nw.server.info)
 
         # The connection has crashed but the socket should have been bound to the provided ip in the configuration
         with pytest.raises(OSError) as excinfo:

--- a/tests/test_newswrapper.py
+++ b/tests/test_newswrapper.py
@@ -193,8 +193,18 @@ class TestNewsWrapper:
     @pytest.mark.parametrize(
         "test_host, local_ip, ip_protocol",
         [
-            (TEST_HOST, get_local_ip(protocol_version=IPProtocolVersion.IPV4), IPProtocolVersion.IPV4),
-            (TEST_HOST_IPV6, get_local_ip(protocol_version=IPProtocolVersion.IPV6), IPProtocolVersion.IPV6),
+            pytest.param(
+                TEST_HOST,
+                get_local_ip(protocol_version=IPProtocolVersion.IPV4),
+                IPProtocolVersion.IPV4,
+                id="ipv4",
+            ),
+            pytest.param(
+                TEST_HOST_IPV6,
+                get_local_ip(protocol_version=IPProtocolVersion.IPV6),
+                IPProtocolVersion.IPV6,
+                id="ipv6",
+            ),
             (TEST_HOST, "", None),
             (TEST_HOST_IPV6, "", None),
         ],

--- a/tests/test_newswrapper.py
+++ b/tests/test_newswrapper.py
@@ -32,6 +32,7 @@ import threading
 import time
 import warnings
 from enum import Enum
+from functools import cached_property
 from typing import Optional
 from unittest import mock
 
@@ -113,8 +114,13 @@ def get_local_ip(protocol_version: IPProtocolVersion) -> Optional[str]:
 
 @flaky
 class TestNewsWrapper:
-    cert_file = os.path.join(tempfile.mkdtemp(), "test.cert")
-    key_file = os.path.join(tempfile.mkdtemp(), "test.key")
+    @cached_property
+    def cert_file(self):
+        return os.path.join(tempfile.mkdtemp(), "test.cert")
+
+    @cached_property
+    def key_file(self):
+        return os.path.join(tempfile.mkdtemp(), "test.key")
 
     @pytest.mark.parametrize(
         "server_tls, expected_client_tls, client_cipher, can_connect",

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -24,40 +24,9 @@ from sabnzbd.notifier import send_notification, send_apprise, NOTIFICATION_TYPES
 from unittest import mock, TestCase
 import sabnzbd.cfg as cfg
 from sabnzbd.config import Option
-from importlib import reload
 
 
 class TestNotifier(TestCase):
-
-    @classmethod
-    def setUpClass(self):
-        # hack since test_misc uses @pytest.mark.config fixture eliminating all of the default configuration
-        # We want to test with the default configuration in place; This safely resets all fields and
-        # replaces them correctly in memory
-        reload(cfg)
-
-        # capture state of config so we can reverse it
-        self._saved_cfg = {}
-        for attr in dir(cfg):
-            if isinstance(getattr(cfg, attr), Option):
-                # Backup configuration as it was before entering this test object
-                self._saved_cfg[attr] = getattr(cfg, attr).get()
-                # Set our value to be a default
-                getattr(cfg, attr).set(getattr(cfg, attr).default)
-
-    @classmethod
-    def setUp(self):
-        # Enforce our default values associated with the class
-        for attr in dir(cfg):
-            if isinstance(getattr(cfg, attr), Option):
-                getattr(cfg, attr).set(getattr(cfg, attr).default)
-
-    @classmethod
-    def tearDownClass(self):
-        # rollback our assignments to be as they were
-        for k, v in self._saved_cfg.items():
-            getattr(cfg, k).set(v)
-
     @mock.patch("sabnzbd.DIR_PROG")
     @mock.patch("apprise.Apprise.notify")
     @mock.patch("apprise.Apprise.add")

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -474,7 +474,7 @@ class TestSortingFunctions:
             assert return_files == [base_dir + "\\TEST\\" + dvd + "\\FILE"]
 
 
-@pytest.mark.usefixtures("clean_cache_dir")
+@pytest.mark.usefixtures("clean_cache_dir", "warm_up_guessit")
 class TestSortingSorter:
     @pytest.mark.parametrize(
         "s_class, jobname, sort_string, result_path, result_setname",

--- a/tests/test_urlgrabber.py
+++ b/tests/test_urlgrabber.py
@@ -28,7 +28,7 @@ import pytest_httpbin
 
 import sabnzbd
 import sabnzbd.urlgrabber as urlgrabber
-from sabnzbd.cfg import selftest_host
+import sabnzbd.cfg as cfg
 
 
 @pytest_httpbin.use_class_based_httpbin
@@ -82,15 +82,15 @@ class TestBuildRequest:
 
     def test_http_basic(self):
         # Use selftest_host for the most basic URL
-        self._runner("http://" + selftest_host(), 200)
+        self._runner("http://" + cfg.selftest_host(), 200)
         # Repeat with httpbin, which runs on a random non-standard port
         self._runner(self.httpbin.url, 200)
 
     def test_https_basic(self):
         # Use a real HTTPS server; httpbin_secure uses a self-signed cert
-        self._runner("https://" + selftest_host(), 200)
+        self._runner("https://" + cfg.selftest_host(), 200)
         # Repeat with the port explicitly specified
-        self._runner("https://" + selftest_host() + ":443/", 200)
+        self._runner("https://" + cfg.selftest_host() + ":443/", 200)
 
     def test_http_code(self):
         # Make the server reply with a non-standard status code

--- a/tests/test_utils/test_sleepless.py
+++ b/tests/test_utils/test_sleepless.py
@@ -19,6 +19,7 @@
 tests.test_sleepless - Test sleepless for macOS
 """
 
+import os
 import subprocess
 import sys
 import time
@@ -32,7 +33,12 @@ import sabnzbd.utils.sleepless as sleepless
 
 
 class TestSleepless:
-    sleep_msg = "SABnzbd is running, don't you stop us now!"
+    # pmset assertions are a machine-global resource, so under pytest-xdist parallel
+    # workers running these tests concurrently would see each other's assertion and
+    # fail the "nothing is set yet" preconditions. Making the message unique per
+    # worker process means each test only ever detects its own assertion. Falls back
+    # to the pid for a serial run (PYTEST_XDIST_WORKER unset).
+    sleep_msg = "SABnzbd is running, don't you stop us now! [%s]" % os.environ.get("PYTEST_XDIST_WORKER", os.getpid())
 
     def check_msg_in_assertions(self):
         return self.sleep_msg in subprocess.check_output(["pmset", "-g", "assertions"], universal_newlines=True)

--- a/tests/test_utils/test_sleepless.py
+++ b/tests/test_utils/test_sleepless.py
@@ -23,6 +23,7 @@ import os
 import subprocess
 import sys
 import time
+from functools import cached_property
 
 import pytest
 
@@ -38,7 +39,9 @@ class TestSleepless:
     # fail the "nothing is set yet" preconditions. Making the message unique per
     # worker process means each test only ever detects its own assertion. Falls back
     # to the pid for a serial run (PYTEST_XDIST_WORKER unset).
-    sleep_msg = "SABnzbd is running, don't you stop us now! [%s]" % os.environ.get("PYTEST_XDIST_WORKER", os.getpid())
+    @cached_property
+    def sleep_msg(self):
+        return "SABnzbd is running, don't you stop us now! [%s]" % os.environ.get("PYTEST_XDIST_WORKER", os.getpid())
 
     def check_msg_in_assertions(self):
         return self.sleep_msg in subprocess.check_output(["pmset", "-g", "assertions"], universal_newlines=True)

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -21,6 +21,7 @@ tests.testhelper - Basic helper functions
 
 import io
 import os
+import socket
 import time
 import uuid
 from http.client import RemoteDisconnected
@@ -56,15 +57,36 @@ import sabnzbd.filesystem as filesystem
 import tests.sabnews
 
 SAB_HOST = "127.0.0.1"
-SAB_PORT = randint(4200, 4299)
+SAB_NEWSSERVER_HOST = "127.0.0.1"
+
+# Each pytest-xdist worker runs in its own process and imports its own copy of
+# these module-level constants. Many test modules capture them with
+# `from tests.testhelper import SAB_PORT, SAB_CACHE_DIR, ...`, so the values must
+# be settled here at import time and never mutated afterwards. To let workers run
+# in parallel (-n auto) without colliding on the shared cache dir or on fixed TCP
+# ports, derive a per-worker suffix and bind free ports once, right here.
+#
+# For a normal single-process run PYTEST_XDIST_WORKER is unset, so the suffix is
+# empty and the cache dir keeps its historical "tests/cache" path.
+_XDIST_WORKER = os.environ.get("PYTEST_XDIST_WORKER", "")
+_WORKER_SUFFIX = ("_" + _XDIST_WORKER) if _XDIST_WORKER else ""
+
+
+def _find_free_port(host: str = SAB_HOST) -> int:
+    """Ask the OS for a currently-unused TCP port and return it."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((host, 0))
+        return sock.getsockname()[1]
+
+
+SAB_PORT = _find_free_port()
 SAB_APIKEY = "apikey"
 SAB_BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-SAB_CACHE_DIR = os.path.join(SAB_BASE_DIR, "cache")
+SAB_CACHE_DIR = os.path.join(SAB_BASE_DIR, "cache" + _WORKER_SUFFIX)
 SAB_DATA_DIR = os.path.join(SAB_BASE_DIR, "data")
 SAB_INCOMPLETE_DIR = os.path.join(SAB_CACHE_DIR, "Downloads", "incomplete")
 SAB_COMPLETE_DIR = os.path.join(SAB_CACHE_DIR, "Downloads", "complete")
-SAB_NEWSSERVER_HOST = "127.0.0.1"
-SAB_NEWSSERVER_PORT = 8888
+SAB_NEWSSERVER_PORT = _find_free_port(SAB_NEWSSERVER_HOST)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -346,8 +346,16 @@ class FakeHistoryDB(db.HistoryDB):
     ]
 
     def __init__(self, db_path):
-        db.HistoryDB.db_path = db_path
+        self._monkeypatch = pytest.MonkeyPatch()
+        self._monkeypatch.setattr(db.HistoryDB, "db_path", db_path)
         super().__init__()
+
+    def close(self):
+        """Close the connection and restore the db_path that was patched on creation"""
+        try:
+            super().close()
+        finally:
+            self._monkeypatch.undo()
 
     def add_fake_history_job(
         self,

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -348,10 +348,11 @@ class FakeHistoryDB(db.HistoryDB):
     def __init__(self, db_path):
         self._monkeypatch = pytest.MonkeyPatch()
         self._monkeypatch.setattr(db.HistoryDB, "db_path", db_path)
+        self._monkeypatch.setattr(db.HistoryDB, "startup_done", False)
         super().__init__()
 
     def close(self):
-        """Close the connection and restore the db_path that was patched on creation"""
+        """Close the connection and restore the class attributes patched on creation"""
         try:
             super().close()
         finally:

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -19,6 +19,7 @@
 tests.testhelper - Basic helper functions
 """
 
+import copy
 import io
 import os
 import socket
@@ -45,10 +46,12 @@ from pyfakefs.fake_filesystem import OSType
 
 import sabnzbd
 import sabnzbd.cfg as cfg
+from sabnzbd.config import Option
 from sabnzbd.constants import (
     DEF_INI_FILE,
     Status,
     PP_LOOKUP,
+    NORMAL_PRIORITY,
 )
 import sabnzbd.database as db
 from sabnzbd.misc import pp_to_opts
@@ -92,6 +95,21 @@ SAB_NEWSSERVER_PORT = _find_free_port(SAB_NEWSSERVER_HOST)
 @pytest.fixture(autouse=True)
 def config_env(monkeypatch, request):
     """Change config-values on the fly, per test"""
+    monkeypatch.setattr(sabnzbd.config, "CONFIG", sabnzbd.config.SABnzbdConfig())
+
+    # Add default categories
+    sabnzbd.config.ConfigCat("*", {"order": 0, "pp": "3", "script": "None", "priority": NORMAL_PRIORITY})
+    sabnzbd.config.ConfigCat("movies", {"order": 1})
+    sabnzbd.config.ConfigCat("tv", {"order": 2})
+    sabnzbd.config.ConfigCat("audio", {"order": 3})
+    sabnzbd.config.ConfigCat("software", {"order": 4})
+
+    for attr in dir(cfg):
+        if isinstance(getattr(cfg, attr), Option):
+            option = copy.copy(getattr(cfg, attr))
+            monkeypatch.setattr(cfg, attr, option)
+            sabnzbd.config.add_to_database(option.section, option.keyword, option)
+
     marker = request.node.get_closest_marker("config")
     if marker is None:
         # No config changes for this test
@@ -113,17 +131,10 @@ def config_env(monkeypatch, request):
             raise RuntimeError("Missing 'config' param for @pytest.mark.config")
 
     # Setting up as requested
-    originals = {}
     for item, val in config.items():
-        cfg_item = getattr(cfg, item)
-        originals[item] = cfg_item.get()
-        cfg_item.set(val)
+        getattr(cfg, item).set(val)
 
     yield
-
-    # Restore values
-    for item, val in originals.items():
-        getattr(cfg, item).set(val)
 
 
 @pytest.mark.parametrize("config", [{"web_host": "0.0.0.0"}, {"web_host": "::1"}])


### PR DESCRIPTION
Removed `-s` because not supported [pytest: Output (stdout and stderr) from workers](https://pytest-xdist.readthedocs.io/en/stable/known-limitations.html#output-stdout-and-stderr-from-workers) you still get captured logging around failures.

At some point we may be able to use `--dist loadscope` to better spread the load, I was still finding too many failures. It's not a huge difference on GitHub runners anyway, locally 25s vs 45s. But overall this should be around 1-2 minutes faster overall, any much faster locally.

Most of the changes are removing global module state, mostly in tests with a little bit in `sabnzbd/config.py` but it also improves testing with more use of monkeypatch to ensure clean state between tetsts.

Fixes a number of tests that were dependant on the order of execution.

We could also maybe add the default args to pyproject.toml.

I've ran this loads over the last few weeks, I kept forgetting to change selftest_host and getting blocked 😆 however, I wouldn't be surprised if we get occasional failures due to order of execution.