### PR TITLE
feat(ui): add responsive Light, Dark, and OLED interface polish

### DIFF
--- a/interfaces/Config/templates/_inc_header_uc.tmpl
+++ b/interfaces/Config/templates/_inc_header_uc.tmpl
@@ -4,7 +4,7 @@
     #set global $root = '../../'#
 #end if#
 <!DOCTYPE HTML>
-<html lang="$active_lang" #if $rtl#dir="rtl"#end if#>
+<html lang="$active_lang" #if $rtl#dir="rtl"#end if# data-server-theme="$color_scheme">
 <head>
     <title>
         SABnzbd $T('menu-config')
@@ -22,7 +22,32 @@
     </title>
 
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, maximum-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#e7e9ec" />
+
+        <script type="text/javascript">
+            (function(document, window) {
+                var root = document.documentElement;
+                var storageKey = 'sabnzbd-ui-theme-v1';
+                var serverTheme = (root.getAttribute('data-server-theme') || 'Auto').toLowerCase();
+                var selected = '';
+                try { selected = window.localStorage.getItem(storageKey) || ''; } catch (error) { selected = ''; }
+                var explicit = selected === 'light' || selected === 'dark' || selected === 'oled';
+                var followsSystem = !explicit && serverTheme !== 'oled' && serverTheme !== 'night' && serverTheme !== 'dark' && serverTheme !== 'light';
+                if (!explicit) {
+                    if (serverTheme === 'oled') selected = 'oled';
+                    else if (serverTheme === 'night' || serverTheme === 'dark') selected = 'dark';
+                    else if (serverTheme === 'light') selected = 'light';
+                    else selected = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+                }
+                root.setAttribute('data-sab-theme', selected);
+                root.setAttribute('data-sab-theme-explicit', explicit ? 'true' : 'false');
+                root.setAttribute('data-sab-theme-follows-system', followsSystem ? 'true' : 'false');
+                root.style.colorScheme = selected === 'light' ? 'light' : 'dark';
+                var themeColor = document.querySelector('meta[name="theme-color"]');
+                if (themeColor) themeColor.setAttribute('content', selected === 'oled' ? '#000000' : selected === 'dark' ? '#1d2024' : '#e7e9ec');
+            }(document, window));
+        </script>
     <meta name="apple-mobile-web-app-title" content="SABnzbd" />
 
     <link rel="apple-touch-icon" sizes="76x76" href="${root}staticcfg/ico/apple-touch-icon-76x76-precomposed.png" />
@@ -34,9 +59,13 @@
     <link rel="stylesheet" type="text/css" href="${root}staticcfg/bootstrap/css/bootstrap.min.css?v=$version" />
     <link rel="stylesheet" type="text/css" href="${root}staticcfg/css/chartist.min.css" />
     <link rel="stylesheet" type="text/css" href="${root}staticcfg/css/style.css?v=$version" />
+    <noscript>
     <!--#if $color_scheme not in ('Light', '') #-->
     <link rel="stylesheet" type="text/css" href="${root}staticcfg/css/${color_scheme}.css?v=$version"/>
     <!--#end if#-->
+    </noscript>
+    <link rel="stylesheet" type="text/css" href="${root}staticcfg/css/theme.css?v=$version" />
+    <link rel="stylesheet" type="text/css" href="${root}staticcfg/css/config.modern.css?v=$version" />
 
     <link rel="shortcut icon" href="${root}staticcfg/ico/favicon.ico?v=$version" />
 
@@ -68,6 +97,7 @@
     <script type="text/javascript" src="${root}staticcfg/js/jquery-3.5.1.min.js?v=$version"></script>
     <script type="text/javascript" src="${root}staticcfg/bootstrap/js/bootstrap.min.js?v=$version"></script>
     <script type="text/javascript" src="${root}staticcfg/js/script.js?v=$version"></script>
+    <script type="text/javascript" defer src="${root}staticcfg/js/theme.js?v=$version"></script>
     <script type="text/javascript">
         // Set default functions for the autocomplete everywhere
 
@@ -85,7 +115,7 @@
 <nav class="navbar navbar-default navbar-fixed-top">
     <div class="container">
         <div class="navbar-header">
-            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar">
+            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="sr-only">Toggle navigation</span>
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
@@ -164,19 +194,31 @@
                     </a>
                 </li>
                 <li>
-                    <a href="$help_uri" target="_blank">
+                    <a href="$help_uri" target="_blank" rel="noopener noreferrer">
                         <span class="glyphicon glyphicon-question-sign"></span>
                         <strong>$T('menu-help')</strong>
                     </a>
                 </li>
+                <li class="sab-theme-nav-item">
+                    <div class="sab-theme-control sab-theme-control--nav">
+                        <label class="sr-only" for="sab-theme-select-config">$T('opt-web_dir')</label>
+                        <span class="glyphicon glyphicon-adjust" aria-hidden="true"></span>
+                        <select id="sab-theme-select-config" data-sab-theme-select aria-label="$T('opt-web_dir')">
+                            <option value="light">Light</option>
+                            <option value="dark">Dark</option>
+                            <option value="oled">OLED</option>
+                        </select>
+                    </div>
+                </li>
                 <li class="dropdown" id="search-menu">
-                    <a data-toggle="dropdown" href="#">
+                    <a data-toggle="dropdown" href="#" aria-label="$T('cmenu-search')" aria-haspopup="true">
                         <span class="glyphicon glyphicon-search"></span>
                         <strong><span class="glyphicon glyphicon-search"></span></strong>
                     </a>
                     <ul class="dropdown-menu" id="search-dropdown">
                         <li>
                             <form onsubmit="return false">
+                                <label class="sr-only" for="search-box">$T('cmenu-search')</label>
                                 <input type="text" name="config-search" id="search-box" placeholder="$T('cmenu-search')" onkeyup="doConfigSearch(this)">
                             </form>
                         </li>

--- a/interfaces/Config/templates/config.tmpl
+++ b/interfaces/Config/templates/config.tmpl
@@ -9,7 +9,7 @@
             <tbody>
                 <tr>
                     <th scope="row">$T('version'): </th>
-                    <td>$version [<a href="https://github.com/sabnzbd/sabnzbd/commit/$build" target="_blank">$build</a>]</td>
+                    <td>$version [<a href="https://github.com/sabnzbd/sabnzbd/commit/$build" target="_blank" rel="noopener noreferrer">$build</a>]</td>
                 </tr>
                 <tr>
                     <th scope="row">$T('uptime'): </th>
@@ -39,7 +39,7 @@
                         <span class="glyphicon glyphicon-ok"></span>
                         <!--#else#-->
                         <span class="label label-warning">$T('notAvailable')</span> $T('explain-getpar2turbo')<br>
-                        <a href="https://sabnzbd.org/wiki/installation/par2cmdline-turbo" target="_blank">https://sabnzbd.org/wiki/installation/par2cmdline-turbo</a>
+                        <a href="https://sabnzbd.org/wiki/installation/par2cmdline-turbo" target="_blank" rel="noopener noreferrer">https://sabnzbd.org/wiki/installation/par2cmdline-turbo</a>
                         <!--#end if#-->
                     </td>
                 </tr>
@@ -49,7 +49,7 @@
                     <th scope="row">$T('opt-enable_7zip'):</th>
                     <td>
                         <span class="label label-warning">$T('notAvailable')</span>
-                        <a href="https://sabnzbd.org/wiki/installation/install-off-modules#toc8" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a>
+                        <a href="https://sabnzbd.org/wiki/installation/install-off-modules#toc8" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a>
                     </td>
                 </tr>
                 <!--#end if#-->
@@ -63,31 +63,31 @@
             <tbody>
                 <tr>
                     <th scope="row">$T('homePage') </th>
-                    <td><a href="https://sabnzbd.org/" target="_blank">https://sabnzbd.org/</a></td>
+                    <td><a href="https://sabnzbd.org/" target="_blank" rel="noopener noreferrer">https://sabnzbd.org/</a></td>
                 </tr>
                 <tr>
                     <th scope="row">$T('menu-wiki') </th>
-                    <td><a href="https://sabnzbd.org/wiki/" target="_blank">https://sabnzbd.org/wiki/</a></td>
+                    <td><a href="https://sabnzbd.org/wiki/" target="_blank" rel="noopener noreferrer">https://sabnzbd.org/wiki/</a></td>
                 </tr>
                 <tr>
                     <th scope="row">$T('menu-forums') </th>
-                    <td><a href="https://forums.sabnzbd.org/" target="_blank">https://forums.sabnzbd.org/</a></td>
+                    <td><a href="https://forums.sabnzbd.org/" target="_blank" rel="noopener noreferrer">https://forums.sabnzbd.org/</a></td>
                 </tr>
                 <tr>
                     <th scope="row">$T('source') </th>
-                    <td><a href="https://github.com/sabnzbd/sabnzbd" target="_blank">https://github.com/sabnzbd/sabnzbd</a></td>
+                    <td><a href="https://github.com/sabnzbd/sabnzbd" target="_blank" rel="noopener noreferrer">https://github.com/sabnzbd/sabnzbd</a></td>
                 </tr>
                 <tr>
                     <th scope="row">$T('menu-live-chat') </th>
-                    <td><a href="https://sabnzbd.org/live-chat/" target="_blank">https://sabnzbd.org/live-chat/</a> (IRC &amp; Discord)</td>
+                    <td><a href="https://sabnzbd.org/live-chat/" target="_blank" rel="noopener noreferrer">https://sabnzbd.org/live-chat/</a> (IRC &amp; Discord)</td>
                 </tr>
                 <tr>
                     <th scope="row">$T('menu-issues') </th>
-                    <td><a href="https://sabnzbd.org/wiki/introduction/known-issues" target="_blank">https://sabnzbd.org/wiki/introduction/known-issues</a></td>
+                    <td><a href="https://sabnzbd.org/wiki/introduction/known-issues" target="_blank" rel="noopener noreferrer">https://sabnzbd.org/wiki/introduction/known-issues</a></td>
                 </tr>
                 <tr>
                     <th scope="row">$T('menu-donate') </th>
-                    <td><a href="https://sabnzbd.org/donate" target="_blank">https://sabnzbd.org/donate</a></td>
+                    <td><a href="https://sabnzbd.org/donate" target="_blank" rel="noopener noreferrer">https://sabnzbd.org/donate</a></td>
                 </tr>
             </tbody>
         </table>
@@ -96,7 +96,7 @@
 
 <div class="colmask">
     <div class="padding">
-        <h5 class="copyright">Copyright &copy; 2007-2026 by The SABnzbd-Team (<a href="https://sabnzbd.org/" target="_blank">sabnzbd.org</a>)</h5>
+        <h5 class="copyright">Copyright &copy; 2007-2026 by The SABnzbd-Team (<a href="https://sabnzbd.org/" target="_blank" rel="noopener noreferrer">sabnzbd.org</a>)</h5>
         <p class="copyright"><small>$T('yourRights')</small></p>
     </div>
 

--- a/interfaces/Config/templates/config_cat.tmpl
+++ b/interfaces/Config/templates/config_cat.tmpl
@@ -4,7 +4,7 @@
 <div class="colmask">
     <div class="section">
         <div class="padTable">
-            <a class="main-helplink" href="$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a>
+            <a class="main-helplink" href="$help_uri" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a>
             <p>$T('explain-catTags2')<br/>$T('explain-catTags')</p>
             <hr>
             <h5 class="darkred"><strong>$T('explain-relFolder'):</strong> <span class="path">$defdir</span></h5>
@@ -90,7 +90,7 @@
                                     <!--#end if#-->
                                 </button>
                                 <!--#if $cansort#-->
-                                <button class="btn btn-default delCat" type="button"><span class="glyphicon glyphicon-trash"></span></button>
+                                <button class="btn btn-default delCat" type="button" aria-label="$T('nzo-delete')"><span class="glyphicon glyphicon-trash" aria-hidden="true"></span></button>
                                 <!--#end if#-->
                             </td>
                         </tr>

--- a/interfaces/Config/templates/config_folders.tmpl
+++ b/interfaces/Config/templates/config_folders.tmpl
@@ -14,7 +14,7 @@
     <input type="hidden" id="ajax" name="ajax" value="1" />
     <div class="section">
         <div class="col2">
-            <h3>$T('userFolders') <a href="$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+            <h3>$T('userFolders') <a href="$help_uri" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a></h3>
             <p>$T('explain-folderConfig')</p>
         </div><!-- /col2 -->
         <div class="col1">
@@ -91,7 +91,7 @@
     </div><!-- /section -->
     <div class="section advanced-settings">
         <div class="col2">
-            <h3>$T('systemFolders') <a href="$help_uri#toc1" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+            <h3>$T('systemFolders') <a href="$help_uri#toc1" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a></h3>
             <p>$T('explain-folderConfig')</p>
         </div><!-- /col2 -->
         <div class="col1">

--- a/interfaces/Config/templates/config_general.tmpl
+++ b/interfaces/Config/templates/config_general.tmpl
@@ -14,7 +14,7 @@
         <input type="hidden" name="output" value="json" />
         <div class="section">
             <div class="col2">
-                <h3>$T('webServer') <a href="$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+                <h3>$T('webServer') <a href="$help_uri" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a></h3>
                 <p><b>$T('restartRequired')</b></p>
             </div><!-- /col2 -->
             <div class="col1">
@@ -61,7 +61,7 @@
                         </select>
                         <span class="desc">$T('explain-language')</span>
                         <div class="alert alert-info alert-translate">
-                           $T('explain-ask-language') <a href="https://sabnzbd.org/wiki/translate" target="_blank" class="alert-link">https://sabnzbd.org/wiki/translate</a>
+                           $T('explain-ask-language') <a href="https://sabnzbd.org/wiki/translate" target="_blank" class="alert-link" rel="noopener noreferrer">https://sabnzbd.org/wiki/translate</a>
                         </div>
                     </div>
                     <div class="field-pair advanced-settings">
@@ -102,7 +102,7 @@
         </div>
         <div class="section">
             <div class="col2">
-                <h3>$T('security') <a href="$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+                <h3>$T('security') <a href="$help_uri" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a></h3>
                 <p><b>$T('restartRequired')</b></p>
             </div><!-- /col2 -->
             <div class="col1">
@@ -137,15 +137,15 @@
                     <div class="field-pair">
                         <label class="config" for="apikey_display">$T('opt-apikey')</label>
                         <input type="text" id="apikey_display" value="$apikey" readonly />
-                        <button class="btn btn-default show_qrcode" title="$T('explain-qr-code')" rel="$apikey" ><span class="glyphicon glyphicon-qrcode"></span></button>
-                        <button class="btn btn-default generate_key" id="generate_new_apikey" title="$T('button-apikey')"><span class="glyphicon glyphicon-repeat"></span></button>
+                        <button class="btn btn-default show_qrcode" title="$T('explain-qr-code')" rel="$apikey"  aria-label="$T('explain-qr-code')"><span class="glyphicon glyphicon-qrcode" aria-hidden="true"></span></button>
+                        <button class="btn btn-default generate_key" id="generate_new_apikey" title="$T('button-apikey')" aria-label="$T('button-apikey')"><span class="glyphicon glyphicon-repeat" aria-hidden="true"></span></button>
                         <span class="desc">$T('explain-apikey')</span>
                     </div>
                     <div class="field-pair">
                         <label class="config" for="nzbkey">$T('opt-nzbkey')</label>
                         <input type="text" id="nzbkey" value="$nzb_key" readonly />
-                        <button class="btn btn-default show_qrcode" title="$T('explain-qr-code')" rel="$nzb_key" ><span class="glyphicon glyphicon-qrcode"></span></button>
-                        <button class="btn btn-default generate_key" id="generate_new_nzbkey" title="$T('button-apikey')"><span class="glyphicon glyphicon-repeat"></span></button>
+                        <button class="btn btn-default show_qrcode" title="$T('explain-qr-code')" rel="$nzb_key"  aria-label="$T('explain-qr-code')"><span class="glyphicon glyphicon-qrcode" aria-hidden="true"></span></button>
+                        <button class="btn btn-default generate_key" id="generate_new_nzbkey" title="$T('button-apikey')" aria-label="$T('button-apikey')"><span class="glyphicon glyphicon-repeat" aria-hidden="true"></span></button>
                         <span class="desc">$T('explain-nzbkey')</span>
                     </div>
                     <div class="field-pair">
@@ -156,7 +156,7 @@
         </div><!-- /section -->
         <div class="section">
             <div class="col2">
-                <h3>$T('cmenu-switches') <a href="$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+                <h3>$T('cmenu-switches') <a href="$help_uri" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a></h3>
             </div><!-- /col2 -->
             <div class="col1">
                 <fieldset>
@@ -191,7 +191,7 @@
         </div><!-- /section -->
         <div class="section">
             <div class="col2">
-                <h3>$T('tuning') <a href="$help_uri#toc2" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+                <h3>$T('tuning') <a href="$help_uri#toc2" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a></h3>
             </div><!-- /col2 -->
             <div class="col1">
                 <fieldset>
@@ -229,7 +229,7 @@
         <input type="hidden" name="output" value="json" />
         <div class="section">
             <div class="col2">
-                <h3>$T('backup') <a href="$help_uri#toc3" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+                <h3>$T('backup') <a href="$help_uri#toc3" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a></h3>
             </div><!-- /col2 -->
             <div class="col1">
                 <fieldset>

--- a/interfaces/Config/templates/config_notify.tmpl
+++ b/interfaces/Config/templates/config_notify.tmpl
@@ -35,7 +35,7 @@
     <input type="hidden" id="ajax" name="ajax" value="1" />
     <div class="section" id="email">
         <div class="col2">
-            <h3>$T('cmenu-email') <a href="$help_uri#toc0" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+            <h3>$T('cmenu-email') <a href="$help_uri#toc0" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a></h3>
             <div class="col2-cats" <!--#if int($email_endjob) > 0 then '' else 'style="display:none"'#-->>
                 <b>$T('affectedCat')</b><br/>
                 <select name="email_cats" multiple="multiple" class="multiple_cats" size="$len($categories)">
@@ -155,7 +155,7 @@
     <!--#if $have_ntfosd#-->
     <div class="section">
         <div class="col2">
-            <h3>$T('section-OSD') <a href="$help_uri#toc4" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+            <h3>$T('section-OSD') <a href="$help_uri#toc4" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a></h3>
             <table>
                 <tr>
                     <td><input type="checkbox" name="ntfosd_enable" id="ntfosd_enable" value="1" <!--#if $ntfosd_enable then 'checked="checked"' else ""#--> /></td>
@@ -180,7 +180,7 @@
     <!--#end if#-->
     <div class="section" id="apprise">
         <div class="col2">
-            <h3>Apprise <a href="$help_uri#apprise" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+            <h3>Apprise <a href="$help_uri#apprise" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a></h3>
             <table>
                 <tr>
                     <td><input type="checkbox" name="apprise_enable" id="apprise_enable" value="1" <!--#if $apprise_enable then 'checked="checked"' else ""#--> /></td>
@@ -188,7 +188,7 @@
                 </tr>
             </table>
             <p>$T('explain-apprise_enable')</p>
-            <p><a href="https://appriseit.com/" target="_blank">Apprise documentation</a></p>
+            <p><a href="https://appriseit.com/" target="_blank" rel="noopener noreferrer">Apprise documentation</a></p>
             <p>$T('version'): ${apprise.__version__}</p>
 
             $show_cat_box('apprise')
@@ -226,14 +226,14 @@
     </div>
     <div class="section" id="nscript">
         <div class="col2">
-            <h3>$T('section-NScript') <a href="$help_uri#nscript" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+            <h3>$T('section-NScript') <a href="$help_uri#nscript" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a></h3>
             <table>
                 <tr>
                     <td><input type="checkbox" name="nscript_enable" id="nscript_enable" value="1" <!--#if $nscript_enable then 'checked="checked"' else ""#--> /></td>
                     <td><label for="nscript_enable"> $T('opt-nscript_enable')</label></td>
                 </tr>
             </table>
-            <em>$T('explain-nscript_enable')</em><br><a href="$help_uri#nscript" target="_blank">$T('readwiki')</a>
+            <em>$T('explain-nscript_enable')</em><br><a href="$help_uri#nscript" target="_blank" rel="noopener noreferrer">$T('readwiki')</a>
             $show_cat_box('nscript')
         </div>
         <div class="col1" <!--#if $nscript_enable then '' else 'style="display:none"'#-->>

--- a/interfaces/Config/templates/config_rss.tmpl
+++ b/interfaces/Config/templates/config_rss.tmpl
@@ -6,7 +6,7 @@
     <!--#if not $active_feed#-->
     <div class="section">
         <div class="padTable">
-            <a class="main-helplink" href="$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a>
+            <a class="main-helplink" href="$help_uri" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a>
             <p>$T('explain-RSS')</p>
             <form action="add_rss_feed" method="post" autocomplete="off">
                 <input type="hidden" name="apikey" value="$apikey" />
@@ -60,7 +60,7 @@
                                     <button type="button" class="btn btn-default testFeed" rel="$feed_item_html"><span class="glyphicon glyphicon-sort"></span> $T('button-preFeed')</button>
                                     <input type="hidden" name="uri" value="$rss[$feed_item]['uris']" />
                                     <button type="button" class="btn btn-default editFeed" rel="$feed_item_html"><span class="glyphicon glyphicon-pencil"></span> $T('rss-edit')</button>
-                                    <button type="button" class="btn btn-default delFeed" rel="$feed_item_html"><span class="glyphicon glyphicon-trash"></span></button>
+                                    <button type="button" class="btn btn-default delFeed" rel="$feed_item_html" aria-label="$T('nzo-delete')"><span class="glyphicon glyphicon-trash" aria-hidden="true"></span></button>
                                 </td>
                             </tr>
                             <!--#for $uri_index, $uri in enumerate($rss[$feed_item]['uri'])#-->
@@ -105,7 +105,7 @@
     <!--#set $feed = html.unescape($active_feed)#-->
     <div class="section rss-section">
         <div class="padTable">
-            <a class="main-helplink" href="$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a>
+            <a class="main-helplink" href="$help_uri" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a>
             <h2 class="nomargin activeRSS">
                 <a href="${root}config/rss/">$T('cmenu-rss')</a> &raquo;
                 $active_feed
@@ -350,7 +350,7 @@
                                 <!--#end if#-->
                                 <td class="nowrap">
                                     <button type="submit" class="btn btn-default Save"><span class="glyphicon glyphicon-ok"></span> $T('button-save')</button>
-                                    <button class="btn btn-default delFilter" type="button"><span class="glyphicon glyphicon-trash"></span></button>
+                                    <button class="btn btn-default delFilter" type="button" aria-label="$T('nzo-delete')"><span class="glyphicon glyphicon-trash" aria-hidden="true"></span></button>
                                     <!--#if not $rss[$feed].filter_states[$fnum]#-->
                                         &nbsp;&nbsp;$T('Incorrect filter')
                                     <!--#end if#-->
@@ -418,7 +418,7 @@
                             <!--#if not $job['infourl']#-->
                             <div class="favicon source-icon" style="background-image: url(//$job['baselink']/favicon.ico);" data-domain="$job['baselink']"></div>
                             <!--#else#-->
-                            <a class="favicon source-icon" href="$job['infourl']" target="_blank" style="background-image: url(//$job['baselink']/favicon.ico);" data-domain="$job['baselink']"></a>
+                            <a class="favicon source-icon" href="$job['infourl']" target="_blank" style="background-image: url(//$job['baselink']/favicon.ico);" data-domain="$job['baselink']" rel="noopener noreferrer"></a>
                             <!--#end if#-->
                         </td>
                     </tr>
@@ -462,7 +462,7 @@
                             <!--#if not $job['infourl']#-->
                             <div class="favicon source-icon" style="background-image: url(//$job['baselink']/favicon.ico);" data-domain="$job['baselink']"></div>
                             <!--#else#-->
-                            <a class="favicon source-icon" href="$job['infourl']" target="_blank" style="background-image: url(//$job['baselink']/favicon.ico);" data-domain="$job['baselink']"></a>
+                            <a class="favicon source-icon" href="$job['infourl']" target="_blank" style="background-image: url(//$job['baselink']/favicon.ico);" data-domain="$job['baselink']" rel="noopener noreferrer"></a>
                             <!--#end if#-->
                         </td>
                     </tr>
@@ -501,7 +501,7 @@
                                 <!--#if not $job['infourl']#-->
                                 <div class="favicon source-icon" style="background-image: url(//$job['baselink']/favicon.ico);" data-domain="$job['baselink']"></div>
                                 <!--#else#-->
-                                <a class="favicon source-icon" href="$job['infourl']" target="_blank" style="background-image: url(//$job['baselink']/favicon.ico);" data-domain="$job['baselink']"></a>
+                                <a class="favicon source-icon" href="$job['infourl']" target="_blank" style="background-image: url(//$job['baselink']/favicon.ico);" data-domain="$job['baselink']" rel="noopener noreferrer"></a>
                                 <!--#end if#-->
                             </td>
                         </tr>

--- a/interfaces/Config/templates/config_scheduling.tmpl
+++ b/interfaces/Config/templates/config_scheduling.tmpl
@@ -15,7 +15,7 @@ else:
 <div class="colmask">
     <div class="section">
         <div class="col2">
-            <h3>$T('addSchedule') <a href="$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+            <h3>$T('addSchedule') <a href="$help_uri" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a></h3>
         </div><!-- /col2 -->
         <form action="addSchedule" method="post" autocomplete="off">
         <input type="hidden" id="apikey" name="apikey" value="$apikey" />
@@ -95,7 +95,7 @@ else:
                                 <input type="hidden" name="line" id="line" value="$line"/>
                                 <div class="field-pair infoTableSeperator <!--#if $odd then "" else " alt"#-->">
                                     <input type="checkbox" name="schedenabled" value="$line" <!--#if int($taskinfo[$schednum][5]) > 0 then 'checked="checked"' else ""#-->>
-                                    <button class="btn btn-default float-left"><span class="glyphicon glyphicon-trash"></span></button>
+                                    <button class="btn btn-default float-left" aria-label="$T('nzo-delete')"><span class="glyphicon glyphicon-trash" aria-hidden="true"></span></button>
                                     <div class="scheduleEntry">
                                         <span class="time">$taskinfo[$schednum][1]:$taskinfo[$schednum][2]</span><span class="frequency">$taskinfo[$schednum][3]</span> <span class="darkred">$taskinfo[$schednum][4]</span>
                                     </div>

--- a/interfaces/Config/templates/config_server.tmpl
+++ b/interfaces/Config/templates/config_server.tmpl
@@ -37,7 +37,7 @@
     </div>
     <div class="section" id="addServerContent" style="display: none;">
         <div class="col2">
-            <h3>$T('addServer') <a href="$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+            <h3>$T('addServer') <a href="$help_uri" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a></h3>
         </div>
         <div class="col1">
             <form action="addServer" method="post" autocomplete="off" onsubmit="removeObfuscation();">
@@ -105,7 +105,7 @@
                         <label class="config" for="ssl_ciphers">$T('opt-ssl_ciphers')</label>
                         <input type="text" name="ssl_ciphers" id="ssl_ciphers" />
                         <span class="desc">$T('explain-ssl_ciphers') <br>$T('readwiki')
-                        <a href="https://sabnzbd.org/wiki/advanced/ssl-ciphers" target="_blank">https://sabnzbd.org/wiki/advanced/ssl-ciphers</a></span>
+                        <a href="https://sabnzbd.org/wiki/advanced/ssl-ciphers" target="_blank" rel="noopener noreferrer">https://sabnzbd.org/wiki/advanced/ssl-ciphers</a></span>
                     </div>
                     <div class="field-pair advanced-settings">
                         <label class="config" for="required">$T('srv-required')</label>
@@ -121,7 +121,7 @@
                         <label class="config" for="pipelining_requests">$T('srv-pipelining_requests')</label>
                         <input type="number" name="pipelining_requests" id="pipelining_requests" min="1" max="20" value="2" />
                         <span class="desc">$T('explain-pipelining_requests')<br>$T('readwiki')
-                        <a href="https://sabnzbd.org/wiki/advanced/nntp-pipelining" target="_blank">https://sabnzbd.org/wiki/advanced/nntp-pipelining</a></span>
+                        <a href="https://sabnzbd.org/wiki/advanced/nntp-pipelining" target="_blank" rel="noopener noreferrer">https://sabnzbd.org/wiki/advanced/nntp-pipelining</a></span>
                     </div>
                     <div class="field-pair advanced-settings">
                         <label class="config" for="expire_date">$T('srv-expire_date')</label>
@@ -161,7 +161,7 @@
 
             <div class="section <!--#if int($server['enable']) == 0 then 'server-disabled' else ""#-->">
                 <div class="col2 <!--#if int($server['enable']) == 0 then 'server-disabled' else ""#-->">
-                    <h3 title="$server['displayname']">$server['displayname'] <a href="$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+                    <h3 title="$server['displayname']">$server['displayname'] <a href="$help_uri" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a></h3>
                     <!--#if int($server['enable']) != 0 #-->
                         <!--#if $last_prio != $server['priority'] and $cur_prio_color+1 < len($prio_colors) #-->
                             <!--#set $cur_prio_color = $cur_prio_color+1 #-->
@@ -242,7 +242,7 @@
                             <label class="config" for="ssl_ciphers$cur">$T('opt-ssl_ciphers')</label>
                             <input type="text" name="ssl_ciphers" id="ssl_ciphers$cur" value="$server['ssl_ciphers']" />
                             <span class="desc">$T('explain-ssl_ciphers') <br>$T('readwiki')
-                            <a href="https://sabnzbd.org/wiki/advanced/ssl-ciphers" target="_blank">https://sabnzbd.org/wiki/advanced/ssl-ciphers</a></span>
+                            <a href="https://sabnzbd.org/wiki/advanced/ssl-ciphers" target="_blank" rel="noopener noreferrer">https://sabnzbd.org/wiki/advanced/ssl-ciphers</a></span>
                         </div>
                         <div class="field-pair advanced-settings">
                             <label class="config" for="required$cur">$T('srv-required')</label>
@@ -258,7 +258,7 @@
                             <label class="config" for="pipelining_requests$cur">$T('srv-pipelining_requests')</label>
                             <input type="number" name="pipelining_requests" id="pipelining_requests$cur" value="$server['pipelining_requests']" min="1" max="20" required />
                             <span class="desc">$T('explain-pipelining_requests')<br>$T('readwiki')
-                            <a href="https://sabnzbd.org/wiki/advanced/nntp-pipelining" target="_blank">https://sabnzbd.org/wiki/advanced/nntp-pipelining</a></span>
+                            <a href="https://sabnzbd.org/wiki/advanced/nntp-pipelining" target="_blank" rel="noopener noreferrer">https://sabnzbd.org/wiki/advanced/nntp-pipelining</a></span>
                         </div>
                         <div class="field-pair advanced-settings">
                             <label class="config" for="expire_date$cur">$T('srv-expire_date')</label>
@@ -299,7 +299,7 @@
                             <p title="$T('readwiki')">
                                 <b>$T('srv-article-availability'):</b><br/>
                                 $T('selectedDates'): <span id="server-article-value-${cur}"></span><br/>
-                                <a href="https://sabnzbd.org/not-complete" id="server-article-not-complete-${cur}" target="_blank">https://sabnzbd.org/not-complete</a>
+                                <a href="https://sabnzbd.org/not-complete" id="server-article-not-complete-${cur}" target="_blank" rel="noopener noreferrer">https://sabnzbd.org/not-complete</a>
                             </p>
                             <!--#if $server['expire_date']#-->
                             <p><b>$T('srv-expire_date'):</b> $(server['expire_date'])</p>
@@ -559,7 +559,7 @@
                 data: "mode=config&name=test_server&" + jQuery(this).parents('form:first').serialize()
             }).then(function(data) {
                 // Let's replace the link
-                msg = data.value.message.replace('https://sabnzbd.org/certificate-errors', '<a href="https://sabnzbd.org/certificate-errors" class="alert-link" target="_blank">https://sabnzbd.org/certificate-errors</a>')
+                msg = data.value.message.replace('https://sabnzbd.org/certificate-errors', '<a href="https://sabnzbd.org/certificate-errors" class="alert-link" target="_blank" rel="noopener noreferrer">https://sabnzbd.org/certificate-errors</a>')
                 msg = msg.replace('-', '<br>')
                 // Fill the box and enable the button
                 resultBox.removeClass('alert-success alert-danger').show()

--- a/interfaces/Config/templates/config_sorting.tmpl
+++ b/interfaces/Config/templates/config_sorting.tmpl
@@ -3,7 +3,7 @@
 <!--#include $webdir + "/_inc_header_uc.tmpl"#-->
 <div class="colmask">
     <div class="padTable section">
-        <a class="main-helplink" href="$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a>
+        <a class="main-helplink" href="$help_uri" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a>
         $T('explain-sorting')
     </div>
     <div class="padding alt section">
@@ -32,9 +32,9 @@
                 </div>
                 <div class="col2">
                     <!--#if $cur == 0#-->
-                    <h3>$T('add-sorter') <a href="$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+                    <h3>$T('add-sorter') <a href="$help_uri" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a></h3>
                     <!--#else#-->
-                    <h3>$slot.name <a href="$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+                    <h3>$slot.name <a href="$help_uri" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a></h3>
                     <div class="sorter-switch-container wide">
                         <input type="checkbox" class="toggleSorterCheckbox sorter-switch float-left" rel="$slot.name" name="is_active" id="is_active_$cur" value="$slot.is_active" <!--#if $slot.is_active != 0 then 'checked="checked"' else ""#--> />
                         <label class="sorter-switch float-left" for="is_active_$cur">$T('enabled')</label>

--- a/interfaces/Config/templates/config_special.tmpl
+++ b/interfaces/Config/templates/config_special.tmpl
@@ -10,7 +10,7 @@
         </div>
         <div class="section">
             <div class="col2">
-                <h3>$T('sptag-boolean') <a href="$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+                <h3>$T('sptag-boolean') <a href="$help_uri" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a></h3>
             </div><!-- /col2 -->
             <div class="col1">
                 <fieldset>
@@ -33,7 +33,7 @@
         </div><!-- /section -->
         <div class="section">
             <div class="col2">
-                <h3>$T('sptag-entries') <a href="$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+                <h3>$T('sptag-entries') <a href="$help_uri" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a></h3>
             </div><!-- /col2 -->
             <div class="col1">
                 <fieldset>

--- a/interfaces/Config/templates/config_switches.tmpl
+++ b/interfaces/Config/templates/config_switches.tmpl
@@ -14,7 +14,7 @@
         <input type="hidden" name="output" value="json" />
         <div class="section advanced-settings">
             <div class="col2">
-                <h3>$T('swtag-server') <a href="$help_uri#toc1" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+                <h3>$T('swtag-server') <a href="$help_uri#toc1" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a></h3>
             </div><!-- /col2 -->
             <div class="col1">
                 <fieldset>
@@ -37,7 +37,7 @@
         </div><!-- /section -->
         <div class="section">
             <div class="col2">
-                <h3>$T('swtag-queue') <a href="$help_uri#toc2" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+                <h3>$T('swtag-queue') <a href="$help_uri#toc2" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a></h3>
             </div><!-- /col2 -->
             <div class="col1">
                 <fieldset>
@@ -98,7 +98,7 @@
                         </select>
                         <span class="desc">
                             $T('explain-no_dupes')<br>
-                            <a href="https://sabnzbd.org/wiki/duplicate-detection" target="_blank">https://sabnzbd.org/wiki/duplicate-detection</a>
+                            <a href="https://sabnzbd.org/wiki/duplicate-detection" target="_blank" rel="noopener noreferrer">https://sabnzbd.org/wiki/duplicate-detection</a>
                         </span>
                     </div>
                     <div class="field-pair">
@@ -112,7 +112,7 @@
                         </select>
                         <span class="desc">
                             $T('explain-no_smart_dupes')<br>
-                            <a href="https://sabnzbd.org/wiki/duplicate-detection" target="_blank">https://sabnzbd.org/wiki/duplicate-detection</a>
+                            <a href="https://sabnzbd.org/wiki/duplicate-detection" target="_blank" rel="noopener noreferrer">https://sabnzbd.org/wiki/duplicate-detection</a>
                         </span>
                     </div>
                     <div class="field-pair advanced-settings">
@@ -175,7 +175,7 @@
         </div><!-- /section -->
         <div class="section">
             <div class="col2">
-                <h3>$T('swtag-pp') <a href="$help_uri#toc3" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+                <h3>$T('swtag-pp') <a href="$help_uri#toc3" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a></h3>
             </div><!-- /col2 -->
             <div class="col1">
                 <fieldset>
@@ -280,7 +280,7 @@
         </div><!-- /section -->
         <div class="section advanced-settings">
             <div class="col2">
-                <h3>$T('swtag-naming') <a href="$help_uri#toc4" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+                <h3>$T('swtag-naming') <a href="$help_uri#toc4" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a></h3>
             </div><!-- /col2 -->
             <div class="col1">
                 <fieldset>
@@ -320,7 +320,7 @@
         </div><!-- /section -->
         <div class="section">
             <div class="col2">
-                <h3>$T('swtag-quota') <a href="$help_uri#toc5" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
+                <h3>$T('swtag-quota') <a href="$help_uri#toc5" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')"><span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span></a></h3>
             </div><!-- /col2 -->
             <div class="col1">
                 <fieldset>

--- a/interfaces/Config/templates/login/main.tmpl
+++ b/interfaces/Config/templates/login/main.tmpl
@@ -1,10 +1,35 @@
 <!DOCTYPE HTML>
-<html lang="$active_lang">
+<html lang="$active_lang" data-server-theme="$color_scheme">
 <head>
     <title>SABnzbd - $T('login')</title>
 
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, maximum-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#e7e9ec" />
+
+        <script type="text/javascript">
+            (function(document, window) {
+                var root = document.documentElement;
+                var storageKey = 'sabnzbd-ui-theme-v1';
+                var serverTheme = (root.getAttribute('data-server-theme') || 'Auto').toLowerCase();
+                var selected = '';
+                try { selected = window.localStorage.getItem(storageKey) || ''; } catch (error) { selected = ''; }
+                var explicit = selected === 'light' || selected === 'dark' || selected === 'oled';
+                var followsSystem = !explicit && serverTheme !== 'oled' && serverTheme !== 'night' && serverTheme !== 'dark' && serverTheme !== 'light';
+                if (!explicit) {
+                    if (serverTheme === 'oled') selected = 'oled';
+                    else if (serverTheme === 'night' || serverTheme === 'dark') selected = 'dark';
+                    else if (serverTheme === 'light') selected = 'light';
+                    else selected = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+                }
+                root.setAttribute('data-sab-theme', selected);
+                root.setAttribute('data-sab-theme-explicit', explicit ? 'true' : 'false');
+                root.setAttribute('data-sab-theme-follows-system', followsSystem ? 'true' : 'false');
+                root.style.colorScheme = selected === 'light' ? 'light' : 'dark';
+                var themeColor = document.querySelector('meta[name="theme-color"]');
+                if (themeColor) themeColor.setAttribute('content', selected === 'oled' ? '#000000' : selected === 'dark' ? '#1d2024' : '#e7e9ec');
+            }(document, window));
+        </script>
     <meta name="apple-mobile-web-app-title" content="SABnzbd" />
 
     <link rel="apple-touch-icon" sizes="76x76" href="../staticcfg/ico/apple-touch-icon-76x76-precomposed.png" />
@@ -16,19 +41,31 @@
 
     <link rel="stylesheet" type="text/css" href="../staticcfg/bootstrap/css/bootstrap.min.css?v=$version" />
     <link rel="stylesheet" type="text/css" href="../staticcfg/css/login.css?v=$version" />
+    <noscript>
     <!--#if $color_scheme not in ('Light', '') #-->
     <link rel="stylesheet" type="text/css" href="../staticcfg/css/${color_scheme}.css?v=$version"/>
     <!--#end if#-->
+    </noscript>
+    <link rel="stylesheet" type="text/css" href="../staticcfg/css/theme.css?v=$version" />
+    <link rel="stylesheet" type="text/css" href="../staticcfg/css/config.modern.css?v=$version" />
 
     <script type="text/javascript" src="../staticcfg/js/jquery-3.5.1.min.js?v=$version"></script>
     <script type="text/javascript" src="../staticcfg/bootstrap/js/bootstrap.min.js?v=$version"></script>
+    <script type="text/javascript" defer src="../staticcfg/js/theme.js?v=$version"></script>
 </head>
-<html>
-    <body>
+    <body class="login">
+        <div class="sab-theme-control sab-theme-control--floating">
+            <label for="sab-theme-select-login">$T('opt-web_dir')</label>
+            <select id="sab-theme-select-login" data-sab-theme-select aria-label="$T('opt-web_dir')">
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+                <option value="oled">OLED</option>
+            </select>
+        </div>
         <div class="account-wall">
             <div class="text-center logo-header">
                 <!--#include $webdir + "/staticcfg/images/logo-full.svg"#-->
-                <a href="https://sabnzbd.org/wiki/faq#why-login" target="_blank">
+                <a href="https://sabnzbd.org/wiki/faq#why-login" target="_blank" rel="noopener noreferrer" aria-label="$T('menu-help')">
                     <span class="glyphicon glyphicon-question-sign"></span>
                 </a>
             </div>
@@ -37,10 +74,12 @@
                 <div class="alert alert-danger" role="alert">$error</div>
                 <!--#end if#-->
 
-                <input type="text" class="form-control" name="username" placeholder="$T('srv-username')" autocomplete="username" required autofocus>
-                <input type="password" class="form-control" name="password" placeholder="$T('srv-password')" autocomplete="current-password" required>
+                <label class="sr-only" for="login-username">$T('srv-username')</label>
+                <input id="login-username" type="text" class="form-control" name="username" placeholder="$T('srv-username')" autocomplete="username" required autofocus>
+                <label class="sr-only" for="login-password">$T('srv-password')</label>
+                <input id="login-password" type="password" class="form-control" name="password" placeholder="$T('srv-password')" autocomplete="current-password" required>
 
-                <button class="btn btn-default"><span class="glyphicon glyphicon-circle-arrow-right"></span> $T('login') </button>
+                <button type="submit" class="btn btn-default"><span class="glyphicon glyphicon-circle-arrow-right"></span> $T('login') </button>
 
                 <div class="checkbox text-center" data-toggle="tooltip" data-placement="bottom" title="$T('explain-sessionExpire')">
                     <label>

--- a/interfaces/Config/templates/staticcfg/css/OLED.css
+++ b/interfaces/Config/templates/staticcfg/css/OLED.css
@@ -1,0 +1,8 @@
+/* OLED color scheme fallback for no-JavaScript clients. */
+html, body { background: #000000; color: #f8f8f8; color-scheme: dark; }
+.navbar-default, .colmask, #inner, body > .container, .account-wall { background: #000000; color: #f8f8f8; border-color: #303030; }
+.col2 h3, .modal-header { background: #050505; color: #ffffff; }
+.field-pair:nth-child(odd), .quoteBlock, .example { background: #101010; }
+.dropdown-menu, .modal-content { background: #0b0b0b; color: #f8f8f8; border-color: #303030; }
+.form-control, select, input, textarea { background: #080808; color: #f8f8f8; border-color: #555555; }
+label, small, .desc, .col2 p { color: #d0d0d0; }

--- a/interfaces/Config/templates/staticcfg/css/config.modern.css
+++ b/interfaces/Config/templates/staticcfg/css/config.modern.css
@@ -1,0 +1,297 @@
+/* Responsive and semantic-theme layer for Config, Login, and Wizard. */
+*, *::before, *::after { box-sizing: border-box; }
+html, body { min-width: 0; min-height: 100%; }
+body { overflow-x: hidden;
+    overflow-x: clip; }
+
+html[data-sab-theme] .navbar-default { background-color: var(--sab-surface); border-color: var(--sab-border); }
+html[data-sab-theme] .navbar-default .navbar-nav > li > a { color: var(--sab-text); }
+html[data-sab-theme] .navbar-default .navbar-nav > li > a:hover,
+html[data-sab-theme] .navbar-default .navbar-nav > li > a:focus { background-color: var(--sab-hover); color: var(--sab-text); }
+html[data-sab-theme] .navbar-default .navbar-nav > li > a.active { background-color: var(--sab-selected); color: var(--sab-text); }
+html[data-sab-theme] .navbar-default .navbar-toggle { border-color: var(--sab-border-strong); }
+html[data-sab-theme] .navbar-default .navbar-toggle .icon-bar { background-color: var(--sab-text); }
+html[data-sab-theme] .navbar-default .navbar-toggle:hover,
+html[data-sab-theme] .navbar-default .navbar-toggle:focus { background-color: var(--sab-hover); }
+
+html[data-sab-theme] #content,
+html[data-sab-theme] .colmask,
+html[data-sab-theme] .section,
+html[data-sab-theme] .account-wall,
+html[data-sab-theme] #inner,
+html[data-sab-theme] .container { color: var(--sab-text); }
+html[data-sab-theme] .colmask,
+html[data-sab-theme] .account-wall,
+html[data-sab-theme] #inner,
+html[data-sab-theme] body > .container { background-color: var(--sab-surface); border-color: var(--sab-border); }
+html[data-sab-theme] .section,
+html[data-sab-theme] #addFeed,
+html[data-sab-theme] #addFeedContent { border-color: var(--sab-border); }
+html[data-sab-theme] .col2 h3 { background: var(--sab-nav); color: var(--sab-nav-text); }
+html[data-sab-theme] .col2 p,
+html[data-sab-theme] .col2-cats,
+html[data-sab-theme] .desc,
+html[data-sab-theme] .desc-check { color: var(--sab-text-muted); }
+html[data-sab-theme] .field-pair:nth-child(odd),
+html[data-sab-theme] .Key tr:nth-child(odd),
+html[data-sab-theme] .tab-pane tr:nth-child(odd),
+html[data-sab-theme] .even,
+html[data-sab-theme] .alt,
+html[data-sab-theme] .infoTableSeperator.alt { background-color: var(--sab-surface-muted); }
+html[data-sab-theme] .example,
+html[data-sab-theme] .quoteBlock { background-color: var(--sab-surface-muted); }
+
+html[data-sab-theme] textarea,
+html[data-sab-theme] select,
+html[data-sab-theme] input[type="date"],
+html[data-sab-theme] input[type="datetime"],
+html[data-sab-theme] input[type="datetime-local"],
+html[data-sab-theme] input[type="email"],
+html[data-sab-theme] input[type="month"],
+html[data-sab-theme] input[type="number"],
+html[data-sab-theme] input[type="password"],
+html[data-sab-theme] input[type="search"],
+html[data-sab-theme] input[type="tel"],
+html[data-sab-theme] input[type="text"],
+html[data-sab-theme] input[type="time"],
+html[data-sab-theme] input[type="url"],
+html[data-sab-theme] input[type="week"],
+html[data-sab-theme] .form-control {
+    background-color: var(--sab-input);
+    color: var(--sab-text);
+    border-color: var(--sab-border-strong);
+}
+html[data-sab-theme] input::placeholder,
+html[data-sab-theme] textarea::placeholder { color: var(--sab-text-muted); opacity: 1; }
+html[data-sab-theme] textarea:hover,
+html[data-sab-theme] input:hover,
+html[data-sab-theme] textarea:focus,
+html[data-sab-theme] input:focus,
+html[data-sab-theme] select:focus { background-color: var(--sab-input); border-color: var(--sab-focus); }
+html[data-sab-theme] .btn-default,
+html[data-sab-theme] .login .btn { background-color: var(--sab-surface-raised) !important; color: var(--sab-text) !important; border-color: var(--sab-border-strong); }
+html[data-sab-theme] .btn-default:hover,
+html[data-sab-theme] .btn-default:focus { background-color: var(--sab-hover) !important; }
+
+html[data-sab-theme] .table > thead > tr > th,
+html[data-sab-theme] .table > tbody > tr > th,
+html[data-sab-theme] .table > tfoot > tr > th,
+html[data-sab-theme] .table > thead > tr > td,
+html[data-sab-theme] .table > tbody > tr > td,
+html[data-sab-theme] .table > tfoot > tr > td,
+html[data-sab-theme] table td,
+html[data-sab-theme] table th { border-color: var(--sab-border); color: var(--sab-text); }
+html[data-sab-theme] .dropdown-menu,
+html[data-sab-theme] .modal-content,
+html[data-sab-theme] .list-group-item { background-color: var(--sab-surface-raised); color: var(--sab-text); border-color: var(--sab-border); }
+html[data-sab-theme] .dropdown-menu > li > a { color: var(--sab-text); }
+html[data-sab-theme] .dropdown-menu > li > a:hover,
+html[data-sab-theme] .dropdown-menu > li > a:focus { background-color: var(--sab-hover); color: var(--sab-text); }
+html[data-sab-theme] .modal-header { background-color: var(--sab-nav); color: var(--sab-nav-text); border-color: var(--sab-border); }
+html[data-sab-theme] .modal-body,
+html[data-sab-theme] .modal-footer { background-color: var(--sab-surface); border-color: var(--sab-border); }
+html[data-sab-theme] .modal-backdrop { background-color: #000000; }
+html[data-sab-theme] .modal-backdrop.in { opacity: .72; }
+html[data-sab-theme] .nav-tabs { border-color: var(--sab-border); }
+html[data-sab-theme] .nav-tabs > li > a { color: var(--sab-text); }
+html[data-sab-theme] .nav-tabs > li.active > a,
+html[data-sab-theme] .nav-tabs > li.active > a:hover,
+html[data-sab-theme] .nav-tabs > li.active > a:focus { background-color: var(--sab-surface); color: var(--sab-text); border-color: var(--sab-border); }
+html[data-sab-theme] .success { color: var(--sab-success) !important; }
+html[data-sab-theme] .darkred,
+html[data-sab-theme] .failed { color: var(--sab-danger) !important; }
+html[data-sab-theme] label { color: var(--sab-text); }
+
+.navbar-toggle,
+.navbar .nav > li > a { min-height: 44px; }
+.navbar-logo { min-width: 44px; min-height: 44px; }
+.sab-theme-nav-item { display: flex !important; align-items: center; }
+.sab-theme-nav-item .sab-theme-control { width: 100%; }
+#search-box { min-height: 38px; width: 100%; }
+
+#content { width: min(100%, 1400px); }
+.colmask, .section, .col1, .col2, .field-pair { min-width: 0; }
+.field-pair { overflow-wrap: anywhere; }
+.field-pair > input:not([type="checkbox"]):not([type="radio"]),
+.field-pair > select,
+.field-pair > textarea,
+.field-pair .form-control { max-width: 100%; }
+.padTable, .tab-pane, .table-responsive-modern { max-width: 100%; overflow-x: auto; overscroll-behavior-inline: contain; }
+.table { max-width: 100%; }
+.modal-dialog { max-width: calc(100vw - 24px); }
+.modal-content { max-height: calc(100dvh - 24px); display: flex; flex-direction: column; }
+.modal-body { overflow: auto; overscroll-behavior: contain; }
+.modal-header .close { min-width: 44px; min-height: 44px; margin-top: -10px; margin-right: -10px; }
+
+.account-wall { max-width: calc(100% - 24px); padding: 18px; background: var(--sab-surface); border: 1px solid var(--sab-border); box-shadow: var(--sab-shadow); }
+.account-wall .form-control { min-height: 44px; font-size: 16px; }
+.account-wall .btn { min-height: 44px; }
+
+body > .container { box-shadow: var(--sab-shadow); }
+.language { min-height: 48px; display: flex; align-items: center; justify-content: center; }
+.language:hover, .language:focus-within { background-color: var(--sab-hover); }
+
+@media (max-width: 1000px) {
+    .section { display: flex; flex-direction: column; }
+    .col2, .col1 { width: 100%; float: none; }
+}
+
+@media (max-width: 767px) {
+    body { padding-bottom: env(safe-area-inset-bottom); }
+    .navbar-fixed-top { position: sticky; top: 0; margin-bottom: 0; }
+    .navbar .container { width: 100%; padding-left: max(8px, env(safe-area-inset-left)); padding-right: max(8px, env(safe-area-inset-right)); }
+    .navbar-header { min-height: 52px; }
+    .navbar-toggle { margin: 4px 0 4px auto; min-width: 44px; padding: 13px 12px; }
+    .navbar-logo { padding: 4px 8px; margin-left: 0; }
+    .navbar-collapse.in,
+    .navbar-collapse.collapsing { max-height: calc(100dvh - 52px); overflow-y: auto; padding-bottom: max(12px, env(safe-area-inset-bottom)); }
+    .navbar-nav { margin: 0 -15px; }
+    .navbar .nav > li > a { min-height: 48px; padding: 13px 15px; }
+    .sab-theme-nav-item { min-height: 52px; }
+
+    #content { width: 100%; padding-top: 8px !important; }
+    .colmask { width: 100%; }
+    .section { border-bottom: 1px solid var(--sab-border); }
+    .col2 { padding: 10px; }
+    .col1 { padding: 4px 0 8px; }
+    .field-pair { padding: 10px; }
+    label.config,
+    .field-pair h5 { width: 100% !important; margin: 0 0 5px; float: none; }
+    .desc,
+    .desc.narrow { margin: 5px 0 0 !important; padding: 0 !important; }
+    .field-pair > input:not([type="checkbox"]):not([type="radio"]),
+    .field-pair > select,
+    .field-pair > textarea,
+    .field-pair .form-control,
+    .fileBrowserField { width: 100% !important; max-width: 100% !important; min-height: 44px; font-size: 16px; }
+    textarea { min-height: 100px; }
+    select[multiple] { min-height: 140px; }
+    input[type="checkbox"], input[type="radio"] { width: 20px; height: 20px; }
+    .btn, button, input[type="button"], input[type="submit"] { min-height: 44px; }
+    .advanced-button, .main-helplink { min-height: 44px; display: inline-flex; align-items: center; }
+    .presets { max-width: 100%; }
+
+    .padTable,
+    .tab-pane { padding-left: 0; padding-right: 0; }
+    .table,
+    .catTable,
+    .pattern-table { display: block; width: 100%; overflow-x: auto; white-space: nowrap; }
+    .table td, .table th, .catTable td, .catTable th { min-width: 90px; }
+    .table td input, .table td select, .catTable td input, .catTable td select { min-width: 120px; }
+
+    .modal-dialog { width: auto !important; margin: max(6px, env(safe-area-inset-top)) 6px max(6px, env(safe-area-inset-bottom)); }
+    .modal-content { max-height: calc(100dvh - 12px); }
+    .modal-footer { display: flex; flex-wrap: wrap; gap: 6px; }
+    .modal-footer .btn { flex: 1 1 130px; margin: 0; }
+
+    .account-wall { position: static; transform: none; width: auto; margin: max(24px, 8dvh) auto 24px; }
+    .logo-header svg { max-width: 100%; height: auto; }
+    .text-center a { min-width: 44px; min-height: 44px; display: grid; place-items: center; top: 3px; right: 3px; }
+
+    body > .container { width: 100%; border-left: 0; border-right: 0; box-shadow: none; }
+    #inner { padding: 12px; }
+    #content { min-height: 0; }
+    #logo { margin: 12px 0 0; }
+    #logo svg { max-width: calc(100% - 24px); height: auto; }
+    .language { width: calc(50% - 10px); min-width: 0; margin: 5px; padding: 10px 6px; }
+    .quoteBlock { overflow-wrap: anywhere; }
+    .text-input, .text-input-wide, .input-group-bw, #server-hidden-settings input[type="number"] { width: 100%; max-width: 100%; }
+    .btn { max-width: 100%; }
+}
+
+@media (max-width: 359px) {
+    .language { width: 100%; margin-left: 0; margin-right: 0; }
+    .sab-theme-control--floating { width: calc(100% - 16px); justify-content: space-between; }
+}
+
+@media (max-height: 500px) and (orientation: landscape) {
+    .navbar-fixed-top { position: relative; }
+    .account-wall { margin-top: 12px; margin-bottom: 12px; }
+    .modal-dialog { margin-top: 4px; margin-bottom: 4px; }
+    .modal-content { max-height: calc(100dvh - 8px); }
+}
+
+/* Theme/navigation and overflow refinements. */
+html[data-sab-theme="dark"] .navbar-default .navbar-nav > li > a.active,
+html[data-sab-theme="oled"] .navbar-default .navbar-nav > li > a.active,
+html[data-sab-theme="dark"] .navbar-default .navbar-nav > .active > a,
+html[data-sab-theme="dark"] .navbar-default .navbar-nav > .active > a:hover,
+html[data-sab-theme="dark"] .navbar-default .navbar-nav > .active > a:focus,
+html[data-sab-theme="oled"] .navbar-default .navbar-nav > .active > a,
+html[data-sab-theme="oled"] .navbar-default .navbar-nav > .active > a:hover,
+html[data-sab-theme="oled"] .navbar-default .navbar-nav > .active > a:focus {
+    background: var(--sab-surface-strong) !important;
+    color: var(--sab-text) !important;
+}
+
+html[data-sab-theme="dark"] .navbar-default .navbar-nav > li > a:hover,
+html[data-sab-theme="dark"] .navbar-default .navbar-nav > li > a:focus,
+html[data-sab-theme="oled"] .navbar-default .navbar-nav > li > a:hover,
+html[data-sab-theme="oled"] .navbar-default .navbar-nav > li > a:focus {
+    background: var(--sab-surface-strong);
+    color: var(--sab-text) !important;
+}
+
+html[data-sab-theme="dark"] .table > thead > tr > th,
+html[data-sab-theme="oled"] .table > thead > tr > th {
+    background: var(--sab-surface-strong) !important;
+    color: var(--sab-text) !important;
+}
+
+html[data-sab-theme="dark"] table > tbody > tr:nth-child(odd) > td,
+html[data-sab-theme="oled"] table > tbody > tr:nth-child(odd) > td {
+    background-color: var(--sab-surface-muted) !important;
+    color: var(--sab-text) !important;
+}
+
+html[data-sab-theme="dark"] table > tbody > tr:nth-child(even) > td,
+html[data-sab-theme="oled"] table > tbody > tr:nth-child(even) > td {
+    background-color: var(--sab-surface) !important;
+    color: var(--sab-text) !important;
+}
+
+html[data-sab-theme="dark"] .table-hover > tbody > tr:hover > td,
+html[data-sab-theme="oled"] .table-hover > tbody > tr:hover > td {
+    background: var(--sab-surface-strong) !important;
+    color: var(--sab-text) !important;
+}
+
+@media (max-width: 767px) {
+    .navbar-fixed-top,
+    .navbar-fixed-bottom {
+        max-width: 100vw;
+    }
+
+    .navbar-fixed-top .container,
+    .navbar-fixed-top .navbar-header,
+    .navbar-fixed-top .navbar-collapse {
+        max-width: 100%;
+    }
+
+    .navbar-fixed-top .navbar-collapse {
+        margin-right: 0;
+        margin-left: 0;
+    }
+
+    .navbar-default .navbar-toggle {
+        margin-right: 8px;
+    }
+
+    #content,
+    #content > .container,
+    .main-content,
+    .config-content {
+        max-width: 100%;
+    }
+
+    .row {
+        margin-right: -8px;
+        margin-left: -8px;
+    }
+
+    [class*="col-"] {
+        min-width: 0;
+        padding-right: 8px;
+        padding-left: 8px;
+    }
+}

--- a/interfaces/Config/templates/staticcfg/css/theme.css
+++ b/interfaces/Config/templates/staticcfg/css/theme.css
@@ -1,0 +1,172 @@
+/* Shared semantic theme tokens and selector styling. */
+:root,
+html[data-sab-theme="light"] {
+    color-scheme: light;
+    --sab-canvas: #e7e9ec;
+    --sab-surface: #ffffff;
+    --sab-surface-raised: #ffffff;
+    --sab-surface-muted: #f3f5f7;
+    --sab-surface-strong: #e2e7ec;
+    --sab-text: #1f252b;
+    --sab-text-muted: #5a6570;
+    --sab-border: #cbd1d7;
+    --sab-border-strong: #9da6af;
+    --sab-accent: #b66f00;
+    --sab-accent-strong: #7a4b00;
+    --sab-link: #075fa8;
+    --sab-focus: #006fc9;
+    --sab-nav: #30353b;
+    --sab-nav-text: #ffffff;
+    --sab-nav-bg: var(--sab-nav);
+    --sab-nav-border: var(--sab-border);
+    --sab-input: #ffffff;
+    --sab-hover: #edf2f6;
+    --sab-selected: #e1edf8;
+    --sab-overlay: rgba(20, 25, 30, 0.58);
+    --sab-success: #247a3d;
+    --sab-warning: #925600;
+    --sab-danger: #b3261e;
+    --sab-shadow: 0 10px 30px rgba(24, 31, 38, 0.16);
+    --sab-shadow-lg: 0 18px 46px rgba(24, 31, 38, 0.24);
+    --sab-radius-sm: 3px;
+    --sab-radius-md: 6px;
+    --sab-radius-lg: 10px;
+}
+
+html[data-sab-theme="dark"] {
+    color-scheme: dark;
+    --sab-canvas: #1d2024;
+    --sab-surface: #272b30;
+    --sab-surface-raised: #30353b;
+    --sab-surface-muted: #22262b;
+    --sab-surface-strong: #3a4148;
+    --sab-text: #f2f4f6;
+    --sab-text-muted: #b8c0c8;
+    --sab-border: #4b535c;
+    --sab-border-strong: #6a747e;
+    --sab-accent: #ffc24a;
+    --sab-accent-strong: #ffd77f;
+    --sab-link: #72b9f2;
+    --sab-focus: #75c3ff;
+    --sab-nav: #15181b;
+    --sab-nav-text: #ffffff;
+    --sab-nav-bg: var(--sab-nav);
+    --sab-nav-border: var(--sab-border);
+    --sab-input: #1e2226;
+    --sab-hover: #343a40;
+    --sab-selected: #243d51;
+    --sab-overlay: rgba(0, 0, 0, 0.72);
+    --sab-success: #77d28d;
+    --sab-warning: #ffbe5c;
+    --sab-danger: #ff8c86;
+    --sab-shadow: 0 12px 34px rgba(0, 0, 0, 0.42);
+    --sab-shadow-lg: 0 20px 50px rgba(0, 0, 0, 0.58);
+}
+
+html[data-sab-theme="oled"] {
+    color-scheme: dark;
+    --sab-canvas: #000000;
+    --sab-surface: #000000;
+    --sab-surface-raised: #0b0b0b;
+    --sab-surface-muted: #101010;
+    --sab-surface-strong: #181818;
+    --sab-text: #f8f8f8;
+    --sab-text-muted: #bdbdbd;
+    --sab-border: #303030;
+    --sab-border-strong: #555555;
+    --sab-accent: #ffc44d;
+    --sab-accent-strong: #ffe09a;
+    --sab-link: #7cc7ff;
+    --sab-focus: #8bd0ff;
+    --sab-nav: #050505;
+    --sab-nav-text: #ffffff;
+    --sab-nav-bg: var(--sab-nav);
+    --sab-nav-border: var(--sab-border);
+    --sab-input: #080808;
+    --sab-hover: #151515;
+    --sab-selected: #10283a;
+    --sab-overlay: rgba(0, 0, 0, 0.86);
+    --sab-success: #83e39b;
+    --sab-warning: #ffc76d;
+    --sab-danger: #ff938e;
+    --sab-shadow: 0 14px 38px rgba(0, 0, 0, 0.82);
+    --sab-shadow-lg: 0 22px 54px rgba(0, 0, 0, 0.94);
+}
+
+html[data-sab-theme] body {
+    background-color: var(--sab-canvas);
+    color: var(--sab-text);
+}
+
+html[data-sab-theme] a { color: var(--sab-link); }
+html[data-sab-theme] small,
+html[data-sab-theme] .text-muted,
+html[data-sab-theme] .help-block { color: var(--sab-text-muted); }
+
+html[data-sab-theme] ::selection {
+    background: var(--sab-accent);
+    color: #111111;
+}
+
+html[data-sab-theme] :focus-visible {
+    outline: 3px solid var(--sab-focus) !important;
+    outline-offset: 2px !important;
+}
+
+.sab-theme-control {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--sab-text);
+}
+
+.sab-theme-control label {
+    margin: 0;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.sab-theme-control select {
+    min-height: 38px;
+    min-width: 112px;
+    padding: 7px 30px 7px 10px;
+    border: 1px solid var(--sab-border-strong);
+    background-color: var(--sab-input);
+    color: var(--sab-text);
+}
+
+.sab-theme-control--menu {
+    padding: 8px 15px 10px;
+    justify-content: space-between;
+}
+
+.sab-theme-control--nav {
+    height: 50px;
+    padding: 6px 8px;
+}
+
+.sab-theme-control--floating {
+    position: fixed;
+    z-index: 1100;
+    top: max(10px, env(safe-area-inset-top));
+    right: max(10px, env(safe-area-inset-right));
+    padding: 6px;
+    background: var(--sab-surface-raised);
+    border: 1px solid var(--sab-border);
+    box-shadow: var(--sab-shadow);
+}
+
+@media (max-width: 767px) {
+    .sab-theme-control select { min-height: 44px; font-size: 16px; }
+    .sab-theme-control--nav { height: auto; min-height: 52px; padding: 6px 15px; justify-content: space-between; }
+    .sab-theme-control--floating { position: static; margin: 10px auto 0; width: max-content; max-width: calc(100% - 24px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        scroll-behavior: auto !important;
+        animation-duration: 0.001ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.001ms !important;
+    }
+}

--- a/interfaces/Config/templates/staticcfg/js/theme.js
+++ b/interfaces/Config/templates/staticcfg/js/theme.js
@@ -1,0 +1,130 @@
+/* SABnzbd runtime theme selector: Light, Dark, and OLED. */
+(function (document, window) {
+    'use strict';
+
+    var root = document.documentElement;
+    var storageKey = 'sabnzbd-ui-theme-v1';
+    var validThemes = ['light', 'dark', 'oled'];
+    var themeColors = {
+        light: '#e7e9ec',
+        dark: '#1d2024',
+        oled: '#000000'
+    };
+    var mediaQuery = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
+
+    function isValid(theme) {
+        return validThemes.indexOf(theme) !== -1;
+    }
+
+    function updateThemeColor(theme) {
+        var meta = document.querySelector('meta[name="theme-color"]');
+        if (!meta) {
+            meta = document.createElement('meta');
+            meta.setAttribute('name', 'theme-color');
+            document.head.appendChild(meta);
+        }
+        meta.setAttribute('content', themeColors[theme]);
+    }
+
+    function syncControls(theme) {
+        var controls = document.querySelectorAll('[data-sab-theme-select]');
+        Array.prototype.forEach.call(controls, function (control) {
+            if (control.value !== theme) control.value = theme;
+        });
+    }
+
+    function announce(theme) {
+        var status = document.getElementById('sab-theme-status');
+        var control = document.querySelector('[data-sab-theme-select]');
+        var selectedOption = control && control.options ? control.options[control.selectedIndex] : null;
+        var controlLabel = control ? control.getAttribute('aria-label') : '';
+        var themeLabel = selectedOption ? selectedOption.text : (theme === 'oled' ? 'OLED' : theme.charAt(0).toUpperCase() + theme.slice(1));
+        if (!status) {
+            status = document.createElement('span');
+            status.id = 'sab-theme-status';
+            status.className = 'sr-only';
+            status.setAttribute('role', 'status');
+            status.setAttribute('aria-live', 'polite');
+            document.body.appendChild(status);
+        }
+        status.textContent = (controlLabel ? controlLabel + ': ' : '') + themeLabel;
+    }
+
+    function applyTheme(theme, persist, shouldAnnounce) {
+        if (!isValid(theme)) return;
+        root.setAttribute('data-sab-theme', theme);
+        root.setAttribute('data-sab-theme-explicit', persist ? 'true' : root.getAttribute('data-sab-theme-explicit') || 'false');
+        if (persist) root.setAttribute('data-sab-theme-follows-system', 'false');
+        root.style.colorScheme = theme === 'light' ? 'light' : 'dark';
+        updateThemeColor(theme);
+        syncControls(theme);
+
+        if (persist) {
+            try { window.localStorage.setItem(storageKey, theme); } catch (error) { /* Storage may be disabled. */ }
+        }
+        if (shouldAnnounce) announce(theme);
+    }
+
+    function bindTabState() {
+        var tabs = document.querySelectorAll('[role="tab"]');
+        if (!tabs.length) return;
+
+        function setSelected(activeTab) {
+            Array.prototype.forEach.call(tabs, function (tab) {
+                tab.setAttribute('aria-selected', tab === activeTab ? 'true' : 'false');
+            });
+        }
+
+        Array.prototype.forEach.call(tabs, function (tab) {
+            tab.addEventListener('click', function () {
+                window.setTimeout(function () { setSelected(tab); }, 0);
+            });
+        });
+
+        var active = document.querySelector('[role="presentation"].active > [role="tab"]') || tabs[0];
+        setSelected(active);
+    }
+
+    function bindControls() {
+        var controls = document.querySelectorAll('[data-sab-theme-select]');
+        Array.prototype.forEach.call(controls, function (control) {
+            control.value = root.getAttribute('data-sab-theme') || 'light';
+            control.addEventListener('change', function () {
+                applyTheme(control.value, true, true);
+            });
+            control.addEventListener('click', function (event) {
+                event.stopPropagation();
+            });
+        });
+    }
+
+    function handleSystemThemeChange(event) {
+        if (root.getAttribute('data-sab-theme-explicit') === 'true') return;
+        if (root.getAttribute('data-sab-theme-follows-system') !== 'true') return;
+        applyTheme(event.matches ? 'dark' : 'light', false, false);
+    }
+
+    function initialize() {
+        var current = root.getAttribute('data-sab-theme');
+        if (!isValid(current)) current = mediaQuery && mediaQuery.matches ? 'dark' : 'light';
+        applyTheme(current, false, false);
+        bindControls();
+        bindTabState();
+    }
+
+    window.addEventListener('storage', function (event) {
+        if (event.key === storageKey && isValid(event.newValue)) {
+            root.setAttribute('data-sab-theme-explicit', 'true');
+            root.setAttribute('data-sab-theme-follows-system', 'false');
+            applyTheme(event.newValue, false, false);
+        }
+    });
+
+    if (mediaQuery) {
+        if (typeof mediaQuery.addEventListener === 'function') mediaQuery.addEventListener('change', handleSystemThemeChange);
+        else if (typeof mediaQuery.addListener === 'function') mediaQuery.addListener(handleSystemThemeChange);
+    }
+
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initialize);
+    else initialize();
+}(document, window));

--- a/interfaces/Glitter/templates/include_history.tmpl
+++ b/interfaces/Glitter/templates/include_history.tmpl
@@ -1,8 +1,8 @@
-<div class="history" id="history-tab">
+<div class="history" id="history-tab" role="tabpanel" aria-labelledby="history-tab-label">
     <div class="history-header">
         <h2>$T('menu-history') <small data-bind="visible: history.showArchive()">($T('archive'))</small></h2>
-        <a href="#" data-bind="click: history.showMultiEdit, visible: hasHistory()">
-            <span class="glyphicon glyphicon-tasks" data-tooltip="true" data-placement="left" title="$T('Glitter-multiOperations')"></span>
+        <a href="#" data-bind="click: history.showMultiEdit, visible: hasHistory()" aria-label="$T('Glitter-multiOperations')">
+            <span class="glyphicon glyphicon-tasks" aria-hidden="true" data-tooltip="true" data-placement="left" title="$T('Glitter-multiOperations')"></span>
         </a>
     </div>
     <table class="table table-hover history-table paginated">
@@ -45,8 +45,8 @@
                         <span class="glyphicon glyphicon-ok"></span>
                     </div>
                     <div data-bind="visible: failed() && canRetry()">
-                        <a class="retry-button" href="#" data-bind="click: retry">
-                            <span class="glyphicon glyphicon-exclamation-sign"></span>
+                        <a class="retry-button" href="#" data-bind="click: retry" aria-label="$T('button-retry')">
+                            <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
                         </a>
                     </div>
                     <div data-bind="visible: failed() && !canRetry()">
@@ -124,8 +124,8 @@
                         </div>
                         <!-- /ko -->
                     </div>
-                    <a href="#" data-bind="click: parent.triggerRemoveDownload">
-                        <span class="hover-button glyphicon glyphicon-trash" data-bind="css: { 'glyphicon-stop' : processingDownload() == 2, disabled : processingDownload() == 1 }, attr: { title: processingDownload() == 2 ? '$T('abort')' : '$T('nzo-delete')' }"></span>
+                    <a href="#" data-bind="click: parent.triggerRemoveDownload, attr: { 'aria-label': processingDownload() == 2 ? '$T('abort')' : '$T('nzo-delete')' }">
+                        <span class="hover-button glyphicon glyphicon-trash" aria-hidden="true" data-bind="css: { 'glyphicon-stop' : processingDownload() == 2, disabled : processingDownload() == 1 }, attr: { title: processingDownload() == 2 ? '$T('abort')' : '$T('nzo-delete')' }"></span>
                     </a>
                 </td>
             </tr>
@@ -134,8 +134,8 @@
 
     <div class="input-group search-box">
         <input type="text" class="form-control" placeholder="$T('Glitter-search')" required data-bind="textInput: history.searchTerm, event: { keydown: history.clearSearchTerm }" />
-        <a data-bind="event: { mousedown: history.clearSearchTerm }">
-            <span class="glyphicon" data-bind="css: { 'glyphicon-search' : !history.searchTerm(), 'glyphicon-remove' : history.searchTerm() }"></span>
+        <a data-bind="event: { mousedown: history.clearSearchTerm }, attr: { 'aria-label': history.searchTerm() ? '$T('button-clear')' : '$T('Glitter-search')' }">
+            <span class="glyphicon" aria-hidden="true" data-bind="css: { 'glyphicon-search' : !history.searchTerm(), 'glyphicon-remove' : history.searchTerm() }"></span>
         </a>
     </div>
 
@@ -147,9 +147,9 @@
 
     <div class="multioperations-selector" id="history-options">
         <a href="#" class="hover-button history-archive" title="$T('showArchive') / $T('showAllHis')" data-tooltip="true" data-placement="top" data-bind="click: history.toggleShowArchive, css: { 'history-options-show-failed': history.showArchive }"><svg viewBox="6 6 36 36" height="14" width="14" class="archive-icon"><path d="M41.09 10.45l-2.77-3.36c-.56-.66-1.39-1.09-2.32-1.09h-24c-.93 0-1.76.43-2.31 1.09l-2.77 3.36c-.58.7-.92 1.58-.92 2.55v25c0 2.21 1.79 4 4 4h28c2.21 0 4-1.79 4-4v-25c0-.97-.34-1.85-.91-2.55zm-17.09 24.55l-11-11h7v-4h8v4h7l-11 11zm-13.75-25l1.63-2h24l1.87 2h-27.5z"/></svg></a>
-        <a href="#" class="hover-button" title="$T('showFailedHis') / $T('showAllHis')" data-tooltip="true" data-placement="top" data-bind="click: history.toggleShowFailed, css: { 'history-options-show-failed': history.showFailed }"><span class="glyphicon glyphicon-exclamation-sign"></span></a>
-        <a href="#" class="hover-button" title="$T('link-retryAll')" data-tooltip="true" data-placement="top" data-bind="click: history.retryAllFailed"><span class="glyphicon glyphicon-repeat"></span></a>
-        <a href="#" class="hover-button" title="$T('button-mark-completed')" data-bind="visible: (history.isMultiEditing() && hasHistory()), click: history.doMultiMarkCompleted" data-tooltip="true" data-placement="top"><span class="glyphicon glyphicon-ok"></span></a>
+        <a href="#" class="hover-button" title="$T('showFailedHis') / $T('showAllHis')" aria-label="$T('showFailedHis') / $T('showAllHis')" data-tooltip="true" data-placement="top" data-bind="click: history.toggleShowFailed, css: { 'history-options-show-failed': history.showFailed }"><span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span></a>
+        <a href="#" class="hover-button" title="$T('link-retryAll')" aria-label="$T('link-retryAll')" data-tooltip="true" data-placement="top" data-bind="click: history.retryAllFailed"><span class="glyphicon glyphicon-repeat" aria-hidden="true"></span></a>
+        <a href="#" class="hover-button" title="$T('button-mark-completed')" aria-label="$T('button-mark-completed')" data-bind="visible: (history.isMultiEditing() && hasHistory()), click: history.doMultiMarkCompleted" data-tooltip="true" data-placement="top"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></a>
 
         <div data-bind="visible: (history.isMultiEditing() && hasHistory())">
             <span class="label label-default" data-bind="text: history.multiEditItems().length">0</span>

--- a/interfaces/Glitter/templates/include_menu.tmpl
+++ b/interfaces/Glitter/templates/include_menu.tmpl
@@ -1,20 +1,20 @@
 <nav class="navbar navbar-inverse main-navbar">
     <div class="navbar-header">
-        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse">
+        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar-collapse" aria-controls="navbar-collapse" aria-expanded="false" aria-label="Toggle navigation">
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
         </button>
-        <a class="navbar-logo" href="./">
+        <a class="navbar-logo" href="./" aria-label="$T('Home')">
             #include $webdir + "/../../Config/templates/staticcfg/images/logo-small.svg"#
         </a>
         <div class="btn-group">
             <div class="btn-group">
-                <button type="button" class="btn btn-default navbar-btn" data-bind="click: pauseToggle, attr: { 'title': downloadsPaused() ? '$T('link-resume')' : '$T('link-pause')' }">
+                <button type="button" class="btn btn-default navbar-btn" data-bind="click: pauseToggle, attr: { 'title': downloadsPaused() ? '$T('link-resume')' : '$T('link-pause')', 'aria-label': downloadsPaused() ? '$T('link-resume')' : '$T('link-pause')' }">
                     <span class="glyphicon" data-bind="css: { 'glyphicon-play' : downloadsPaused(), 'glyphicon-pause' : !downloadsPaused() }"></span>
                 </button>
-                <button type="button" class="btn btn-default navbar-btn dropdown-toggle" data-toggle="dropdown">
-                    <span class="caret"></span>
+                <button type="button" class="btn btn-default navbar-btn dropdown-toggle" data-toggle="dropdown" aria-label="$T('pauseFor')" aria-haspopup="true">
+                    <span class="caret" aria-hidden="true"></span>
                 </button>
                 <ul class="dropdown-menu">
                     <li><a href="#" data-time="5" data-bind="click: pauseTime">$T('Glitter-pause5m')</a></li>
@@ -61,35 +61,47 @@
                 </div>
             </li>
             <li data-tooltip="true" data-placement="bottom" title="$T('Glitter-addNZB')">
-                <a href="#modal-add-nzb" data-toggle="modal"><span class="glyphicon glyphicon-plus-sign"></span></a>
+                <a href="#modal-add-nzb" data-toggle="modal" aria-label="$T('Glitter-addNZB')"><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span><span class="mobile-nav-label">$T('Glitter-addNZB')</span></a>
             </li>
             <li data-tooltip="true" data-placement="bottom" title="$T('Glitter-statusInterfaceOptions')" data-bind="click: loadStatusInfo">
-                <a href="#modal-options" data-toggle="modal"><span class="glyphicon glyphicon-wrench"></span></a>
+                <a href="#modal-options" data-toggle="modal" aria-label="$T('Glitter-statusInterfaceOptions')"><span class="glyphicon glyphicon-wrench" aria-hidden="true"></span><span class="mobile-nav-label">$T('Glitter-statusInterfaceOptions')</span></a>
             </li>
             <!--#if $have_rss_defined#-->
             <li data-tooltip="true" data-placement="bottom" title="$T('cmenu-rss')">
-                <a href="./config/rss/">
-                    <svg class="rss-icon-svg" viewBox="0 0 8 8">
+                <a href="./config/rss/" aria-label="$T('cmenu-rss')">
+                    <svg class="rss-icon-svg" aria-hidden="true" viewBox="0 0 8 8">
                         <rect class="rss-button" width="8" height="8" />
                         <circle class="rss-symbol" cx="2" cy="6" r="1" />
                         <path class="rss-symbol" d="m 1,4 a 3,3 0 0 1 3,3 h 1 a 4,4 0 0 0 -4,-4 z" />
                         <path class="rss-symbol" d="m 1,2 a 5,5 0 0 1 5,5 h 1 a 6,6 0 0 0 -6,-6 z" />
-                    </svg>
+                    </svg><span class="mobile-nav-label">$T('cmenu-rss')</span>
                 </a>
             </li>
             <!--#end if#-->
             <li data-tooltip="true" data-placement="bottom" title="SABnzbd $T('menu-config')">
-                <a href="./config/"><span class="glyphicon glyphicon-cog"></span></a>
+                <a href="./config/" aria-label="SABnzbd $T('menu-config')"><span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="mobile-nav-label">$T('menu-config')</span></a>
             </li>
             <li class="dropdown main-menu-link" data-bind="css: { 'active-on-queue-finish-menu': finishaction()}">
-                <a href="#" data-toggle="dropdown"  onclick="keepOpen(this)">
+                <a href="#" data-toggle="dropdown" onclick="keepOpen(this)" aria-label="$T('Glitter-more')" aria-haspopup="true">
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
+                    <span class="mobile-nav-label">$T('Glitter-more')</span>
                 </a>
                 <ul class="dropdown-menu menu-options">
                     <li><a href="#modal-help" data-toggle="modal"><span class="glyphicon glyphicon-question-sign"></span> $T('menu-help')</a></li>
-                    <li><a href="https://sabnzbd.org/donate" target="_blank"><span class="glyphicon glyphicon-heart"></span> $T('menu-donate')</a></li>
+                    <li><a href="https://sabnzbd.org/donate" target="_blank" rel="noopener noreferrer"><span class="glyphicon glyphicon-heart"></span> $T('menu-donate')</a></li>
+                    <li class="divider" role="separator"></li>
+                    <li class="sab-theme-menu" onclick="event.stopPropagation()">
+                        <div class="sab-theme-control sab-theme-control--menu">
+                            <label for="sab-theme-select-main"><span class="glyphicon glyphicon-adjust" aria-hidden="true"></span> $T('opt-web_dir')</label>
+                            <select id="sab-theme-select-main" data-sab-theme-select aria-label="$T('opt-web_dir')">
+                                <option value="light">Light</option>
+                                <option value="dark">Dark</option>
+                                <option value="oled">OLED</option>
+                            </select>
+                        </div>
+                    </li>
                     <!--#if $have_logout or $have_quota or $have_rss_defined or $have_watched_dir or $pp_pause_event#--><li class="divider"></li><!--#end if#-->
                     <!--#if $have_logout#--><li><a href="./login/?logout=1"><span class="glyphicon glyphicon-log-out"></span> $T('logout')</a></li><!--#end if#-->
                     <!--#if $have_quota#--><li><a href="#" data-bind="click: doQueueAction" data-mode="reset_quota">$T('link-resetQuota')</a></li><!--#end if#-->

--- a/interfaces/Glitter/templates/include_messages.tmpl
+++ b/interfaces/Glitter/templates/include_messages.tmpl
@@ -1,4 +1,4 @@
-<div id="queue-messages" class="queue-messages" data-bind="visible: hasMessages() || displayTabbed()" style="display: none;">
+<div id="queue-messages" class="queue-messages" role="tabpanel" aria-labelledby="messages-tab-label" data-bind="visible: hasMessages() || displayTabbed()" style="display: none;">
     <table class="table table-hover table-messages">
         <thead>
             <tr>
@@ -11,7 +11,7 @@
                 <tr>
                     <td class="table-messages-hide"></td>
                     <td data-bind="attr: { 'rowspan': parseInt(nrWarnings())+1 }, click: clearWarnings" class="table-messages-remove">
-                        <a href="#" class="hover-button"><span class="glyphicon glyphicon-remove"></span></a>
+                        <a href="#" class="hover-button" aria-label="$T('button-clear')"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
                     </td>
                 </tr>
                 <!-- ko foreach: allWarnings -->
@@ -32,7 +32,7 @@
                     </td>
                     <!-- ko if: \$data.hasOwnProperty("clear") -->
                     <td class="table-messages-remove">
-                        <a href="#" data-bind="click: clear"  class="hover-button"><span class="glyphicon glyphicon-remove"></span></a>
+                        <a href="#" data-bind="click: clear" class="hover-button" aria-label="$T('button-clear')"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></a>
                     </td>
                     <!-- /ko -->
                 </tr>

--- a/interfaces/Glitter/templates/include_overlays.tmpl
+++ b/interfaces/Glitter/templates/include_overlays.tmpl
@@ -65,9 +65,9 @@
     <div id="feedback-slider-inner">
         <p><strong>If anything is not working as expected, or could be improved, let us know!</strong></p>
         <p><strong>If you encounter an error, please include the log file (click on <span class="glyphicon glyphicon-wrench"></span> ) when contacting us.</strong></p>
-        <span class="glyphicon glyphicon-home"></span> <a href="https://forums.sabnzbd.org/viewforum.php?f=11" target="_blank">SABnzbd Forum</a><br />
-        <span class="glyphicon glyphicon-plane"></span> <a href="https://github.com/sabnzbd/sabnzbd/" target="_blank">SABnzbd on Github</a><br />
-        <span class="glyphicon glyphicon-globe"></span> <a href="https://sabnzbd.org/wiki/translate" target="_blank">Translations of SABnzbd</a><br />
+        <span class="glyphicon glyphicon-home"></span> <a href="https://forums.sabnzbd.org/viewforum.php?f=11" target="_blank" rel="noopener noreferrer">SABnzbd Forum</a><br />
+        <span class="glyphicon glyphicon-plane"></span> <a href="https://github.com/sabnzbd/sabnzbd/" target="_blank" rel="noopener noreferrer">SABnzbd on Github</a><br />
+        <span class="glyphicon glyphicon-globe"></span> <a href="https://sabnzbd.org/wiki/translate" target="_blank" rel="noopener noreferrer">Translations of SABnzbd</a><br />
     </div>
 </div>
 
@@ -77,7 +77,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal">&times;</button>
-                <a href="#" data-bind="click: loadStatusInfo, css: { 'rotate-refresh': !hasStatusInfo() }" title="$T('Glitter-interfaceRefresh')"><span class="glyphicon glyphicon-repeat"></span></a>
+                <a href="#" data-bind="click: loadStatusInfo, css: { 'rotate-refresh': !hasStatusInfo() }" title="$T('Glitter-interfaceRefresh')" aria-label="$T('Glitter-interfaceRefresh')"><span class="glyphicon glyphicon-repeat" aria-hidden="true"></span></a>
                 <h4 class="modal-title">$T('Glitter-statusInterfaceOptions')</h4>
             </div>
             <div class="modal-body">
@@ -138,7 +138,7 @@
                             <div class="col-sm-6">$T('dashboard-systemPerformance') &nbsp; </div>
                             <div class="col-sm-6 col-dot-overflow" data-bind="visible: hasPerformanceInfo">
                                 <span data-bind="text: statusInfo.pystone"></span>
-                                <a href="#" class="diskspeed-button" data-bind="click: loadStatusInfo" data-tooltip="true" data-placement="right" title="$T('dashboard-repeatTest') (~10 $T('seconds'))"><span class="glyphicon glyphicon-repeat"></span></a>
+                                <a href="#" class="diskspeed-button" data-bind="click: loadStatusInfo" data-tooltip="true" data-placement="right" title="$T('dashboard-repeatTest') (~10 $T('seconds'))" aria-label="$T('dashboard-repeatTest') (~10 $T('seconds'))"><span class="glyphicon glyphicon-repeat" aria-hidden="true"></span></a>
                                 <small title="$cpumodel $cpusimd" data-tooltip="true">$cpumodel $cpusimd</small>
                             </div>
                             <div class="col-sm-6 col-loading" data-bind="visible: !hasPerformanceInfo()">$T('Glitter-loading')<span class="loader-dot-one">.</span><span class="loader-dot-two">.</span><span class="loader-dot-three">.</span></div>
@@ -147,7 +147,7 @@
                             <div class="col-sm-6">$T('dashboard-downloadDirSpeed') &nbsp; </div>
                             <div class="col-sm-6 col-dot-overflow" data-bind="visible: hasPerformanceInfo">
                                 <span data-bind="text: statusInfo.downloaddirspeed()"></span> MB/s
-                                <a href="#" class="diskspeed-button" data-bind="click: loadStatusInfo" data-tooltip="true" data-placement="right" title="$T('dashboard-repeatTest') (~10 $T('seconds'))"><span class="glyphicon glyphicon-repeat"></span></a>
+                                <a href="#" class="diskspeed-button" data-bind="click: loadStatusInfo" data-tooltip="true" data-placement="right" title="$T('dashboard-repeatTest') (~10 $T('seconds'))" aria-label="$T('dashboard-repeatTest') (~10 $T('seconds'))"><span class="glyphicon glyphicon-repeat" aria-hidden="true"></span></a>
                                 <small data-bind="text: statusInfo.downloaddir, attr: { 'data-original-title': statusInfo.downloaddir }" data-tooltip="true"></small>
                             </div>
                             <div class="col-sm-6 col-loading" data-bind="visible: !hasPerformanceInfo()">$T('Glitter-loading')<span class="loader-dot-one">.</span><span class="loader-dot-two">.</span><span class="loader-dot-three">.</span></div>
@@ -156,7 +156,7 @@
                             <div class="col-sm-6">$T('dashboard-completeDirSpeed') &nbsp; </div>
                             <div class="col-sm-6 col-dot-overflow" data-bind="visible: hasPerformanceInfo">
                                 <span data-bind="text: statusInfo.completedirspeed()"></span> MB/s
-                                <a href="#" class="diskspeed-button" data-bind="click: loadStatusInfo" data-tooltip="true" data-placement="right" title="$T('dashboard-repeatTest') (~10 $T('seconds'))"><span class="glyphicon glyphicon-repeat"></span></a>
+                                <a href="#" class="diskspeed-button" data-bind="click: loadStatusInfo" data-tooltip="true" data-placement="right" title="$T('dashboard-repeatTest') (~10 $T('seconds'))" aria-label="$T('dashboard-repeatTest') (~10 $T('seconds'))"><span class="glyphicon glyphicon-repeat" aria-hidden="true"></span></a>
                                 <small data-bind="text: statusInfo.completedir, attr: { 'data-original-title': statusInfo.completedir }" data-tooltip="true"></small>
                             </div>
                             <div class="col-sm-6 col-loading" data-bind="visible: !hasPerformanceInfo()">$T('Glitter-loading')<span class="loader-dot-one">.</span><span class="loader-dot-two">.</span><span class="loader-dot-three">.</span></div>
@@ -165,7 +165,7 @@
                             <div class="col-sm-6">$T('dashboard-internetBandwidth') &nbsp; </div>
                             <div class="col-sm-6" data-bind="visible: hasPerformanceInfo">
                                 <span data-bind="text: statusInfo.internetbandwidth()"></span> MB/s
-                                <a href="#" class="diskspeed-button" data-bind="click: loadStatusInfo" data-tooltip="true" data-placement="right" title="$T('dashboard-repeatTest') (~10 $T('seconds'))"><span class="glyphicon glyphicon-repeat"></span></a>
+                                <a href="#" class="diskspeed-button" data-bind="click: loadStatusInfo" data-tooltip="true" data-placement="right" title="$T('dashboard-repeatTest') (~10 $T('seconds'))" aria-label="$T('dashboard-repeatTest') (~10 $T('seconds'))"><span class="glyphicon glyphicon-repeat" aria-hidden="true"></span></a>
                                 <small><span data-bind="text: statusInfo.internetbandwidth()*8"></span> Mbps</small>
                             </div>
                             <div class="col-sm-6 col-loading" data-bind="visible: !hasPerformanceInfo()">$T('Glitter-loading')<span class="loader-dot-one">.</span><span class="loader-dot-two">.</span><span class="loader-dot-three">.</span></div>
@@ -197,7 +197,7 @@
                         </div>
                         <div class="row options-function-box">
                             <div class="col-sm-6">
-                                <a href="./api?mode=showlog&apikey=$apikey" target="_blank" class="btn btn-default" data-tooltip="true" data-placement="top" title="$T('Glitter-logText')">
+                                <a href="./api?mode=showlog&apikey=$apikey" target="_blank" class="btn btn-default" data-tooltip="true" data-placement="top" title="$T('Glitter-logText')" rel="noopener noreferrer">
                                     <span class="glyphicon glyphicon-file"></span> $T('link-showLog')
                                 </a>
                             </div>
@@ -317,8 +317,8 @@
                                 <tr>
                                     <td><span class="glyphicon glyphicon-folder-open"></span></td>
                                     <td class="row-wrap-text"><strong data-bind="html: \$data"></strong></td>
-                                    <td><a href="#" data-bind="click: \$root.folderProcess" data-action="add_orphan" class="hover-button" data-tooltip="true" data-placement="left" title="$T('Glitter-backToQueue')"><span class="glyphicon glyphicon-plus-sign"></span></a></td>
-                                    <td><a href="#" data-bind="click: \$root.folderProcess" data-action="delete_orphan" class="hover-button" data-tooltip="true" data-placement="left" title="$T('Glitter-deleteJobAndFolders')"><span class="glyphicon glyphicon-trash"></span></a></td>
+                                    <td><a href="#" data-bind="click: \$root.folderProcess" data-action="add_orphan" class="hover-button" data-tooltip="true" data-placement="left" title="$T('Glitter-backToQueue')" aria-label="$T('Glitter-backToQueue')"><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span></a></td>
+                                    <td><a href="#" data-bind="click: \$root.folderProcess" data-action="delete_orphan" class="hover-button" data-tooltip="true" data-placement="left" title="$T('Glitter-deleteJobAndFolders')" aria-label="$T('Glitter-deleteJobAndFolders')"><span class="glyphicon glyphicon-trash" aria-hidden="true"></span></a></td>
                                 </tr>
                             </tbody>
                         </table>
@@ -618,8 +618,8 @@
                                                 <div class="fileDetails">
                                                     <span data-bind="truncatedTextCenter: filename"></span>
                                                     <div class="fileControls">
-                                                        <a href="#" data-bind="click: \$parent.filelist.moveButton" class="hover-button buttonMoveToTop" title="$T('Glitter-top')"><span class="glyphicon glyphicon-chevron-up"></span></a>
-                                                        <a href="#" data-bind="click: \$parent.filelist.moveButton" class="hover-button buttonMoveToBottom" title="$T('Glitter-bottom')"><span class="glyphicon glyphicon-chevron-down"></span></a>
+                                                        <a href="#" data-bind="click: \$parent.filelist.moveButton" class="hover-button buttonMoveToTop" title="$T('Glitter-top')" aria-label="$T('Glitter-top')"><span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span></a>
+                                                        <a href="#" data-bind="click: \$parent.filelist.moveButton" class="hover-button buttonMoveToBottom" title="$T('Glitter-bottom')" aria-label="$T('Glitter-bottom')"><span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span></a>
                                                     </div>
                                                     <small>(<span data-bind="text: file_age"></span> - <span data-bind="text: mb"></span> MB)</small>
                                                 </div>
@@ -767,24 +767,24 @@
                     <tbody>
                         <tr>
                             <td><strong>$T('menu-wiki'):</strong></td>
-                            <td><a href="https://sabnzbd.org/wiki/" target="_blank">https://sabnzbd.org/wiki/</a></td>
+                            <td><a href="https://sabnzbd.org/wiki/" target="_blank" rel="noopener noreferrer">https://sabnzbd.org/wiki/</a></td>
                         </tr>
                         <tr>
                             <td><strong>$T('menu-forums'):</strong></td>
-                            <td><a href="https://forums.sabnzbd.org/" target="_blank">https://forums.sabnzbd.org/</a></td>
+                            <td><a href="https://forums.sabnzbd.org/" target="_blank" rel="noopener noreferrer">https://forums.sabnzbd.org/</a></td>
                         </tr>
                         <tr>
                             <td><strong>GitHub:</strong></td>
-                            <td><a href="https://github.com/sabnzbd/sabnzbd" target="_blank">https://github.com/sabnzbd/sabnzbd/</a></td>
+                            <td><a href="https://github.com/sabnzbd/sabnzbd" target="_blank" rel="noopener noreferrer">https://github.com/sabnzbd/sabnzbd/</a></td>
                         </tr>
                         <tr>
                             <td><strong>$T('menu-live-chat'):</strong></td>
-                            <td><a href="https://sabnzbd.org/live-chat" target="_blank">https://sabnzbd.org/live-chat</a></td>
+                            <td><a href="https://sabnzbd.org/live-chat" target="_blank" rel="noopener noreferrer">https://sabnzbd.org/live-chat</a></td>
                         </tr>
                     </tbody>
                 </table>
                 <hr/>
-                <p><small>Copyright &copy; 2007-2026 by The SABnzbd-Team (<a href="https://sabnzbd.org/" target="_blank">sabnzbd.org</a>)<br/>$T('yourRights') </small></p>
+                <p><small>Copyright &copy; 2007-2026 by The SABnzbd-Team (<a href="https://sabnzbd.org/" target="_blank" rel="noopener noreferrer">sabnzbd.org</a>)<br/>$T('yourRights') </small></p>
             </div>
         </div>
     </div>

--- a/interfaces/Glitter/templates/include_queue.tmpl
+++ b/interfaces/Glitter/templates/include_queue.tmpl
@@ -1,4 +1,4 @@
-<div class="queue active" id="queue-tab">
+<div class="queue active" id="queue-tab" role="tabpanel" aria-labelledby="queue-tab-label">
     <h2>$T('menu-queue')</h2>
 
     <div class="info-container" data-bind="visible: diskSpaceLeft1()" style="display: none;">
@@ -34,16 +34,16 @@
         </div>
         <!-- /ko -->
         <div class="info-container-box-sorting" style="display: none" data-bind="visible: refreshRate() > 2">
-            <a href="#" data-bind="click: refresh">
-                <span class="glyphicon glyphicon-repeat" data-tooltip="true" data-placement="left" title="$T('Glitter-refresh')"></span>
+            <a href="#" data-bind="click: refresh" aria-label="$T('Glitter-refresh')">
+                <span class="glyphicon glyphicon-repeat" aria-hidden="true" data-tooltip="true" data-placement="left" title="$T('Glitter-refresh')"></span>
             </a>
         </div>
         <div class="info-container-box-sorting dropdown" data-bind="visible: hasQueue()">
-            <a href="#" data-toggle="dropdown">
-                <span class="glyphicon glyphicon-sort-by-alphabet" data-tooltip="true" data-placement="left" title="$T('cmenu-sorting')"></span>
+            <a href="#" data-toggle="dropdown" aria-label="$T('cmenu-sorting')" aria-haspopup="true">
+                <span class="glyphicon glyphicon-sort-by-alphabet" aria-hidden="true" data-tooltip="true" data-placement="left" title="$T('cmenu-sorting')"></span>
             </a>
-            <a href="#" data-bind="click: queue.showMultiEdit">
-                <span class="glyphicon glyphicon-tasks" data-tooltip="true" data-placement="left" title="$T('Glitter-multiOperations')"></span>
+            <a href="#" data-bind="click: queue.showMultiEdit" aria-label="$T('Glitter-multiOperations')">
+                <span class="glyphicon glyphicon-tasks" aria-hidden="true" data-tooltip="true" data-placement="left" title="$T('Glitter-multiOperations')"></span>
             </a>
             <ul class="dropdown-menu">
                 <li><a href="#" data-action="sortRemainingAsc" data-bind="click: queue.queueSorting">$T('Glitter-sortRemaining')</a></li>
@@ -108,10 +108,10 @@
                         <span class="glyphicon glyphicon-compressed"></span> <span data-bind="text: direct_unpack"></span>
                     </div>
                     <div class="name-options" data-bind="visible: !editingName(), css: { disabled: isGrabbing() }">
-                        <a href="#" data-bind="click: \$parent.queue.moveButton" class="hover-button buttonMoveToTop" title="$T('Glitter-top')"><span class="glyphicon glyphicon-chevron-up"></span></a>
-                        <a href="#" data-bind="click: \$parent.queue.moveButton" class="hover-button buttonMoveToBottom" title="$T('Glitter-bottom')"><span class="glyphicon glyphicon-chevron-down"></span></a>
-                        <a href="#" data-bind="click: editName" class="hover-button" title="$T('Glitter-rename')"><span class="glyphicon glyphicon-pencil"></span></a>
-                        <a href="#" data-bind="click: showFiles" class="hover-button" title="$T('nzoDetails') - $T('srv-password')"><span class="glyphicon glyphicon-folder-open"></span></a>
+                        <a href="#" data-bind="click: \$parent.queue.moveButton" class="hover-button buttonMoveToTop" title="$T('Glitter-top')" aria-label="$T('Glitter-top')"><span class="glyphicon glyphicon-chevron-up" aria-hidden="true"></span></a>
+                        <a href="#" data-bind="click: \$parent.queue.moveButton" class="hover-button buttonMoveToBottom" title="$T('Glitter-bottom')" aria-label="$T('Glitter-bottom')"><span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span></a>
+                        <a href="#" data-bind="click: editName" class="hover-button" title="$T('Glitter-rename')" aria-label="$T('Glitter-rename')"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span></a>
+                        <a href="#" data-bind="click: showFiles" class="hover-button" title="$T('nzoDetails') - $T('srv-password')" aria-label="$T('nzoDetails') - $T('srv-password')"><span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span></a>
                         <small data-bind="text: avg_age"></small>
                     </div>
                 </td>
@@ -163,7 +163,7 @@
                         <!-- /ko -->
                     </div>
                     <!-- /ko -->
-                    <a href="#" class="hover-button" title="$T('removeNZB-Files')" data-bind="click: parent.triggerRemoveDownload"><span class="glyphicon glyphicon-trash"></span></a>
+                    <a href="#" class="hover-button" title="$T('removeNZB-Files')" aria-label="$T('removeNZB-Files')" data-bind="click: parent.triggerRemoveDownload"><span class="glyphicon glyphicon-trash" aria-hidden="true"></span></a>
                 </td>
             </tr>
         </tbody>
@@ -217,8 +217,8 @@
 
     <div class="input-group search-box" data-bind="visible: queue.hasQueueSearch" style="display: none;">
         <input type="text" class="form-control" placeholder="$T('Glitter-search')" required data-bind="textInput: queue.searchTerm, event: { keydown: queue.clearSearchTerm }" />
-        <a data-bind="event: { mousedown: queue.clearSearchTerm }">
-            <span class="glyphicon" data-bind="css: { 'glyphicon-search' : !queue.searchTerm(), 'glyphicon-remove' : queue.searchTerm() }"></span>
+        <a data-bind="event: { mousedown: queue.clearSearchTerm }, attr: { 'aria-label': queue.searchTerm() ? '$T('button-clear')' : '$T('Glitter-search')' }">
+            <span class="glyphicon" aria-hidden="true" data-bind="css: { 'glyphicon-search' : !queue.searchTerm(), 'glyphicon-remove' : queue.searchTerm() }"></span>
         </a>
     </div>
 

--- a/interfaces/Glitter/templates/main.tmpl
+++ b/interfaces/Glitter/templates/main.tmpl
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--#set $active_lang=$active_lang.replace('_', '-').lower()#-->
-<html lang="$active_lang" <!--#if $rtl#-->dir="rtl"<!--#end if#--> id="sabnzbd" data-bind="filedrop: { overlaySelector: '.main-filedrop', onFileDrop: addNZBFromFile }">
+<html lang="$active_lang" <!--#if $rtl#-->dir="rtl"<!--#end if#--> id="sabnzbd" data-server-theme="$color_scheme" data-bind="filedrop: { overlaySelector: '.main-filedrop', onFileDrop: addNZBFromFile }">
     <head>
         <!--
                 Glitter V2
@@ -16,14 +16,38 @@
         <title data-bind="text: title">SABnzbd</title>
 
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, maximum-scale=1" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="application-name" content="SABnzbd">
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-title" content="SABnzbd" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black" />
         <meta name="msapplication-navbutton-color" content="#000000" />
-        <meta name="theme-color" content="#000000" />
+        <meta name="theme-color" content="#e7e9ec" />
+
+        <script type="text/javascript">
+            (function(document, window) {
+                var root = document.documentElement;
+                var storageKey = 'sabnzbd-ui-theme-v1';
+                var serverTheme = (root.getAttribute('data-server-theme') || 'Auto').toLowerCase();
+                var selected = '';
+                try { selected = window.localStorage.getItem(storageKey) || ''; } catch (error) { selected = ''; }
+                var explicit = selected === 'light' || selected === 'dark' || selected === 'oled';
+                var followsSystem = !explicit && serverTheme !== 'oled' && serverTheme !== 'night' && serverTheme !== 'dark' && serverTheme !== 'light';
+                if (!explicit) {
+                    if (serverTheme === 'oled') selected = 'oled';
+                    else if (serverTheme === 'night' || serverTheme === 'dark') selected = 'dark';
+                    else if (serverTheme === 'light') selected = 'light';
+                    else selected = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+                }
+                root.setAttribute('data-sab-theme', selected);
+                root.setAttribute('data-sab-theme-explicit', explicit ? 'true' : 'false');
+                root.setAttribute('data-sab-theme-follows-system', followsSystem ? 'true' : 'false');
+                root.style.colorScheme = selected === 'light' ? 'light' : 'dark';
+                var themeColor = document.querySelector('meta[name="theme-color"]');
+                if (themeColor) themeColor.setAttribute('content', selected === 'oled' ? '#000000' : selected === 'dark' ? '#1d2024' : '#e7e9ec');
+            }(document, window));
+        </script>
 
         <link rel="apple-touch-icon" sizes="76x76" href="./staticcfg/ico/apple-touch-icon-76x76-precomposed.png" />
         <link rel="apple-touch-icon" sizes="120x120" href="./staticcfg/ico/apple-touch-icon-120x120-precomposed.png" />
@@ -36,9 +60,14 @@
         <link rel="stylesheet" type="text/css" href="./static/bootstrap/css/bootstrap.min.css?v=$version" />
         <link rel="stylesheet" type="text/css" href="./static/stylesheets/glitter.css?v=$version" />
         <link rel="stylesheet" type="text/css" href="./static/stylesheets/glitter.mobile.css?v=$version" media="all and (max-width: 768px)" />
+        <noscript>
         <!--#if $color_scheme not in ('Light', '') #-->
         <link rel="stylesheet" type="text/css" href="./static/stylesheets/colorschemes/${color_scheme}.css?v=$version"/>
         <!--#end if#-->
+        </noscript>
+        <link rel="stylesheet" type="text/css" href="./staticcfg/css/theme.css?v=$version" />
+        <link rel="stylesheet" type="text/css" href="./static/stylesheets/glitter.modern.css?v=$version" />
+        <script type="text/javascript" defer src="./staticcfg/js/theme.js?v=$version"></script>
 
         <!-- Make translations available in scripts -->
         <script type="text/javascript">
@@ -141,15 +170,15 @@
 
         <div class="container main-content">
             <div class="history-queue-swicher">
-                <ul class="nav nav-tabs">
-                    <li class="active">
-                        <a href="#queue-tab" data-toggle="tab">$T('menu-queue') <span class="badge" data-bind="text: queue.totalItems"></span></a>
+                <ul class="nav nav-tabs" role="tablist" aria-label="Download views">
+                    <li class="active" role="presentation">
+                        <a id="queue-tab-label" href="#queue-tab" data-toggle="tab" role="tab" aria-controls="queue-tab" aria-selected="true">$T('menu-queue') <span class="badge" data-bind="text: queue.totalItems"></span></a>
                     </li>
-                    <li>
-                        <a href="#history-tab" data-toggle="tab">$T('menu-history') <span class="badge badge-info" data-bind="text: history.ppItems, visible: history.ppItems"></span><span class="badge" data-bind="text: history.totalItems"></span></a>
+                    <li role="presentation">
+                        <a id="history-tab-label" href="#history-tab" data-toggle="tab" role="tab" aria-controls="history-tab" aria-selected="false">$T('menu-history') <span class="badge badge-info" data-bind="text: history.ppItems, visible: history.ppItems"></span><span class="badge" data-bind="text: history.totalItems"></span></a>
                     </li>
-                    <li>
-                        <a href="#queue-messages" data-toggle="tab">$T('warnings') <span class="badge" data-bind="text: hasMessages, css: { 'badge-warning':  hasMessages() }"></span></a>
+                    <li role="presentation">
+                        <a id="messages-tab-label" href="#queue-messages" data-toggle="tab" role="tab" aria-controls="queue-messages" aria-selected="false">$T('warnings') <span class="badge" data-bind="text: hasMessages, css: { 'badge-warning':  hasMessages() }"></span></a>
                     </li>
                 </ul>
             </div>

--- a/interfaces/Glitter/templates/static/javascripts/glitter.basic.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.basic.js
@@ -8,20 +8,7 @@ var hasLocalStorage = true;
 function localStorageSetItem(varToSet, valueToSet) { try { return localStorage.setItem(varToSet, valueToSet); } catch(e) { hasLocalStorage = false; } }
 function localStorageGetItem(varToGet) { try { return localStorage.getItem(varToGet); } catch(e) {  hasLocalStorage = false; } }
 
-// For mobile we disable zoom while a modal is being opened
-// so it will not zoom unnecessarily on the modal
-if(isMobile) {
-    $('.modal').on('show.bs.modal', function() {
-        $('meta[name="viewport"]').attr('content', 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no');
-    });
-
-    // Restore on modal-close. Need timeout, otherwise it doesn't work
-    $('.modal').on('hidden.bs.modal', function() {
-        setTimeout(function() {
-            $('meta[name="viewport"]').attr('content', 'width=device-width, initial-scale=1');
-        },500);
-    });
-}
+// Keep browser zoom available on mobile. Responsive modal sizing is handled in CSS.
 
 // Basic API-call
 function callAPI(data, timeout = 10000) {

--- a/interfaces/Glitter/templates/static/stylesheets/colorschemes/OLED.css
+++ b/interfaces/Glitter/templates/static/stylesheets/colorschemes/OLED.css
@@ -1,0 +1,9 @@
+/* OLED color scheme fallback for no-JavaScript clients. */
+html, body { background: #000000; color: #f8f8f8; color-scheme: dark; }
+.container { background: transparent; }
+.main-content { background: #000000; color: #f8f8f8; border-color: #303030; }
+.navbar-inverse, .modal-header { background: #050505; border-color: #303030; }
+.dropdown-menu, .modal-content, .main-notification-box { background: #0b0b0b; color: #f8f8f8; border-color: #303030; }
+.dropdown-menu > li > a, .nav-tabs > li > a { color: #f8f8f8 !important; }
+.table-striped > tbody > tr:nth-of-type(odd), .dropdown-menu > li > a:hover { background: #101010; }
+.form-control, select, input, textarea { background: #080808; color: #f8f8f8; border-color: #555555; }

--- a/interfaces/Glitter/templates/static/stylesheets/glitter.modern.css
+++ b/interfaces/Glitter/templates/static/stylesheets/glitter.modern.css
@@ -1,0 +1,465 @@
+/* Responsive and semantic-theme layer for Glitter. */
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body { min-width: 0; min-height: 100%; }
+body { margin: 0; overflow-x: hidden;
+    overflow-x: clip; }
+
+html[data-sab-theme] .container { background: transparent; }
+html[data-sab-theme] .navbar-inverse,
+html[data-sab-theme] .navbar-inverse .navbar-collapse,
+html[data-sab-theme] .navbar-inverse .navbar-form { background-color: var(--sab-nav); border-color: var(--sab-border); }
+html[data-sab-theme] .navbar-inverse .navbar-nav > li > a,
+html[data-sab-theme] .navbar-inverse .navbar-nav > li > a:visited { color: var(--sab-nav-text) !important; }
+html[data-sab-theme] .navbar-inverse .navbar-toggle { border-color: rgba(255,255,255,.5); }
+html[data-sab-theme] .navbar-inverse .navbar-toggle:hover,
+html[data-sab-theme] .navbar-inverse .navbar-toggle:focus { background: rgba(255,255,255,.13); }
+
+html[data-sab-theme] .main-content,
+html[data-sab-theme] .modal-content,
+html[data-sab-theme] .main-notification-box {
+    background-color: var(--sab-surface);
+    color: var(--sab-text);
+    border-color: var(--sab-border);
+}
+
+html[data-sab-theme] .modal-header { background-color: var(--sab-nav); color: var(--sab-nav-text); }
+html[data-sab-theme] .modal-body,
+html[data-sab-theme] .modal-footer { background-color: var(--sab-surface); border-color: var(--sab-border); }
+html[data-sab-theme] .modal-backdrop { background-color: #000000; }
+html[data-sab-theme] .modal-backdrop.in { opacity: .72; }
+
+html[data-sab-theme] .dropdown-menu,
+html[data-sab-theme] .navbar-collapse.in .dropdown-menu {
+    background-color: var(--sab-surface-raised);
+    color: var(--sab-text);
+    border-color: var(--sab-border);
+    box-shadow: var(--sab-shadow);
+}
+html[data-sab-theme] .dropdown-menu > li > a,
+html[data-sab-theme] .navbar-collapse.in .dropdown-menu a { color: var(--sab-text) !important; }
+html[data-sab-theme] .dropdown-menu > li > a:hover,
+html[data-sab-theme] .dropdown-menu > li > a:focus { background-color: var(--sab-hover); color: var(--sab-text) !important; }
+html[data-sab-theme] .dropdown-menu .divider { background-color: var(--sab-border); }
+html[data-sab-theme] .dropdown-header { color: var(--sab-text-muted); }
+
+html[data-sab-theme] .table > thead > tr > th,
+html[data-sab-theme] .table > tbody > tr > th,
+html[data-sab-theme] .table > tfoot > tr > th,
+html[data-sab-theme] .table > thead > tr > td,
+html[data-sab-theme] .table > tbody > tr > td,
+html[data-sab-theme] .table > tfoot > tr > td { border-color: var(--sab-border); color: var(--sab-text); }
+html[data-sab-theme] .table-striped > tbody > tr:nth-of-type(odd) { background-color: var(--sab-surface-muted); }
+html[data-sab-theme] .table-hover > tbody > tr:hover { background-color: var(--sab-hover); }
+
+html[data-sab-theme] .nav-tabs { border-color: var(--sab-border); }
+html[data-sab-theme] .nav-tabs > li > a { color: var(--sab-text) !important; }
+html[data-sab-theme] .nav-tabs > li > a:hover { background-color: var(--sab-hover); border-color: var(--sab-border); }
+html[data-sab-theme] .nav-tabs > li.active > a,
+html[data-sab-theme] .nav-tabs > li.active > a:hover,
+html[data-sab-theme] .nav-tabs > li.active > a:focus { background-color: var(--sab-surface); color: var(--sab-text) !important; border-color: var(--sab-border); }
+
+html[data-sab-theme] .form-control,
+html[data-sab-theme] .input-group-addon,
+html[data-sab-theme] select,
+html[data-sab-theme] textarea,
+html[data-sab-theme] input[type="text"],
+html[data-sab-theme] input[type="number"],
+html[data-sab-theme] input[type="password"],
+html[data-sab-theme] input[type="search"],
+html[data-sab-theme] input[type="url"] {
+    background-color: var(--sab-input);
+    color: var(--sab-text);
+    border-color: var(--sab-border-strong);
+}
+html[data-sab-theme] .form-control::placeholder { color: var(--sab-text-muted); opacity: 1; }
+html[data-sab-theme] .btn-default { background-color: var(--sab-surface-raised); color: var(--sab-text); border-color: var(--sab-border-strong); }
+html[data-sab-theme] .btn-default:hover,
+html[data-sab-theme] .btn-default:focus { background-color: var(--sab-hover); color: var(--sab-text); }
+html[data-sab-theme] .progress { background-color: var(--sab-surface-muted); }
+html[data-sab-theme] hr,
+html[data-sab-theme] legend { border-color: var(--sab-border); color: var(--sab-text); }
+html[data-sab-theme] .pagination > li > a,
+html[data-sab-theme] .pagination > li > span { background: var(--sab-surface-raised); color: var(--sab-text); border-color: var(--sab-border); }
+html[data-sab-theme] .pagination > .active > a,
+html[data-sab-theme] .pagination > .active > span { background: var(--sab-selected); color: var(--sab-text); border-color: var(--sab-border-strong); }
+html[data-sab-theme] .queue-error-info,
+html[data-sab-theme] .text-danger { color: var(--sab-danger) !important; }
+
+.main-navbar,
+.main-content { width: min(calc(100% - 24px), 1400px); }
+.container-full-width .main-navbar,
+.container-full-width .main-content { width: calc(100% - 24px); max-width: none; }
+.main-navbar { position: relative; }
+.main-content { box-shadow: 0 1px 2px rgba(0,0,0,.08); }
+.navbar-logo { min-width: 44px; min-height: 44px; display: inline-flex; align-items: center; justify-content: center; }
+.navbar-nav > li > a,
+.navbar-toggle,
+.main-navbar .navbar-btn { min-height: 44px; }
+.navbar-nav > li > a { display: flex; align-items: center; justify-content: center; }
+.main-menu-link > a { min-width: 44px; }
+
+@media (min-width: 768px) {
+    .main-menu-link > a { flex-direction: column; }
+}
+
+.history-queue-swicher { max-width: 100%; }
+.history-queue-swicher .nav-tabs { display: flex; flex-wrap: nowrap; }
+.history-queue-swicher .nav-tabs > li { flex: 0 0 auto; }
+.history-queue-swicher .nav-tabs > li > a { min-height: 44px; display: flex; align-items: center; }
+.queue, .history, .queue-messages, .tab-content { min-width: 0; }
+.row-wrap-text { min-width: 0; }
+.info-container { max-width: 100%; }
+.info-container-box { margin-bottom: 4px; }
+
+.dropdown-menu { max-width: min(360px, calc(100vw - 24px)); max-height: min(72dvh, 620px); overflow-y: auto; overscroll-behavior: contain; }
+.menu-options { min-width: min(260px, calc(100vw - 24px)); }
+.sab-theme-menu { list-style: none; }
+.sab-theme-menu .sab-theme-control { color: var(--sab-text); }
+
+.modal { padding-left: 0 !important; padding-right: 0 !important; }
+.modal-dialog { max-width: calc(100vw - 24px); }
+.modal-content { max-height: calc(100dvh - 24px); display: flex; flex-direction: column; }
+.modal-body { overflow: auto; overscroll-behavior: contain; }
+.modal-header .close { min-width: 44px; min-height: 44px; margin-top: -11px; margin-right: -10px; }
+
+@media (max-width: 767px) {
+    body { padding-bottom: env(safe-area-inset-bottom); }
+    .container,
+    .main-navbar,
+    .main-content,
+    .container-full-width .main-navbar,
+    .container-full-width .main-content {
+        width: 100%;
+        max-width: none;
+        margin-left: 0;
+        margin-right: 0;
+        padding-left: max(8px, env(safe-area-inset-left));
+        padding-right: max(8px, env(safe-area-inset-right));
+    }
+    .main-navbar { padding-left: 0; padding-right: 0; position: sticky; top: 0; z-index: 1030; }
+    .main-content { padding-top: 8px; min-height: calc(100dvh - 52px); }
+    .navbar { margin-bottom: 0; }
+    .navbar-header { display: flex; align-items: center; min-width: 0; }
+    .navbar-toggle { order: 4; margin: 4px 7px 4px auto; min-width: 44px; padding: 13px 12px; }
+    .navbar-logo { flex: 0 0 48px; margin: 2px 4px; }
+    .navbar-logo svg { width: 38px; height: 38px; }
+    .navbar-header > .btn-group { flex: 1 1 auto; min-width: 0; }
+    .navbar-header > .btn-group > .btn-group { display: flex; max-width: 190px; }
+    .navbar-header .navbar-btn { margin-top: 4px; margin-bottom: 4px; }
+    .navbar-timeleft { min-width: 62px; flex: 1 1 70px; overflow: hidden; text-overflow: ellipsis; }
+    .navbar-collapse.in,
+    .navbar-collapse.collapsing { max-height: calc(100dvh - 54px); overflow-y: auto; overflow-x: hidden; padding-bottom: max(12px, env(safe-area-inset-bottom)); }
+    .navbar-collapse ul { float: none; width: 100%; }
+    .navbar-nav { margin: 0; }
+    .navbar-nav > li { width: 100%; margin-right: 0; }
+    .navbar-nav > li > a { justify-content: flex-start; padding: 12px 15px; }
+    .speedlimit-dropdown .btn-group { width: 100%; }
+    .speedlimit-dropdown .btn-group > .btn-group { display: flex; padding: 4px 8px; }
+    .navbar-speed { flex: 1 1 auto; min-width: 0; }
+    .navbar-collapse.in .dropdown-menu,
+    .navbar-collapse.collapsing .dropdown-menu,
+    .navbar-nav .open .dropdown-menu {
+        position: static;
+        float: none;
+        width: 100%;
+        max-width: none;
+        margin: 0;
+        border-width: 1px 0;
+        box-shadow: none;
+    }
+    .max-speed-input { width: 100% !important; margin: 0 !important; }
+    .main-menu-link > a .icon-bar { margin-left: 2px; }
+    .menu-options { width: 100%; }
+
+    .history-queue-swicher { float: none; overflow-x: auto; overscroll-behavior-inline: contain; scrollbar-width: thin; margin-top: 0 !important; }
+    .history-queue-swicher .nav-tabs { width: max-content; min-width: 100%; }
+    .history-queue-swicher .nav-tabs > li > a { padding: 10px 12px; white-space: nowrap; }
+    .queue h2, .history h2 { font-size: 23px; }
+    .info-container { display: flex; flex-wrap: wrap; gap: 4px 12px; line-height: 1.5; padding: 4px 0; }
+    .info-container-box { float: none; }
+    .info-container .info-container-box-sorting { top: 4px; right: 8px; }
+
+    .queue-table,
+    .history-table { table-layout: fixed; width: 100%; }
+    .queue-table td.name,
+    .history-table td.name { overflow: hidden; }
+    .queue-table .timeleft { width: 74px; }
+    .queue-table .delete,
+    .history-table .delete { width: 50px; }
+    .queue-table td.name .row-wrap-text,
+    .queue-table td.name:hover .row-wrap-text { max-width: calc(100vw - 190px); }
+    .row-extra-text { display: none; }
+    .queue-item-settings { width: min(300px, calc(100vw - 24px)); }
+    .queue-item-settings li { display: grid; grid-template-columns: 24px 1fr; align-items: center; gap: 6px; padding: 4px 8px; }
+    .queue-item-settings select { width: 100%; min-height: 44px; }
+
+    .multioperations-selector { min-width: 0 !important; display: flex; flex-wrap: wrap; gap: 6px; }
+    .multioperations-selector .add-nzb-inputbox,
+    .multioperations-selector .add-nzb-inputbox-small,
+    .multioperations-selector .add-nzb-inputbox-options { width: calc(50% - 3px); min-width: 0; margin: 0; }
+    .multioperations-selector .add-nzb-inputbox-clear { display: none; }
+    .multioperations-selector .form-control { width: 100%; }
+    .search-box { width: 100%; }
+    .search-box input,
+    .search-box input:focus,
+    .search-box input:valid { width: 100% !important; min-height: 44px; padding-right: 44px; font-size: 16px; }
+    .search-box a { top: 0; right: 0; min-width: 44px; min-height: 44px; padding: 0; display: flex; align-items: center; justify-content: center; }
+    .pagination { display: flex; max-width: 100%; overflow-x: auto; padding-bottom: 3px; }
+    .pagination > li > a,
+    .pagination > li > span { min-width: 44px; min-height: 44px; display: grid; place-items: center; }
+
+    .form-control,
+    input,
+    select,
+    textarea { font-size: 16px; }
+    .btn { min-height: 44px; }
+    .modal-dialog { width: auto !important; margin: max(6px, env(safe-area-inset-top)) 6px max(6px, env(safe-area-inset-bottom)); padding: 0; }
+    .modal-content { max-height: calc(100dvh - max(12px, env(safe-area-inset-top) + env(safe-area-inset-bottom))); }
+    .modal-footer { display: flex; flex-wrap: wrap; gap: 6px; }
+    .modal-footer .btn { flex: 1 1 130px; margin: 0; }
+}
+
+@media (max-width: 359px) {
+    .navbar-timeleft { display: none; }
+    .navbar-header > .btn-group > .btn-group { max-width: 100px; }
+    .history-queue-swicher .nav-tabs > li > a { padding-left: 9px; padding-right: 9px; }
+    .queue-table .timeleft { width: 64px; }
+    .queue-table td.name .row-wrap-text,
+    .queue-table td.name:hover .row-wrap-text { max-width: calc(100vw - 160px); }
+}
+
+@media (max-height: 500px) and (orientation: landscape) {
+    .main-navbar { position: relative; }
+    .navbar-collapse.in { max-height: calc(100dvh - 48px); }
+    .modal-dialog { margin-top: 4px !important; margin-bottom: 4px !important; }
+    .modal-content { max-height: calc(100dvh - 8px); }
+}
+
+/* Theme contrast and mobile navigation refinements. */
+.mobile-nav-label {
+    display: none;
+}
+
+html[data-sab-theme="dark"] .table > thead > tr > th,
+html[data-sab-theme="oled"] .table > thead > tr > th {
+    background: var(--sab-surface-strong) !important;
+    color: var(--sab-text) !important;
+    border-bottom-color: var(--sab-border-strong) !important;
+}
+
+html[data-sab-theme="dark"] .table-hover > tbody > tr:hover > td,
+html[data-sab-theme="dark"] .table-hover > tbody > tr:hover > th,
+html[data-sab-theme="oled"] .table-hover > tbody > tr:hover > td,
+html[data-sab-theme="oled"] .table-hover > tbody > tr:hover > th {
+    background: var(--sab-surface-strong) !important;
+    color: var(--sab-text) !important;
+}
+
+html[data-sab-theme="dark"] .queue-table tbody > tr > td,
+html[data-sab-theme="oled"] .queue-table tbody > tr > td,
+html[data-sab-theme="dark"] .history-table tbody > tr > td,
+html[data-sab-theme="oled"] .history-table tbody > tr > td {
+    color: var(--sab-text);
+    border-color: var(--sab-border) !important;
+}
+
+html[data-sab-theme="dark"] .queue-table > tbody > tr:nth-child(odd) > td,
+html[data-sab-theme="dark"] .history-table > tbody > tr:nth-child(odd) > td,
+html[data-sab-theme="oled"] .queue-table > tbody > tr:nth-child(odd) > td,
+html[data-sab-theme="oled"] .history-table > tbody > tr:nth-child(odd) > td {
+    background-color: var(--sab-surface-muted) !important;
+}
+
+html[data-sab-theme="dark"] .queue-table > tbody > tr:nth-child(even) > td,
+html[data-sab-theme="dark"] .history-table > tbody > tr:nth-child(even) > td,
+html[data-sab-theme="oled"] .queue-table > tbody > tr:nth-child(even) > td,
+html[data-sab-theme="oled"] .history-table > tbody > tr:nth-child(even) > td {
+    background-color: var(--sab-surface) !important;
+}
+
+html[data-sab-theme="dark"] .table-hover > tbody > tr:hover > td,
+html[data-sab-theme="oled"] .table-hover > tbody > tr:hover > td {
+    background-color: var(--sab-surface-strong) !important;
+}
+
+html[data-sab-theme="dark"] .queue-table small,
+html[data-sab-theme="oled"] .queue-table small,
+html[data-sab-theme="dark"] .history-table small,
+html[data-sab-theme="oled"] .history-table small,
+html[data-sab-theme="dark"] .text-muted,
+html[data-sab-theme="oled"] .text-muted {
+    color: var(--sab-text-muted) !important;
+}
+
+html[data-sab-theme="dark"] .progress,
+html[data-sab-theme="oled"] .progress {
+    background: var(--sab-surface-strong);
+    border: 1px solid var(--sab-border);
+    box-shadow: none;
+}
+
+html[data-sab-theme="dark"] .progress > span,
+html[data-sab-theme="oled"] .progress > span,
+html[data-sab-theme="dark"] .progress .progress-bar .fileDetails,
+html[data-sab-theme="oled"] .progress .progress-bar .fileDetails {
+    color: var(--sab-text) !important;
+}
+
+html[data-sab-theme="dark"] .progress-bar strong,
+html[data-sab-theme="dark"] .progress-bar i,
+html[data-sab-theme="oled"] .progress-bar strong,
+html[data-sab-theme="oled"] .progress-bar i {
+    color: #071015 !important;
+}
+
+html[data-sab-theme="dark"] tbody.no-downloads tr td,
+html[data-sab-theme="oled"] tbody.no-downloads tr td {
+    border-bottom-color: var(--sab-border) !important;
+}
+
+@media (max-width: 767px) {
+    .main-navbar > .navbar {
+        position: relative;
+    }
+
+    .main-navbar .navbar-collapse.in,
+    .main-navbar .navbar-collapse.collapsing {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+        z-index: 1050;
+        max-height: calc(100dvh - 56px) !important;
+        overflow-y: auto !important;
+        overflow-x: hidden;
+        overscroll-behavior: contain;
+        -webkit-overflow-scrolling: touch;
+        background: var(--sab-nav-bg);
+        border: 1px solid var(--sab-nav-border);
+        border-top: 0;
+        border-radius: 0 0 var(--sab-radius-lg) var(--sab-radius-lg);
+        box-shadow: var(--sab-shadow-lg);
+    }
+
+    .main-navbar .navbar-nav {
+        margin: 0;
+        padding: 6px 0 max(10px, env(safe-area-inset-bottom));
+    }
+
+    .main-navbar .navbar-nav > li > a,
+    .main-navbar .navbar-nav > li.main-menu-link > a {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        min-height: 48px;
+        padding: 10px 16px;
+        color: var(--sab-nav-text);
+        text-align: left;
+    }
+
+    .main-navbar .navbar-nav > li > a > .glyphicon,
+    .main-navbar .navbar-nav > li > a > .rss-icon-svg,
+    .main-navbar .navbar-nav > li.main-menu-link > a > .icon-bar:first-child {
+        flex: 0 0 20px;
+        width: 20px;
+        margin: 0;
+        text-align: center;
+    }
+
+    .main-navbar .navbar-nav > li.main-menu-link > a > .icon-bar:nth-child(2),
+    .main-navbar .navbar-nav > li.main-menu-link > a > .icon-bar:nth-child(3) {
+        display: none;
+    }
+
+    .main-navbar .navbar-nav > li.main-menu-link > a > .icon-bar:first-child {
+        position: relative;
+        height: 14px;
+        border-top: 2px solid currentColor;
+        border-bottom: 2px solid currentColor;
+        background: transparent;
+    }
+
+    .main-navbar .navbar-nav > li.main-menu-link > a > .icon-bar:first-child::after {
+        position: absolute;
+        top: 4px;
+        left: 0;
+        width: 20px;
+        border-top: 2px solid currentColor;
+        content: "";
+    }
+
+    .mobile-nav-label {
+        display: inline;
+        color: inherit;
+        font-size: 15px;
+        font-weight: 600;
+        line-height: 1.3;
+        white-space: normal;
+    }
+
+    .sparkline-container {
+        display: none !important;
+    }
+
+    .speedlimit-dropdown {
+        padding: 6px 12px 8px;
+    }
+
+    .speedlimit-dropdown > .btn-group,
+    .speedlimit-dropdown > .btn-group > .btn-group {
+        display: flex;
+        width: 100%;
+    }
+
+    .speedlimit-dropdown .navbar-speed {
+        flex: 1 1 auto;
+        text-align: left;
+    }
+
+    .speedlimit-dropdown .dropdown-toggle {
+        flex: 0 0 48px;
+    }
+
+    .main-menu-link.open > .dropdown-menu.menu-options {
+        position: static;
+        float: none;
+        width: auto;
+        max-width: none;
+        max-height: none;
+        margin: 0 10px 8px;
+        overflow: visible;
+        border: 1px solid var(--sab-border);
+        border-radius: var(--sab-radius-md);
+        box-shadow: none;
+    }
+
+    .main-menu-link.open > .dropdown-menu.menu-options > li > a {
+        min-height: 44px;
+        padding: 11px 14px;
+    }
+
+    .pagination {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+        margin: 8px 0 0;
+    }
+
+    .pagination > li > a,
+    .pagination > li > span {
+        min-width: 40px;
+        min-height: 40px;
+        margin: 0;
+        padding: 9px 12px;
+        border-radius: var(--sab-radius-sm) !important;
+        text-align: center;
+    }
+}
+
+@media (max-width: 767px) and (orientation: landscape) {
+    .main-navbar .navbar-collapse.in,
+    .main-navbar .navbar-collapse.collapsing {
+        max-height: calc(100dvh - 48px) !important;
+    }
+}

--- a/interfaces/wizard/inc_top.tmpl
+++ b/interfaces/wizard/inc_top.tmpl
@@ -1,18 +1,57 @@
 <!DOCTYPE html>
-<html lang="$active_lang">
+<html lang="$active_lang" data-server-theme="$color_scheme">
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+        <meta name="theme-color" content="#e7e9ec" />
+
+        <script type="text/javascript">
+            (function(document, window) {
+                var root = document.documentElement;
+                var storageKey = 'sabnzbd-ui-theme-v1';
+                var serverTheme = (root.getAttribute('data-server-theme') || 'Auto').toLowerCase();
+                var selected = '';
+                try { selected = window.localStorage.getItem(storageKey) || ''; } catch (error) { selected = ''; }
+                var explicit = selected === 'light' || selected === 'dark' || selected === 'oled';
+                var followsSystem = !explicit && serverTheme !== 'oled' && serverTheme !== 'night' && serverTheme !== 'dark' && serverTheme !== 'light';
+                if (!explicit) {
+                    if (serverTheme === 'oled') selected = 'oled';
+                    else if (serverTheme === 'night' || serverTheme === 'dark') selected = 'dark';
+                    else if (serverTheme === 'light') selected = 'light';
+                    else selected = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+                }
+                root.setAttribute('data-sab-theme', selected);
+                root.setAttribute('data-sab-theme-explicit', explicit ? 'true' : 'false');
+                root.setAttribute('data-sab-theme-follows-system', followsSystem ? 'true' : 'false');
+                root.style.colorScheme = selected === 'light' ? 'light' : 'dark';
+                var themeColor = document.querySelector('meta[name="theme-color"]');
+                if (themeColor) themeColor.setAttribute('content', selected === 'oled' ? '#000000' : selected === 'dark' ? '#1d2024' : '#e7e9ec');
+            }(document, window));
+        </script>
         <title>$T('wizard-quickstart')</title>
         <link rel="stylesheet" type="text/css" href="../staticcfg/bootstrap/css/bootstrap.min.css?v=$version"/>
         <link rel="stylesheet" type="text/css" href="static/style.css?v=$version"/>
+        <noscript>
         <!--#if $color_scheme not in ('Light', '') #-->
         <link rel="stylesheet" type="text/css" href="../staticcfg/css/${color_scheme}.css?v=$version"/>
         <!--#end if#-->
+        </noscript>
+        <link rel="stylesheet" type="text/css" href="../staticcfg/css/theme.css?v=$version" />
+        <link rel="stylesheet" type="text/css" href="../staticcfg/css/config.modern.css?v=$version" />
         <link rel="shortcut icon" href="../staticcfg/ico/favicon.ico?v=$version" />
         <script type="text/javascript" src="../staticcfg/js/jquery-3.5.1.min.js?v=$version"></script>
         <script type="text/javascript" src="../staticcfg/bootstrap/js/bootstrap.min.js?v=$version"></script>
+        <script type="text/javascript" defer src="../staticcfg/js/theme.js?v=$version"></script>
     </head>
     <body>
+        <div class="sab-theme-control sab-theme-control--floating">
+            <label for="sab-theme-select-wizard">$T('opt-web_dir')</label>
+            <select id="sab-theme-select-wizard" data-sab-theme-select aria-label="$T('opt-web_dir')">
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+                <option value="oled">OLED</option>
+            </select>
+        </div>
         <div id="logo">
             #include $webdir + "/../Config/templates/staticcfg/images/logo-full.svg"#
         </div>

--- a/interfaces/wizard/two.html
+++ b/interfaces/wizard/two.html
@@ -22,17 +22,17 @@
             <p><strong>$T('opt-complete_dir')</strong></p>
             <div class="quoteBlock">
                 $complete_dir
-                <a href="${access_url}/config/folders#complete_dir" class="indented"><span class="glyphicon glyphicon-cog"></span></a>
+                <a href="${access_url}/config/folders#complete_dir" class="indented" aria-label="$T('cmenu-folders')"><span class="glyphicon glyphicon-cog" aria-hidden="true"></span></a>
             </div>
 
             <p><strong>$T('opt-download_dir')</strong></p>
             <div class="quoteBlock">
                 $download_dir
-                <a href="${access_url}/config/folders#complete_dir" class="indented"><span class="glyphicon glyphicon-cog"></span></a>
+                <a href="${access_url}/config/folders#complete_dir" class="indented" aria-label="$T('cmenu-folders')"><span class="glyphicon glyphicon-cog" aria-hidden="true"></span></a>
             </div>
 
             <hr/>
-            <p>$T('wizard-tip-wiki') <a target="_blank" href="https://sabnzbd.org/wiki/">$T('menu-wiki')</a> <span class="glyphicon glyphicon-info-sign"></span></p>
+            <p>$T('wizard-tip-wiki') <a target="_blank" href="https://sabnzbd.org/wiki/" rel="noopener noreferrer">$T('menu-wiki')</a> <span class="glyphicon glyphicon-info-sign"></span></p>
 
         </div>
         <hr />


### PR DESCRIPTION
## Summary

This PR gives the SABnzbd 5.0.x interface a responsive, theme-aware presentation from 320 px phones through desktop screens. It updates Glitter, Config, login, and the Quick-Start Wizard without replacing the existing Bootstrap 3, jQuery, Knockout, Cheetah-template, or `web_color` architecture.

The change adds a true-black OLED scheme, a persistent Light/Dark/OLED browser selector, mobile-safe navigation and dense-content layouts, and focused accessibility improvements. It changes presentation templates, CSS, and small UI scripts only. It does not change controllers, routes, APIs, queue/history models, downloader behavior, or persistent server data.

<p align="center">
  <img src="https://raw.githubusercontent.com/Nou4r/sabnzbd/pr-assets/mobile-responsive-oled/screenshots/mobile-responsive-oled/01-main-mobile-before-after.png" alt="SABnzbd mobile queue before and after" width="798">
</p>

## Why

The 5.0.4 interface is functional on desktop, but narrow screens expose several usability problems:

- navigation and queue actions become compressed;
- dense tables and dialogs can exceed the viewport;
- important controls are small for touch input;
- login, Config, and wizard layouts do not share one responsive system;
- the server theme list has no OLED option, and there is no fast cross-interface browser selector.

This PR extends the current interface instead of introducing a second frontend stack.

## What changed

| Area | Change |
|---|---|
| Theme foundation | Adds semantic theme tokens, true-black OLED compatibility schemes, no-flash startup selection, browser `theme-color`/`color-scheme`, and a shared theme runtime. |
| Glitter | Reflows navigation, queue, history, messages, search, and dialogs; contains dense data; supports safe areas, portrait, landscape, tablet, and desktop layouts. |
| Config and entry screens | Makes forms and tables responsive; updates Config, login, and wizard; uses 16 px mobile inputs and dynamic viewport sizing. |
| Accessibility and safety | Keeps pinch zoom enabled, adds visible focus, tab/panel relationships, names for icon controls, a polite theme status, reduced-motion handling, and `noopener noreferrer` for new-tab links. |

### Theme behavior

1. An explicit Light, Dark, or OLED browser choice is stored in `sabnzbd-ui-theme-v1`.
2. Without a browser choice, fixed server Light, Night/Dark, or OLED is honored.
3. Server Auto or an unknown/default value follows `prefers-color-scheme`.
4. Legacy server theme files remain available as no-JavaScript fallbacks. They do not override a JavaScript-enabled browser choice.

## Visual review

### Light, Dark, and OLED

<p align="center">
  <img src="https://raw.githubusercontent.com/Nou4r/sabnzbd/pr-assets/mobile-responsive-oled/screenshots/mobile-responsive-oled/03-theme-main-mobile.png" alt="SABnzbd mobile queue in Light, Dark, and OLED" width="1000">
</p>

### Config before and after

<p align="center">
  <img src="https://raw.githubusercontent.com/Nou4r/sabnzbd/pr-assets/mobile-responsive-oled/screenshots/mobile-responsive-oled/04-config-mobile-before-after.png" alt="SABnzbd mobile Config before and after" width="798">
</p>

<details>
<summary><strong>More mobile states</strong></summary>

#### Quick-Start Wizard

<img src="https://raw.githubusercontent.com/Nou4r/sabnzbd/pr-assets/mobile-responsive-oled/screenshots/mobile-responsive-oled/wizard-mobile-before-after.png" alt="SABnzbd mobile wizard before and after" width="798">

#### Add NZB dialog

<img src="https://raw.githubusercontent.com/Nou4r/sabnzbd/pr-assets/mobile-responsive-oled/screenshots/mobile-responsive-oled/06-add-nzb-modal-mobile.png" alt="SABnzbd Add NZB dialog on mobile" width="390">

#### Expanded OLED navigation

<img src="https://raw.githubusercontent.com/Nou4r/sabnzbd/pr-assets/mobile-responsive-oled/screenshots/mobile-responsive-oled/07-navigation-oled-mobile.png" alt="SABnzbd expanded OLED navigation on mobile" width="390">

</details>

The review images are hosted on a separate fork branch. Generated screenshots are not part of this product diff.

## Validation

### Fresh verification on upstream `5.0.x`

| Check | Result |
|---|---:|
| SABnzbd command startup (`python SABnzbd.py --help`) | Passed |
| Interface regression tests (`tests/test_api_and_interface.py`) | 17 passed |
| Full pytest collection | 13,116 tests collected |
| Theme runtime simulation | 8/8 passed |
| JavaScript syntax (`theme.js`, `glitter.basic.js`) | Passed |
| Git whitespace check | Passed |
| Live SABnzbd 5.0.4 mobile smoke at 390×844 | Glitter, Config, login, and wizard passed |
| Live route/reload theme persistence | Passed |
| Live cross-tab storage synchronization | Passed |
| Live OLED canvas | `rgb(0, 0, 0)` |
| Page-level horizontal overflow in live mobile smoke | None observed |
| Protected brand paths in this diff | 0 |

The interface test run emitted one shutdown warning after all 17 tests passed: the test fixture saw a Windows connection reset while stopping its SABnzbd process.

### Supplied visual evidence

The accompanying isolated Chromium harness used the production templates, CSS, JavaScript, Bootstrap assets, and representative queue/config state:

- 63/63 viewport and state cases passed across portrait phones, landscape phones, tablets, and 1280–1920 px desktops;
- 16/16 interactive Light/Dark/OLED switch cases passed across Glitter, Config, login, and wizard;
- 57/57 static frontend checks and 5/5 source-integrity checks passed;
- no page-level overflow, console errors, request failures, or unexpected responses were recorded;
- all ten reviewed normal-text contrast pairs were at least 4.98:1;
- 26/26 protected brand hashes matched the 5.0.4 baseline.

The archived visual matrix is fixture-driven rather than a live CherryPy/API capture. Firefox, WebKit, real-device touch behavior, and a full screen-reader/WCAG audit are outside this verification scope.

## Accessibility

- Pinch zoom remains available during mobile dialog use.
- Tabs and panels have explicit relationships and selected state.
- Static icon actions have accessible names; decorative icons are hidden from assistive technology.
- Theme changes update a polite live status.
- Keyboard focus is visible against Light, Dark, and OLED surfaces.
- Reduced-motion preferences are honored.
- Important mobile controls use approximately 44 px targets, and mobile text inputs use 16 px text.

These are targeted improvements, not a claim of full WCAG conformance.

## Compatibility and scope

- Existing Light, Night, and Auto files remain.
- New theme and responsive layers load after the established styles.
- With JavaScript disabled, the configured server scheme still loads through the legacy fallback.
- Modern CSS features such as custom properties, `dvh`, safe-area `env()`, `:focus-visible`, and `overflow: clip` enhance current browsers. Core Bootstrap content remains available when an older browser ignores an enhancement.
- This PR does not modify protected SABnzbd logos, wordmarks, favicons, installer icons, application icons, or tray icons.

## Risk and rollback

The main risk is CSS specificity against legacy Bootstrap 3 selectors. Browser-local theme precedence is also intentional: a saved browser choice can override the server default for that browser.

Rollback is one PR revert. Remove the `sabnzbd-ui-theme-v1` localStorage value if a browser must also discard its saved theme choice.

## Reviewer guide

1. Open the Queue at a narrow viewport and inspect navigation, rows, search, and the Add NZB dialog.
2. Switch Light → Dark → OLED, reload, and confirm the selection persists without a wrong-theme flash.
3. Open Config, login, and wizard at the same width; confirm no page-level horizontal overflow.
4. Open a second tab and change the theme in the first tab; confirm the second tab synchronizes.
5. Disable JavaScript once and confirm the configured server scheme remains usable.
