### PR TITLE
Don't log a warning during clean shutdown (#3548)

### DIFF
--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -205,7 +205,7 @@ def sig_handler(signum=None, frame=None):
         # Ignore the "logoff" event when running as a Win32 daemon
         return True
     if signum is not None:
-        logging.warning(T("Signal %s caught, saving and exiting..."), signum)
+        logging.info(T("Signal %s caught, saving and exiting..."), signum)
         sabnzbd.shutdown_program()
 
 


### PR DESCRIPTION
`SIGTERM` is an expected part of a clean shutdown on POSIX-like OSes (Linux and macOS, not Windows).

Previously, the signal handler posted a log warning for any signal received, which turned into Warning notifications every time the server shut down.

This PR turns down the log level to `info` for handled signals (the log was issued on non-Windows OSes only). This only affects the two signals we handle, `SIGTERM` (aka `kill`) and `SIGINT` (aka Control-C), both of which are user-issued and shouldn't cause warnings.

Tested:

```
% python3 -m venv venv
% source venv/bin/activate
% pip install -r dependencies.txt
% python3 -OO SABnzbd.py
```

In another terminal, ran `kill -TERM $PID`.

Confirmed in logs that `Signal X caught, saving and exiting...` appeared at `INFO` level (previously it appeared with `WARNING` level and pushed a push notification.)

Repeated with Control-C, confirmed it worked and logged at `INFO`.

Fixes #3548.
