### PR TITLE
Replace CherryPy with Uvicorn and Starlette

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -144,7 +144,7 @@ jobs:
       run: |
         python3 --version
         pip3 install --upgrade pip wheel
-        pip3 install -r requirements.txt --no-binary cffi,CT3,PyYAML --no-dependencies
+        pip3 install -r requirements.txt --no-binary cffi,CT3,PyYAML,httptools --no-dependencies
         pip3 install -r builder/requirements.txt --no-dependencies
     - name: Import macOS codesign certificates
       # Taken from https://github.com/Apple-Actions/import-codesign-certs/pull/27 (comments)

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1354,7 +1354,8 @@ def main():
     notifier.send_notification("SABnzbd", T("SABnzbd shutdown finished"), "startup")
     logging.info("Leaving SABnzbd")
     sabnzbd.pid_file()
-    sabnzbd.WEB_SERVER.stop()
+    if sabnzbd.WEB_SERVER:
+        sabnzbd.WEB_SERVER.stop()
 
     try:
         sys.stderr.flush()

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1215,7 +1215,14 @@ def main():
         ssl_ca_certs=https_chain if enable_https else None,
     )
     sabnzbd.WEB_SERVER = sabnzbd.interface.ThreadedServer(config=server_config)
-    sabnzbd.WEB_SERVER.run_in_thread()
+    try:
+        sabnzbd.WEB_SERVER.run_in_thread()
+    except Exception:
+        # The webserver runs in a separate thread; if it fails to start (bad cert,
+        # port taken between the free-check and bind, bad host) surface the error
+        # and abort instead of hanging. Details are also shown on the console.
+        logging.error(T("Failed to start web-interface: "), exc_info=True)
+        abort_and_show_error(browserhost, web_port)
 
     # Set URL for browser
     if enable_https:

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -86,6 +86,7 @@ from sabnzbd.misc import (
     split_host,
     port_is_free,
     find_free_port,
+    xff_trusted_networks,
     create_https_certificates,
     ip_extract,
     set_serv_parms,
@@ -1213,6 +1214,8 @@ def main():
         ssl_keyfile=https_key if enable_https else None,
         ssl_certfile=https_cert if enable_https else None,
         ssl_ca_certs=https_chain if enable_https else None,
+        proxy_headers=bool(sabnzbd.cfg.verify_xff_header()),
+        forwarded_allow_ips=xff_trusted_networks(),
     )
     sabnzbd.WEB_SERVER = sabnzbd.interface.ThreadedServer(config=server_config)
     try:

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1206,7 +1206,7 @@ def main():
     }
 
     server_config = uvicorn.Config(
-        sabnzbd.interface.app,
+        sabnzbd.interface.create_app(),
         host=web_host,
         port=web_port,
         log_config=uvicorn_logging_config,

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -40,7 +40,6 @@ import time
 import re
 import gc
 import threading
-import http.cookies
 from typing import Any
 
 try:
@@ -48,9 +47,7 @@ try:
     import Cheetah
     import feedparser
     import configobj
-    import cherrypy
-    import cheroot.errors
-    import portend
+    import uvicorn
     import cryptography
     import charset_normalizer
     import guessit
@@ -81,13 +78,14 @@ from sabnzbd.constants import (
     RSS_FILE_NAME,
     DEF_LOG_FILE,
     DEF_STD_CONFIG,
-    DEF_LOG_CHERRY,
     CONFIG_BACKUP_HTTPS,
 )
 import sabnzbd.newsunpack
 from sabnzbd.misc import (
     exit_sab,
     split_host,
+    port_is_free,
+    find_free_port,
     create_https_certificates,
     ip_extract,
     set_serv_parms,
@@ -205,7 +203,7 @@ def print_help():
     print("  -t  --templates <templ>     Template directory [*]")
     print()
     print("  -l  --logging <-1..2>       Set logging level (-1=off, 0=least,2= most) [*]")
-    print("  -w  --weblogging            Enable cherrypy access logging")
+    print("  -w  --weblogging            Enable uvicorn access logging")
     print()
     print("  -b  --browser <0..1>        Auto browser launch (0= off, 1= on) [*]")
     if sabnzbd.WINDOWS:
@@ -652,19 +650,6 @@ def get_webhost(web_host, web_port, https_port):
     return web_host, web_port, browserhost, https_port
 
 
-def attach_server(host, port, cert=None, key=None, chain=None):
-    """Define and attach server, optionally HTTPS"""
-    if sabnzbd.cfg.ipv6_hosting() or "::1" not in host:
-        http_server = cherrypy._cpserver.Server()
-        http_server.bind_addr = (host, port)
-        if cert and key:
-            http_server.ssl_module = "builtin"
-            http_server.ssl_certificate = cert
-            http_server.ssl_private_key = key
-            http_server.ssl_certificate_chain = chain
-        http_server.subscribe()
-
-
 def is_sabnzbd_running(url):
     """Return True when there's already a SABnzbd instance running."""
     try:
@@ -676,19 +661,6 @@ def is_sabnzbd_running(url):
         return ver and (re.search(r"\d+\.\d+\.", ver) or ver.strip() == sabnzbd.__version__)
     except Exception:
         return False
-
-
-def find_free_port(host, currentport):
-    """Return a free port, 0 when nothing is free"""
-    n = 0
-    while n < 10 and currentport <= 49151:
-        try:
-            portend.free(host, currentport, timeout=0.025)
-            return currentport
-        except Exception:
-            currentport += 5
-            n += 1
-    return 0
 
 
 def check_for_sabnzbd(url, upload_nzbs, allow_browser=True):
@@ -837,7 +809,7 @@ def main():
     web_host = None
     web_port = None
     https_port = None
-    cherrypylogging = None
+    weblogging = None
     clean_up = False
     logging_level = None
     console_logging = False
@@ -883,7 +855,7 @@ def main():
         elif opt in ("-c", "--clean"):
             clean_up = True
         elif opt in ("-w", "--weblogging"):
-            cherrypylogging = True
+            weblogging = True
         elif opt in ("-l", "--logging"):
             try:
                 logging_level = int(arg)
@@ -1002,18 +974,10 @@ def main():
     # When this is a daemon, just check and bail out if port in use
     if sabnzbd.DAEMON:
         if enable_https and https_port:
-            try:
-                portend.free(web_host, https_port, timeout=0.05)
-            except IOError:
+            if not port_is_free(web_host, https_port):
                 abort_and_show_error(browserhost, web_port)
-            except Exception:
-                abort_and_show_error(browserhost, web_port, "49")
-        try:
-            portend.free(web_host, web_port, timeout=0.05)
-        except IOError:
+        if not port_is_free(web_host, web_port):
             abort_and_show_error(browserhost, web_port)
-        except Exception:
-            abort_and_show_error(browserhost, web_port, "49")
 
     # Windows instance is reachable through registry
     url = None
@@ -1025,55 +989,39 @@ def main():
     # SSL
     if enable_https:
         port = https_port or web_port
-        try:
-            portend.free(browserhost, port, timeout=0.05)
-        except IOError as error:
-            if str(error) == "Port not bound.":
-                pass
-            else:
-                if not url:
-                    url = "https://%s:%s%s/api?" % (browserhost, port, sabnzbd.cfg.url_base())
-                if new_instance or not check_for_sabnzbd(url, upload_nzbs, autobrowser):
-                    # Bail out if we have fixed our ports after first start-up
-                    if sabnzbd.cfg.fixed_ports():
-                        abort_and_show_error(browserhost, web_port)
-                    # Find free port to bind
-                    newport = find_free_port(browserhost, port)
-                    if newport > 0:
-                        # Save the new port
-                        if https_port:
-                            https_port = newport
-                            sabnzbd.cfg.https_port.set(newport)
-                        else:
-                            # In case HTTPS == HTTP port
-                            web_port = newport
-                            sabnzbd.cfg.web_port.set(newport)
-        except Exception:
-            # Something else wrong, probably badly specified host
-            abort_and_show_error(browserhost, web_port, "49")
+        if not port_is_free(browserhost, port):
+            if not url:
+                url = "https://%s:%s%s/api?" % (browserhost, port, sabnzbd.cfg.url_base())
+            if new_instance or not check_for_sabnzbd(url, upload_nzbs, autobrowser):
+                # Bail out if we have fixed our ports after first start-up
+                if sabnzbd.cfg.fixed_ports():
+                    abort_and_show_error(browserhost, web_port)
+                # Find free port to bind
+                newport = find_free_port(browserhost, port)
+                if newport > 0:
+                    # Save the new port
+                    if https_port:
+                        https_port = newport
+                        sabnzbd.cfg.https_port.set(newport)
+                    else:
+                        # In case HTTPS == HTTP port
+                        web_port = newport
+                        sabnzbd.cfg.web_port.set(newport)
 
     # NonSSL check if there's no HTTPS or we only use 1 port
     if not (enable_https and not https_port):
-        try:
-            portend.free(browserhost, web_port, timeout=0.05)
-        except IOError as error:
-            if str(error) == "Port not bound.":
-                pass
-            else:
-                if not url:
-                    url = "http://%s:%s%s/api?" % (browserhost, web_port, sabnzbd.cfg.url_base())
-                if new_instance or not check_for_sabnzbd(url, upload_nzbs, autobrowser):
-                    # Bail out if we have fixed our ports after first start-up
-                    if sabnzbd.cfg.fixed_ports():
-                        abort_and_show_error(browserhost, web_port)
-                    # Find free port to bind
-                    port = find_free_port(browserhost, web_port)
-                    if port > 0:
-                        sabnzbd.cfg.web_port.set(port)
-                        web_port = port
-        except Exception:
-            # Something else wrong, probably badly specified host
-            abort_and_show_error(browserhost, web_port, "49")
+        if not port_is_free(browserhost, web_port):
+            if not url:
+                url = "http://%s:%s%s/api?" % (browserhost, web_port, sabnzbd.cfg.url_base())
+            if new_instance or not check_for_sabnzbd(url, upload_nzbs, autobrowser):
+                # Bail out if we have fixed our ports after first start-up
+                if sabnzbd.cfg.fixed_ports():
+                    abort_and_show_error(browserhost, web_port)
+                # Find free port to bind
+                port = find_free_port(browserhost, web_port)
+                if port > 0:
+                    sabnzbd.cfg.web_port.set(port)
+                    web_port = port
 
     # We found a port, now we never check again
     sabnzbd.cfg.fixed_ports.set(True)
@@ -1219,41 +1167,14 @@ def main():
     # Starting of the webserver
     # Determine if this system has multiple definitions for 'localhost'
     hosts = all_localhosts()
-    multilocal = len(hosts) > 1 and web_host in ("localhost", "0.0.0.0")
-
-    # For 0.0.0.0 CherryPy will always pick IPv4, so make sure the secondary localhost is IPv6
-    if multilocal and web_host == "0.0.0.0" and hosts[1] == "127.0.0.1":
-        hosts[1] = "::1"
 
     # The Windows binary requires numeric localhost as primary address
     if web_host == "localhost":
         web_host = hosts[0]
 
-    if enable_https:
-        if https_port:
-            # Extra HTTP port for primary localhost
-            attach_server(web_host, web_port)
-            if multilocal:
-                # Extra HTTP port for secondary localhost
-                attach_server(hosts[1], web_port)
-                # Extra HTTPS port for secondary localhost
-                attach_server(hosts[1], https_port, https_cert, https_key, https_chain)
-            web_port = https_port
-        elif multilocal:
-            # Extra HTTPS port for secondary localhost
-            attach_server(hosts[1], web_port, https_cert, https_key, https_chain)
-
-        cherrypy.config.update(
-            {
-                "server.ssl_module": "builtin",
-                "server.ssl_certificate": https_cert,
-                "server.ssl_private_key": https_key,
-                "server.ssl_certificate_chain": https_chain,
-            }
-        )
-    elif multilocal:
-        # Extra HTTP port for secondary localhost
-        attach_server(hosts[1], web_port)
+    if enable_https and https_port:
+        # Separate HTTPS port: switch the main server to the HTTPS port
+        web_port = https_port
 
     if no_login:
         sabnzbd.cfg.username.set("")
@@ -1263,107 +1184,38 @@ def main():
     if inet_exposure:
         sabnzbd.cfg.inet_exposure.set(inet_exposure)
 
-    mime_gzip = (
-        "text/*",
-        "application/javascript",
-        "application/x-javascript",
-        "application/json",
-        "application/xml",
-        "application/vnd.ms-fontobject",
-        "application/font*",
-        "image/svg+xml",
-    )
-    cherrypy.config.update(
-        {
-            "server.environment": "production",
-            "server.socket_host": web_host,
-            "server.socket_port": web_port,
-            "server.shutdown_timeout": 0,
-            "engine.autoreload.on": False,
-            "tools.encode.on": True,
-            "tools.gzip.on": True,
-            "tools.gzip.mime_types": mime_gzip,
-            "error_page.401": sabnzbd.panic.error_page_401,
-            "error_page.404": sabnzbd.panic.error_page_404,
-        }
-    )
-
-    # Monkey-patch key validation to prevent cherrypy from stumbling over invalid cookies
-    http.cookies._is_legal_key = lambda _: True
-
-    # Catch shutdown errors that can break cherrypy/cheroot
-    # See https://github.com/cherrypy/cheroot/issues/710
-    try:
-        cheroot.errors.acceptable_sock_shutdown_exceptions += (OSError,)
-    except AttributeError:
-        pass
-
-    # Do we want CherryPy Logging? Cannot be done via the config
-    cherrypy.log.screen = False
-    cherrypy.log.access_log.propagate = False
-    if cherrypylogging:
-        sabnzbd.WEBLOGFILE = os.path.join(logdir, DEF_LOG_CHERRY)
-        cherrypy.log.access_file = str(sabnzbd.WEBLOGFILE)
-
-    # Force mimetypes (OS might overwrite them)
-    forced_mime_types = {"css": "text/css", "js": "application/javascript"}
-
-    static = {
-        "tools.staticdir.on": True,
-        "tools.staticdir.dir": os.path.join(sabnzbd.WEB_DIR, "static"),
-        "tools.staticdir.content_types": forced_mime_types,
-    }
-    staticcfg = {
-        "tools.staticdir.on": True,
-        "tools.staticdir.dir": os.path.join(sabnzbd.WEB_DIR_CONFIG, "staticcfg"),
-        "tools.staticdir.content_types": forced_mime_types,
-    }
-    wizard_static = {
-        "tools.staticdir.on": True,
-        "tools.staticdir.dir": os.path.join(sabnzbd.WIZARD_DIR, "static"),
-        "tools.staticdir.content_types": forced_mime_types,
-    }
-
-    appconfig = {
-        "/api": {
-            "tools.auth_basic.on": False,
-            "tools.response_headers.on": True,
-            "tools.response_headers.headers": [("Access-Control-Allow-Origin", "*")],
-        },
-        "/static": static,
-        "/wizard/static": wizard_static,
-        "/favicon.ico": {
-            "tools.staticfile.on": True,
-            "tools.staticfile.filename": os.path.join(sabnzbd.WEB_DIR_CONFIG, "staticcfg", "ico", "favicon.ico"),
-        },
-        "/staticcfg": staticcfg,
-    }
-
-    # Make available from both URLs
-    main_page = sabnzbd.interface.MainPage()
-    cherrypy.Application.relative_urls = "server"
-    cherrypy.tree.mount(main_page, "/", config=appconfig)
-    cherrypy.tree.mount(main_page, sabnzbd.cfg.url_base(), config=appconfig)
-
-    # Set authentication for CherryPy
-    sabnzbd.interface.set_auth(cherrypy.config)
     logging.info("Starting web-interface on %s:%s", web_host, web_port)
 
     sabnzbd.cfg.log_level.callback(guard_loglevel)
-
-    try:
-        cherrypy.engine.start()
-    except Exception:
-        # Since the webserver is started by cherrypy in a separate thread, we can't really catch any
-        # start-up errors. This try/except only catches very few errors, the rest is only shown in the console.
-        logging.error(T("Failed to start web-interface: "), exc_info=True)
-        abort_and_show_error(browserhost, web_port)
 
     # Create a record of the active cert/key/chain files, for use with config.create_config_backup()
     if enable_https:
         for setting in CONFIG_BACKUP_HTTPS.values():
             if full_path := getattr(sabnzbd.cfg, setting).get_path():
                 sabnzbd.CONFIG_BACKUP_HTTPS_OK.append(full_path)
+
+    # Catch logging using SABnzbd handlers
+    # Format: https://github.com/encode/uvicorn/blob/d43afed1cfa018a85c83094da8a2dd29f656d676/uvicorn/config.py#L82-L114
+    uvicorn_logging_config = {
+        "version": 1,
+        "loggers": {
+            "uvicorn": {"propagate": True},
+            "uvicorn.error": {"propagate": True},
+            "uvicorn.access": {"propagate": bool(weblogging)},
+        },
+    }
+
+    server_config = uvicorn.Config(
+        sabnzbd.interface.app,
+        host=web_host,
+        port=web_port,
+        log_config=uvicorn_logging_config,
+        ssl_keyfile=https_key if enable_https else None,
+        ssl_certfile=https_cert if enable_https else None,
+        ssl_ca_certs=https_chain if enable_https else None,
+    )
+    sabnzbd.WEB_SERVER = sabnzbd.interface.ThreadedServer(config=server_config)
+    sabnzbd.WEB_SERVER.run_in_thread()
 
     # Set URL for browser
     if enable_https:
@@ -1482,13 +1334,20 @@ def main():
                     # Just a simple restart of the exe
                     os.execv(sys.executable, ['"%s"' % arg for arg in sys.argv])
             else:
-                # CherryPy has special logic to include interpreter options such as "-OO"
-                cherrypy.engine._do_execv()
+                # Re-exec with interpreter flags (replaces cherrypy.engine._do_execv)
+                args = [sys.executable]
+                if sys.flags.optimize == 1:
+                    args.append("-O")
+                elif sys.flags.optimize >= 2:
+                    args.append("-OO")
+                args.extend(sys.argv)
+                os.execv(sys.executable, args)
 
     # Send our final goodbyes!
     notifier.send_notification("SABnzbd", T("SABnzbd shutdown finished"), "startup")
     logging.info("Leaving SABnzbd")
     sabnzbd.pid_file()
+    sabnzbd.WEB_SERVER.stop()
 
     try:
         sys.stderr.flush()

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -99,7 +99,7 @@ from sabnzbd.misc import (
     set_https_verification,
 )
 from sabnzbd.filesystem import get_ext, real_path, long_path, globber_full, remove_file
-from sabnzbd.panic import panic_tmpl, panic_port, panic_host, panic, launch_a_browser
+from sabnzbd.panic import panic_tmpl, panic_port, panic_port_permission, panic_host, panic, launch_a_browser
 import sabnzbd.config as config
 import sabnzbd.cfg
 import sabnzbd.notifier as notifier
@@ -291,16 +291,36 @@ def daemonize():
         os.dup2(f.fileno(), sys.stderr.fileno())
 
 
-def abort_and_show_error(browserhost, web_port, err=""):
-    """Abort program because of CherryPy troubles"""
+def abort_and_show_error(browserhost, web_port, err="", no_permission=False):
+    """Abort program because the web-interface could not be started"""
     logging.error(T("Failed to start web-interface") + " : " + str(err))
     if not sabnzbd.DAEMON:
-        if "49" in err:
+        if no_permission:
+            panic_port_permission(browserhost, web_port)
+        elif "49" in err:
             panic_host(browserhost, web_port)
         else:
             panic_port(browserhost, web_port)
     sabnzbd.halt()
     exit_sab(2)
+
+
+def port_is_free_or_abort(host, port, browserhost):
+    """port_is_free(), but abort when the port may not be bound at all. Reporting
+    that up front beats a search that can only fail, followed by a message
+    claiming some other program holds the port."""
+    try:
+        return port_is_free(host, port)
+    except PermissionError as err:
+        abort_and_show_error(browserhost, port, err, no_permission=True)
+
+
+def find_free_port_or_abort(host, currentport, browserhost):
+    """find_free_port(), but abort when the ports may not be bound at all"""
+    try:
+        return find_free_port(host, currentport)
+    except PermissionError as err:
+        abort_and_show_error(browserhost, currentport, err, no_permission=True)
 
 
 def identify_web_template(key, defweb, wdir):
@@ -976,9 +996,9 @@ def main():
     # When this is a daemon, just check and bail out if port in use
     if sabnzbd.DAEMON:
         if enable_https and https_port:
-            if not port_is_free(web_host, https_port):
+            if not port_is_free_or_abort(web_host, https_port, browserhost):
                 abort_and_show_error(browserhost, web_port)
-        if not port_is_free(web_host, web_port):
+        if not port_is_free_or_abort(web_host, web_port, browserhost):
             abort_and_show_error(browserhost, web_port)
 
     # Windows instance is reachable through registry
@@ -991,7 +1011,7 @@ def main():
     # SSL
     if enable_https:
         port = https_port or web_port
-        if not port_is_free(browserhost, port):
+        if not port_is_free_or_abort(web_host, port, browserhost):
             if not url:
                 url = "https://%s:%s%s/api?" % (browserhost, port, sabnzbd.cfg.url_base())
             if new_instance or not check_for_sabnzbd(url, upload_nzbs, autobrowser):
@@ -999,8 +1019,8 @@ def main():
                 if sabnzbd.cfg.fixed_ports():
                     abort_and_show_error(browserhost, web_port)
                 # Find free port to bind
-                newport = find_free_port(browserhost, port)
-                if newport > 0:
+                newport = find_free_port_or_abort(web_host, port, browserhost)
+                if newport:
                     # Save the new port
                     if https_port:
                         https_port = newport
@@ -1012,7 +1032,7 @@ def main():
 
     # NonSSL check if there's no HTTPS or we only use 1 port
     if not (enable_https and not https_port):
-        if not port_is_free(browserhost, web_port):
+        if not port_is_free_or_abort(web_host, web_port, browserhost):
             if not url:
                 url = "http://%s:%s%s/api?" % (browserhost, web_port, sabnzbd.cfg.url_base())
             if new_instance or not check_for_sabnzbd(url, upload_nzbs, autobrowser):
@@ -1020,8 +1040,8 @@ def main():
                 if sabnzbd.cfg.fixed_ports():
                     abort_and_show_error(browserhost, web_port)
                 # Find free port to bind
-                port = find_free_port(browserhost, web_port)
-                if port > 0:
+                port = find_free_port_or_abort(web_host, web_port, browserhost)
+                if port:
                     sabnzbd.cfg.web_port.set(port)
                     web_port = port
 

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -66,6 +66,7 @@ import sabnzbd.interface
 from sabnzbd.constants import (
     DEF_NETWORKING_TIMEOUT,
     DEF_LOG_ERRFILE,
+    DEF_LOG_ACCESSFILE,
     DEF_MAIN_TMPL,
     DEF_STD_WEB_DIR,
     DEF_WORKDIR,
@@ -1199,12 +1200,34 @@ def main():
     # Format: https://github.com/encode/uvicorn/blob/d43afed1cfa018a85c83094da8a2dd29f656d676/uvicorn/config.py#L82-L114
     uvicorn_logging_config = {
         "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "access": {
+                "()": "uvicorn.logging.AccessFormatter",
+                "fmt": '%(asctime)s::%(levelname)s::%(client_addr)s - "%(request_line)s" %(status_code)s',
+                "use_colors": False,
+            },
+        },
+        "handlers": {},
         "loggers": {
             "uvicorn": {"propagate": True},
             "uvicorn.error": {"propagate": True},
-            "uvicorn.access": {"propagate": bool(weblogging)},
+            "uvicorn.access": {"propagate": False, "level": "INFO"},
         },
     }
+
+    # Do we want web-server access logging? Cannot be done via the config
+    if weblogging:
+        sabnzbd.WEBLOGFILE = os.path.join(logdir, DEF_LOG_ACCESSFILE)
+        uvicorn_logging_config["handlers"]["access_file"] = {
+            "class": "logging.handlers.RotatingFileHandler",
+            "formatter": "access",
+            "filename": sabnzbd.WEBLOGFILE,
+            "maxBytes": sabnzbd.cfg.log_size(),
+            "backupCount": sabnzbd.cfg.log_backups(),
+            "encoding": "utf-8",
+        }
+        uvicorn_logging_config["loggers"]["uvicorn.access"]["handlers"] = ["access_file"]
 
     server_config = uvicorn.Config(
         sabnzbd.interface.create_app(),

--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -87,6 +87,8 @@ from sabnzbd.misc import (
     split_host,
     port_is_free,
     find_free_port,
+    bind_web_socket,
+    HostNotAvailableError,
     xff_trusted_networks,
     create_https_certificates,
     ip_extract,
@@ -291,36 +293,39 @@ def daemonize():
         os.dup2(f.fileno(), sys.stderr.fileno())
 
 
-def abort_and_show_error(browserhost, web_port, err="", no_permission=False):
+def abort_and_show_error(browserhost, web_port, err="", panic_func=panic_port):
     """Abort program because the web-interface could not be started"""
     logging.error(T("Failed to start web-interface") + " : " + str(err))
     if not sabnzbd.DAEMON:
-        if no_permission:
-            panic_port_permission(browserhost, web_port)
-        elif "49" in err:
-            panic_host(browserhost, web_port)
-        else:
-            panic_port(browserhost, web_port)
+        panic_func(browserhost, web_port)
     sabnzbd.halt()
     exit_sab(2)
 
 
+def abort_for_unusable_address(browserhost, port, err):
+    """Abort with the panic that matches why the address could not be used"""
+    if isinstance(err, PermissionError):
+        abort_and_show_error(browserhost, port, err, panic_func=panic_port_permission)
+    else:
+        abort_and_show_error(browserhost, port, err, panic_func=panic_host)
+
+
 def port_is_free_or_abort(host, port, browserhost):
-    """port_is_free(), but abort when the port may not be bound at all. Reporting
-    that up front beats a search that can only fail, followed by a message
-    claiming some other program holds the port."""
+    """port_is_free(), but abort when the address cannot be used at all. Saying so
+    up front beats a search that can only fail, followed by a message claiming
+    some other program holds the port."""
     try:
         return port_is_free(host, port)
-    except PermissionError as err:
-        abort_and_show_error(browserhost, port, err, no_permission=True)
+    except (PermissionError, HostNotAvailableError) as err:
+        abort_for_unusable_address(browserhost, port, err)
 
 
 def find_free_port_or_abort(host, currentport, browserhost):
-    """find_free_port(), but abort when the ports may not be bound at all"""
+    """find_free_port(), but abort when the address cannot be used at all"""
     try:
         return find_free_port(host, currentport)
-    except PermissionError as err:
-        abort_and_show_error(browserhost, currentport, err, no_permission=True)
+    except (PermissionError, HostNotAvailableError) as err:
+        abort_for_unusable_address(browserhost, currentport, err)
 
 
 def identify_web_template(key, defweb, wdir):
@@ -1249,6 +1254,17 @@ def main():
         }
         uvicorn_logging_config["loggers"]["uvicorn.access"]["handlers"] = ["access_file"]
 
+    # Claim the port here rather than letting uvicorn do it, because this is the
+    # first point where the host and port are final. Everything before this was
+    # only picking a port, and anything could still have taken it since.
+    try:
+        web_socket = bind_web_socket(web_host, web_port)
+    except (PermissionError, HostNotAvailableError) as err:
+        abort_for_unusable_address(browserhost, web_port, err)
+    except OSError as err:
+        logging.error(T("Failed to start web-interface: "), exc_info=True)
+        abort_and_show_error(browserhost, web_port, err)
+
     server_config = uvicorn.Config(
         sabnzbd.interface.create_app(),
         host=web_host,
@@ -1260,13 +1276,13 @@ def main():
         proxy_headers=bool(sabnzbd.cfg.verify_xff_header()),
         forwarded_allow_ips=xff_trusted_networks(),
     )
-    sabnzbd.WEB_SERVER = sabnzbd.interface.ThreadedServer(config=server_config)
+    sabnzbd.WEB_SERVER = sabnzbd.interface.ThreadedServer(config=server_config, sockets=[web_socket])
     try:
         sabnzbd.WEB_SERVER.run_in_thread()
     except Exception:
         # The webserver runs in a separate thread; if it fails to start (bad cert,
-        # port taken between the free-check and bind, bad host) surface the error
-        # and abort instead of hanging. Details are also shown on the console.
+        # unusable TLS material) surface the error and abort instead of hanging.
+        # Details are also shown on the console.
         logging.error(T("Failed to start web-interface: "), exc_info=True)
         abort_and_show_error(browserhost, web_port)
 

--- a/builder/SABnzbd.spec
+++ b/builder/SABnzbd.spec
@@ -13,7 +13,7 @@ from builder.common import EXTRA_FILES, EXTRA_FOLDERS, RELEASE_VERSION, RELEASE_
 extra_pyinstaller_files = []
 
 # Add hidden imports
-extra_hiddenimports = ["Cheetah.DummyTransaction", "cheroot.ssl.builtin", "certifi"]
+extra_hiddenimports = ["Cheetah.DummyTransaction", "certifi"]
 extra_hiddenimports.extend(collect_submodules("apprise"))
 extra_hiddenimports.extend(collect_submodules("babelfish.converters"))
 extra_hiddenimports.extend(collect_submodules("guessit.data"))

--- a/interfaces/Config/templates/_inc_header_uc.tmpl
+++ b/interfaces/Config/templates/_inc_header_uc.tmpl
@@ -1,8 +1,3 @@
-#if $pane == "Config"#
-    #set global $root = '../'#
-#else#
-    #set global $root = '../../'#
-#end if#
 <!DOCTYPE HTML>
 <html lang="$active_lang" #if $rtl#dir="rtl"#end if#>
 <head>
@@ -25,20 +20,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, maximum-scale=1" />
     <meta name="apple-mobile-web-app-title" content="SABnzbd" />
 
-    <link rel="apple-touch-icon" sizes="76x76" href="${root}staticcfg/ico/apple-touch-icon-76x76-precomposed.png" />
-    <link rel="apple-touch-icon" sizes="120x120" href="${root}staticcfg/ico/apple-touch-icon-120x120-precomposed.png" />
-    <link rel="apple-touch-icon" sizes="152x152" href="${root}staticcfg/ico/apple-touch-icon-152x152-precomposed.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="${root}staticcfg/ico/apple-touch-icon-180x180-precomposed.png" />
-    <link rel="apple-touch-icon" sizes="192x192" href="${root}staticcfg/ico/android-192x192.png" />
+    <link rel="apple-touch-icon" sizes="76x76" href="$url('staticcfg/ico/apple-touch-icon-76x76-precomposed.png')" />
+    <link rel="apple-touch-icon" sizes="120x120" href="$url('staticcfg/ico/apple-touch-icon-120x120-precomposed.png')" />
+    <link rel="apple-touch-icon" sizes="152x152" href="$url('staticcfg/ico/apple-touch-icon-152x152-precomposed.png')" />
+    <link rel="apple-touch-icon" sizes="180x180" href="$url('staticcfg/ico/apple-touch-icon-180x180-precomposed.png')" />
+    <link rel="apple-touch-icon" sizes="192x192" href="$url('staticcfg/ico/android-192x192.png')" />
 
-    <link rel="stylesheet" type="text/css" href="${root}staticcfg/bootstrap/css/bootstrap.min.css?v=$cache_buster" />
-    <link rel="stylesheet" type="text/css" href="${root}staticcfg/css/chartist.min.css?v=$cache_buster" />
-    <link rel="stylesheet" type="text/css" href="${root}staticcfg/css/style.css?v=$cache_buster" />
+    <link rel="stylesheet" type="text/css" href="$url('staticcfg/bootstrap/css/bootstrap.min.css', v=$cache_buster)" />
+    <link rel="stylesheet" type="text/css" href="$url('staticcfg/css/chartist.min.css', v=$cache_buster)" />
+    <link rel="stylesheet" type="text/css" href="$url('staticcfg/css/style.css', v=$cache_buster)" />
     <!--#if $color_scheme not in ('Light', '') #-->
-    <link rel="stylesheet" type="text/css" href="${root}staticcfg/css/${color_scheme}.css?v=$cache_buster"/>
+    <link rel="stylesheet" type="text/css" href="$url('staticcfg/css/' + $color_scheme + '.css', v=$cache_buster)" />
     <!--#end if#-->
 
-    <link rel="shortcut icon" href="${root}staticcfg/ico/favicon.ico?v=$cache_buster" />
+    <link rel="shortcut icon" href="$url('staticcfg/ico/favicon.ico', v=$cache_buster)" />
 
     <script type="text/javascript">
         // Keeping track of the form state
@@ -47,9 +42,9 @@
 
         // Information we need
         var sabSession = '$apikey';
-        var rootURL = '${root}'
+        var rootURL = '$url()'
         var urlBase = '${url_base}'
-        var folderBrowseUrl = '${root}api?mode=browse&output=json&apikey=$apikey';
+        var folderBrowseUrl = "$url('api', mode='browse', output='json', apikey=$apikey)";
         var folderSeperator = '#if $os.sep == '\\' then '\\\\' else '/'#'
 
         // Translations
@@ -65,9 +60,9 @@
         configTranslate.confirmLeave = "$T('confirmWithoutSavingPrompt')";
         configTranslate.searchPages = ['$T('cmenu-general')', '$T('cmenu-folders')', '$T('cmenu-switches')', '$T('cmenu-sorting')', '$T('cmenu-notif')', '$T('cmenu-special')']
     </script>
-    <script type="text/javascript" src="${root}staticcfg/js/jquery-3.5.1.min.js?v=$cache_buster"></script>
-    <script type="text/javascript" src="${root}staticcfg/bootstrap/js/bootstrap.min.js?v=$cache_buster"></script>
-    <script type="text/javascript" src="${root}staticcfg/js/script.js?v=$cache_buster"></script>
+    <script type="text/javascript" src="$url('staticcfg/js/jquery-3.5.1.min.js', v=$cache_buster)"></script>
+    <script type="text/javascript" src="$url('staticcfg/bootstrap/js/bootstrap.min.js', v=$cache_buster)"></script>
+    <script type="text/javascript" src="$url('staticcfg/js/script.js', v=$cache_buster)"></script>
     <script type="text/javascript">
         // Set default functions for the autocomplete everywhere
 
@@ -92,62 +87,62 @@
                 <span class="icon-bar"></span>
             </button>
 
-            <a class="navbar-logo navbar-logo-small" href="${root}" title="$T('Home')" data-placement="bottom">
+            <a class="navbar-logo navbar-logo-small" href="$url()" title="$T('Home')" data-placement="bottom">
                 #include $webdir + "/staticcfg/images/logo-small.svg"#
             </a>
         </div>
         <div id="navbar" class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
                 <li>
-                    <a href="${root}config/general/" #if $pane == "General" then 'class="active"' else ""#>
+                    <a href="$url('config/general')" #if $pane == "General" then 'class="active"' else ""#>
                         <span class="glyphicon glyphicon-cog"></span>
                         <strong>$T('cmenu-general')</strong>
                     </a>
                 </li>
                 <li>
-                    <a href="${root}config/folders/" #if $pane == "Folders" then 'class="active"' else ""#>
+                    <a href="$url('config/folders')" #if $pane == "Folders" then 'class="active"' else ""#>
                         <span class="glyphicon glyphicon-folder-open"></span>
                         <strong>$T('cmenu-folders')</strong>
                     </a>
                 </li>
                 <li>
-                    <a href="${root}config/server/" #if $pane == "Servers" then 'class="active"' else ""#>
+                    <a href="$url('config/server')" #if $pane == "Servers" then 'class="active"' else ""#>
                         <span class="glyphicon glyphicon-sort"></span>
                         <strong>$T('cmenu-servers')</strong>
                     </a>
                 </li>
                 <li>
-                    <a href="${root}config/categories/" #if $pane == "Categories" then 'class="active"' else ""#>
+                    <a href="$url('config/categories')" #if $pane == "Categories" then 'class="active"' else ""#>
                         <span class="glyphicon glyphicon-tag"></span>
                         <strong>$T('cmenu-cat')</strong>
                     </a>
                 </li>
                 <li>
-                    <a href="${root}config/switches/" #if $pane == "Switches" then 'class="active"' else ""#>
+                    <a href="$url('config/switches')" #if $pane == "Switches" then 'class="active"' else ""#>
                         <span class="glyphicon glyphicon-check"></span>
                         <strong>$T('cmenu-switches')</strong>
                     </a>
                 </li>
                 <li>
-                    <a href="${root}config/sorting/" #if $pane == "Sorting" then 'class="active"' else ""#>
+                    <a href="$url('config/sorting')" #if $pane == "Sorting" then 'class="active"' else ""#>
                         <span class="glyphicon glyphicon-sort-by-alphabet"></span>
                         <strong>$T('cmenu-sorting')</strong>
                     </a>
                 </li>
                 <li>
-                    <a href="${root}config/notify/" #if $pane == "Notify" then 'class="active"' else ""#>
+                    <a href="$url('config/notify')" #if $pane == "Notify" then 'class="active"' else ""#>
                         <span class="glyphicon glyphicon-comment"></span>
                         <strong>$T('cmenu-notif')</strong>
                     </a>
                 </li>
                 <li>
-                    <a href="${root}config/scheduling/" #if $pane == "Scheduling" then 'class="active"' else ""#>
+                    <a href="$url('config/scheduling')" #if $pane == "Scheduling" then 'class="active"' else ""#>
                         <span class="glyphicon glyphicon-time"></span>
                         <strong>$T('cmenu-scheduling')</strong>
                     </a>
                 </li>
                 <li>
-                    <a href="${root}config/rss/" #if $pane == "RSS" then 'class="active"' else ""#>
+                    <a href="$url('config/rss')" #if $pane == "RSS" then 'class="active"' else ""#>
                         <svg class="rss-icon-svg" viewBox="0 0 8 8">
                             <rect class="rss-button" width="8" height="8" />
                             <circle class="rss-symbol" cx="2" cy="6" r="1" />
@@ -158,7 +153,7 @@
                     </a>
                 </li>
                 <li>
-                    <a href="${root}config/special/" #if $pane == "Special" then 'class="active"' else ""#>
+                    <a href="$url('config/special')" #if $pane == "Special" then 'class="active"' else ""#>
                         <span class="glyphicon glyphicon-education"></span>
                         <strong>$T('cmenu-special')</strong>
                     </a>

--- a/interfaces/Config/templates/config_cat.tmpl
+++ b/interfaces/Config/templates/config_cat.tmpl
@@ -10,7 +10,7 @@
             <h5 class="darkred"><strong>$T('explain-relFolder'):</strong> <span class="path">$defdir</span></h5>
             <!--#for $cur, $slot in enumerate($slotinfo)#-->
                 <!--#set $cansort = $slot.name != '*' and $slot.name != ''#-->
-                <form action="save" method="post" <!--#if $cansort#-->class="sorting-row"<!--#end if#-->>
+                <form action="categories/save" method="post" class="fullform <!--#if $cansort then 'sorting-row' else ''#-->">
                     <table class="catTable">
                         <!--#if $cur == 0#-->
                         <tr>
@@ -108,7 +108,7 @@
     jQuery(document).ready(function() {
         jQuery('.delCat').click(function() {
             var theForm = jQuery(this).closest("form");
-            theForm.attr("action", "delete").submit();
+            theForm.attr("action", "categories/delete").submit();
         });
 
         // Add autocomplete and file-browser
@@ -128,7 +128,7 @@
                         var data = {}
                         jQuery(elm).extractFormDataTo(data);
                         jQuery.ajax({
-                            type: "GET",
+                            type: "POST",
                             url: window.location.pathname + 'save',
                             data: data,
                             async: false // To prevent race-conditions when updating categories

--- a/interfaces/Config/templates/config_cat.tmpl
+++ b/interfaces/Config/templates/config_cat.tmpl
@@ -10,7 +10,7 @@
             <h5 class="darkred"><strong>$T('explain-relFolder'):</strong> <span class="path">$defdir</span></h5>
             <!--#for $cur, $slot in enumerate($slotinfo)#-->
                 <!--#set $cansort = $slot.name != '*' and $slot.name != ''#-->
-                <form action="categories/save" method="post" class="fullform <!--#if $cansort then 'sorting-row' else ''#-->">
+                <form action="$url('config/categories/save')" method="post" class="fullform <!--#if $cansort then 'sorting-row' else ''#-->">
                     <table class="catTable">
                         <!--#if $cur == 0#-->
                         <tr>
@@ -103,12 +103,12 @@
         </div>
     </div>
 </div>
-<script type="text/javascript" src="${root}staticcfg/js/jquery-ui.min.js"></script>
+<script type="text/javascript" src="$url('staticcfg/js/jquery-ui.min.js', v=$cache_buster)"></script>
 <script type="text/javascript">
     jQuery(document).ready(function() {
         jQuery('.delCat').click(function() {
             var theForm = jQuery(this).closest("form");
-            theForm.attr("action", "categories/delete").submit();
+            theForm.attr("action", "$url('config/categories/delete')").submit();
         });
 
         // Add autocomplete and file-browser
@@ -129,7 +129,7 @@
                         jQuery(elm).extractFormDataTo(data);
                         jQuery.ajax({
                             type: "POST",
-                            url: window.location.pathname + 'save',
+                            url: "$url('config/categories/save')",
                             data: data,
                             async: false // To prevent race-conditions when updating categories
                         })

--- a/interfaces/Config/templates/config_folders.tmpl
+++ b/interfaces/Config/templates/config_folders.tmpl
@@ -8,10 +8,9 @@
             <input type="checkbox" id="advanced-settings-button" name="advanced-settings-button"> $T('button-advanced')
         </label>
     </div>
-    <form action="saveDirectories" method="post" name="fullform" class="fullform" autocomplete="off">
+    <form action="folders/save" method="post" class="fullform" autocomplete="off">
     <input type="hidden" id="apikey" name="apikey" value="$apikey" />
     <input type="hidden" name="output" value="json" />
-    <input type="hidden" id="ajax" name="ajax" value="1" />
     <div class="section">
         <div class="col2">
             <h3>$T('userFolders') <a href="$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>

--- a/interfaces/Config/templates/config_folders.tmpl
+++ b/interfaces/Config/templates/config_folders.tmpl
@@ -8,7 +8,7 @@
             <input type="checkbox" id="advanced-settings-button" name="advanced-settings-button"> $T('button-advanced')
         </label>
     </div>
-    <form action="folders/save" method="post" class="fullform" autocomplete="off">
+    <form action="$url('config/folders/save')" method="post" class="fullform" autocomplete="off">
     <input type="hidden" id="apikey" name="apikey" value="$apikey" />
     <input type="hidden" name="output" value="json" />
     <div class="section">
@@ -34,7 +34,7 @@
                 <div class="field-pair">
                     <label class="config" for="complete_dir">$T('opt-complete_dir')</label>
                     <input type="text" name="complete_dir" id="complete_dir" value="$complete_dir" data-initialdir="$my_home" />
-                    <a class="btn btn-default" href="${root}config/sorting/"><span class="glyphicon glyphicon-sort-by-alphabet"></span> $T('cmenu-sorting')</a>
+                    <a class="btn btn-default" href="$url('config/sorting')"><span class="glyphicon glyphicon-sort-by-alphabet"></span> $T('cmenu-sorting')</a>
                     <span class="desc">$T('explain-complete_dir') <br/> $T('explain-complete_dir-sorting')</span>
                 </div>
                 <div class="field-pair advanced-settings">
@@ -112,7 +112,7 @@
                 <div class="field-pair">
                     <label class="config" for="log_dir">$T('opt-log_dir')</label>
                     <input type="text" name="log_dir" id="log_dir" value="$log_dir" data-initialdir="$my_lcldata" />
-                    <a class="btn btn-default" id="purge_log_files" href="${root}"><span class="glyphicon glyphicon-trash"></span> $T('purge_log_files')</a>
+                    <a class="btn btn-default" id="purge_log_files" href="$url()"><span class="glyphicon glyphicon-trash"></span> $T('purge_log_files')</a>
                     <span class="desc">$T('explain-log_dir')</span>
                 </div>
                 <div class="field-pair">
@@ -138,7 +138,7 @@
             if ( confirm("$T('confirm')") ) {
                 $.ajax({
                     type: "POST",
-                    url: "../../api",
+                    url: "$url('api')",
                     data: {mode: 'config', name: 'purge_log_files', output: 'json', apikey: jQuery('#apikey').val()}
                 })
             } else {

--- a/interfaces/Config/templates/config_general.tmpl
+++ b/interfaces/Config/templates/config_general.tmpl
@@ -8,9 +8,8 @@
             <input type="checkbox" id="advanced-settings-button" name="advanced-settings-button"> $T('button-advanced')
         </label>
     </div>
-    <form action="saveGeneral" method="post" name="fullform" class="fullform" autocomplete="off">
+    <form action="general/save" method="post" class="fullform" autocomplete="off">
         <input type="hidden" id="apikey" name="apikey" value="$apikey" />
-        <input type="hidden" id="ajax" name="ajax" value="1" />
         <input type="hidden" name="output" value="json" />
         <div class="section">
             <div class="col2">
@@ -46,7 +45,6 @@
                             <!--#end if#-->
                         <!--#end for#-->
                         </select>
-                        <span class="desc">$T('explain-web_dir')&nbsp;&nbsp;<a href="$caller_url">$caller_url</a></span>
                     </div>
                     <div class="field-pair">
                         <label class="config" for="language">$T('opt-language')</label>
@@ -223,9 +221,8 @@
         </div><!-- /section -->
     </form>
 
-    <form action="uploadConfig" method="post" name="fullform" class="fullform" autocomplete="off" enctype="multipart/form-data">
+    <form action="general/upload_config" method="post" class="fullform" autocomplete="off" enctype="multipart/form-data">
         <input type="hidden" name="apikey" value="$apikey" />
-        <input type="hidden" name="ajax" value="1" />
         <input type="hidden" name="output" value="json" />
         <div class="section">
             <div class="col2">
@@ -280,8 +277,6 @@ jQuery(document).ready(function(){
             // Skip the fancy stuff, just submit
             this.submit()
         })
-        // No JSON response
-        jQuery('#ajax').val('')
     })
     hideOrShowTranslate()
 

--- a/interfaces/Config/templates/config_general.tmpl
+++ b/interfaces/Config/templates/config_general.tmpl
@@ -8,7 +8,7 @@
             <input type="checkbox" id="advanced-settings-button" name="advanced-settings-button"> $T('button-advanced')
         </label>
     </div>
-    <form action="general/save" method="post" class="fullform" autocomplete="off">
+    <form action="$url('config/general/save')" method="post" class="fullform" autocomplete="off">
         <input type="hidden" id="apikey" name="apikey" value="$apikey" />
         <input type="hidden" name="output" value="json" />
         <div class="section">
@@ -221,7 +221,7 @@
         </div><!-- /section -->
     </form>
 
-    <form action="general/upload_config" method="post" class="fullform" autocomplete="off" enctype="multipart/form-data">
+    <form action="$url('config/general/upload_config')" method="post" class="fullform" autocomplete="off" enctype="multipart/form-data">
         <input type="hidden" name="apikey" value="$apikey" />
         <input type="hidden" name="output" value="json" />
         <div class="section">
@@ -313,7 +313,7 @@ jQuery(document).ready(function(){
       if (confirm("$T('confirm')")) {
         $.ajax({
           type: "POST",
-          url: "../../api",
+          url: "$url('api')",
           data: {mode:'config', name:'set_apikey', apikey: jQuery('#apikey').val()},
           success: function(msg){
             jQuery('#apikey').val(msg);
@@ -326,7 +326,7 @@ jQuery(document).ready(function(){
       if (confirm("$T('confirm')")) {
         $.ajax({
           type: "POST",
-          url: "../../api",
+          url: "$url('api')",
           data: { mode:'config', name:'set_nzbkey', apikey: jQuery('#apikey').val() },
           success: function(msg){
             jQuery('#nzbkey').val(msg);
@@ -361,7 +361,7 @@ jQuery(document).ready(function(){
         // Submit request and then restart
         $.ajax({
             type: "POST",
-            url: "../../api",
+            url: "$url('api')",
             data: { mode: 'config', name: 'regenerate_certs', apikey: jQuery('#apikey').val() },
             success: function(msg) {
                 do_restart()
@@ -399,7 +399,7 @@ jQuery(document).ready(function(){
     jQuery('#create_backup').click(function () {
         $.ajax({
           type: "POST",
-          url: "../../api",
+          url: "$url('api')",
           data: {mode:'config', name:'create_backup', output:'json', apikey: jQuery('#apikey').val()},
           success: function(data) {
               if(data.value.result) {

--- a/interfaces/Config/templates/config_notify.tmpl
+++ b/interfaces/Config/templates/config_notify.tmpl
@@ -30,10 +30,9 @@
 <!--#end def#-->
 
 <div class="colmask">
-    <form action="saveNotify" method="post" name="fullform" class="fullform" autocomplete="off">
+    <form action="notify/save" method="post" class="fullform" autocomplete="off">
     <input type="hidden" id="apikey" name="apikey" value="$apikey" />
     <input type="hidden" name="output" value="json" />
-    <input type="hidden" id="ajax" name="ajax" value="1" />
     <div class="section" id="email">
         <div class="col2">
             <h3>$T('cmenu-email') <a href="$help_uri#toc0" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>

--- a/interfaces/Config/templates/config_notify.tmpl
+++ b/interfaces/Config/templates/config_notify.tmpl
@@ -30,7 +30,7 @@
 <!--#end def#-->
 
 <div class="colmask">
-    <form action="notify/save" method="post" class="fullform" autocomplete="off">
+    <form action="$url('config/notify/save')" method="post" class="fullform" autocomplete="off">
     <input type="hidden" id="apikey" name="apikey" value="$apikey" />
     <input type="hidden" name="output" value="json" />
     <div class="section" id="email">
@@ -455,7 +455,7 @@ jQuery(document).ready(function(){
         // Get the request
         jQuery.ajax({
             type: "GET",
-            url: "../../api",
+            url: "$url('api')",
             data: data
         }).then(function(data) {
             // Remove disabled and make the box

--- a/interfaces/Config/templates/config_rss.tmpl
+++ b/interfaces/Config/templates/config_rss.tmpl
@@ -8,7 +8,7 @@
         <div class="padTable">
             <a class="main-helplink" href="$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a>
             <p>$T('explain-RSS')</p>
-            <form action="add_rss_feed" method="post" autocomplete="off">
+            <form action="rss/add_rss_feed" method="post" autocomplete="off">
                 <input type="hidden" name="apikey" value="$apikey" />
                 <table class="catTable addRssTable">
                     <tr>
@@ -38,7 +38,7 @@
     <!--#if $rss#-->
     <div class="section">
         <div class="padTable">
-            <form action="save_rss_feed" method="post" autocomplete="off">
+            <form action="rss/save_rss_feed" method="post" autocomplete="off">
                 <input type="hidden" name="apikey" value="$apikey" />
                 <table id="subscriptions">
                     <tbody>
@@ -75,7 +75,7 @@
             </form>
             <!--#if $feeds#-->
             <br/>
-            <form action="rss_now" method="post" autocomplete="off">
+            <form action="rss/rss_now" method="post" autocomplete="off">
                 <input type="hidden" name="apikey" value="$apikey" />
                 <button type="submit" class="btn btn-default readAll"><span class="glyphicon glyphicon-sort"></span> $T('button-rssNow')</button>
             </form>
@@ -84,7 +84,7 @@
     </div>
     <!--#end if#-->
     <div class="section">
-        <form action="save_rss_rate" method="post" autocomplete="off">
+        <form action="rss/save_rss_rate" method="post" autocomplete="off">
             <input type="hidden" name="apikey" value="$apikey" />
             <div class="col1">
                 <fieldset>
@@ -116,7 +116,7 @@
                 $error
             </div>
             <!--#end if#-->
-            <form action="upd_rss_feed" method="post">
+            <form action="rss/upd_rss_feed" method="post">
                 <input type="hidden" name="apikey" value="$apikey" />
                 <input type="hidden" name="feed" value="$active_feed" />
                 <input type="hidden" name="uri" value="$rss[$feed]['uris']" />
@@ -208,7 +208,7 @@
                 </table>
             </form>
             <!-- add new filter -->
-            <form action="upd_rss_filter" method="post">
+            <form action="rss/upd_rss_filter" method="post">
                 <input type="hidden" name="apikey" value="$apikey" />
                 <input type="hidden" name="index" value="$rss[$feed]['filtercount']" />
                 <input type="hidden" name="feed" value="$active_feed" />
@@ -285,7 +285,7 @@
             <!--#set $fnum = 0#-->
             <!--#for $filter in $rss[$feed].filters#-->
                 <!--#set $odd = not $odd#-->
-                <form action="upd_rss_filter" method="post" autocomplete="off">
+                <form action="rss/upd_rss_filter" method="post" autocomplete="off">
                     <input type="hidden" name="apikey" value="$apikey" />
                     <input type="hidden" name="index" value="$fnum" />
                     <input type="hidden" name="feed" value="$active_feed" />
@@ -364,7 +364,7 @@
                 </form>
                 <!--#set $fnum = $fnum+1#-->
             <!--#end for#-->
-            <form action="download_rss_feed" method="post">
+            <form action="rss/download_rss_feed" method="post">
                 <input type="hidden" name="apikey" value="$apikey" />
                 <input type="hidden" name="feed" value="$active_feed" />
                 <div class="padding">
@@ -400,7 +400,7 @@
                     <!--#for $job in $matched#-->
                         <tr class="infoTableSeperator">
                             <td>
-                                <form action="download" method="get">
+                                <form action="rss/download" method="post">
                                     <input type="hidden" value="$active_feed" name="feed" />
                                     <input type="hidden" name="apikey" value="$apikey" />
                                     <input type="hidden" name="url" value="$job['url']" />
@@ -444,7 +444,7 @@
                     <!--#for $job in $unmatched#-->
                         <tr class="infoTableSeperator">
                             <td>
-                                <form action="download" method="get">
+                                <form action="rss/download" method="post">
                                     <input type="hidden" value="$active_feed" name="feed" />
                                     <input type="hidden" name="apikey" value="$apikey" />
                                     <input type="hidden" name="url" value="$job['url']" />
@@ -473,24 +473,32 @@
             </div>
             <div class="tab-pane padTable" id="rss-tab-done">
                 <!--#if $downloaded#-->
-                <form action="clean_rss_jobs" method="post">
+                <form action="rss/clean_rss_jobs" method="post">
                     <input type="hidden" value="$active_feed" name="feed" />
                     <input type="hidden" name="apikey" value="$apikey" />
                     <table class="catTable">
                         <thead>
                             <tr>
-                                <th class="default-sort">$T('rss-added')</th>
+                                <th class="no-sort">$T('link-download')</th>
                                 <th>$T('rss-filter')</th>
                                 <th>$T('size')</th>
                                 <th width="60%">$T('sort-title')</th>
                                 <th>$T('category')</th>
-                                <th>$T('nzo-age')</th>
+                                <th class="default-sort">$T('nzo-age')</th>
                                 <th>$T('source')</th>
                             </tr>
                         </thead>
-                        <!--#for $job in $downloaded#-->
+                        <!--#for $job in $matched#-->
                             <tr class="infoTableSeperator">
-                                <td data-sort-value="$job['time_downloaded_ms']">$job['time_downloaded']</td>
+                                <td>
+                                    <form action="download" method="get">
+                                        <input type="hidden" value="$active_feed" name="feed" />
+                                        <input type="hidden" name="apikey" value="$apikey" />
+                                        <input type="hidden" name="url" value="$job['url']" />
+                                        <input type="hidden" name="nzbname" value="$job['nzbname']" />
+                                        <button type="submit" class="btn btn-default"><span class="glyphicon glyphicon-plus-sign"></span> $T('link-download')</button>
+                                    </form>
+                                </td>
                                 <td>$job['rule'] $job['skip']</td>
                                 <td data-sort-value="$job['size']">$job['size_units']</td>
                                 <td>$job['title']</td>
@@ -508,7 +516,7 @@
                     </table>
                 </form>
                 <!--#else#-->
-                    $T('none')
+                $T('none')
                 <!--#end if#-->
             </div>
             <!--#end if#-->
@@ -517,7 +525,7 @@
 </div>
 <!-- /colmask -->
 
-<form method="post" action="save_rss_feed" class="modal fade" id="rss_edit_modal" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="rss-edit-modal-title">
+<form method="post" action="rss/save_rss_feed" class="modal fade" id="rss_edit_modal" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="rss-edit-modal-title">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
@@ -589,7 +597,7 @@ jQuery(document).ready(function(){
             var whichFeed = jQuery(this).attr("rel");
             jQuery.ajax({
                 type: "POST",
-                url: "del_rss_feed",
+                url: "rss/del_rss_feed",
                 data: {feed: whichFeed, apikey: "$apikey" }
             }).done(function( msg ) {
                 // Let us leave!
@@ -604,7 +612,7 @@ jQuery(document).ready(function(){
         var whichFeed = jQuery(this).attr("rel");
         jQuery.ajax({
             type: "POST",
-            url: "toggle_rss_feed",
+            url: "rss/toggle_rss_feed",
             data: {feed: whichFeed, apikey: "$apikey" }
         }).done(function() {
             // Let us leave!
@@ -615,7 +623,7 @@ jQuery(document).ready(function(){
     });
 
     // Only the Accept filter needs all the options
-    jQuery('form[action="upd_rss_filter"]').find('select[name="filter_type"]').change(function() {
+    jQuery('form[action="rss/upd_rss_filter"]').find('select[name="filter_type"]').change(function() {
         jQuery(this).parent().parent().find('select:not([name="filter_type"])').attr('disabled', jQuery(this).val() !== "A" && jQuery(this).val() !== "S")
     })
     // Trigger on-load for all
@@ -644,7 +652,7 @@ jQuery(document).ready(function(){
         var whichFeed = jQuery(this).attr("rel");
         jQuery.ajax({
             type: "POST",
-            url: "test_rss_feed",
+            url: "rss/test_rss_feed",
             data: {feed: whichFeed, apikey: "$apikey" }
         }).done(function( msg ) {
             // Let us leave!
@@ -657,15 +665,21 @@ jQuery(document).ready(function(){
     jQuery('.cleanFeed').click(function(){
         setActiveIcon(this)
         var theForm = jQuery(this).closest("form");
-        theForm.attr("action", "clean_rss_jobs").submit();
+        theForm.attr("action", "rss/clean_rss_jobs").submit();
+    });
+
+    jQuery('.evalFeed').click(function(){
+        setActiveIcon(this)
+        var theForm = jQuery(this).closest("form");
+        theForm.attr("action", "rss/eval_rss_feed").submit();
     });
 
     jQuery('.delFilter').click(function(){
         var theForm = jQuery(this).closest("form");
-        theForm.attr("action", "del_rss_filter").submit();
+        theForm.attr("action", "rss/del_rss_filter").submit();
     });
 
-    jQuery('form[action="download"]').ajaxForm({
+    jQuery('form[action="rss/download"]').ajaxForm({
         datatype: 'json',
         beforeSubmit: function (_, form) {
             jQuery(form).find('button').attr("disabled", "disabled")

--- a/interfaces/Config/templates/config_rss.tmpl
+++ b/interfaces/Config/templates/config_rss.tmpl
@@ -8,7 +8,7 @@
         <div class="padTable">
             <a class="main-helplink" href="$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a>
             <p>$T('explain-RSS')</p>
-            <form action="rss/add_rss_feed" method="post" autocomplete="off">
+            <form data-form="add-rss-feed" action="$url('config/rss/add_rss_feed')" method="post" autocomplete="off">
                 <input type="hidden" name="apikey" value="$apikey" />
                 <table class="catTable addRssTable">
                     <tr>
@@ -38,7 +38,7 @@
     <!--#if $rss#-->
     <div class="section">
         <div class="padTable">
-            <form action="rss/save_rss_feed" method="post" autocomplete="off">
+            <form action="$url('config/rss/save_rss_feed')" method="post" autocomplete="off">
                 <input type="hidden" name="apikey" value="$apikey" />
                 <table id="subscriptions">
                     <tbody>
@@ -75,7 +75,7 @@
             </form>
             <!--#if $feeds#-->
             <br/>
-            <form action="rss/rss_now" method="post" autocomplete="off">
+            <form action="$url('config/rss/rss_now')" method="post" autocomplete="off">
                 <input type="hidden" name="apikey" value="$apikey" />
                 <button type="submit" class="btn btn-default readAll"><span class="glyphicon glyphicon-sort"></span> $T('button-rssNow')</button>
             </form>
@@ -84,7 +84,7 @@
     </div>
     <!--#end if#-->
     <div class="section">
-        <form action="rss/save_rss_rate" method="post" autocomplete="off">
+        <form action="$url('config/rss/save_rss_rate')" method="post" autocomplete="off">
             <input type="hidden" name="apikey" value="$apikey" />
             <div class="col1">
                 <fieldset>
@@ -107,7 +107,7 @@
         <div class="padTable">
             <a class="main-helplink" href="$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a>
             <h2 class="nomargin activeRSS">
-                <a href="${root}config/rss/">$T('cmenu-rss')</a> &raquo;
+                <a href="$url('config/rss')">$T('cmenu-rss')</a> &raquo;
                 $active_feed
             </h2>
             <!--#if $error#-->
@@ -116,7 +116,7 @@
                 $error
             </div>
             <!--#end if#-->
-            <form action="rss/upd_rss_feed" method="post">
+            <form action="$url('config/rss/upd_rss_feed')" method="post">
                 <input type="hidden" name="apikey" value="$apikey" />
                 <input type="hidden" name="feed" value="$active_feed" />
                 <input type="hidden" name="uri" value="$rss[$feed]['uris']" />
@@ -208,7 +208,7 @@
                 </table>
             </form>
             <!-- add new filter -->
-            <form action="rss/upd_rss_filter" method="post">
+            <form data-form="update-rss-filter" action="$url('config/rss/upd_rss_filter')" method="post">
                 <input type="hidden" name="apikey" value="$apikey" />
                 <input type="hidden" name="index" value="$rss[$feed]['filtercount']" />
                 <input type="hidden" name="feed" value="$active_feed" />
@@ -285,7 +285,7 @@
             <!--#set $fnum = 0#-->
             <!--#for $filter in $rss[$feed].filters#-->
                 <!--#set $odd = not $odd#-->
-                <form action="rss/upd_rss_filter" method="post" autocomplete="off">
+                <form data-form="update-rss-filter" action="$url('config/rss/upd_rss_filter')" method="post" autocomplete="off">
                     <input type="hidden" name="apikey" value="$apikey" />
                     <input type="hidden" name="index" value="$fnum" />
                     <input type="hidden" name="feed" value="$active_feed" />
@@ -364,7 +364,7 @@
                 </form>
                 <!--#set $fnum = $fnum+1#-->
             <!--#end for#-->
-            <form action="rss/download_rss_feed" method="post">
+            <form action="$url('config/rss/download_rss_feed')" method="post">
                 <input type="hidden" name="apikey" value="$apikey" />
                 <input type="hidden" name="feed" value="$active_feed" />
                 <div class="padding">
@@ -400,7 +400,7 @@
                     <!--#for $job in $matched#-->
                         <tr class="infoTableSeperator">
                             <td>
-                                <form action="rss/download" method="post">
+                                <form data-form="download-rss-job" action="$url('config/rss/download')" method="post">
                                     <input type="hidden" value="$active_feed" name="feed" />
                                     <input type="hidden" name="apikey" value="$apikey" />
                                     <input type="hidden" name="url" value="$job['url']" />
@@ -444,7 +444,7 @@
                     <!--#for $job in $unmatched#-->
                         <tr class="infoTableSeperator">
                             <td>
-                                <form action="rss/download" method="post">
+                                <form data-form="download-rss-job" action="$url('config/rss/download')" method="post">
                                     <input type="hidden" value="$active_feed" name="feed" />
                                     <input type="hidden" name="apikey" value="$apikey" />
                                     <input type="hidden" name="url" value="$job['url']" />
@@ -473,7 +473,7 @@
             </div>
             <div class="tab-pane padTable" id="rss-tab-done">
                 <!--#if $downloaded#-->
-                <form action="rss/clean_rss_jobs" method="post">
+                <form action="$url('config/rss/clean_rss_jobs')" method="post">
                     <input type="hidden" value="$active_feed" name="feed" />
                     <input type="hidden" name="apikey" value="$apikey" />
                     <table class="catTable">
@@ -491,7 +491,7 @@
                         <!--#for $job in $matched#-->
                             <tr class="infoTableSeperator">
                                 <td>
-                                    <form action="download" method="get">
+                                    <form action="$url('config/rss/download')" method="post">
                                         <input type="hidden" value="$active_feed" name="feed" />
                                         <input type="hidden" name="apikey" value="$apikey" />
                                         <input type="hidden" name="url" value="$job['url']" />
@@ -525,7 +525,7 @@
 </div>
 <!-- /colmask -->
 
-<form method="post" action="rss/save_rss_feed" class="modal fade" id="rss_edit_modal" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="rss-edit-modal-title">
+<form method="post" action="$url('config/rss/save_rss_feed')" class="modal fade" id="rss_edit_modal" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="rss-edit-modal-title">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
@@ -553,7 +553,7 @@
     </div><!-- /.modal-dialog -->
 </form><!-- /.modal -->
 
-<script type="text/javascript" src="${root}staticcfg/js/jquery.tablesort.min.js"></script>
+<script type="text/javascript" src="$url('staticcfg/js/jquery.tablesort.min.js', v=$cache_buster)"></script>
 <script type="text/javascript">
 function urlencode(str) {
     return encodeURIComponent(str).replace(/!/g, '%21').replace(/'/g, '%27').replace(/\(/g, '%28').replace(/\)/g, '%29').replace(/\*/g, '%2A').replace(/%20/g, '+');
@@ -597,7 +597,7 @@ jQuery(document).ready(function(){
             var whichFeed = jQuery(this).attr("rel");
             jQuery.ajax({
                 type: "POST",
-                url: "rss/del_rss_feed",
+                url: "$url('config/rss/del_rss_feed')",
                 data: {feed: whichFeed, apikey: "$apikey" }
             }).done(function( msg ) {
                 // Let us leave!
@@ -612,7 +612,7 @@ jQuery(document).ready(function(){
         var whichFeed = jQuery(this).attr("rel");
         jQuery.ajax({
             type: "POST",
-            url: "rss/toggle_rss_feed",
+            url: "$url('config/rss/toggle_rss_feed')",
             data: {feed: whichFeed, apikey: "$apikey" }
         }).done(function() {
             // Let us leave!
@@ -623,7 +623,7 @@ jQuery(document).ready(function(){
     });
 
     // Only the Accept filter needs all the options
-    jQuery('form[action="rss/upd_rss_filter"]').find('select[name="filter_type"]').change(function() {
+    jQuery('form[data-form="update-rss-filter"]').find('select[name="filter_type"]').change(function() {
         jQuery(this).parent().parent().find('select:not([name="filter_type"])').attr('disabled', jQuery(this).val() !== "A" && jQuery(this).val() !== "S")
     })
     // Trigger on-load for all
@@ -652,7 +652,7 @@ jQuery(document).ready(function(){
         var whichFeed = jQuery(this).attr("rel");
         jQuery.ajax({
             type: "POST",
-            url: "rss/test_rss_feed",
+            url: "$url('config/rss/test_rss_feed')",
             data: {feed: whichFeed, apikey: "$apikey" }
         }).done(function( msg ) {
             // Let us leave!
@@ -665,21 +665,21 @@ jQuery(document).ready(function(){
     jQuery('.cleanFeed').click(function(){
         setActiveIcon(this)
         var theForm = jQuery(this).closest("form");
-        theForm.attr("action", "rss/clean_rss_jobs").submit();
+        theForm.attr("action", "$url('config/rss/clean_rss_jobs')").submit();
     });
 
     jQuery('.evalFeed').click(function(){
         setActiveIcon(this)
         var theForm = jQuery(this).closest("form");
-        theForm.attr("action", "rss/eval_rss_feed").submit();
+        theForm.attr("action", "$url('config/rss/eval_rss_feed')").submit();
     });
 
     jQuery('.delFilter').click(function(){
         var theForm = jQuery(this).closest("form");
-        theForm.attr("action", "rss/del_rss_filter").submit();
+        theForm.attr("action", "$url('config/rss/del_rss_filter')").submit();
     });
 
-    jQuery('form[action="rss/download"]').ajaxForm({
+    jQuery('form[data-form="download-rss-job"]').ajaxForm({
         datatype: 'json',
         beforeSubmit: function (_, form) {
             jQuery(form).find('button').attr("disabled", "disabled")

--- a/interfaces/Config/templates/config_scheduling.tmpl
+++ b/interfaces/Config/templates/config_scheduling.tmpl
@@ -17,7 +17,7 @@ else:
         <div class="col2">
             <h3>$T('addSchedule') <a href="$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
         </div><!-- /col2 -->
-        <form action="addSchedule" method="post" autocomplete="off">
+        <form action="scheduling/add_schedule" method="post" autocomplete="off">
         <input type="hidden" id="apikey" name="apikey" value="$apikey" />
         <div class="col1">
             <fieldset>
@@ -90,7 +90,7 @@ else:
                         <!--#set $odd = True#-->
                         <!--#for $schednum, $line in enumerate($schedlines)#-->
                             <!--#set $odd = not $odd#-->
-                            <form action="delSchedule" method="post">
+                            <form action="scheduling/del_schedule" method="post">
                                 <input type="hidden" name="apikey" value="$apikey"/>
                                 <input type="hidden" name="line" value="$line"/>
                                 <div class="field-pair infoTableSeperator <!--#if $odd then "" else " alt"#-->">
@@ -136,7 +136,7 @@ else:
     jQuery('[name="schedenabled"]').click(function() {
         jQuery.ajax({
             type: "POST",
-            url: "toggleSchedule",
+            url: "scheduling/toggle_schedule",
             data: {line: jQuery(this).val(), apikey: "$apikey" }
         }).done(function() {
             // Let us leave!

--- a/interfaces/Config/templates/config_scheduling.tmpl
+++ b/interfaces/Config/templates/config_scheduling.tmpl
@@ -17,7 +17,7 @@ else:
         <div class="col2">
             <h3>$T('addSchedule') <a href="$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
         </div><!-- /col2 -->
-        <form action="scheduling/add_schedule" method="post" autocomplete="off">
+        <form data-form="add-schedule" action="$url('config/scheduling/add_schedule')" method="post" autocomplete="off">
         <input type="hidden" id="apikey" name="apikey" value="$apikey" />
         <div class="col1">
             <fieldset>
@@ -90,7 +90,7 @@ else:
                         <!--#set $odd = True#-->
                         <!--#for $schednum, $line in enumerate($schedlines)#-->
                             <!--#set $odd = not $odd#-->
-                            <form action="scheduling/del_schedule" method="post">
+                            <form data-form="del-schedule" action="$url('config/scheduling/del_schedule')" method="post">
                                 <input type="hidden" name="apikey" value="$apikey"/>
                                 <input type="hidden" name="line" value="$line"/>
                                 <div class="field-pair infoTableSeperator <!--#if $odd then "" else " alt"#-->">
@@ -136,7 +136,7 @@ else:
     jQuery('[name="schedenabled"]').click(function() {
         jQuery.ajax({
             type: "POST",
-            url: "scheduling/toggle_schedule",
+            url: "$url('config/scheduling/toggle_schedule')",
             data: {line: jQuery(this).val(), apikey: "$apikey" }
         }).done(function() {
             // Let us leave!

--- a/interfaces/Config/templates/config_server.tmpl
+++ b/interfaces/Config/templates/config_server.tmpl
@@ -40,7 +40,7 @@
             <h3>$T('addServer') <a href="$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
         </div>
         <div class="col1">
-            <form action="addServer" method="post" autocomplete="off" onsubmit="removeObfuscation();">
+            <form action="server/add_server" method="post" autocomplete="off">
                 <input type="hidden" name="apikey" value="$apikey" />
                 <input type="hidden" name="output" value="json" />
                 <fieldset>
@@ -153,11 +153,10 @@
     <!--#set $cur_prio_color = -1 #-->
     <!--#set $last_prio = -1 #-->
     <!--#for $cur, $server in enumerate($servers) #-->
-        <form action="saveServer" method="post" class="fullform" autocomplete="off">
+        <form action="server/save_server" method="post" class="fullform" autocomplete="off">
             <input type="hidden" name="apikey" value="$apikey" />
             <input type="hidden" name="output" value="json" />
             <input type="hidden" name="server" value="$server['name']" />
-            <input type="hidden" name="ajax" value=1 />
 
             <div class="section <!--#if int($server['enable']) == 0 then 'server-disabled' else ""#-->">
                 <div class="col2 <!--#if int($server['enable']) == 0 then 'server-disabled' else ""#-->">
@@ -484,7 +483,6 @@
         jQuery('input[name="priority"], input[name="displayname"], textarea[name="notes"]').on('change', function(event) {
             var parentForm = jQuery(event.target).parents("form")
             parentForm.unbind("submit")
-            parentForm.find('input[name="ajax"]').val('')
         })
 
         /**
@@ -570,7 +568,7 @@
                     resultBox.prepend('<span class="glyphicon glyphicon-ok-sign"></span> ')
 
                     // Allow adding the new server if we are in the new-server section
-                    if(theButton.parents("form[action='addServer']").length) {
+                    if(theButton.parents("form[action='server/add_server']").length) {
                         jQuery(".addNewServer").removeAttr("disabled")
                         jQuery(".addNewServer").removeAttr("data-toggle")
                         jQuery(".addNewServer").removeAttr("title")
@@ -581,7 +579,7 @@
                     resultBox.prepend('<span class="glyphicon glyphicon-exclamation-sign"></span> ')
 
                     // Disable the adding of new server, just to be sure
-                    if(theButton.parents("form[action='addServer']").length) {
+                    if(theButton.parents("form[action='server/add_server']").length) {
                         jQuery(".addNewServer").attr("disabled", "disabled")
                         jQuery(".addNewServer").attr("data-toggle", "tooltip")
                         jQuery(".addNewServer").attr("data-placement", "top")
@@ -592,9 +590,34 @@
             });
         });
 
+        jQuery('.addNewServer').click(function(event){
+            event.preventDefault()
+            removeObfuscation()
+            var theButton = jQuery(this)
+            var resultBox = theButton.parents('.col1').find('.result-box .alert')
+            theButton.attr("disabled", "disabled")
+            jQuery.ajax({
+                type: "POST",
+                url: "server/add_server",
+                data: theButton.parents('form:first').serialize()
+            }).then(function(data) {
+                if(data.status) {
+                    // Success — reload to show the new server
+                    formWasSubmitted = true
+                    formHasChanged = false
+                    location.reload()
+                } else {
+                    // Show error in the result box
+                    resultBox.removeClass('alert-success').addClass('alert-danger').show()
+                    resultBox.html('<span class="glyphicon glyphicon-exclamation-sign"></span> ' + data.error)
+                    theButton.removeAttr("disabled")
+                }
+            })
+        })
+
         jQuery('.delServer').click(function(){
             if( confirm("$T('confirm')") ) {
-                jQuery(this).parents('form:first').attr('action','delServer').submit();
+                jQuery(this).parents('form:first').attr('action','server/delete_server').submit();
                 // Let us leave!
                 formWasSubmitted = true;
                 formHasChanged = false;
@@ -605,7 +628,7 @@
 
         jQuery('.clrServer').click(function(){
             if( confirm("$T('confirm')") ) {
-                jQuery(this).parents('form:first').attr('action','clrServer').submit();
+                jQuery(this).parents('form:first').attr('action','server/clear_server').submit();
                 // Let us leave!
                 formWasSubmitted = true;
                 formHasChanged = false;
@@ -618,7 +641,7 @@
             var whichServer = jQuery(this).attr("name");
             jQuery.ajax({
                 type: "POST",
-                url: "toggleServer",
+                url: "server/toggle_server",
                 data: {server: whichServer, apikey: "$apikey" }
             }).done(function() {
                 // Let us leave!

--- a/interfaces/Config/templates/config_server.tmpl
+++ b/interfaces/Config/templates/config_server.tmpl
@@ -40,7 +40,7 @@
             <h3>$T('addServer') <a href="$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
         </div>
         <div class="col1">
-            <form action="server/add_server" method="post" autocomplete="off">
+            <form data-form="add-server" action="$url('config/server/add_server')" method="post" autocomplete="off">
                 <input type="hidden" name="apikey" value="$apikey" />
                 <input type="hidden" name="output" value="json" />
                 <fieldset>
@@ -153,7 +153,7 @@
     <!--#set $cur_prio_color = -1 #-->
     <!--#set $last_prio = -1 #-->
     <!--#for $cur, $server in enumerate($servers) #-->
-        <form action="server/save_server" method="post" class="fullform" autocomplete="off">
+        <form action="$url('config/server/save_server')" method="post" class="fullform" autocomplete="off">
             <input type="hidden" name="apikey" value="$apikey" />
             <input type="hidden" name="output" value="json" />
             <input type="hidden" name="server" value="$server['name']" />
@@ -327,8 +327,8 @@
     <!--#end for#-->
 </div>
 
-<script type="text/javascript" src="${root}staticcfg/js/chartist.min.js"></script>
-<script type="text/javascript" src="${root}staticcfg/js/filesize.min.js"></script>
+<script type="text/javascript" src="$url('staticcfg/js/chartist.min.js', v=$cache_buster)"></script>
+<script type="text/javascript" src="$url('staticcfg/js/filesize.min.js', v=$cache_buster)"></script>
 <script type="text/javascript">
     // Standardize chart options
     var chartOptions = {
@@ -550,7 +550,7 @@
             theButton.find('span').toggleClass('glyphicon-sort glyphicon-refresh spin-glyphicon')
             jQuery.ajax({
                 type: "POST",
-                url: "../../api",
+                url: "$url('api')",
                 data: "mode=config&name=test_server&" + jQuery(this).parents('form:first').serialize()
             }).then(function(data) {
                 // Let's replace the link
@@ -568,7 +568,7 @@
                     resultBox.prepend('<span class="glyphicon glyphicon-ok-sign"></span> ')
 
                     // Allow adding the new server if we are in the new-server section
-                    if(theButton.parents("form[action='server/add_server']").length) {
+                    if(theButton.parents("form[data-form='add-server']").length) {
                         jQuery(".addNewServer").removeAttr("disabled")
                         jQuery(".addNewServer").removeAttr("data-toggle")
                         jQuery(".addNewServer").removeAttr("title")
@@ -579,7 +579,7 @@
                     resultBox.prepend('<span class="glyphicon glyphicon-exclamation-sign"></span> ')
 
                     // Disable the adding of new server, just to be sure
-                    if(theButton.parents("form[action='server/add_server']").length) {
+                    if(theButton.parents("form[data-form='add-server']").length) {
                         jQuery(".addNewServer").attr("disabled", "disabled")
                         jQuery(".addNewServer").attr("data-toggle", "tooltip")
                         jQuery(".addNewServer").attr("data-placement", "top")
@@ -598,7 +598,7 @@
             theButton.attr("disabled", "disabled")
             jQuery.ajax({
                 type: "POST",
-                url: "server/add_server",
+                url: "$url('config/server/add_server')",
                 data: theButton.parents('form:first').serialize()
             }).then(function(data) {
                 if(data.status) {
@@ -617,7 +617,7 @@
 
         jQuery('.delServer').click(function(){
             if( confirm("$T('confirm')") ) {
-                jQuery(this).parents('form:first').attr('action','server/delete_server').submit();
+                jQuery(this).parents('form:first').attr('action',"$url('config/server/delete_server')").submit();
                 // Let us leave!
                 formWasSubmitted = true;
                 formHasChanged = false;
@@ -628,7 +628,7 @@
 
         jQuery('.clrServer').click(function(){
             if( confirm("$T('confirm')") ) {
-                jQuery(this).parents('form:first').attr('action','server/clear_server').submit();
+                jQuery(this).parents('form:first').attr('action',"$url('config/server/clear_server')").submit();
                 // Let us leave!
                 formWasSubmitted = true;
                 formHasChanged = false;
@@ -641,7 +641,7 @@
             var whichServer = jQuery(this).attr("name");
             jQuery.ajax({
                 type: "POST",
-                url: "server/toggle_server",
+                url: "$url('config/server/toggle_server')",
                 data: {server: whichServer, apikey: "$apikey" }
             }).done(function() {
                 // Let us leave!

--- a/interfaces/Config/templates/config_sorting.tmpl
+++ b/interfaces/Config/templates/config_sorting.tmpl
@@ -20,7 +20,7 @@
         <!--#set $selected_types = ["0"] if not len($selected_types) else $selected_types #-->
         <!-- SORTER $cur -->
         <div class="section <!--#if $cur != 0#-->sorter<!--#end if#-->" id="sorter_$cur" <!--#if $cur == 0#-->style="display: none;"<!--#end if#-->>
-            <form action="save_sorter" method="post" autocomplete="off" <!--#if $cur != 0#-->class="sorting-row"<!--#end if#-->>
+            <form action="sorting/save_sorter" method="post" autocomplete="off" <!--#if $cur != 0#-->class="sorting-row"<!--#end if#-->>
                 <input type="hidden" name="apikey" value="$apikey" />
                 <input type="hidden" name="order" value="$slot.order" />
                 <input type="hidden" value="$slot.name" name="name" />
@@ -347,7 +347,7 @@
     <div class="section align-center sorting-quick-setup">
         <h3>$T('sort-quick-add'):</h3>
         <!--#if "tv" in $categories#-->
-        <form action="save_sorter" method="post" autocomplete="off">
+        <form action="sorting/save_sorter" method="post" autocomplete="off">
             <input type="hidden" name="apikey" value="$apikey" />
             <input type="hidden" name="order" value="0" />
             <input type="hidden" name="is_active" value="1" />
@@ -366,7 +366,7 @@
         </form>
         <!--#end if#-->
         <!--#if "movies" in $categories#-->
-        <form action="save_sorter" method="post" autocomplete="off">
+        <form action="sorting/save_sorter" method="post" autocomplete="off">
             <input type="hidden" name="apikey" value="$apikey" />
             <input type="hidden" name="order" value="0" />
             <input type="hidden" name="is_active" value="1" />
@@ -437,7 +437,7 @@
     jQuery(document).ready(function() {
         jQuery('.delSorter').click(function() {
             var theForm = jQuery(this).closest("form");
-            theForm.attr("action", "delete").submit();
+            theForm.attr("action", "sorting/delete").submit();
         });
 
         jQuery('.addSorter').click(function(){
@@ -494,7 +494,7 @@
                         var data = {}
                         jQuery(elm).extractFormDataTo(data);
                         jQuery.ajax({
-                            type: "GET",
+                            type: "POST",
                             url: window.location.pathname + 'save_sorter',
                             data: data,
                             async: false // To prevent race-conditions when updating sorters
@@ -509,7 +509,7 @@
             var whichSorter = jQuery(this).attr("rel");
             jQuery.ajax({
                 type: "POST",
-                url: "toggle_sorter",
+                url: "sorting/toggle_sorter",
                 data: {sorter: whichSorter, apikey: "$apikey" }
             }).done(function() {
                 formWasSubmitted = true;

--- a/interfaces/Config/templates/config_sorting.tmpl
+++ b/interfaces/Config/templates/config_sorting.tmpl
@@ -20,7 +20,7 @@
         <!--#set $selected_types = ["0"] if not len($selected_types) else $selected_types #-->
         <!-- SORTER $cur -->
         <div class="section <!--#if $cur != 0#-->sorter<!--#end if#-->" id="sorter_$cur" <!--#if $cur == 0#-->style="display: none;"<!--#end if#-->>
-            <form action="sorting/save_sorter" method="post" autocomplete="off" <!--#if $cur != 0#-->class="sorting-row"<!--#end if#-->>
+            <form action="$url('config/sorting/save_sorter')" method="post" autocomplete="off" <!--#if $cur != 0#-->class="sorting-row"<!--#end if#-->>
                 <input type="hidden" name="apikey" value="$apikey" />
                 <input type="hidden" name="order" value="$slot.order" />
                 <input type="hidden" value="$slot.name" name="name" />
@@ -347,7 +347,7 @@
     <div class="section align-center sorting-quick-setup">
         <h3>$T('sort-quick-add'):</h3>
         <!--#if "tv" in $categories#-->
-        <form action="sorting/save_sorter" method="post" autocomplete="off">
+        <form action="$url('config/sorting/save_sorter')" method="post" autocomplete="off">
             <input type="hidden" name="apikey" value="$apikey" />
             <input type="hidden" name="order" value="0" />
             <input type="hidden" name="is_active" value="1" />
@@ -366,7 +366,7 @@
         </form>
         <!--#end if#-->
         <!--#if "movies" in $categories#-->
-        <form action="sorting/save_sorter" method="post" autocomplete="off">
+        <form action="$url('config/sorting/save_sorter')" method="post" autocomplete="off">
             <input type="hidden" name="apikey" value="$apikey" />
             <input type="hidden" name="order" value="0" />
             <input type="hidden" name="is_active" value="1" />
@@ -388,7 +388,7 @@
     </div>
     <!--#end if#-->
 </div>
-<script type="text/javascript" src="${root}staticcfg/js/jquery-ui.min.js"></script>
+<script type="text/javascript" src="$url('staticcfg/js/jquery-ui.min.js')"></script>
 <script type="text/javascript">
     // http://stackoverflow.com/questions/2219924/
     var typewatch = (function(){
@@ -414,7 +414,7 @@
             typewatch(function () {
                 jQuery.ajax({
                     type: "GET",
-                    url: "../../api",
+                    url: "$url('api')",
                     data: {
                         mode: 'eval_sort',
                         job_name: jQuery('#preview_name_' + sort_nr).val(),
@@ -437,7 +437,7 @@
     jQuery(document).ready(function() {
         jQuery('.delSorter').click(function() {
             var theForm = jQuery(this).closest("form");
-            theForm.attr("action", "sorting/delete").submit();
+            theForm.attr("action", "$url('config/sorting/delete')").submit();
         });
 
         jQuery('.addSorter').click(function(){
@@ -495,7 +495,7 @@
                         jQuery(elm).extractFormDataTo(data);
                         jQuery.ajax({
                             type: "POST",
-                            url: window.location.pathname + 'save_sorter',
+                            url: "$url('config/sorting/save_sorter')",
                             data: data,
                             async: false // To prevent race-conditions when updating sorters
                         })
@@ -509,7 +509,7 @@
             var whichSorter = jQuery(this).attr("rel");
             jQuery.ajax({
                 type: "POST",
-                url: "sorting/toggle_sorter",
+                url: "$url('config/sorting/toggle_sorter')",
                 data: {sorter: whichSorter, apikey: "$apikey" }
             }).done(function() {
                 formWasSubmitted = true;

--- a/interfaces/Config/templates/config_special.tmpl
+++ b/interfaces/Config/templates/config_special.tmpl
@@ -3,7 +3,7 @@
 <!--#include $webdir + "/_inc_header_uc.tmpl"#-->
 
 <div class="colmask">
-    <form action="saveSpecial" method="post" autocomplete="off">
+    <form action="special/save" method="post" class="fullform" autocomplete="off">
         <input type="hidden" id="apikey" name="apikey" value="$apikey" />
         <div class="padTable">
             <h4 class="darkred nomargin">$T('explain-special')</h4>

--- a/interfaces/Config/templates/config_special.tmpl
+++ b/interfaces/Config/templates/config_special.tmpl
@@ -3,7 +3,7 @@
 <!--#include $webdir + "/_inc_header_uc.tmpl"#-->
 
 <div class="colmask">
-    <form action="special/save" method="post" class="fullform" autocomplete="off">
+    <form action="$url('config/special/save')" method="post" class="fullform" autocomplete="off">
         <input type="hidden" id="apikey" name="apikey" value="$apikey" />
         <div class="padTable">
             <h4 class="darkred nomargin">$T('explain-special')</h4>

--- a/interfaces/Config/templates/config_switches.tmpl
+++ b/interfaces/Config/templates/config_switches.tmpl
@@ -8,9 +8,8 @@
             <input type="checkbox" id="advanced-settings-button" name="advanced-settings-button"> $T('button-advanced')
         </label>
     </div>
-    <form action="saveSwitches" method="post" name="fullform" class="fullform" autocomplete="off">
+    <form action="switches/save" method="post" class="fullform" autocomplete="off">
         <input type="hidden" id="apikey" name="apikey" value="$apikey" />
-        <input type="hidden" id="ajax" name="ajax" value="1" />
         <input type="hidden" name="output" value="json" />
         <div class="section advanced-settings">
             <div class="col2">

--- a/interfaces/Config/templates/config_switches.tmpl
+++ b/interfaces/Config/templates/config_switches.tmpl
@@ -8,7 +8,7 @@
             <input type="checkbox" id="advanced-settings-button" name="advanced-settings-button"> $T('button-advanced')
         </label>
     </div>
-    <form action="switches/save" method="post" class="fullform" autocomplete="off">
+    <form action="$url('config/switches/save')" method="post" class="fullform" autocomplete="off">
         <input type="hidden" id="apikey" name="apikey" value="$apikey" />
         <input type="hidden" name="output" value="json" />
         <div class="section advanced-settings">
@@ -395,7 +395,7 @@ jQuery(document).ready(function() {
         // Send request
         jQuery.ajax({
             type: "GET",
-            url: "../../api",
+            url: "$url('api')",
             data: "mode=set_config_default&apikey=${apikey}&output=json&keyword=" + key_container.join('&keyword=')
         }).then(function(data) {
             // Reload page

--- a/interfaces/Config/templates/login/main.tmpl
+++ b/interfaces/Config/templates/login/main.tmpl
@@ -32,7 +32,7 @@
                     <span class="glyphicon glyphicon-question-sign" aria-hidden="true"></span>
                 </a>
             </div>
-            <form class="form-signin" action="./" method="post">
+            <form class="form-signin" action="./login" method="post">
                 <!--#if $error#-->
                 <div class="alert alert-danger" role="alert">$error</div>
                 <!--#end if#-->

--- a/interfaces/Config/templates/login/main.tmpl
+++ b/interfaces/Config/templates/login/main.tmpl
@@ -7,21 +7,21 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no, maximum-scale=1" />
     <meta name="apple-mobile-web-app-title" content="SABnzbd" />
 
-    <link rel="apple-touch-icon" sizes="76x76" href="../staticcfg/ico/apple-touch-icon-76x76-precomposed.png" />
-    <link rel="apple-touch-icon" sizes="120x120" href="../staticcfg/ico/apple-touch-icon-120x120-precomposed.png" />
-    <link rel="apple-touch-icon" sizes="152x152" href="../staticcfg/ico/apple-touch-icon-152x152-precomposed.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="../staticcfg/ico/apple-touch-icon-180x180-precomposed.png" />
-    <link rel="apple-touch-icon" sizes="192x192" href="../staticcfg/ico/android-192x192.png" />
-    <link rel="shortcut icon" href="../staticcfg/ico/favicon.ico?v=$cache_buster" />
+    <link rel="apple-touch-icon" sizes="76x76" href="$url('staticcfg/ico/apple-touch-icon-76x76-precomposed.png')" />
+    <link rel="apple-touch-icon" sizes="120x120" href="$url('staticcfg/ico/apple-touch-icon-120x120-precomposed.png')" />
+    <link rel="apple-touch-icon" sizes="152x152" href="$url('staticcfg/ico/apple-touch-icon-152x152-precomposed.png')" />
+    <link rel="apple-touch-icon" sizes="180x180" href="$url('staticcfg/ico/apple-touch-icon-180x180-precomposed.png')" />
+    <link rel="apple-touch-icon" sizes="192x192" href="$url('staticcfg/ico/android-192x192.png')" />
+    <link rel="shortcut icon" href="$url('staticcfg/ico/favicon.ico', v=$cache_buster)" />
 
-    <link rel="stylesheet" type="text/css" href="../staticcfg/bootstrap/css/bootstrap.min.css?v=$cache_buster" />
-    <link rel="stylesheet" type="text/css" href="../staticcfg/css/login.css?v=$cache_buster" />
+    <link rel="stylesheet" type="text/css" href="$url('staticcfg/bootstrap/css/bootstrap.min.css', v=$cache_buster)" />
+    <link rel="stylesheet" type="text/css" href="$url('staticcfg/css/login.css', v=$cache_buster)" />
     <!--#if $color_scheme not in ('Light', '') #-->
-    <link rel="stylesheet" type="text/css" href="../staticcfg/css/${color_scheme}.css?v=$cache_buster"/>
+    <link rel="stylesheet" type="text/css" href="$url('staticcfg/css/' + $color_scheme + '.css', v=$cache_buster)" />
     <!--#end if#-->
 
-    <script type="text/javascript" src="../staticcfg/js/jquery-3.5.1.min.js?v=$cache_buster"></script>
-    <script type="text/javascript" src="../staticcfg/bootstrap/js/bootstrap.min.js?v=$cache_buster"></script>
+    <script type="text/javascript" src="$url('staticcfg/js/jquery-3.5.1.min.js', v=$cache_buster)"></script>
+    <script type="text/javascript" src="$url('staticcfg/bootstrap/js/bootstrap.min.js', v=$cache_buster)"></script>
 </head>
 <html>
     <body>

--- a/interfaces/Config/templates/staticcfg/css/Night.css
+++ b/interfaces/Config/templates/staticcfg/css/Night.css
@@ -186,7 +186,8 @@ ul.tabs a,
 #addFeed,
 #addFeedContent,
 #subscriptions,
-.RSS form[action="add_rss_feed"] tr:nth-child(even) {
+.RSS form[action="rss/add_rss_feed"] tr:nth-child(even),
+.Config .table {
     border: 1px solid var(--clr-border);
 }
 

--- a/interfaces/Config/templates/staticcfg/css/Night.css
+++ b/interfaces/Config/templates/staticcfg/css/Night.css
@@ -186,7 +186,7 @@ ul.tabs a,
 #addFeed,
 #addFeedContent,
 #subscriptions,
-.RSS form[action="rss/add_rss_feed"] tr:nth-child(even),
+.RSS form[data-form="add-rss-feed"] tr:nth-child(even),
 .Config .table {
     border: 1px solid var(--clr-border);
 }

--- a/interfaces/Config/templates/staticcfg/css/style.css
+++ b/interfaces/Config/templates/staticcfg/css/style.css
@@ -502,7 +502,7 @@ tr.separator {
 .RSS .catTable select {
     max-width: 120px;
 }
-.RSS form[action="rss/add_rss_feed"] tr:nth-child(even) {
+.RSS form[data-form="add-rss-feed"] tr:nth-child(even) {
     border: 1px solid #E5E5E5;
 }
 .RSS .tab-pane table th:not(.no-sort) {
@@ -1008,12 +1008,12 @@ input[type="checkbox"] {
     max-width: 150px !important;
 }
 
-.Scheduling form[action="scheduling/add_schedule"] input[type="checkbox"] {
+.Scheduling form[data-form="add-schedule"] input[type="checkbox"] {
     margin-top: 0px;
     margin-left: -20px;
 }
 
-.Scheduling form[action="scheduling/del_schedule"] input[type="checkbox"] {
+.Scheduling form[data-form="del-schedule"] input[type="checkbox"] {
     position: initial;
     float: left;
     margin: 9px 10px 0px 5px;
@@ -1402,7 +1402,7 @@ html[dir="rtl"] .checkbox-days {
     float: none;
 }
 
-html[dir="rtl"] .Scheduling form[action="scheduling/add_schedule"] input[type="checkbox"] {
+html[dir="rtl"] .Scheduling form[data-form="add-schedule"] input[type="checkbox"] {
     right: 5px;
 }
 

--- a/interfaces/Config/templates/staticcfg/css/style.css
+++ b/interfaces/Config/templates/staticcfg/css/style.css
@@ -502,7 +502,7 @@ tr.separator {
 .RSS .catTable select {
     max-width: 120px;
 }
-.RSS form[action="add_rss_feed"] tr:nth-child(even) {
+.RSS form[action="rss/add_rss_feed"] tr:nth-child(even) {
     border: 1px solid #E5E5E5;
 }
 .RSS .tab-pane table th:not(.no-sort) {
@@ -1008,12 +1008,12 @@ input[type="checkbox"] {
     max-width: 150px !important;
 }
 
-.Scheduling form[action="addSchedule"] input[type="checkbox"] {
+.Scheduling form[action="scheduling/add_schedule"] input[type="checkbox"] {
     margin-top: 0px;
     margin-left: -20px;
 }
 
-.Scheduling form[action="delSchedule"] input[type="checkbox"] {
+.Scheduling form[action="scheduling/del_schedule"] input[type="checkbox"] {
     position: initial;
     float: left;
     margin: 9px 10px 0px 5px;
@@ -1402,7 +1402,7 @@ html[dir="rtl"] .checkbox-days {
     float: none;
 }
 
-html[dir="rtl"] .Scheduling form[action="addSchedule"] input[type="checkbox"] {
+html[dir="rtl"] .Scheduling form[action="scheduling/add_schedule"] input[type="checkbox"] {
     right: 5px;
 }
 

--- a/interfaces/Config/templates/staticcfg/js/script.js
+++ b/interfaces/Config/templates/staticcfg/js/script.js
@@ -509,7 +509,7 @@ $(document).ready(function() {
         // Load things to search if we haven't yet
         if(!pagesContainer[0]) {
             $.each(arrPages, function(index, page) {
-                $.get(rootURL + 'config/' + page + '/', function(data) {
+                $.get(rootURL + 'config/' + page, function(data) {
                     pagesContainer[index] = $(data).find('label')
                 });
             });
@@ -638,7 +638,7 @@ function doConfigSearch(value) {
                 searchOutput.append($('<li class="divider"></li>'))
                 searchOutput.append($('<li class="dropdown-header"></li>').text(configTranslate.searchPages[page_index]))
                 $.each(subResults, function(index, result) {
-                    var resultUrl = rootURL + 'config/' + arrPages[page_index] +  '/#' + $(result).attr('for')
+                    var resultUrl = rootURL + 'config/' + arrPages[page_index] +  '#' + $(result).attr('for')
                     searchOutput.append(
                         $('<li></li>').append(
                             $('<a class="config-search-result"></a>')

--- a/interfaces/Glitter/templates/include_menu.tmpl
+++ b/interfaces/Glitter/templates/include_menu.tmpl
@@ -91,7 +91,7 @@
                     <li><a href="#modal-help" data-toggle="modal"><span class="glyphicon glyphicon-question-sign"></span> $T('menu-help')</a></li>
                     <li><a href="https://sabnzbd.org/donate" target="_blank"><span class="glyphicon glyphicon-heart"></span> $T('menu-donate')</a></li>
                     <!--#if $have_logout or $have_quota or $have_rss_defined or $have_watched_dir or $pp_pause_event#--><li class="divider"></li><!--#end if#-->
-                    <!--#if $have_logout#--><li><a href="./login/?logout=1"><span class="glyphicon glyphicon-log-out"></span> $T('logout')</a></li><!--#end if#-->
+                    <!--#if $have_logout#--><li><a href="./logout"><span class="glyphicon glyphicon-log-out"></span> $T('logout')</a></li><!--#end if#-->
                     <!--#if $have_quota#--><li><a href="#" data-bind="click: doQueueAction" data-mode="reset_quota">$T('link-resetQuota')</a></li><!--#end if#-->
                     <!--#if $have_rss_defined#--><li><a href="#" data-bind="click: doQueueAction" data-mode="rss_now">$T('button-rssNow')</a></li><!--#end if#-->
                     <!--#if $have_watched_dir#--><li><a href="#" data-bind="click: doQueueAction" data-mode="watched_now">$T('sch-scan_folder')</a></li><!--#end if#-->

--- a/interfaces/Glitter/templates/include_menu.tmpl
+++ b/interfaces/Glitter/templates/include_menu.tmpl
@@ -5,7 +5,7 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
         </button>
-        <a class="navbar-logo" href="./" aria-label="SABnzbd $T('menu-queue')">
+        <a class="navbar-logo" href="$url()" aria-label="SABnzbd $T('menu-queue')">
             #include $webdir + "/../../Config/templates/staticcfg/images/logo-small.svg"#
         </a>
         <div class="btn-group">
@@ -48,7 +48,7 @@
                         </a>
                         <div class="dropdown-menu max-speed-input">
                             <div data-bind="visible: !bandwithLimit()">
-                                <a href="./config/general/#bandwidth_max_value">
+                                <a href="$url('config/general#bandwidth_max_value')">
                                     <span class="glyphicon glyphicon-cog"></span> $T('Glitter-setMaxLinespeed')
                                 </a>
                             </div>
@@ -68,7 +68,7 @@
             </li>
             <!--#if $have_rss_defined#-->
             <li data-tooltip="true" data-placement="bottom" title="$T('cmenu-rss')">
-                <a href="./config/rss/" aria-label="$T('cmenu-rss')">
+                <a href="$url('config/rss')" aria-label="$T('cmenu-rss')">
                     <svg class="rss-icon-svg" viewBox="0 0 8 8">
                         <rect class="rss-button" width="8" height="8" />
                         <circle class="rss-symbol" cx="2" cy="6" r="1" />
@@ -79,7 +79,7 @@
             </li>
             <!--#end if#-->
             <li data-tooltip="true" data-placement="bottom" title="SABnzbd $T('menu-config')">
-                <a href="./config/" aria-label="SABnzbd $T('menu-config')"><span class="glyphicon glyphicon-cog"></span></a>
+                <a href="$url('config')" aria-label="SABnzbd $T('menu-config')"><span class="glyphicon glyphicon-cog"></span></a>
             </li>
             <li class="dropdown main-menu-link" data-bind="css: { 'active-on-queue-finish-menu': finishaction()}">
                 <a href="#" data-toggle="dropdown"  onclick="keepOpen(this)" aria-label="$T('Glitter-mainMenu')" aria-haspopup="true" aria-expanded="false">
@@ -91,13 +91,13 @@
                     <li><a href="#modal-help" data-toggle="modal"><span class="glyphicon glyphicon-question-sign"></span> $T('menu-help')</a></li>
                     <li><a href="https://sabnzbd.org/donate" target="_blank"><span class="glyphicon glyphicon-heart"></span> $T('menu-donate')</a></li>
                     <!--#if $have_logout or $have_quota or $have_rss_defined or $have_watched_dir or $pp_pause_event#--><li class="divider"></li><!--#end if#-->
-                    <!--#if $have_logout#--><li><a href="./logout"><span class="glyphicon glyphicon-log-out"></span> $T('logout')</a></li><!--#end if#-->
+                    <!--#if $have_logout#--><li><a href="$url('logout')"><span class="glyphicon glyphicon-log-out"></span> $T('logout')</a></li><!--#end if#-->
                     <!--#if $have_quota#--><li><a href="#" data-bind="click: doQueueAction" data-mode="reset_quota">$T('link-resetQuota')</a></li><!--#end if#-->
                     <!--#if $have_rss_defined#--><li><a href="#" data-bind="click: doQueueAction" data-mode="rss_now">$T('button-rssNow')</a></li><!--#end if#-->
                     <!--#if $have_watched_dir#--><li><a href="#" data-bind="click: doQueueAction" data-mode="watched_now">$T('sch-scan_folder')</a></li><!--#end if#-->
                     <!--#if $pp_pause_event#--><li><a href="#" data-bind="click: doQueueAction" data-mode="resume_pp">$T('sch-resume_post')</a></li><!--#end if#-->
                     <li class="divider"></li>
-                    <li><a href="./shutdown/?apikey=$apikey&amp;pid=$pid" data-bind="click: shutdownSAB">$T('shutdownSab')</a></li>
+                    <li><a href="$url('shutdown', apikey=$apikey, pid=$pid)" data-bind="click: shutdownSAB">$T('shutdownSab')</a></li>
                     <li><a href="#" data-bind="click: restartSAB">$T('Glitter-restartSab')</a></li>
                     <li class="divider"></li>
                     <li class="dropdown-header"><span class="glyphicon glyphicon-off"></span> $T('Glitter-onFinish'):</li>

--- a/interfaces/Glitter/templates/include_overlays.tmpl
+++ b/interfaces/Glitter/templates/include_overlays.tmpl
@@ -747,7 +747,7 @@
                 <button type="button" class="close" data-dismiss="modal" aria-label="$T('close')"><span aria-hidden="true">&times;</span></button>
                 <h4 class="modal-title" id="history-script-log-title">$T('Glitter-scriptLog')</h4>
             </div>
-            <div class="modal-body"></div>
+            <div class="modal-body"><pre></pre></div>
         </div>
     </div>
 </div>

--- a/interfaces/Glitter/templates/include_overlays.tmpl
+++ b/interfaces/Glitter/templates/include_overlays.tmpl
@@ -197,7 +197,7 @@
                         </div>
                         <div class="row options-function-box">
                             <div class="col-sm-6">
-                                <a href="./api?mode=showlog&apikey=$apikey" target="_blank" class="btn btn-default" data-tooltip="true" data-placement="top" title="$T('Glitter-logText')">
+                                <a href="$url('api', mode='showlog', apikey=$apikey)" target="_blank" class="btn btn-default" data-tooltip="true" data-placement="top" title="$T('Glitter-logText')">
                                     <span class="glyphicon glyphicon-file"></span> $T('link-showLog')
                                 </a>
                             </div>

--- a/interfaces/Glitter/templates/main.tmpl
+++ b/interfaces/Glitter/templates/main.tmpl
@@ -25,19 +25,19 @@
         <meta name="msapplication-navbutton-color" content="#000000" />
         <meta name="theme-color" content="#000000" />
 
-        <link rel="apple-touch-icon" sizes="76x76" href="./staticcfg/ico/apple-touch-icon-76x76-precomposed.png" />
-        <link rel="apple-touch-icon" sizes="120x120" href="./staticcfg/ico/apple-touch-icon-120x120-precomposed.png" />
-        <link rel="apple-touch-icon" sizes="152x152" href="./staticcfg/ico/apple-touch-icon-152x152-precomposed.png" />
-        <link rel="apple-touch-icon" sizes="180x180" href="./staticcfg/ico/apple-touch-icon-180x180-precomposed.png" />
-        <link rel="apple-touch-icon" sizes="192x192" href="./staticcfg/ico/android-192x192.png" />
-        <link rel="mask-icon" href="./staticcfg/ico/safari-pinned-tab.svg" color="#383F45">
-        <link rel="shortcut icon" type="image/ico" href="./staticcfg/ico/favicon.ico?v=$cache_buster" data-bind="attr: { 'href': SABIcon }" />
+        <link rel="apple-touch-icon" sizes="76x76" href="$url('staticcfg/ico/apple-touch-icon-76x76-precomposed.png')" />
+        <link rel="apple-touch-icon" sizes="120x120" href="$url('staticcfg/ico/apple-touch-icon-120x120-precomposed.png')" />
+        <link rel="apple-touch-icon" sizes="152x152" href="$url('staticcfg/ico/apple-touch-icon-152x152-precomposed.png')" />
+        <link rel="apple-touch-icon" sizes="180x180" href="$url('staticcfg/ico/apple-touch-icon-180x180-precomposed.png')" />
+        <link rel="apple-touch-icon" sizes="192x192" href="$url('staticcfg/ico/android-192x192.png')" />
+        <link rel="mask-icon" href="$url('staticcfg/ico/safari-pinned-tab.svg')" color="#383F45">
+        <link rel="shortcut icon" type="image/ico" href="$url('staticcfg/ico/favicon.ico', v=$cache_buster)" data-bind="attr: { 'href': SABIcon }" />
 
-        <link rel="stylesheet" type="text/css" href="./static/bootstrap/css/bootstrap.min.css?v=$cache_buster" />
-        <link rel="stylesheet" type="text/css" href="./static/stylesheets/glitter.css?v=$cache_buster" />
-        <link rel="stylesheet" type="text/css" href="./static/stylesheets/glitter.mobile.css?v=$cache_buster" media="all and (max-width: 768px)" />
+        <link rel="stylesheet" type="text/css" href="$url('static/bootstrap/css/bootstrap.min.css', v=$cache_buster)" />
+        <link rel="stylesheet" type="text/css" href="$url('static/stylesheets/glitter.css', v=$cache_buster)" />
+        <link rel="stylesheet" type="text/css" href="$url('static/stylesheets/glitter.mobile.css', v=$cache_buster)" media="all and (max-width: 768px)" />
         <!--#if $color_scheme not in ('Light', '') #-->
-        <link rel="stylesheet" type="text/css" href="./static/stylesheets/colorschemes/${color_scheme}.css?v=$cache_buster"/>
+        <link rel="stylesheet" type="text/css" href="$url('static/stylesheets/colorschemes/' + $color_scheme + '.css', v=$cache_buster)"/>
         <!--#end if#-->
 
         <!-- Make translations available in scripts -->
@@ -138,7 +138,7 @@
             <!--#include $webdir + "/static/javascripts/glitter.js"#-->
         </script>
         <!--#if active_lang != 'en'#-->
-        <script type="text/javascript" src="./static/javascripts/momentjs_locale/${active_lang}.js?v=$cache_buster"></script>
+        <script type="text/javascript" src="$url('static/javascripts/momentjs_locale/' + $active_lang + '.js', v=$cache_buster)"></script>
         <!--#end if#-->
     </head>
     <body>

--- a/interfaces/Glitter/templates/static/javascripts/glitter.history.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.history.js
@@ -638,11 +638,10 @@ function HistoryModel(parent, data) {
                 $(this).hide()
             } else {
                // Info in modal
-                $('#history-script-log .modal-body').load($(this).attr('href'), function(result) {
-                    // Set title and then remove it
-                    $('#history-script-log .modal-title').text($(this).find("h3").text())
-                    $(this).find("h3, title").remove()
-                    $('#history-script-log').modal('show');
+                $('#history-script-log .modal-body pre').load($(this).attr('href'), function(result) {
+                    var modal = $('#history-script-log');
+                    modal.find('.modal-title').text(self.historyStatus.name());
+                    modal.modal('show');
                 });
             }
             return false;

--- a/interfaces/Glitter/templates/static/javascripts/glitter.main.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.main.js
@@ -1224,7 +1224,7 @@ function ViewModel() {
             }
         });
         $(document).bind('keydown', 'c', function(e) {
-            window.location.href = './config/';
+            window.location.href = './config';
         });
         $(document).bind('keydown', 's', function(e) {
             // Update the data

--- a/interfaces/wizard/inc_top.tmpl
+++ b/interfaces/wizard/inc_top.tmpl
@@ -3,14 +3,14 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <title>$T('wizard-quickstart')</title>
-        <link rel="stylesheet" type="text/css" href="${url_base}/staticcfg/bootstrap/css/bootstrap.min.css?v=$cache_buster"/>
-        <link rel="stylesheet" type="text/css" href="${url_base}/wizard/static/style.css?v=$cache_buster"/>
+        <link rel="stylesheet" type="text/css" href="$url('staticcfg/bootstrap/css/bootstrap.min.css', v=$cache_buster)"/>
+        <link rel="stylesheet" type="text/css" href="$url('wizard/static/style.css', v=$cache_buster)"/>
         <!--#if $color_scheme not in ('Light', '') #-->
-        <link rel="stylesheet" type="text/css" href="${url_base}/staticcfg/css/${color_scheme}.css?v=$cache_buster"/>
+        <link rel="stylesheet" type="text/css" href="$url('staticcfg/css/' + $color_scheme + '.css', v=$cache_buster)"/>
         <!--#end if#-->
-        <link rel="shortcut icon" href="${url_base}/staticcfg/ico/favicon.ico?v=$cache_buster" />
-        <script type="text/javascript" src="${url_base}/staticcfg/js/jquery-3.5.1.min.js?v=$cache_buster"></script>
-        <script type="text/javascript" src="${url_base}/staticcfg/bootstrap/js/bootstrap.min.js?v=$cache_buster"></script>
+        <link rel="shortcut icon" href="$url('staticcfg/ico/favicon.ico', v=$cache_buster)" />
+        <script type="text/javascript" src="$url('staticcfg/js/jquery-3.5.1.min.js', v=$cache_buster)"></script>
+        <script type="text/javascript" src="$url('staticcfg/bootstrap/js/bootstrap.min.js', v=$cache_buster)"></script>
     </head>
     <body>
         <div id="logo">

--- a/interfaces/wizard/inc_top.tmpl
+++ b/interfaces/wizard/inc_top.tmpl
@@ -3,14 +3,14 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <title>$T('wizard-quickstart')</title>
-        <link rel="stylesheet" type="text/css" href="../staticcfg/bootstrap/css/bootstrap.min.css?v=$cache_buster"/>
-        <link rel="stylesheet" type="text/css" href="static/style.css?v=$cache_buster"/>
+        <link rel="stylesheet" type="text/css" href="${url_base}/staticcfg/bootstrap/css/bootstrap.min.css?v=$cache_buster"/>
+        <link rel="stylesheet" type="text/css" href="${url_base}/wizard/static/style.css?v=$cache_buster"/>
         <!--#if $color_scheme not in ('Light', '') #-->
-        <link rel="stylesheet" type="text/css" href="../staticcfg/css/${color_scheme}.css?v=$cache_buster"/>
+        <link rel="stylesheet" type="text/css" href="${url_base}/staticcfg/css/${color_scheme}.css?v=$cache_buster"/>
         <!--#end if#-->
-        <link rel="shortcut icon" href="../staticcfg/ico/favicon.ico?v=$cache_buster" />
-        <script type="text/javascript" src="../staticcfg/js/jquery-3.5.1.min.js?v=$cache_buster"></script>
-        <script type="text/javascript" src="../staticcfg/bootstrap/js/bootstrap.min.js?v=$cache_buster"></script>
+        <link rel="shortcut icon" href="${url_base}/staticcfg/ico/favicon.ico?v=$cache_buster" />
+        <script type="text/javascript" src="${url_base}/staticcfg/js/jquery-3.5.1.min.js?v=$cache_buster"></script>
+        <script type="text/javascript" src="${url_base}/staticcfg/bootstrap/js/bootstrap.min.js?v=$cache_buster"></script>
     </head>
     <body>
         <div id="logo">

--- a/interfaces/wizard/index.html
+++ b/interfaces/wizard/index.html
@@ -1,5 +1,5 @@
 <!--#include $webdir + "/inc_top.tmpl"#-->
-<form action="${url_base}/wizard/one" method="post">
+<form action="$url('wizard/one')" method="post">
     <div class="container">
         <div id="inner">
             <div id="content" class="bigger">
@@ -27,10 +27,10 @@
             <hr />
             <div class="row">
                 <div class="col-md-4 text-center">
-                    <a class="btn btn-danger" href="${url_base}/shutdown??apikey=$apikey&amp;pid=$pid"><span class="glyphicon glyphicon-remove"></span> $T('wizard-exit')</a>
+                    <a class="btn btn-danger" href="$url('shutdown', apikey=$apikey, pid=$pid)"><span class="glyphicon glyphicon-remove"></span> $T('wizard-exit')</a>
                 </div>
                 <div class="col-md-4 text-center">
-                    <a class="btn btn-default" href="${url_base}/config/general#config_backup_file"><span class="glyphicon glyphicon-open"></span> $T('restore-backup')</a>
+                    <a class="btn btn-default" href="$url('config/general#config_backup_file')"><span class="glyphicon glyphicon-open"></span> $T('restore-backup')</a>
                 </div>
                 <div class="col-md-4 text-center">
                     <button class="btn btn-default">$T('wizard-start') <span class="glyphicon glyphicon-chevron-right"></span></button>

--- a/interfaces/wizard/index.html
+++ b/interfaces/wizard/index.html
@@ -1,5 +1,5 @@
 <!--#include $webdir + "/inc_top.tmpl"#-->
-<form action="./one" method="post">
+<form action="${url_base}/wizard/one" method="post">
     <div class="container">
         <div id="inner">
             <div id="content" class="bigger">
@@ -27,10 +27,10 @@
             <hr />
             <div class="row">
                 <div class="col-md-4 text-center">
-                    <a class="btn btn-danger" href="../shutdown/?apikey=$apikey&amp;pid=$pid"><span class="glyphicon glyphicon-remove"></span> $T('wizard-exit')</a>
+                    <a class="btn btn-danger" href="${url_base}/shutdown??apikey=$apikey&amp;pid=$pid"><span class="glyphicon glyphicon-remove"></span> $T('wizard-exit')</a>
                 </div>
                 <div class="col-md-4 text-center">
-                    <a class="btn btn-default" href="../config/general/#config_backup_file"><span class="glyphicon glyphicon-open"></span> $T('restore-backup')</a>
+                    <a class="btn btn-default" href="${url_base}/config/general#config_backup_file"><span class="glyphicon glyphicon-open"></span> $T('restore-backup')</a>
                 </div>
                 <div class="col-md-4 text-center">
                     <button class="btn btn-default">$T('wizard-start') <span class="glyphicon glyphicon-chevron-right"></span></button>

--- a/interfaces/wizard/one.html
+++ b/interfaces/wizard/one.html
@@ -102,12 +102,13 @@
                         <iframe style="float: right; width: 325px; height: 325px;" frameborder="0" src="https://sabnzbd.org/wizard#$active_lang"></iframe>
                     </div>
                 </div>
+                <input type="hidden" name="enable" value="1">
                 <input type="hidden" name="apikey" value="$apikey" />
             </div>
             <hr />
             <div class="row">
                 <div class="col-xs-4 text-center">
-                    <a class="btn btn-default" href="./index"><span class="glyphicon glyphicon-chevron-left"></span> $T('wizard-previous')</a>
+                    <a class="btn btn-default" href="./"><span class="glyphicon glyphicon-chevron-left"></span> $T('wizard-previous')</a>
                 </div>
                 <div class="col-xs-4 text-center">
                 </div>

--- a/interfaces/wizard/one.html
+++ b/interfaces/wizard/one.html
@@ -1,5 +1,5 @@
 <!--#include $webdir + "/inc_top.tmpl"#-->
-<form action="${url_base}/wizard/two" method="post" autocomplete="off">
+<form action="$url('wizard/two')" method="post" autocomplete="off">
     <div class="container">
         <div id="inner">
             <div id="content" class="bigger">
@@ -108,7 +108,7 @@
             <hr />
             <div class="row">
                 <div class="col-xs-4 text-center">
-                    <a class="btn btn-default" href="${url_base}/wizard"><span class="glyphicon glyphicon-chevron-left"></span> $T('wizard-previous')</a>
+                    <a class="btn btn-default" href="$url('wizard')"><span class="glyphicon glyphicon-chevron-left"></span> $T('wizard-previous')</a>
                 </div>
                 <div class="col-xs-4 text-center">
                 </div>

--- a/interfaces/wizard/one.html
+++ b/interfaces/wizard/one.html
@@ -1,5 +1,5 @@
 <!--#include $webdir + "/inc_top.tmpl"#-->
-<form action="./two" method="post" autocomplete="off">
+<form action="${url_base}/wizard/two" method="post" autocomplete="off">
     <div class="container">
         <div id="inner">
             <div id="content" class="bigger">
@@ -108,7 +108,7 @@
             <hr />
             <div class="row">
                 <div class="col-xs-4 text-center">
-                    <a class="btn btn-default" href="./"><span class="glyphicon glyphicon-chevron-left"></span> $T('wizard-previous')</a>
+                    <a class="btn btn-default" href="${url_base}/wizard"><span class="glyphicon glyphicon-chevron-left"></span> $T('wizard-previous')</a>
                 </div>
                 <div class="col-xs-4 text-center">
                 </div>

--- a/interfaces/wizard/two.html
+++ b/interfaces/wizard/two.html
@@ -12,8 +12,8 @@
             <p>$T('wizard-tip4')</p>
 
             <div class="quoteBlock">
-                <!--#for $url in $urls#-->
-                    <a href="$url">$url</a><br />
+                <!--#for $access_url in $urls#-->
+                    <a href="$access_url">$access_url</a><br />
                 <!--#end for#-->
             </div>
 
@@ -22,13 +22,13 @@
             <p><strong>$T('opt-complete_dir')</strong></p>
             <div class="quoteBlock">
                 $complete_dir
-                <a href="${access_url}/config/folders#complete_dir" class="indented"><span class="glyphicon glyphicon-cog"></span></a>
+                <a href="$url('config/folders#complete_dir')" class="indented"><span class="glyphicon glyphicon-cog"></span></a>
             </div>
 
             <p><strong>$T('opt-download_dir')</strong></p>
             <div class="quoteBlock">
                 $download_dir
-                <a href="${access_url}/config/folders#complete_dir" class="indented"><span class="glyphicon glyphicon-cog"></span></a>
+                <a href="$url('config/folders#complete_dir')" class="indented"><span class="glyphicon glyphicon-cog"></span></a>
             </div>
 
             <hr/>
@@ -39,7 +39,7 @@
         <div class="row">
             <div class="col-xs-12 text-center">
                 <input type="hidden" name="apikey" id="apikey" value="$apikey"/>
-                <a class="btn btn-success" href="$access_url">$T('wizard-goto') <span class="glyphicon glyphicon-chevron-right"></span></a>
+                <a class="btn btn-success" href="$url()">$T('wizard-goto') <span class="glyphicon glyphicon-chevron-right"></span></a>
             </div>
         </div>
     </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,13 +21,14 @@ rebulk==6.0.1
 hachoir==3.3.0
 
 # New for starlette/uvicorn
-starlette==1.0.0
-anyio==4.13.0
+starlette==1.3.1
+itsdangerous==2.2.0
+anyio==4.14.2
 sniffio==1.3.1
-uvicorn==0.44.0
-click==8.3.2
-python-multipart==0.0.22
-httptools==0.7.1
+uvicorn==0.51.0
+click==8.4.2
+python-multipart==0.0.32
+httptools==0.8.0
 
 # Recent cryptography versions require Rust. If you run into issues compiling this
 # SABnzbd will also work with older pre-Rust versions such as cryptography==3.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,21 +7,10 @@ cffi==2.1.0
 pycparser==3.0
 feedparser==6.0.12
 configobj==5.0.9
-cheroot==11.1.2
 six==1.17.0
-cherrypy==18.10.0
-jaraco.functools==4.6.0
-jaraco.collections==5.0.0
-jaraco.text==3.8.1 # Newer version introduces irrelevant extra dependencies
-jaraco.classes==3.4.0
-jaraco.context==4.3.0
 more-itertools==11.1.0
-zc.lockfile==4.0
 python-dateutil==2.9.0.post0
-tempora==5.8.1
-pytz==2026.3.post1
 sgmllib3k==1.0.0
-portend==3.2.1
 PySocks==1.7.1
 puremagic # Version-less for Python 3.11 and below
 puremagic==2.2.0; python_version > '3.11'
@@ -30,6 +19,15 @@ guessit==4.1.0
 babelfish==0.6.1
 rebulk==6.0.1
 hachoir==3.3.0
+
+# New for starlette/uvicorn
+starlette==1.0.0
+anyio==4.13.0
+sniffio==1.3.1
+uvicorn==0.44.0
+click==8.3.2
+python-multipart==0.0.22
+httptools==0.7.1
 
 # Recent cryptography versions require Rust. If you run into issues compiling this
 # SABnzbd will also work with older pre-Rust versions such as cryptography==3.3.2

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -445,7 +445,8 @@ def shutdown_program():
     try:
         logging.info("[%s] Performing SABnzbd shutdown", misc.caller_name())
         sabnzbd.halt()
-        sabnzbd.WEB_SERVER.stop()
+        if sabnzbd.WEB_SERVER:
+            sabnzbd.WEB_SERVER.stop()
         sabnzbd.SABSTOP = True
         notify_shutdown_loop()
     finally:

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -26,7 +26,6 @@ from typing import Optional
 import platform
 import concurrent.futures
 import sys
-import threading
 from threading import Lock, Condition
 
 ##############################################################################
@@ -217,14 +216,9 @@ def sig_handler(signum=None, frame=None):
 INIT_LOCK = Lock()
 
 
-_thread_local = threading.local()
-
-
-def get_db_connection(thread_index=0):
-    # Create a connection and store it in the current thread
-    if not getattr(_thread_local, "history_db", None):
-        _thread_local.history_db = sabnzbd.database.HistoryDB()
-    return _thread_local.history_db
+# Pool of History database connections, shared by web handlers and workers.
+# Borrow with: with sabnzbd.db_pool.connection() as history_db
+db_pool = sabnzbd.database.HistoryDBPool()
 
 
 @synchronized(INIT_LOCK)
@@ -424,6 +418,11 @@ def halt():
         # We must tell the scheduler to deactivate.
         logging.debug("Terminating scheduler")
         sabnzbd.Scheduler.abort()
+
+        # All writers have stopped; close the database connections so the
+        # WAL is checkpointed into the main database file
+        logging.debug("Closing database pool")
+        sabnzbd.db_pool.close()
 
         logging.info("All processes stopped")
 

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -270,6 +270,8 @@ def initialize(pause_downloader=False, clean_up=False, repair=0):
     cfg.https_key.callback(cfg.guard_restart)
     cfg.https_chain.callback(cfg.guard_restart)
     cfg.enable_https.callback(cfg.guard_restart)
+    cfg.verify_xff_header.callback(cfg.guard_restart)
+    cfg.local_ranges.callback(cfg.guard_restart)
     cfg.socks5_proxy_url.callback(cfg.guard_restart)
     cfg.top_only.callback(cfg.guard_top_only)
     cfg.pause_on_post_processing.callback(cfg.guard_pause_on_pp)

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -21,11 +21,12 @@ import datetime
 import ctypes.util
 import time
 import ssl
+from typing import Optional
 
-import cherrypy
 import platform
 import concurrent.futures
 import sys
+import threading
 from threading import Lock, Condition
 
 ##############################################################################
@@ -155,6 +156,7 @@ LOGFILE = None
 WEBLOGFILE = None
 GUIHANDLER = None
 LOG_ALL = False
+WEB_SERVER: Optional[sabnzbd.interface.ThreadedServer] = None
 WIN_SERVICE = None  # Instance of our Win32 Service Class
 BROWSER_URL = None
 
@@ -215,11 +217,14 @@ def sig_handler(signum=None, frame=None):
 INIT_LOCK = Lock()
 
 
+_thread_local = threading.local()
+
+
 def get_db_connection(thread_index=0):
     # Create a connection and store it in the current thread
-    if not (hasattr(cherrypy.thread_data, "history_db") and cherrypy.thread_data.history_db):
-        cherrypy.thread_data.history_db = sabnzbd.database.HistoryDB()
-    return cherrypy.thread_data.history_db
+    if not getattr(_thread_local, "history_db", None):
+        _thread_local.history_db = sabnzbd.database.HistoryDB()
+    return _thread_local.history_db
 
 
 @synchronized(INIT_LOCK)
@@ -230,9 +235,6 @@ def initialize(pause_downloader=False, clean_up=False, repair=0):
     sabnzbd.__SHUTTING_DOWN__ = False
 
     sys.setswitchinterval(cfg.switchinterval())
-
-    # Set global database connection for Web-UI threads
-    cherrypy.engine.subscribe("start_thread", get_db_connection)
 
     # Paused?
     pause_downloader = pause_downloader or cfg.start_paused()
@@ -443,7 +445,7 @@ def shutdown_program():
     try:
         logging.info("[%s] Performing SABnzbd shutdown", misc.caller_name())
         sabnzbd.halt()
-        cherrypy.engine.exit()
+        sabnzbd.WEB_SERVER.stop()
         sabnzbd.SABSTOP = True
         notify_shutdown_loop()
     finally:

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -454,13 +454,12 @@ def shutdown_program():
         SHUTDOWN_LOCK.release()
 
 
-def trigger_restart(timeout=None):
-    """Trigger a restart by setting a flag an shutting down CP"""
-    # Sometimes we need to wait a bit to send good-bye to the browser
-    if timeout:
-        time.sleep(timeout)
+def trigger_restart():
+    """Trigger a restart by setting a flag and waking up the main loop.
 
-    # Set the flag and wake up the main loop
+    Callers that must let a response reach the browser first arrange the ordering
+    themselves (e.g. the API restart handler defers this to a post-response
+    background task), so no delay is needed here."""
     sabnzbd.TRIGGER_RESTART = True
     notify_shutdown_loop()
 

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -28,8 +28,9 @@ import socket
 import time
 import getpass
 from threading import Thread
-from typing import Any, Callable, Optional, TypeAlias
+from typing import Any, Awaitable, Callable, Optional, TypeAlias
 
+from starlette.concurrency import run_in_threadpool
 from starlette.datastructures import QueryParams
 from starlette.responses import Response, StreamingResponse
 
@@ -124,9 +125,21 @@ _MSG_NO_SUCH_CONFIG = "Config item does not exist"
 _MSG_CONFIG_LOCKED = "Configuration locked"
 
 
-def api_handler(kwargs: QueryParams) -> Response:
-    """API Dispatcher"""
+def api_handler(kwargs: QueryParams) -> Response | Awaitable[Response]:
+    """API Dispatcher. Handlers are either plain functions returning a Response,
+    or coroutine functions (e.g. shutdown) whose result must be awaited by the caller."""
     return _api_table.get(kwargs.get("mode", ""), (_api_undefined, 2))[0](kwargs.get("name", ""), kwargs)
+
+
+async def halt_and_shutdown():
+    """Single implementation for both the /shutdown route and mode=shutdown API-call.
+    Persist all state before replying, matching the pre-uvicorn behaviour where the
+    request blocked until shutdown had saved everything. Run halt() off the event
+    loop so we don't block it. The web server itself cannot be stopped from within
+    its own event loop, so that part is deferred to a separate thread."""
+    if not sabnzbd.SABSTOP:
+        await run_in_threadpool(sabnzbd.halt)
+        Thread(target=sabnzbd.shutdown_program).start()
 
 
 def _api_get_config(name: str, kwargs: QueryParams) -> Response:
@@ -686,12 +699,8 @@ def _api_resume(name: str, kwargs: QueryParams) -> Response:
     return report(kwargs)
 
 
-def _api_shutdown(name: str, kwargs: QueryParams) -> Response:
-    if not sabnzbd.SABSTOP:
-        # Persist all state before replying (see the /shutdown route). The web server
-        # cannot be stopped from within its own thread, so that part is deferred.
-        sabnzbd.halt()
-        Thread(target=sabnzbd.shutdown_program).start()
+async def _api_shutdown(name: str, kwargs: QueryParams) -> Response:
+    await halt_and_shutdown()
     return report(kwargs)
 
 

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -687,8 +687,11 @@ def _api_resume(name: str, kwargs: QueryParams) -> Response:
 
 
 def _api_shutdown(name: str, kwargs: QueryParams) -> Response:
-    # In separate thread, because the server thread cannot shut down itself
-    Thread(target=sabnzbd.shutdown_program).start()
+    if not sabnzbd.SABSTOP:
+        # Persist all state before replying (see the /shutdown route). The web server
+        # cannot be stopped from within its own thread, so that part is deferred.
+        sabnzbd.halt()
+        Thread(target=sabnzbd.shutdown_program).start()
     return report(kwargs)
 
 

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -27,9 +27,11 @@ import gc
 import socket
 import time
 import getpass
-import cherrypy
 from threading import Thread
-from typing import Any, Callable, Generator, Optional, TypeAlias
+from typing import Any, Callable, Optional, TypeAlias
+
+from starlette.datastructures import QueryParams
+from starlette.responses import Response, StreamingResponse
 
 # For json.dumps, orjson is magnitudes faster than ujson, but it is harder to
 # compile due to Rust dependency. Since the output is the same, we support all modules.
@@ -98,7 +100,7 @@ from sabnzbd.encoding import xml_name, utob
 from sabnzbd.getipaddress import local_ipv4, public_ipv4, public_ipv6, dnslookup, active_socks5_proxy
 from sabnzbd.database import HistoryDB
 from sabnzbd.lang import is_rtl
-from sabnzbd.nzb import TryList, NzbObject
+from sabnzbd.nzb import NzbObject, TryList
 from sabnzbd.newswrapper import NewsWrapper, NNTPPermanentError
 import sabnzbd.emailer
 import sabnzbd.sorting
@@ -122,51 +124,43 @@ _MSG_NO_SUCH_CONFIG = "Config item does not exist"
 _MSG_CONFIG_LOCKED = "Configuration locked"
 
 
-def api_handler(kwargs: ApiParams) -> bytes:
+def api_handler(kwargs: QueryParams) -> Response:
     """API Dispatcher"""
-    # Clean-up the arguments
-    for vr in ("mode", "name", "value", "value2", "value3", "start", "limit", "search"):
-        if vr in kwargs and isinstance(kwargs[vr], list):
-            kwargs[vr] = kwargs[vr][0]
-
-    mode: str = kwargs.get("mode", "")
-    name: str = kwargs.get("name", "")
-
-    response = _api_table.get(mode, (_api_undefined, 2))[0](name, kwargs)
-    return response
+    return _api_table.get(kwargs.get("mode", ""), (_api_undefined, 2))[0](kwargs.get("name", ""), kwargs)
 
 
-def _api_get_config(name: str, kwargs: ApiParams) -> bytes:
+def _api_get_config(name: str, kwargs: QueryParams) -> Response:
     """API: accepts keyword, section"""
     data = config.get_dconfig(kwargs.get("section"), kwargs.get("keyword"))
-    return report(keyword="config", data=data)
+    return report(kwargs, keyword="config", data=data)
 
 
-def _api_set_config(name: str, kwargs: ApiParams) -> bytes:
+def _api_set_config(name: str, kwargs: QueryParams) -> Response:
     """API: accepts keyword, section"""
     if cfg.configlock():
-        return report(_MSG_CONFIG_LOCKED)
+        return report(kwargs, _MSG_CONFIG_LOCKED)
+    keyword = kwargs.get("keyword")
     if kwargs.get("section") == "servers":
-        kwargs["keyword"] = handle_server_api(kwargs)
+        keyword = handle_server_api(kwargs)
     elif kwargs.get("section") == "rss":
-        kwargs["keyword"] = handle_rss_api(kwargs)
+        keyword = handle_rss_api(kwargs)
     elif kwargs.get("section") == "categories":
-        kwargs["keyword"] = handle_cat_api(kwargs)
+        keyword = handle_cat_api(kwargs)
     elif kwargs.get("section") == "sorters":
-        kwargs["keyword"] = handle_sorter_api(kwargs)
+        keyword = handle_sorter_api(kwargs)
     else:
         res = config.set_config(kwargs)
         if not res:
-            return report(_MSG_NO_SUCH_CONFIG)
+            return report(kwargs, _MSG_NO_SUCH_CONFIG)
     config.save_config()
-    data = config.get_dconfig(kwargs.get("section"), kwargs.get("keyword"))
-    return report(keyword="config", data=data)
+    data = config.get_dconfig(kwargs.get("section"), keyword)
+    return report(kwargs, keyword="config", data=data)
 
 
-def _api_set_config_default(name: str, kwargs: ApiParams) -> bytes:
+def _api_set_config_default(name: str, kwargs: QueryParams) -> Response:
     """API: Reset requested config variables back to defaults. Currently only for misc-section"""
     if cfg.configlock():
-        return report(_MSG_CONFIG_LOCKED)
+        return report(kwargs, _MSG_CONFIG_LOCKED)
     keywords = kwargs.get("keyword", [])
     if not isinstance(keywords, list):
         keywords = [keywords]
@@ -175,89 +169,91 @@ def _api_set_config_default(name: str, kwargs: ApiParams) -> bytes:
         if item:
             item.set(item.default)
     config.save_config()
-    return report()
+    return report(kwargs)
 
 
-def _api_del_config(name: str, kwargs: ApiParams) -> bytes:
+def _api_del_config(name: str, kwargs: QueryParams) -> Response:
     """API: accepts keyword, section"""
     if cfg.configlock():
-        return report(_MSG_CONFIG_LOCKED)
+        return report(kwargs, _MSG_CONFIG_LOCKED)
     if del_from_section(kwargs):
-        return report()
+        return report(
+            kwargs,
+        )
     else:
-        return report(_MSG_NOT_IMPLEMENTED)
+        return report(kwargs, _MSG_NOT_IMPLEMENTED)
 
 
-def _api_queue(name: str, kwargs: ApiParams) -> bytes:
+def _api_queue(name: str, kwargs: QueryParams) -> Response:
     """API: Dispatcher for mode=queue"""
     value = kwargs.get("value", "")
     return _api_queue_table.get(name, (_api_queue_default, 2))[0](value, kwargs)
 
 
-def _api_queue_delete(value: str, kwargs: ApiParams) -> bytes:
+def _api_queue_delete(value: str, kwargs: QueryParams) -> Response:
     """API: accepts value"""
     if value.lower() == "all":
         removed = sabnzbd.NzbQueue.remove_all(kwargs.get("search"))
-        return report(keyword="", data={"status": bool(removed), "nzo_ids": removed})
+        return report(kwargs, keyword="", data={"status": bool(removed), "nzo_ids": removed})
     elif items := clean_comma_separated_list(value):
         delete_all_data = bool_conv(kwargs.get("del_files"))
         removed = sabnzbd.NzbQueue.remove_multiple(items, delete_all_data=delete_all_data)
-        return report(keyword="", data={"status": bool(removed), "nzo_ids": removed})
+        return report(kwargs, keyword="", data={"status": bool(removed), "nzo_ids": removed})
     else:
-        return report(_MSG_NO_VALUE)
+        return report(kwargs, _MSG_NO_VALUE)
 
 
-def _api_queue_delete_nzf(value: str, kwargs: ApiParams) -> bytes:
+def _api_queue_delete_nzf(value: str, kwargs: QueryParams) -> Response:
     """API: accepts value(=nzo_id), value2(=nzf_ids)"""
     nzf_ids = clean_comma_separated_list(kwargs.get("value2"))
     if value and nzf_ids:
         removed = sabnzbd.NzbQueue.remove_nzfs(value, nzf_ids)
-        return report(keyword="", data={"status": bool(removed), "nzf_ids": removed})
+        return report(kwargs, keyword="", data={"status": bool(removed), "nzf_ids": removed})
     else:
-        return report(_MSG_NO_VALUE2)
+        return report(kwargs, _MSG_NO_VALUE2)
 
 
-def _api_queue_rename(value: str, kwargs: ApiParams) -> bytes:
+def _api_queue_rename(value: str, kwargs: QueryParams) -> Response:
     """API: accepts value(=old name), value2(=new name), value3(=password)"""
     value2 = kwargs.get("value2")
     value3 = kwargs.get("value3")
     if value and value2:
         ret = sabnzbd.NzbQueue.change_name(value, value2, value3)
-        return report(keyword="", data={"status": ret})
+        return report(kwargs, keyword="", data={"status": ret})
     else:
-        return report(_MSG_NO_VALUE2)
+        return report(kwargs, _MSG_NO_VALUE2)
 
 
-def _api_queue_change_complete_action(value: str, kwargs: ApiParams) -> bytes:
+def _api_queue_change_complete_action(value: str, kwargs: QueryParams) -> Response:
     """API: accepts value(=action)"""
     change_queue_complete_action(value)
-    return report()
+    return report(kwargs)
 
 
-def _api_queue_purge(value: str, kwargs: ApiParams) -> bytes:
+def _api_queue_purge(value: str, kwargs: QueryParams) -> Response:
     removed = sabnzbd.NzbQueue.remove_all(kwargs.get("search"))
-    return report(keyword="", data={"status": bool(removed), "nzo_ids": removed})
+    return report(kwargs, keyword="", data={"status": bool(removed), "nzo_ids": removed})
 
 
-def _api_queue_pause(value: str, kwargs: ApiParams) -> bytes:
+def _api_queue_pause(value: str, kwargs: QueryParams) -> Response:
     """API: accepts value(=list of nzo_id)"""
     if items := clean_comma_separated_list(value):
         handled = sabnzbd.NzbQueue.pause_multiple_nzo(items)
     else:
         handled = False
-    return report(keyword="", data={"status": bool(handled), "nzo_ids": handled})
+    return report(kwargs, keyword="", data={"status": bool(handled), "nzo_ids": handled})
 
 
-def _api_queue_resume(value: str, kwargs: ApiParams) -> bytes:
+def _api_queue_resume(value: str, kwargs: QueryParams) -> Response:
     """API: accepts value(=list of nzo_id)"""
     if items := clean_comma_separated_list(value):
         handled = sabnzbd.NzbQueue.resume_multiple_nzo(items)
     else:
         handled = False
-    return report(keyword="", data={"status": bool(handled), "nzo_ids": handled})
+    return report(kwargs, keyword="", data={"status": bool(handled), "nzo_ids": handled})
 
 
-def _api_queue_priority(value: str, kwargs: ApiParams) -> bytes:
+def _api_queue_priority(value: str, kwargs: QueryParams) -> Response:
     """API: accepts value(=nzo_id), value2(=priority)"""
     nzo_ids = clean_comma_separated_list(value)
     priority = kwargs.get("value2")
@@ -266,28 +262,28 @@ def _api_queue_priority(value: str, kwargs: ApiParams) -> bytes:
             try:
                 priority = int(priority)
             except Exception:
-                return report(_MSG_INT_VALUE)
+                return report(kwargs, _MSG_INT_VALUE)
             pos = sabnzbd.NzbQueue.set_priority(nzo_ids, priority)
             # Returns the position in the queue, -1 is incorrect job-id
-            return report(keyword="position", data=pos)
+            return report(kwargs, keyword="position", data=pos)
         except Exception:
-            return report(_MSG_NO_VALUE2)
+            return report(kwargs, _MSG_NO_VALUE2)
     else:
-        return report(_MSG_NO_VALUE2)
+        return report(kwargs, _MSG_NO_VALUE2)
 
 
-def _api_queue_sort(value: str, kwargs: ApiParams) -> bytes:
+def _api_queue_sort(value: str, kwargs: QueryParams) -> Response:
     """API: accepts sort, dir"""
     sort = kwargs.get("sort", "")
     direction = kwargs.get("dir", "")
     if sort:
         sabnzbd.NzbQueue.sort_queue(sort, direction)
-        return report()
+        return report(kwargs)
     else:
-        return report(_MSG_NO_VALUE2)
+        return report(kwargs, _MSG_NO_VALUE2)
 
 
-def _api_queue_default(value: str, kwargs: ApiParams) -> bytes:
+def _api_queue_default(value: str, kwargs: QueryParams) -> Response:
     """API: accepts sort, dir, start, limit and search terms"""
     start = int_conv(kwargs.get("start"))
     limit = int_conv(kwargs.get("limit"))
@@ -302,6 +298,7 @@ def _api_queue_default(value: str, kwargs: ApiParams) -> bytes:
         priorities = [int_conv(prio) for prio in priorities]
 
     return report(
+        kwargs,
         keyword="queue",
         data=build_queue(
             start=start,
@@ -315,12 +312,12 @@ def _api_queue_default(value: str, kwargs: ApiParams) -> bytes:
     )
 
 
-def _api_translate(name: str, kwargs: ApiParams) -> bytes:
+def _api_translate(name: str, kwargs: QueryParams) -> Response:
     """API: accepts value(=acronym)"""
-    return report(keyword="value", data=T(kwargs.get("value", "")))
+    return report(kwargs, keyword="value", data=T(kwargs.get("value", "")))
 
 
-def _api_addfile(name: str, kwargs: ApiParams) -> bytes:
+def _api_addfile(name: str, kwargs: QueryParams) -> Response:
     """API: accepts name, pp, script, cat, priority, nzbname"""
     # Normal upload will send the nzb in a kw arg called name or nzbfile
     if not name or isinstance(name, str):
@@ -336,12 +333,12 @@ def _api_addfile(name: str, kwargs: ApiParams) -> bytes:
             nzbname=kwargs.get("nzbname"),
             password=kwargs.get("password"),
         )
-        return report(keyword="", data={"status": res is AddNzbFileResult.OK, "nzo_ids": nzo_ids})
+        return report(kwargs, keyword="", data={"status": res is AddNzbFileResult.OK, "nzo_ids": nzo_ids})
     else:
-        return report(_MSG_NO_VALUE)
+        return report(kwargs, _MSG_NO_VALUE)
 
 
-def _api_retry(name: str, kwargs: ApiParams) -> bytes:
+def _api_retry(name: str, kwargs: QueryParams) -> Response:
     """API: accepts name, value(=nzo_id), nzbfile(=optional NZB), password (optional)"""
     value = kwargs.get("value")
     # Normal upload will send the nzb in a kw arg called nzbfile
@@ -351,20 +348,20 @@ def _api_retry(name: str, kwargs: ApiParams) -> bytes:
     password = password[0] if isinstance(password, list) else password
 
     if nzo_id := retry_job(value, name, password):
-        return report(keyword="", data={"status": True, "nzo_id": nzo_id})
+        return report(kwargs, keyword="", data={"status": True, "nzo_id": nzo_id})
     else:
-        return report(_MSG_NO_ITEM)
+        return report(kwargs, _MSG_NO_ITEM)
 
 
-def _api_cancel_pp(name: str, kwargs: ApiParams) -> bytes:
+def _api_cancel_pp(name: str, kwargs: QueryParams) -> Response:
     """API: accepts name, value(=nzo_ids)"""
     if nzo_ids := clean_comma_separated_list(kwargs.get("value")):
         if sabnzbd.PostProcessor.cancel_pp(nzo_ids):
-            return report(keyword="", data={"status": True, "nzo_ids": nzo_ids})
-    return report(_MSG_NO_ITEM)
+            return report(kwargs, keyword="", data={"status": True, "nzo_ids": nzo_ids})
+    return report(kwargs, _MSG_NO_ITEM)
 
 
-def _api_addlocalfile(name: str, kwargs: ApiParams) -> bytes:
+def _api_addlocalfile(name: str, kwargs: QueryParams) -> Response:
     """API: accepts name, pp, script, cat, priority, nzbname"""
     if name:
         if os.path.exists(name):
@@ -379,31 +376,31 @@ def _api_addlocalfile(name: str, kwargs: ApiParams) -> bytes:
                     nzbname=kwargs.get("nzbname"),
                     password=kwargs.get("password"),
                 )
-                return report(keyword="", data={"status": res is AddNzbFileResult.OK, "nzo_ids": nzo_ids})
+                return report(kwargs, keyword="", data={"status": res is AddNzbFileResult.OK, "nzo_ids": nzo_ids})
             else:
                 logging.info('API-call addlocalfile: "%s" is not a supported file', name)
-                return report(_MSG_NO_FILE)
+                return report(kwargs, _MSG_NO_FILE)
         else:
             logging.info('API-call addlocalfile: file "%s" not found', name)
-            return report(_MSG_NO_PATH)
+            return report(kwargs, _MSG_NO_PATH)
     else:
         logging.info("API-call addlocalfile: no file name given")
-        return report(_MSG_NO_VALUE)
+        return report(kwargs, _MSG_NO_VALUE)
 
 
-def _api_switch(name: str, kwargs: ApiParams) -> bytes:
+def _api_switch(name: str, kwargs: QueryParams) -> Response:
     """API: accepts value(=first id), value2(=second id)"""
     value = kwargs.get("value")
     value2 = kwargs.get("value2")
     if value and value2:
         pos, prio = sabnzbd.NzbQueue.switch(value, value2)
         # Returns the new position and new priority (if different)
-        return report(keyword="result", data={"position": pos, "priority": prio})
+        return report(kwargs, keyword="result", data={"position": pos, "priority": prio})
     else:
-        return report(_MSG_NO_VALUE2)
+        return report(kwargs, _MSG_NO_VALUE2)
 
 
-def _api_change_cat(name: str, kwargs: ApiParams) -> bytes:
+def _api_change_cat(name: str, kwargs: QueryParams) -> Response:
     """API: accepts value(=nzo_id), value2(=category)"""
     nzo_ids = clean_comma_separated_list(kwargs.get("value"))
     cat = kwargs.get("value2")
@@ -411,12 +408,12 @@ def _api_change_cat(name: str, kwargs: ApiParams) -> bytes:
         if is_none(cat):
             cat = None
         result = sabnzbd.NzbQueue.change_cat(nzo_ids, cat)
-        return report(keyword="status", data=bool(result > 0))
+        return report(kwargs, keyword="status", data=bool(result > 0))
     else:
-        return report(_MSG_NO_VALUE)
+        return report(kwargs, _MSG_NO_VALUE)
 
 
-def _api_change_script(name: str, kwargs: ApiParams) -> bytes:
+def _api_change_script(name: str, kwargs: QueryParams) -> Response:
     """API: accepts value(=nzo_id), value2(=script)"""
     nzo_ids = clean_comma_separated_list(kwargs.get("value"))
     script = kwargs.get("value2")
@@ -424,43 +421,43 @@ def _api_change_script(name: str, kwargs: ApiParams) -> bytes:
         if is_none(script):
             script = None
         result = sabnzbd.NzbQueue.change_script(nzo_ids, script)
-        return report(keyword="status", data=bool(result > 0))
+        return report(kwargs, keyword="status", data=bool(result > 0))
     else:
-        return report(_MSG_NO_VALUE)
+        return report(kwargs, _MSG_NO_VALUE)
 
 
-def _api_change_opts(name: str, kwargs: ApiParams) -> bytes:
+def _api_change_opts(name: str, kwargs: QueryParams) -> Response:
     """API: accepts value(=nzo_id), value2(=pp)"""
     nzo_ids = clean_comma_separated_list(kwargs.get("value"))
     pp = kwargs.get("value2")
     if nzo_ids and pp and pp.isdigit():
         result = sabnzbd.NzbQueue.change_opts(nzo_ids, int(pp))
-        return report(keyword="status", data=bool(result > 0))
-    return report(_MSG_NO_ITEM)
+        return report(kwargs, keyword="status", data=bool(result > 0))
+    return report(kwargs, _MSG_NO_ITEM)
 
 
-def _api_fullstatus(name: str, kwargs: ApiParams) -> bytes:
+def _api_fullstatus(name: str, kwargs: QueryParams) -> Response:
     """API: full history status"""
     status = build_status(
         calculate_performance=bool_conv(kwargs.get("calculate_performance")),
         skip_dashboard=bool_conv(kwargs.get("skip_dashboard")),
     )
-    return report(keyword="status", data=status)
+    return report(kwargs, keyword="status", data=status)
 
 
-def _api_status(name: str, kwargs: ApiParams) -> bytes:
+def _api_status(name: str, kwargs: QueryParams) -> Response:
     """API: Dispatcher for mode=status, passing on the value"""
     value = kwargs.get("value", "")
     return _api_status_table.get(name, (_api_fullstatus, 2))[0](value, kwargs)
 
 
-def _api_unblock_server(value: str, kwargs: ApiParams) -> bytes:
+def _api_unblock_server(value: str, kwargs: QueryParams) -> Response:
     """Unblock a blocked server"""
     sabnzbd.Downloader.unblock(value)
-    return report()
+    return report(kwargs)
 
 
-def _api_delete_orphan(value: str, kwargs: ApiParams) -> bytes:
+def _api_delete_orphan(value: str, kwargs: QueryParams) -> Response:
     """Remove orphaned job"""
     if value:
         download_dir = cfg.download_dir.get_path()
@@ -469,19 +466,19 @@ def _api_delete_orphan(value: str, kwargs: ApiParams) -> bytes:
         if same_directory(download_dir, path) == 2:
             logging.info("Removing orphaned job %s", path)
             remove_all(path, recursive=True)
-            return report()
-    return report(_MSG_NO_ITEM)
+            return report(kwargs)
+    return report(kwargs, _MSG_NO_ITEM)
 
 
-def _api_delete_all_orphan(value: str, kwargs: ApiParams) -> bytes:
+def _api_delete_all_orphan(value: str, kwargs: QueryParams) -> Response:
     """Remove all orphaned jobs"""
     paths = sabnzbd.NzbQueue.scan_jobs(all_jobs=False, action=False)
     for path in paths:
         _api_delete_orphan(path, kwargs)
-    return report()
+    return report(kwargs)
 
 
-def _api_add_orphan(value: str, kwargs: ApiParams):
+def _api_add_orphan(value: str, kwargs: QueryParams):
     """Add orphaned job"""
     if value:
         download_dir = cfg.download_dir.get_path()
@@ -490,25 +487,25 @@ def _api_add_orphan(value: str, kwargs: ApiParams):
         if same_directory(download_dir, path) == 2:
             logging.info("Re-adding orphaned job %s", path)
             sabnzbd.NzbQueue.repair_job(path, None, None)
-            return report()
-    return report(_MSG_NO_ITEM)
+            return report(kwargs)
+    return report(kwargs, _MSG_NO_ITEM)
 
 
-def _api_add_all_orphan(value: str, kwargs: ApiParams) -> bytes:
+def _api_add_all_orphan(value: str, kwargs: QueryParams) -> Response:
     """Add all orphaned jobs"""
     paths = sabnzbd.NzbQueue.scan_jobs(all_jobs=False, action=False)
     for path in paths:
         _api_add_orphan(path, kwargs)
-    return report()
+    return report(kwargs)
 
 
-def _api_history(name: str, kwargs: ApiParams) -> bytes:
-    """API: Dispatcher for mode=history"""
+def _api_history(name: str, kwargs: QueryParams) -> Response:
+    """API: accepts value(=nzo_id), start, limit, search, nzo_ids"""
     value = kwargs.get("value", "")
     return _api_history_table.get(name, (_api_history_default, 2))[0](value, kwargs)
 
 
-def _api_history_delete(value: str, kwargs: ApiParams) -> bytes:
+def _api_history_delete(value: str, kwargs: QueryParams) -> Response:
     """API: accepts value(=nzo_id or special), search, archive, del_files"""
     search = kwargs.get("search")
     archive = True
@@ -534,7 +531,7 @@ def _api_history_delete(value: str, kwargs: ApiParams) -> bytes:
             else:
                 history_db.remove_with_status(Status.COMPLETED, search)
         history_updated()
-        return report()
+        return report(kwargs)
     elif value:
         for job in clean_comma_separated_list(value):
             if sabnzbd.PostProcessor.get_path(job):
@@ -549,12 +546,12 @@ def _api_history_delete(value: str, kwargs: ApiParams) -> bytes:
                 else:
                     history_db.remove(job)
         history_updated()
-        return report()
+        return report(kwargs)
     else:
-        return report(_MSG_NO_VALUE)
+        return report(kwargs, _MSG_NO_VALUE)
 
 
-def _api_history_mark_as_completed(value: str, kwargs: ApiParams) -> bytes:
+def _api_history_mark_as_completed(value: str, kwargs: QueryParams) -> Response:
     """API: accepts value(=nzo_id)"""
     if value:
         history_db = sabnzbd.get_db_connection()
@@ -568,12 +565,12 @@ def _api_history_mark_as_completed(value: str, kwargs: ApiParams) -> bytes:
                 remove_all(incomplete_path, recursive=True)
 
         history_updated()
-        return report()
+        return report(kwargs)
     else:
-        return report(_MSG_NO_VALUE)
+        return report(kwargs, _MSG_NO_VALUE)
 
 
-def _api_history_default(value: str, kwargs: ApiParams) -> bytes:
+def _api_history_default(value: str, kwargs: QueryParams) -> Response:
     """API: accepts start, limit, search, failed_only, archive, cat, status, nzo_ids"""
     start = int_conv(kwargs.get("start"))
     limit = int_conv(kwargs.get("limit"))
@@ -592,7 +589,7 @@ def _api_history_default(value: str, kwargs: ApiParams) -> bytes:
 
     # Do we need to send anything?
     if last_history_update == current_history_update:
-        return report(keyword="history", data=False)
+        return report(kwargs, keyword="history", data=False)
 
     if failed_only:
         # We ignore any other statuses, having both doesn't make sense
@@ -621,19 +618,19 @@ def _api_history_default(value: str, kwargs: ApiParams) -> bytes:
     )
     history["last_history_update"] = current_history_update
     history["version"] = sabnzbd.__version__
-    return report(keyword="history", data=history)
+    return report(kwargs, keyword="history", data=history)
 
 
-def _api_get_files(name: str, kwargs: ApiParams) -> bytes:
+def _api_get_files(name: str, kwargs: QueryParams) -> Response:
     """API: accepts value(=nzo_id)"""
     value = kwargs.get("value")
     if value:
-        return report(keyword="files", data=build_file_list(value))
+        return report(kwargs, keyword="files", data=build_file_list(value))
     else:
-        return report(_MSG_NO_VALUE)
+        return report(kwargs, _MSG_NO_VALUE)
 
 
-def _api_move_nzf_bulk(name: str, kwargs: ApiParams) -> bytes:
+def _api_move_nzf_bulk(name: str, kwargs: QueryParams) -> Response:
     """API: accepts name(=top/up/down/bottom), value=(=nzo_id), nzf_ids, size (optional)"""
     nzo_id = kwargs.get("value")
     nzf_ids = clean_comma_separated_list(kwargs.get("nzf_ids"))
@@ -655,11 +652,11 @@ def _api_move_nzf_bulk(name: str, kwargs: ApiParams) -> bytes:
             sabnzbd.NzbQueue.move_nzf_bottom_bulk(nzo_id, nzf_ids)
             nzf_moved = True
         if nzf_moved:
-            return report(keyword="", data={"status": True, "nzf_ids": nzf_ids})
-    return report(_MSG_NO_VALUE)
+            return report(kwargs, keyword="", data={"status": True, "nzf_ids": nzf_ids})
+    return report(kwargs, _MSG_NO_VALUE)
 
 
-def _api_addurl(name: str, kwargs: ApiParams) -> bytes:
+def _api_addurl(name: str, kwargs: QueryParams) -> Response:
     """API: accepts name, output, pp, script, cat, priority, nzbname"""
     pp = kwargs.get("pp")
     script = kwargs.get("script")
@@ -671,38 +668,39 @@ def _api_addurl(name: str, kwargs: ApiParams) -> bytes:
     if name:
         # Reporting a list of NZO's, for compatibility with other add-methods
         res, nzo_ids = sabnzbd.urlgrabber.add_url(name, pp, script, cat, priority, nzbname, password)
-        return report(keyword="", data={"status": res is AddNzbFileResult.OK, "nzo_ids": nzo_ids})
+        return report(kwargs, keyword="", data={"status": res is AddNzbFileResult.OK, "nzo_ids": nzo_ids})
     else:
         logging.info("API-call addurl: no URLs received")
-        return report(_MSG_NO_VALUE)
+        return report(kwargs, _MSG_NO_VALUE)
 
 
-def _api_pause(name: str, kwargs: ApiParams) -> bytes:
+def _api_pause(name: str, kwargs: QueryParams) -> Response:
     sabnzbd.Scheduler.plan_resume(0)
     sabnzbd.Downloader.pause()
-    return report()
+    return report(kwargs)
 
 
-def _api_resume(name: str, kwargs: ApiParams) -> bytes:
+def _api_resume(name: str, kwargs: QueryParams) -> Response:
     sabnzbd.Scheduler.plan_resume(0)
     sabnzbd.downloader.unpause_all()
-    return report()
+    return report(kwargs)
 
 
-def _api_shutdown(name: str, kwargs: ApiParams) -> bytes:
-    sabnzbd.shutdown_program()
-    return report()
+def _api_shutdown(name: str, kwargs: QueryParams) -> Response:
+    # In separate thread, because the server thread cannot shut down itself
+    Thread(target=sabnzbd.shutdown_program).start()
+    return report(kwargs)
 
 
-def _api_warnings(name: str, kwargs: ApiParams) -> bytes:
+def _api_warnings(name: str, kwargs: QueryParams) -> Response:
     """API: accepts name, output"""
     if name == "clear":
-        return report(keyword="warnings", data=sabnzbd.GUIHANDLER.clear())
+        return report(kwargs, keyword="warnings", data=sabnzbd.GUIHANDLER.clear())
     elif name == "show":
-        return report(keyword="warnings", data=sabnzbd.GUIHANDLER.content())
+        return report(kwargs, keyword="warnings", data=sabnzbd.GUIHANDLER.content())
     elif name:
-        return report(_MSG_NOT_IMPLEMENTED)
-    return report(keyword="warnings", data=sabnzbd.GUIHANDLER.content())
+        return report(kwargs, _MSG_NOT_IMPLEMENTED)
+    return report(kwargs, keyword="warnings", data=sabnzbd.GUIHANDLER.content())
 
 
 LOG_JSON_RE = re.compile(
@@ -751,57 +749,62 @@ def sanitize_line(line: bytes, cur_user_bytes: Optional[bytes] = None) -> bytes:
     return line
 
 
-def _api_showlog(name: str, kwargs: ApiParams) -> Generator[bytes, Any, None]:
+def _api_showlog(name: str, kwargs: QueryParams) -> StreamingResponse:
     """Fetch the INI and the log-data and add a message at the top"""
-    # Set headers
-    cherrypy.response.headers["Content-Type"] = "application/x-download;charset=utf-8"
-    cherrypy.response.headers["Content-Disposition"] = 'attachment;filename="sabnzbd.log"'
-    # Build header with version and environment info
-    header = "--------------------------------\n"
-    header += f"SABnzbd version: {sabnzbd.__version__}\n"
-    header += f"Commit: {sabnzbd.__baseline__}\n"
-    header += f"Python-version: {sys.version}\n"
-    header += f"Platform: {get_platform_description()}\n"
-    header += "--------------------------------\n\n"
-    header += "The log includes a copy of your sabnzbd.ini with\nall usernames, passwords and API-keys removed."
-    header += "\n\n--------------------------------\n"
-    yield header.encode("utf-8")
 
-    # Try to replace the username
-    cur_user_bytes: Optional[bytes] = None
-    try:
-        if cur_user := getpass.getuser():
-            cur_user_bytes = utob(cur_user)
-    except Exception:
-        pass
+    def _generate_log():
+        # Build header with version and environment info
+        header = "--------------------------------\n"
+        header += f"SABnzbd version: {sabnzbd.__version__}\n"
+        header += f"Commit: {sabnzbd.__baseline__}\n"
+        header += f"Python-version: {sys.version}\n"
+        header += f"Platform: {get_platform_description()}\n"
+        header += "--------------------------------\n\n"
+        header += "The log includes a copy of your sabnzbd.ini with\nall usernames, passwords and API-keys removed."
+        header += "\n\n--------------------------------\n"
+        yield header.encode("utf-8")
 
-    # Stream log file line by line
-    if sabnzbd.LOGFILE and os.path.exists(sabnzbd.LOGFILE):
-        with open(sabnzbd.LOGFILE, "rb") as f:
+        # Try to replace the username
+        cur_user_bytes = None
+        try:
+            if cur_user := getpass.getuser():
+                cur_user_bytes = utob(cur_user)
+        except Exception:
+            cur_user_bytes = None
+
+        # Stream log file line by line
+        if sabnzbd.LOGFILE and os.path.exists(sabnzbd.LOGFILE):
+            with open(sabnzbd.LOGFILE, "rb") as f:
+                for line in f:
+                    yield sanitize_line(line, cur_user_bytes)
+        else:
+            yield b"\nFile log disabled or not found.\n\n"
+
+        # Stream config file line by line
+        with open(config.get_filename(), "rb") as f:
             for line in f:
                 yield sanitize_line(line, cur_user_bytes)
-    else:
-        yield b"\nFile log disabled or not found.\n\n"
 
-    # Stream config file line by line
-    with open(config.get_filename(), "rb") as f:
-        for line in f:
-            yield sanitize_line(line, cur_user_bytes)
-
-
-def _api_get_cats(name: str, kwargs: ApiParams) -> bytes:
-    return report(keyword="categories", data=list_cats(False))
+    return StreamingResponse(
+        _generate_log(),
+        media_type="application/x-download;charset=utf-8",
+        headers={"Content-Disposition": 'attachment;filename="sabnzbd.log"'},
+    )
 
 
-def _api_get_scripts(name: str, kwargs: ApiParams) -> bytes:
-    return report(keyword="scripts", data=list_scripts())
+def _api_get_cats(name: str, kwargs: QueryParams) -> Response:
+    return report(kwargs, keyword="categories", data=list_cats(False))
 
 
-def _api_version(name: str, kwargs: ApiParams) -> bytes:
-    return report(keyword="version", data=sabnzbd.__version__)
+def _api_get_scripts(name: str, kwargs: QueryParams) -> Response:
+    return report(kwargs, keyword="scripts", data=list_scripts())
 
 
-def _api_auth(name: str, kwargs: ApiParams) -> bytes:
+def _api_version(name: str, kwargs: QueryParams) -> Response:
+    return report(kwargs, keyword="version", data=sabnzbd.__version__)
+
+
+def _api_auth(name: str, kwargs: QueryParams) -> Response:
     key = kwargs.get("key", "")
     if not key:
         auth = "apikey"
@@ -811,75 +814,75 @@ def _api_auth(name: str, kwargs: ApiParams) -> bytes:
             auth = "nzbkey"
         if key == cfg.api_key():
             auth = "apikey"
-    return report(keyword="auth", data=auth)
+    return report(kwargs, keyword="auth", data=auth)
 
 
-def _api_restart(name: str, kwargs: ApiParams) -> bytes:
+def _api_restart(name: str, kwargs: QueryParams) -> Response:
     logging.info("Restart requested by API")
     # Do the shutdown async to still send goodbye to browser
     Thread(target=sabnzbd.trigger_restart, kwargs={"timeout": 1}).start()
-    return report()
+    return report(kwargs)
 
 
-def _api_restart_repair(name: str, kwargs: ApiParams) -> bytes:
+def _api_restart_repair(name: str, kwargs: QueryParams) -> Response:
     logging.info("Queue repair requested by API")
     request_repair()
     # Do the shutdown async to still send goodbye to browser
     Thread(target=sabnzbd.trigger_restart, kwargs={"timeout": 1}).start()
-    return report()
+    return report(kwargs)
 
 
-def _api_disconnect(name: str, kwargs: ApiParams) -> bytes:
+def _api_disconnect(name: str, kwargs: QueryParams) -> Response:
     sabnzbd.Downloader.disconnect()
-    return report()
+    return report(kwargs)
 
 
-def _api_eval_sort(name: str, kwargs: ApiParams) -> bytes:
+def _api_eval_sort(name: str, kwargs: QueryParams) -> Response:
     """API: evaluate sorting expression"""
     sort_string = kwargs.get("sort_string", "")
     job_name = kwargs.get("job_name", "")
     multipart_label = kwargs.get("multipart_label", "")
     path = sabnzbd.sorting.eval_sort(sort_string, job_name, multipart_label)
     if path is None:
-        return report(_MSG_NOT_IMPLEMENTED)
+        return report(kwargs, _MSG_NOT_IMPLEMENTED)
     else:
-        return report(keyword="result", data=path)
+        return report(kwargs, keyword="result", data=path)
 
 
-def _api_watched_now(name: str, kwargs: ApiParams) -> bytes:
+def _api_watched_now(name: str, kwargs: QueryParams) -> Response:
     sabnzbd.DirScanner.scan()
-    return report()
+    return report(kwargs)
 
 
-def _api_resume_pp(name: str, kwargs: ApiParams) -> bytes:
+def _api_resume_pp(name: str, kwargs: QueryParams) -> Response:
     sabnzbd.PostProcessor.resume()
-    return report()
+    return report(kwargs)
 
 
-def _api_pause_pp(name: str, kwargs: ApiParams) -> bytes:
+def _api_pause_pp(name: str, kwargs: QueryParams) -> Response:
     sabnzbd.PostProcessor.pause()
-    return report()
+    return report(kwargs)
 
 
-def _api_rss_now(name: str, kwargs: ApiParams) -> bytes:
+def _api_rss_now(name: str, kwargs: QueryParams) -> Response:
     # Run RSS scan async, because it can take a long time
     sabnzbd.Scheduler.force_rss()
-    return report()
+    return report(kwargs)
 
 
-def _api_retry_all(name: str, kwargs: ApiParams) -> bytes:
+def _api_retry_all(name: str, kwargs: QueryParams) -> Response:
     """API: Retry all failed items in History"""
     nzo_ids = [retry_job(job["nzo_id"]) for job in sabnzbd.get_db_connection().get_retryable_jobs()]
-    return report(keyword="status", data=nzo_ids)
+    return report(kwargs, keyword="status", data=nzo_ids)
 
 
-def _api_reset_quota(name: str, kwargs: ApiParams) -> bytes:
+def _api_reset_quota(name: str, kwargs: QueryParams) -> Response:
     """Reset quota left"""
     sabnzbd.BPSMeter.reset_quota(force=True)
-    return report()
+    return report(kwargs)
 
 
-def _api_test_email(name: str, kwargs: ApiParams) -> bytes:
+def _api_test_email(name: str, kwargs: QueryParams) -> Response:
     """API: send a test email, return result"""
     logging.info("Sending test email")
     pack = {"download": ["action 1", "action 2"], "unpack": ["action 1", "action 2"]}
@@ -897,71 +900,71 @@ def _api_test_email(name: str, kwargs: ApiParams) -> bytes:
         test=kwargs,
     )
     if res == T("Email succeeded"):
-        return report()
-    return report(error=res)
+        return report(kwargs)
+    return report(kwargs, error=res)
 
 
-def _api_test_windows(name: str, kwargs: ApiParams) -> bytes:
+def _api_test_windows(name: str, kwargs: QueryParams) -> Response:
     """API: send a test to Windows, return result"""
     logging.info("Sending test notification")
     res = sabnzbd.notifier.send_windows("SABnzbd", T("Test Notification"), "other")
-    return report(error=res)
+    return report(kwargs, error=res)
 
 
-def _api_test_notif(name: str, kwargs: ApiParams) -> bytes:
+def _api_test_notif(name: str, kwargs: QueryParams) -> Response:
     """API: send a test to Notification Center, return result"""
     logging.info("Sending test notification")
     res = sabnzbd.notifier.send_notification_center("SABnzbd", T("Test Notification"), "other")
-    return report(error=res)
+    return report(kwargs, error=res)
 
 
-def _api_test_osd(name: str, kwargs: ApiParams) -> bytes:
+def _api_test_osd(name: str, kwargs: QueryParams) -> Response:
     """API: send a test OSD notification, return result"""
     logging.info("Sending OSD notification")
     res = sabnzbd.notifier.send_notify_osd("SABnzbd", T("Test Notification"))
-    return report(error=res)
+    return report(kwargs, error=res)
 
 
-def _api_test_prowl(name: str, kwargs: ApiParams) -> bytes:
+def _api_test_prowl(name: str, kwargs: QueryParams) -> Response:
     """API: send a test Prowl notification, return result"""
     logging.info("Sending Prowl notification")
     res = sabnzbd.notifier.send_prowl("SABnzbd", T("Test Notification"), "other", force=True, test=kwargs)
-    return report(error=res)
+    return report(kwargs, error=res)
 
 
-def _api_test_pushover(name: str, kwargs: ApiParams) -> bytes:
+def _api_test_pushover(name: str, kwargs: QueryParams) -> Response:
     """API: send a test Pushover notification, return result"""
     logging.info("Sending Pushover notification")
     res = sabnzbd.notifier.send_pushover("SABnzbd", T("Test Notification"), "other", force=True, test=kwargs)
-    return report(error=res)
+    return report(kwargs, error=res)
 
 
-def _api_test_pushbullet(name: str, kwargs: ApiParams) -> bytes:
+def _api_test_pushbullet(name: str, kwargs: QueryParams) -> Response:
     """API: send a test Pushbullet notification, return result"""
     logging.info("Sending Pushbullet notification")
     res = sabnzbd.notifier.send_pushbullet("SABnzbd", T("Test Notification"), "other", force=True, test=kwargs)
-    return report(error=res)
+    return report(kwargs, error=res)
 
 
-def _api_test_apprise(name: str, kwargs: ApiParams) -> bytes:
+def _api_test_apprise(name: str, kwargs: QueryParams) -> Response:
     """API: send a test Apprise notification, return result"""
     logging.info("Sending Apprise notification")
     res = sabnzbd.notifier.send_apprise("SABnzbd", T("Test Notification"), "other", force=True, test=kwargs)
-    return report(error=res)
+    return report(kwargs, error=res)
 
 
-def _api_test_nscript(name: str, kwargs: ApiParams) -> bytes:
+def _api_test_nscript(name: str, kwargs: QueryParams) -> Response:
     """API: execute a test notification script, return result"""
     logging.info("Executing notification script")
     res = sabnzbd.notifier.send_nscript("SABnzbd", T("Test Notification"), "other", force=True, test=kwargs)
-    return report(error=res)
+    return report(kwargs, error=res)
 
 
-def _api_undefined(name: str, kwargs: ApiParams) -> bytes:
-    return report(_MSG_NOT_IMPLEMENTED)
+def _api_undefined(name: str, kwargs: QueryParams) -> Response:
+    return report(kwargs, _MSG_NOT_IMPLEMENTED)
 
 
-def _api_browse(name: str, kwargs: ApiParams) -> bytes:
+def _api_browse(name: str, kwargs: QueryParams) -> Response:
     """Return tree of local path"""
     compact = bool_conv(kwargs.get("compact"))
     show_files = bool_conv(kwargs.get("show_files"))
@@ -975,45 +978,45 @@ def _api_browse(name: str, kwargs: ApiParams) -> bytes:
                 paths.append(entry["path"])
     else:
         paths = pathbrowser(name, show_hidden, show_files)
-    return report(keyword="paths", data=paths)
+    return report(kwargs, keyword="paths", data=paths)
 
 
-def _api_config(name: str, kwargs: ApiParams) -> bytes:
+def _api_config(name: str, kwargs: QueryParams) -> Response:
     """API: Dispatcher for "config" """
     if cfg.configlock():
-        return report(_MSG_CONFIG_LOCKED)
-    return _api_config_table.get(name, (_api_config_undefined, 2))[0](name, kwargs)
+        return report(kwargs, _MSG_CONFIG_LOCKED)
+    return _api_config_table.get(name, (_api_config_undefined, 2))[0](kwargs)
 
 
-def _api_config_speedlimit(name: str, kwargs: ApiParams) -> bytes:
+def _api_config_speedlimit(kwargs: QueryParams) -> Response:
     """API: accepts value(=speed)"""
     value = kwargs.get("value")
     if not value:
         value = "0"
     sabnzbd.Downloader.limit_speed(value)
-    return report()
+    return report(kwargs)
 
 
-def _api_config_set_pause(name: str, kwargs: ApiParams) -> bytes:
+def _api_config_set_pause(kwargs: QueryParams) -> Response:
     """API: accepts value(=pause interval)"""
     value = kwargs.get("value")
     sabnzbd.Scheduler.plan_resume(int_conv(value))
-    return report()
+    return report(kwargs)
 
 
-def _api_config_set_apikey(name: str, kwargs: ApiParams) -> bytes:
+def _api_config_set_apikey(kwargs: QueryParams) -> Response:
     cfg.api_key.set(config.create_api_key())
     config.save_config()
-    return report(keyword="apikey", data=cfg.api_key())
+    return report(kwargs, keyword="apikey", data=cfg.api_key())
 
 
-def _api_config_set_nzbkey(name: str, kwargs: ApiParams) -> bytes:
+def _api_config_set_nzbkey(kwargs: QueryParams) -> Response:
     cfg.nzb_key.set(config.create_api_key())
     config.save_config()
-    return report(keyword="nzbkey", data=cfg.nzb_key())
+    return report(kwargs, keyword="nzbkey", data=cfg.nzb_key())
 
 
-def _api_config_regenerate_certs(name: str, kwargs: ApiParams) -> bytes:
+def _api_config_regenerate_certs(kwargs: QueryParams) -> Response:
     # Make sure we only over-write default locations
     result = False
     if (
@@ -1024,30 +1027,30 @@ def _api_config_regenerate_certs(name: str, kwargs: ApiParams) -> bytes:
         https_key = sabnzbd.cfg.https_key.get_path()
         result = create_https_certificates(https_cert, https_key)
         sabnzbd.RESTART_REQ = True
-    return report(data=result)
+    return report(kwargs, data=result)
 
 
-def _api_config_test_server(name: str, kwargs: ApiParams) -> bytes:
+def _api_config_test_server(kwargs: QueryParams) -> Response:
     """API: accepts server-params"""
     result, msg = test_nntp_server_dict(kwargs)
-    return report(data={"result": result, "message": msg})
+    return report(kwargs, data={"result": result, "message": msg})
 
 
-def _api_config_create_backup(name: str, kwargs: ApiParams) -> bytes:
+def _api_config_create_backup(kwargs: QueryParams) -> Response:
     backup_file = config.create_config_backup()
-    return report(data={"result": bool(backup_file), "message": backup_file})
+    return report(kwargs, data={"result": bool(backup_file), "message": backup_file})
 
 
-def _api_config_purge_log_files(name: str, kwargs: ApiParams) -> bytes:
+def _api_config_purge_log_files(kwargs: QueryParams) -> Response:
     purge_log_files()
-    return report()
+    return report(kwargs)
 
 
-def _api_config_undefined(name: str, kwargs: ApiParams) -> bytes:
-    return report(_MSG_NOT_IMPLEMENTED)
+def _api_config_undefined(kwargs: QueryParams) -> Response:
+    return report(kwargs, _MSG_NOT_IMPLEMENTED)
 
 
-def _api_server_stats(name: str, kwargs: ApiParams) -> bytes:
+def _api_server_stats(name: str, kwargs: QueryParams) -> Response:
     sum_t, sum_m, sum_w, sum_d = sabnzbd.BPSMeter.get_sums()
     stats = {"total": sum_t, "month": sum_m, "week": sum_w, "day": sum_d, "servers": {}}
 
@@ -1063,15 +1066,15 @@ def _api_server_stats(name: str, kwargs: ApiParams) -> bytes:
             "articles_success": articles_success,
         }
 
-    return report(keyword="", data=stats)
+    return report(kwargs, keyword="", data=stats)
 
 
-def _api_gc_stats(name: str, kwargs: ApiParams) -> bytes:
+def _api_gc_stats(name: str, kwargs: QueryParams) -> Response:
     """Function only intended for internal testing of the memory handling"""
     # Collect before we check
     gc.collect()
     # We cannot create any lists/dicts, as they would create a reference
-    return report(data=[str(obj) for obj in gc.get_objects() if isinstance(obj, TryList)])
+    return report(kwargs, data=[str(obj) for obj in gc.get_objects() if isinstance(obj, TryList)])
 
 
 ##############################################################################
@@ -1184,13 +1187,18 @@ def api_level(mode: str, name: str) -> int:
     return 4
 
 
-def report(error: Optional[str] = None, keyword: str = "value", data: Optional[Any] = None) -> bytes:
+def report(
+    kwargs: QueryParams,
+    error: Optional[str] = None,
+    keyword: str = "value",
+    data: Optional[Any] = None,
+) -> Response:
     """Report message in json, xml or plain text
     If error is set, only a status/error report is made.
     If no error and no data, only a status report is made.
     Else, a data report is made (optional 'keyword' for outer XML section).
     """
-    if cherrypy.request.params.get("output") == "xml":
+    if kwargs.get("output") == "xml":
         if not keyword:
             # xml always needs an outer keyword, even when json doesn't
             keyword = "result"
@@ -1204,7 +1212,7 @@ def report(error: Optional[str] = None, keyword: str = "value", data: Optional[A
             status_str = xmlmaker.run(keyword, data)
         response = '<?xml version="1.0" encoding="UTF-8" ?>\n%s\n' % status_str
     else:
-        content = "application/json;charset=UTF-8"
+        content = "application/json; charset=utf-8"
         if error:
             info = {"status": False, "error": error}
         elif data is None:
@@ -1217,9 +1225,14 @@ def report(error: Optional[str] = None, keyword: str = "value", data: Optional[A
 
         response = utob(json.dumps(info))
 
-    cherrypy.response.headers["Content-Type"] = content
-    cherrypy.response.headers["Pragma"] = "no-cache"
-    return response
+    return Response(
+        response,
+        media_type=content,
+        headers={
+            "Pragma": "no-cache",
+            "Access-Control-Allow-Origin": "*",
+        },
+    )
 
 
 class XmlOutputFactory:
@@ -1277,7 +1290,7 @@ class XmlOutputFactory:
         return text
 
 
-def handle_server_api(kwargs: ApiParams) -> str:
+def handle_server_api(kwargs: QueryParams) -> str:
     """Special handler for API-call 'set_config' [servers]"""
     name = kwargs.get("keyword")
     if not name:
@@ -1295,7 +1308,7 @@ def handle_server_api(kwargs: ApiParams) -> str:
     return name
 
 
-def handle_sorter_api(kwargs: ApiParams) -> Optional[str]:
+def handle_sorter_api(kwargs: QueryParams) -> Optional[str]:
     """Special handler for API-call 'set_config' [sorters]"""
     name = kwargs.get("keyword")
     if not name:
@@ -1311,7 +1324,7 @@ def handle_sorter_api(kwargs: ApiParams) -> Optional[str]:
     return name
 
 
-def handle_rss_api(kwargs: ApiParams) -> Optional[str]:
+def handle_rss_api(kwargs: QueryParams) -> Optional[str]:
     """Special handler for API-call 'set_config' [rss]"""
     name = kwargs.get("keyword")
     if not name:
@@ -1327,25 +1340,19 @@ def handle_rss_api(kwargs: ApiParams) -> Optional[str]:
 
     action = kwargs.get("filter_action")
     if action in ("add", "update"):
-        # Use the general function, but catch the redirect-raise
-        try:
-            kwargs["feed"] = name
-            sabnzbd.interface.ConfigRss("/").internal_upd_rss_filter(**kwargs)
-        except cherrypy.HTTPRedirect:
-            pass
+        filter_kwargs = dict(kwargs)
+        filter_kwargs["feed"] = name
+        sabnzbd.interface.do_upd_rss_filter(filter_kwargs)
 
     elif action == "delete":
-        # Use the general function, but catch the redirect-raise
-        try:
-            kwargs["feed"] = name
-            sabnzbd.interface.ConfigRss("/").internal_del_rss_filter(**kwargs)
-        except cherrypy.HTTPRedirect:
-            pass
+        filter_kwargs = dict(kwargs)
+        filter_kwargs["feed"] = name
+        sabnzbd.interface.do_del_rss_filter(filter_kwargs)
 
     return name
 
 
-def handle_cat_api(kwargs: ApiParams) -> Optional[str]:
+def handle_cat_api(kwargs: QueryParams) -> Optional[str]:
     """Special handler for API-call 'set_config' [categories]"""
     name = kwargs.get("keyword")
     if not name:
@@ -1362,7 +1369,7 @@ def handle_cat_api(kwargs: ApiParams) -> Optional[str]:
     return name
 
 
-def test_nntp_server_dict(kwargs: ApiParams) -> tuple[bool, str]:
+def test_nntp_server_dict(kwargs: QueryParams) -> tuple[bool, str]:
     """Will connect (blocking) to the NNTP server and report back any errors"""
     host = kwargs.get("host", "").strip()
     port = int_conv(kwargs.get("port", 0))
@@ -1819,7 +1826,7 @@ def build_file_list(nzo_id: str) -> list[dict[str, Any]]:
 
 def retry_job(
     job: str,
-    new_nzb: Optional[cherrypy._cpreqbody.Part] = None,
+    new_nzb=None,
     password: Optional[str] = None,
 ) -> Optional[str]:
     """Re enter failed job in the download queue"""
@@ -2116,7 +2123,7 @@ def plural_to_single(kw, def_kw=""):
         return def_kw
 
 
-def del_from_section(kwargs: ApiParams) -> bool:
+def del_from_section(kwargs: dict[str, str | list[str]]) -> bool:
     """Remove keyword in section"""
     section = kwargs.get("section", "")
     if section in ("sorters", "servers", "rss", "categories"):

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -32,6 +32,7 @@ import urllib.parse
 from threading import Thread
 from typing import Any, Callable, NamedTuple, Optional, TypeAlias, Awaitable, TypeGuard
 
+from starlette.background import BackgroundTask
 from starlette.concurrency import run_in_threadpool
 from starlette.datastructures import QueryParams
 from starlette.requests import Request
@@ -192,6 +193,8 @@ async def halt_and_shutdown():
     loop so we don't block it. The web server itself cannot be stopped from within
     its own event loop, so that part is deferred to a separate thread."""
     if not sabnzbd.SABSTOP:
+        if sabnzbd.WEB_SERVER:
+            sabnzbd.WEB_SERVER.stop_accepting_connections()
         await run_in_threadpool(sabnzbd.halt)
         Thread(target=sabnzbd.shutdown_program).start()
 
@@ -856,19 +859,32 @@ def _api_auth(name: str, kwargs: QueryParams) -> Response:
     return report(kwargs, keyword="auth", data=auth)
 
 
-def _api_restart(name: str, kwargs: QueryParams) -> Response:
+async def _api_restart(name: str, kwargs: QueryParams) -> Response:
     logging.info("Restart requested by API")
-    # Do the shutdown async to still send goodbye to browser
-    Thread(target=sabnzbd.trigger_restart, kwargs={"timeout": 1}).start()
-    return report(kwargs)
+    return _restart_response(kwargs)
 
 
-def _api_restart_repair(name: str, kwargs: QueryParams) -> Response:
+async def _api_restart_repair(name: str, kwargs: QueryParams) -> Response:
     logging.info("Queue repair requested by API")
     request_repair()
-    # Do the shutdown async to still send goodbye to browser
-    Thread(target=sabnzbd.trigger_restart, kwargs={"timeout": 1}).start()
-    return report(kwargs)
+    return _restart_response(kwargs)
+
+
+def _restart_response(kwargs: QueryParams) -> Response:
+    """Reply to a restart request, then restart once the reply has been sent.
+
+    Stop accepting new connections up-front so a client that receives the reply
+    cannot reconnect to this soon-to-be-replaced process, and defer the actual
+    re-exec to a background task that runs after the response is flushed. Together
+    these replace the old blind one-second delay before triggering the restart.
+
+    Must be called from an async handler (event-loop thread) so closing the
+    listening sockets is safe."""
+    if sabnzbd.WEB_SERVER:
+        sabnzbd.WEB_SERVER.stop_accepting_connections()
+    response = report(kwargs)
+    response.background = BackgroundTask(sabnzbd.trigger_restart)
+    return response
 
 
 def _api_disconnect(name: str, kwargs: QueryParams) -> Response:

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -21,6 +21,7 @@ sabnzbd.api - api
 
 import os
 import sys
+import inspect
 import logging
 import re
 import gc
@@ -28,7 +29,7 @@ import socket
 import time
 import getpass
 from threading import Thread
-from typing import Any, Awaitable, Callable, Optional, TypeAlias
+from typing import Any, Callable, Optional, TypeAlias
 
 from starlette.concurrency import run_in_threadpool
 from starlette.datastructures import QueryParams
@@ -125,10 +126,15 @@ _MSG_NO_SUCH_CONFIG = "Config item does not exist"
 _MSG_CONFIG_LOCKED = "Configuration locked"
 
 
-def api_handler(kwargs: QueryParams) -> Response | Awaitable[Response]:
-    """API Dispatcher. Handlers are either plain functions returning a Response,
-    or coroutine functions (e.g. shutdown) whose result must be awaited by the caller."""
-    return _api_table.get(kwargs.get("mode", ""), (_api_undefined, 2))[0](kwargs.get("name", ""), kwargs)
+async def api_handler(kwargs: QueryParams) -> Response:
+    """API Dispatcher. Coroutine handlers (e.g. shutdown) are awaited on the
+    event loop; plain sync handlers are executed in the threadpool so blocking
+    work (disk, database, network tests, benchmarks) cannot stall the loop.
+    This also allows incremental conversion of handlers to native async."""
+    handler = _api_table.get(kwargs.get("mode", ""), (_api_undefined, 2))[0]
+    if inspect.iscoroutinefunction(handler):
+        return await handler(kwargs.get("name", ""), kwargs)
+    return await run_in_threadpool(handler, kwargs.get("name", ""), kwargs)
 
 
 async def halt_and_shutdown():

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1862,6 +1862,7 @@ def retry_job(
 ) -> Optional[str]:
     """Re enter failed job in the download queue"""
     if job:
+        nzo_id: Optional[str] = None
         with sabnzbd.db_pool.connection() as history_db:
             futuretype, url, pp, script, cat = history_db.get_other(job)
             if futuretype:

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -802,7 +802,7 @@ def _api_showlog(name: str, kwargs: QueryParams) -> StreamingResponse:
     return StreamingResponse(
         _generate_log(),
         media_type="application/x-download;charset=utf-8",
-        headers={"Content-Disposition": 'attachment;filename="sabnzbd.log"'},
+        headers={"Content-Disposition": 'attachment;filename="sabnzbd.log"', "Cache-Control": "no-store"},
     )
 
 
@@ -1241,10 +1241,14 @@ def report(
 
         response = utob(json.dumps(info))
 
+    # No-store: API responses must never be cached, by browsers or intermediaries.
+    # Pragma is kept only for ancient HTTP/1.0 proxies; Cache-Control is what
+    # modern clients actually honor (Pragma is not a defined response header).
     return Response(
         response,
         media_type=content,
         headers={
+            "Cache-Control": "no-store",
             "Pragma": "no-cache",
             "Access-Control-Allow-Origin": "*",
         },

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -34,7 +34,7 @@ from typing import Any, Callable, NamedTuple, Optional, TypeAlias, Awaitable, Ty
 
 from starlette.background import BackgroundTask
 from starlette.concurrency import run_in_threadpool
-from starlette.datastructures import QueryParams
+from starlette.datastructures import QueryParams, UploadFile
 from starlette.requests import Request
 from starlette.responses import Response, StreamingResponse
 
@@ -1861,7 +1861,7 @@ def build_file_list(nzo_id: str) -> list[dict[str, Any]]:
 
 def retry_job(
     job: str,
-    new_nzb=None,
+    new_nzb: Optional[UploadFile] = None,
     password: Optional[str] = None,
 ) -> Optional[str]:
     """Re enter failed job in the download queue"""
@@ -1948,11 +1948,14 @@ def url_for(path: str = "", request: Optional[Request] = None, absolute: bool = 
     return url
 
 
-def url_netloc(host: str, scheme: str, port: Optional[int]) -> str:
+def url_netloc(host: Optional[str], scheme: str, port: Optional[int]) -> str:
     """Join a host and port, leaving the port off when it is the default for the scheme.
 
     An explicit :80 on http or :443 on https is redundant, and carrying it around makes
     otherwise identical URLs compare as different."""
+    if host is None:
+        host = ""
+
     # Bare IPv6 addresses need bracketing before a port can be appended
     if ":" in host and not host.startswith("["):
         host = "[%s]" % host
@@ -2219,7 +2222,7 @@ def plural_to_single(kw, def_kw=""):
         return def_kw
 
 
-def del_from_section(kwargs: dict[str, str | list[str]]) -> bool:
+def del_from_section(kwargs: QueryParams) -> bool:
     """Remove keyword in section"""
     section = kwargs.get("section", "")
     if section in ("sorters", "servers", "rss", "categories"):

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -400,7 +400,6 @@ def _api_retry(name: str, kwargs: QueryParams) -> Response:
     if name is None or isinstance(name, str):
         name = kwargs.get("nzbfile")
     password = kwargs.get("password")
-    password = password[0] if isinstance(password, list) else password
 
     if nzo_id := retry_job(value, name, password):
         return report(kwargs, keyword="", data={"status": True, "nzo_id": nzo_id})

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -179,10 +179,7 @@ def _api_set_config_default(name: str, kwargs: QueryParams) -> Response:
     """API: Reset requested config variables back to defaults. Currently only for misc-section"""
     if cfg.configlock():
         return report(kwargs, _MSG_CONFIG_LOCKED)
-    keywords = kwargs.get("keyword", [])
-    if not isinstance(keywords, list):
-        keywords = [keywords]
-    for keyword in keywords:
+    for keyword in kwargs.getlist("keyword"):
         item = config.get_config("misc", keyword)
         if item:
             item.set(item.default)

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -28,11 +28,13 @@ import gc
 import socket
 import time
 import getpass
+import urllib.parse
 from threading import Thread
 from typing import Any, Callable, Optional, TypeAlias
 
 from starlette.concurrency import run_in_threadpool
 from starlette.datastructures import QueryParams
+from starlette.requests import Request
 from starlette.responses import Response, StreamingResponse
 
 # For json.dumps, orjson is magnitudes faster than ujson, but it is harder to
@@ -1906,7 +1908,69 @@ def clear_trans_cache():
     sabnzbd.WEBUI_READY = True
 
 
-def build_header(webdir: str = "", for_template: bool = True, trans_functions: bool = True) -> dict[str, Any]:
+def url_for(path: str = "", request: Optional[Request] = None, absolute: bool = True, **kwargs) -> str:
+    """Build an absolute URL below the configured URL base.
+
+    Templates reach this as $url(...), so a link never depends on the depth of the
+    page it appears on: $url("config/general") yields the full scheme://host/<base>/config/general.
+    Query parameters are passed as keyword arguments and a #fragment may be part of
+    the path: $url("config/general#cache_limit").
+
+    Pass absolute=False to get a root-relative URL instead (/<base>/config/general), which
+    is what a Location header wants and what stays correct if the page is reached by some
+    other host or scheme than the one that generated it."""
+    # Split off the fragment first so query parameters stay in front of it
+    path, _, fragment = path.partition("#")
+
+    # url_base() is either empty or starts with a slash and has no trailing one,
+    # so normalising the path to a single leading slash is enough to join them
+    url = cfg.url_base() + "/" + path.lstrip("/")
+
+    if absolute:
+        url = url_origin(request) + url
+    if kwargs:
+        url = "%s?%s" % (url, urllib.parse.urlencode(kwargs))
+    if fragment:
+        url = "%s#%s" % (url, fragment)
+    return url
+
+
+def url_netloc(host: str, scheme: str, port: Optional[int]) -> str:
+    """Join a host and port, leaving the port off when it is the default for the scheme.
+
+    An explicit :80 on http or :443 on https is redundant, and carrying it around makes
+    otherwise identical URLs compare as different."""
+    # Bare IPv6 addresses need bracketing before a port can be appended
+    if ":" in host and not host.startswith("["):
+        host = "[%s]" % host
+
+    if port is None or (scheme == "https" and port == 443) or (scheme == "http" and port == 80):
+        return host
+    return "%s:%s" % (host, port)
+
+
+def url_origin(request: Optional[Request] = None) -> str:
+    """The scheme://host[:port] SABnzbd was reached by, for use in absolute URLs.
+
+    Taken from the request when there is one: uvicorn's ProxyHeadersMiddleware has
+    already applied X-Forwarded-Proto by then (when verify_xff_header is enabled), so
+    this stays correct behind a reverse proxy terminating TLS on another port. Without
+    a request there is nothing to observe, so fall back to the configured scheme and
+    port on localhost."""
+    if request:
+        return "%s://%s" % (request.url.scheme, url_netloc(request.url.hostname, request.url.scheme, request.url.port))
+
+    scheme = "https" if cfg.enable_https() else "http"
+    port = cfg.https_port() if cfg.enable_https() else cfg.web_port()
+    return "%s://%s" % (scheme, url_netloc("localhost", scheme, port))
+
+
+def build_header(
+    webdir: str = "",
+    for_template: bool = True,
+    trans_functions: bool = True,
+    request: Optional[Request] = None,
+) -> dict[str, Any]:
     """Build the basic header"""
     header = {}
 
@@ -1916,6 +1980,16 @@ def build_header(webdir: str = "", for_template: bool = True, trans_functions: b
         if trans_functions:
             header["T"] = Ttemplate
             header["Tspec"] = Tspec
+
+            # Bound to this request so $url() can see the scheme and host it was reached by.
+            # Deliberately a closure rather than functools.partial: template_filtered_response
+            # deep-copies the search list, and deepcopy treats a function as atomic but walks a
+            # partial's keywords -- which would drag in the request's scope, the app and its
+            # whole route graph, and blow the recursion limit.
+            def bound_url_for(path: str = "", **kwargs) -> str:
+                return url_for(path, request=request, **kwargs)
+
+            header["url"] = bound_url_for
 
         header["uptime"] = calc_age(sabnzbd.START)
         header["color_scheme"] = sabnzbd.WEB_COLOR or ""

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1865,7 +1865,9 @@ def retry_job(
         with sabnzbd.db_pool.connection() as history_db:
             futuretype, url, pp, script, cat = history_db.get_other(job)
             if futuretype:
-                nzo_id = next(iter(sabnzbd.urlgrabber.add_url(url, pp, script, cat, dup_check=False)[1]), None)
+                res, nzo_ids = sabnzbd.urlgrabber.add_url(url, pp, script, cat, dup_check=False)
+                if res is AddNzbFileResult.OK:
+                    nzo_id = nzo_ids[0]
             else:
                 path = history_db.get_incomplete_path(job)
                 nzo_id = sabnzbd.NzbQueue.repair_job(path, new_nzb, password)

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1869,7 +1869,7 @@ def retry_job(
         with sabnzbd.db_pool.connection() as history_db:
             futuretype, url, pp, script, cat = history_db.get_other(job)
             if futuretype:
-                nzo_id = sabnzbd.urlgrabber.add_url(url, pp, script, cat, dup_check=False)
+                nzo_id = next(iter(sabnzbd.urlgrabber.add_url(url, pp, script, cat, dup_check=False)[1]), None)
             else:
                 path = history_db.get_incomplete_path(job)
                 nzo_id = sabnzbd.NzbQueue.repair_job(path, new_nzb, password)

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -100,7 +100,6 @@ from sabnzbd.filesystem import (
 )
 from sabnzbd.encoding import xml_name, utob
 from sabnzbd.getipaddress import local_ipv4, public_ipv4, public_ipv6, dnslookup, active_socks5_proxy
-from sabnzbd.database import HistoryDB
 from sabnzbd.lang import is_rtl
 from sabnzbd.nzb import NzbObject, TryList
 from sabnzbd.newswrapper import NewsWrapper, NNTPPermanentError
@@ -536,34 +535,34 @@ def _api_history_delete(value: str, kwargs: QueryParams) -> Response:
     special = value.lower()
     del_files = bool_conv(kwargs.get("del_files"))
     if special in ("all", "failed", "completed"):
-        history_db = sabnzbd.get_db_connection()
-        if special in ("all", "failed"):
-            if del_files:
-                del_job_files(history_db.get_failed_paths(search))
-            if archive:
-                history_db.archive_with_status(Status.FAILED, search)
-            else:
-                history_db.remove_with_status(Status.FAILED, search)
-        if special in ("all", "completed"):
-            if archive:
-                history_db.archive_with_status(Status.COMPLETED, search)
-            else:
-                history_db.remove_with_status(Status.COMPLETED, search)
+        with sabnzbd.db_pool.connection() as history_db:
+            if special in ("all", "failed"):
+                if del_files:
+                    del_job_files(history_db.get_failed_paths(search))
+                if archive:
+                    history_db.archive_with_status(Status.FAILED, search)
+                else:
+                    history_db.remove_with_status(Status.FAILED, search)
+            if special in ("all", "completed"):
+                if archive:
+                    history_db.archive_with_status(Status.COMPLETED, search)
+                else:
+                    history_db.remove_with_status(Status.COMPLETED, search)
         history_updated()
         return report(kwargs)
     elif value:
-        for job in clean_comma_separated_list(value):
-            if sabnzbd.PostProcessor.get_path(job):
-                # This is always a permanent delete, no archiving
-                sabnzbd.PostProcessor.delete(job, del_files=del_files)
-            else:
-                history_db = sabnzbd.get_db_connection()
-                if del_files:
-                    remove_all(history_db.get_incomplete_path(job), recursive=True)
-                if archive:
-                    history_db.archive(job)
+        with sabnzbd.db_pool.connection() as history_db:
+            for job in clean_comma_separated_list(value):
+                if sabnzbd.PostProcessor.get_path(job):
+                    # This is always a permanent delete, no archiving
+                    sabnzbd.PostProcessor.delete(job, del_files=del_files)
                 else:
-                    history_db.remove(job)
+                    if del_files:
+                        remove_all(history_db.get_incomplete_path(job), recursive=True)
+                    if archive:
+                        history_db.archive(job)
+                    else:
+                        history_db.remove(job)
         history_updated()
         return report(kwargs)
     else:
@@ -573,15 +572,15 @@ def _api_history_delete(value: str, kwargs: QueryParams) -> Response:
 def _api_history_mark_as_completed(value: str, kwargs: QueryParams) -> Response:
     """API: accepts value(=nzo_id)"""
     if value:
-        history_db = sabnzbd.get_db_connection()
-        for job in clean_comma_separated_list(value):
-            # Get incomplete path before marking as completed
-            incomplete_path = history_db.get_incomplete_path(job)
-            history_db.mark_as_completed(job)
+        with sabnzbd.db_pool.connection() as history_db:
+            for job in clean_comma_separated_list(value):
+                # Get incomplete path before marking as completed
+                incomplete_path = history_db.get_incomplete_path(job)
+                history_db.mark_as_completed(job)
 
-            # Remove incomplete folder if it exists
-            if incomplete_path:
-                remove_all(incomplete_path, recursive=True)
+                # Remove incomplete folder if it exists
+                if incomplete_path:
+                    remove_all(incomplete_path, recursive=True)
 
         history_updated()
         return report(kwargs)
@@ -890,7 +889,9 @@ def _api_rss_now(name: str, kwargs: QueryParams) -> Response:
 
 def _api_retry_all(name: str, kwargs: QueryParams) -> Response:
     """API: Retry all failed items in History"""
-    nzo_ids = [retry_job(job["nzo_id"]) for job in sabnzbd.get_db_connection().get_retryable_jobs()]
+    with sabnzbd.db_pool.connection() as history_db:
+        retryable_jobs = history_db.get_retryable_jobs()
+    nzo_ids = [retry_job(job["nzo_id"]) for job in retryable_jobs]
     return report(kwargs, keyword="status", data=nzo_ids)
 
 
@@ -1849,17 +1850,17 @@ def retry_job(
 ) -> Optional[str]:
     """Re enter failed job in the download queue"""
     if job:
-        history_db = sabnzbd.get_db_connection()
-        futuretype, url, pp, script, cat = history_db.get_other(job)
-        if futuretype:
-            nzo_id = sabnzbd.urlgrabber.add_url(url, pp, script, cat, dup_check=False)
-        else:
-            path = history_db.get_incomplete_path(job)
-            nzo_id = sabnzbd.NzbQueue.repair_job(path, new_nzb, password)
-        if nzo_id:
-            # Only remove from history if we repaired something
-            history_db.remove(job)
-            return nzo_id
+        with sabnzbd.db_pool.connection() as history_db:
+            futuretype, url, pp, script, cat = history_db.get_other(job)
+            if futuretype:
+                nzo_id = sabnzbd.urlgrabber.add_url(url, pp, script, cat, dup_check=False)
+            else:
+                path = history_db.get_incomplete_path(job)
+                nzo_id = sabnzbd.NzbQueue.repair_job(path, new_nzb, password)
+            if nzo_id:
+                # Only remove from history if we repaired something
+                history_db.remove(job)
+                return nzo_id
     return None
 
 
@@ -2008,37 +2009,29 @@ def build_history(
         postproc_queue = []
         postproc_queue_size = 0
 
-    # Acquire the db instance
-    try:
-        history_db = sabnzbd.get_db_connection()
-        close_db = False
-    except Exception:
-        # Required for repairs at startup because Cherrypy isn't active yet
-        history_db = HistoryDB()
-        close_db = True
-
     # Fetch history items
-    if not database_history_limit:
-        items, total_items = history_db.fetch_history(
-            start=database_history_start,
-            limit=1,
-            archive=archive,
-            search=search,
-            categories=categories,
-            statuses=statuses,
-            nzo_ids=nzo_ids,
-        )
-        items = []
-    else:
-        items, total_items = history_db.fetch_history(
-            start=database_history_start,
-            limit=database_history_limit,
-            archive=archive,
-            search=search,
-            categories=categories,
-            statuses=statuses,
-            nzo_ids=nzo_ids,
-        )
+    with sabnzbd.db_pool.connection() as history_db:
+        if not database_history_limit:
+            items, total_items = history_db.fetch_history(
+                start=database_history_start,
+                limit=1,
+                archive=archive,
+                search=search,
+                categories=categories,
+                statuses=statuses,
+                nzo_ids=nzo_ids,
+            )
+            items = []
+        else:
+            items, total_items = history_db.fetch_history(
+                start=database_history_start,
+                limit=database_history_limit,
+                archive=archive,
+                search=search,
+                categories=categories,
+                statuses=statuses,
+                nzo_ids=nzo_ids,
+            )
 
     # Add the postproc items to the top of the history
     # Reverse the queue to add items to the top (faster than insert)
@@ -2046,9 +2039,6 @@ def build_history(
     add_active_history(postproc_queue, items)
     total_items += postproc_queue_size
     items.reverse()
-
-    if close_db:
-        history_db.close()
 
     return items, postproc_queue_size, total_items
 
@@ -2162,7 +2152,7 @@ def del_from_section(kwargs: dict[str, str | list[str]]) -> bool:
 def history_remove_failed():
     """Remove all failed jobs from history, including files"""
     logging.info("Scheduled removal of all failed jobs")
-    with HistoryDB() as history_db:
+    with sabnzbd.db_pool.connection() as history_db:
         del_job_files(history_db.get_failed_paths())
         history_db.remove_with_status(Status.FAILED)
 
@@ -2170,5 +2160,5 @@ def history_remove_failed():
 def history_remove_completed():
     """Remove all completed jobs from history"""
     logging.info("Scheduled removal of all completed jobs")
-    with HistoryDB() as history_db:
+    with sabnzbd.db_pool.connection() as history_db:
         history_db.remove_with_status(Status.COMPLETED)

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -30,7 +30,7 @@ import time
 import getpass
 import urllib.parse
 from threading import Thread
-from typing import Any, Callable, NamedTuple, Optional, TypeAlias, Awaitable, TypeGuard
+from typing import Any, Callable, NamedTuple, Optional, TypeAlias, Awaitable
 
 from starlette.background import BackgroundTask
 from starlette.concurrency import run_in_threadpool
@@ -143,10 +143,6 @@ _MSG_NO_SUCH_CONFIG = "Config item does not exist"
 _MSG_CONFIG_LOCKED = "Configuration locked"
 
 
-def is_async_handler(fn: ApiHandler) -> TypeGuard[AsyncHandler]:
-    return inspect.iscoroutinefunction(fn)
-
-
 def _api_lookup(mode: str, name: str, value: str = "") -> tuple[ApiEntry, str]:
     """Resolve a call to its entry, plus the first parameter routing did not consume.
     A call routed on mode and name passes "value" to its handler, one routed on mode
@@ -181,7 +177,7 @@ async def api_handler(kwargs: QueryParams, resolved: Optional[tuple[ApiEntry, st
     if entry.config_locked and cfg.configlock():
         return report(kwargs, _MSG_CONFIG_LOCKED)
 
-    if is_async_handler(entry.handler):
+    if inspect.iscoroutinefunction(entry.handler):
         return await entry.handler(argument, kwargs)
     return await run_in_threadpool(entry.handler, argument, kwargs)
 

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -151,19 +151,31 @@ def _api_lookup(mode: str, name: str, value: str = "") -> tuple[ApiEntry, str]:
     A call routed on mode and name passes "value" to its handler, one routed on mode
     alone still has "name" free to use as a parameter. An unknown name falls back to
     the entry for the mode itself, so it lands on the same handler and access level as
-    an omitted one. Used by both the dispatcher and api_level(), so the two can never
-    disagree about which entry, and therefore which access level, a call resolves to."""
+    an omitted one. Used by both resolve_api_call() and api_level(), so the access
+    check and the dispatch can never disagree about which entry, and therefore which
+    access level, a call resolves to."""
     if name and (entry := _api_table.get((mode, name))):
         return entry, value
     return _api_table.get((mode, ""), _API_UNDEFINED), name
 
 
-async def api_handler(kwargs: QueryParams) -> Response:
+def resolve_api_call(kwargs: QueryParams) -> tuple[ApiEntry, str]:
+    """Resolve a request's parameters to the ApiEntry that will handle it and the
+    first parameter its handler receives. The /api route resolves the call once here
+    for its access check (see check_apikey) and hands the result straight to
+    api_handler, so the api table is consulted only once per request."""
+    return _api_lookup(kwargs.get("mode", ""), kwargs.get("name", ""), kwargs.get("value", ""))
+
+
+async def api_handler(kwargs: QueryParams, resolved: Optional[tuple[ApiEntry, str]] = None) -> Response:
     """API Dispatcher. Coroutine handlers (e.g. shutdown) are awaited on the
     event loop; plain sync handlers are executed in the threadpool so blocking
     work (disk, database, network tests, benchmarks) cannot stall the loop.
-    This also allows incremental conversion of handlers to native async."""
-    entry, argument = _api_lookup(kwargs.get("mode", ""), kwargs.get("name", ""), kwargs.get("value", ""))
+    This also allows incremental conversion of handlers to native async.
+
+    The /api route already resolved the call for its access check and passes the
+    result as "resolved"; other callers omit it and the call is resolved here."""
+    entry, argument = resolved if resolved is not None else resolve_api_call(kwargs)
 
     if entry.config_locked and cfg.configlock():
         return report(kwargs, _MSG_CONFIG_LOCKED)

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -30,7 +30,7 @@ import time
 import getpass
 import urllib.parse
 from threading import Thread
-from typing import Any, Callable, Optional, TypeAlias
+from typing import Any, Callable, NamedTuple, Optional, TypeAlias, Awaitable, TypeGuard
 
 from starlette.concurrency import run_in_threadpool
 from starlette.datastructures import QueryParams
@@ -109,8 +109,23 @@ import sabnzbd.emailer
 import sabnzbd.sorting
 
 # Type handler shorthands
-ApiParams: TypeAlias = dict[str, str | list[str]]
-ApiHandler: TypeAlias = Callable[[str, ApiParams], bytes]
+SyncHandler: TypeAlias = Callable[[str, QueryParams], Response]
+AsyncHandler: TypeAlias = Callable[[str, QueryParams], Awaitable[Response]]
+ApiHandler: TypeAlias = SyncHandler | AsyncHandler
+
+
+class ApiEntry(NamedTuple):
+    """A single api-call. Handlers take the first parameter the call did not
+    consume for routing, plus the full set of request parameters."""
+
+    handler: ApiHandler
+    access_level: int
+    config_locked: bool = False
+
+
+# The api is addressed as mode(+name), so calls are keyed on both. An empty name is
+# the entry for the mode itself, and doubles as the fallback for an unknown name.
+ApiHandlerTable: TypeAlias = dict[tuple[str, str], ApiEntry]
 
 ##############################################################################
 # API error messages
@@ -127,15 +142,35 @@ _MSG_NO_SUCH_CONFIG = "Config item does not exist"
 _MSG_CONFIG_LOCKED = "Configuration locked"
 
 
+def is_async_handler(fn: ApiHandler) -> TypeGuard[AsyncHandler]:
+    return inspect.iscoroutinefunction(fn)
+
+
+def _api_lookup(mode: str, name: str, value: str = "") -> tuple[ApiEntry, str]:
+    """Resolve a call to its entry, plus the first parameter routing did not consume.
+    A call routed on mode and name passes "value" to its handler, one routed on mode
+    alone still has "name" free to use as a parameter. An unknown name falls back to
+    the entry for the mode itself, so it lands on the same handler and access level as
+    an omitted one. Used by both the dispatcher and api_level(), so the two can never
+    disagree about which entry, and therefore which access level, a call resolves to."""
+    if name and (entry := _api_table.get((mode, name))):
+        return entry, value
+    return _api_table.get((mode, ""), _API_UNDEFINED), name
+
+
 async def api_handler(kwargs: QueryParams) -> Response:
     """API Dispatcher. Coroutine handlers (e.g. shutdown) are awaited on the
     event loop; plain sync handlers are executed in the threadpool so blocking
     work (disk, database, network tests, benchmarks) cannot stall the loop.
     This also allows incremental conversion of handlers to native async."""
-    handler = _api_table.get(kwargs.get("mode", ""), (_api_undefined, 2))[0]
-    if inspect.iscoroutinefunction(handler):
-        return await handler(kwargs.get("name", ""), kwargs)
-    return await run_in_threadpool(handler, kwargs.get("name", ""), kwargs)
+    entry, argument = _api_lookup(kwargs.get("mode", ""), kwargs.get("name", ""), kwargs.get("value", ""))
+
+    if entry.config_locked and cfg.configlock():
+        return report(kwargs, _MSG_CONFIG_LOCKED)
+
+    if is_async_handler(entry.handler):
+        return await entry.handler(argument, kwargs)
+    return await run_in_threadpool(entry.handler, argument, kwargs)
 
 
 async def halt_and_shutdown():
@@ -157,8 +192,6 @@ def _api_get_config(name: str, kwargs: QueryParams) -> Response:
 
 def _api_set_config(name: str, kwargs: QueryParams) -> Response:
     """API: accepts keyword, section"""
-    if cfg.configlock():
-        return report(kwargs, _MSG_CONFIG_LOCKED)
     keyword = kwargs.get("keyword")
     if kwargs.get("section") == "servers":
         keyword = handle_server_api(kwargs)
@@ -179,8 +212,6 @@ def _api_set_config(name: str, kwargs: QueryParams) -> Response:
 
 def _api_set_config_default(name: str, kwargs: QueryParams) -> Response:
     """API: Reset requested config variables back to defaults. Currently only for misc-section"""
-    if cfg.configlock():
-        return report(kwargs, _MSG_CONFIG_LOCKED)
     for keyword in kwargs.getlist("keyword"):
         item = config.get_config("misc", keyword)
         if item:
@@ -191,20 +222,12 @@ def _api_set_config_default(name: str, kwargs: QueryParams) -> Response:
 
 def _api_del_config(name: str, kwargs: QueryParams) -> Response:
     """API: accepts keyword, section"""
-    if cfg.configlock():
-        return report(kwargs, _MSG_CONFIG_LOCKED)
     if del_from_section(kwargs):
         return report(
             kwargs,
         )
     else:
         return report(kwargs, _MSG_NOT_IMPLEMENTED)
-
-
-def _api_queue(name: str, kwargs: QueryParams) -> Response:
-    """API: Dispatcher for mode=queue"""
-    value = kwargs.get("value", "")
-    return _api_queue_table.get(name, (_api_queue_default, 2))[0](value, kwargs)
 
 
 def _api_queue_delete(value: str, kwargs: QueryParams) -> Response:
@@ -462,12 +485,6 @@ def _api_fullstatus(name: str, kwargs: QueryParams) -> Response:
     return report(kwargs, keyword="status", data=status)
 
 
-def _api_status(name: str, kwargs: QueryParams) -> Response:
-    """API: Dispatcher for mode=status, passing on the value"""
-    value = kwargs.get("value", "")
-    return _api_status_table.get(name, (_api_fullstatus, 2))[0](value, kwargs)
-
-
 def _api_unblock_server(value: str, kwargs: QueryParams) -> Response:
     """Unblock a blocked server"""
     sabnzbd.Downloader.unblock(value)
@@ -514,12 +531,6 @@ def _api_add_all_orphan(value: str, kwargs: QueryParams) -> Response:
     for path in paths:
         _api_add_orphan(path, kwargs)
     return report(kwargs)
-
-
-def _api_history(name: str, kwargs: QueryParams) -> Response:
-    """API: accepts value(=nzo_id), start, limit, search, nzo_ids"""
-    value = kwargs.get("value", "")
-    return _api_history_table.get(name, (_api_history_default, 2))[0](value, kwargs)
 
 
 def _api_history_delete(value: str, kwargs: QueryParams) -> Response:
@@ -999,42 +1010,31 @@ def _api_browse(name: str, kwargs: QueryParams) -> Response:
     return report(kwargs, keyword="paths", data=paths)
 
 
-def _api_config(name: str, kwargs: QueryParams) -> Response:
-    """API: Dispatcher for "config" """
-    if cfg.configlock():
-        return report(kwargs, _MSG_CONFIG_LOCKED)
-    return _api_config_table.get(name, (_api_config_undefined, 2))[0](kwargs)
-
-
-def _api_config_speedlimit(kwargs: QueryParams) -> Response:
+def _api_config_speedlimit(value: str, kwargs: QueryParams) -> Response:
     """API: accepts value(=speed)"""
-    value = kwargs.get("value")
-    if not value:
-        value = "0"
-    sabnzbd.Downloader.limit_speed(value)
+    sabnzbd.Downloader.limit_speed(value or "0")
     return report(kwargs)
 
 
-def _api_config_set_pause(kwargs: QueryParams) -> Response:
+def _api_config_set_pause(value: str, kwargs: QueryParams) -> Response:
     """API: accepts value(=pause interval)"""
-    value = kwargs.get("value")
     sabnzbd.Scheduler.plan_resume(int_conv(value))
     return report(kwargs)
 
 
-def _api_config_set_apikey(kwargs: QueryParams) -> Response:
+def _api_config_set_apikey(value: str, kwargs: QueryParams) -> Response:
     cfg.api_key.set(config.create_api_key())
     config.save_config()
     return report(kwargs, keyword="apikey", data=cfg.api_key())
 
 
-def _api_config_set_nzbkey(kwargs: QueryParams) -> Response:
+def _api_config_set_nzbkey(value: str, kwargs: QueryParams) -> Response:
     cfg.nzb_key.set(config.create_api_key())
     config.save_config()
     return report(kwargs, keyword="nzbkey", data=cfg.nzb_key())
 
 
-def _api_config_regenerate_certs(kwargs: QueryParams) -> Response:
+def _api_config_regenerate_certs(value: str, kwargs: QueryParams) -> Response:
     # Make sure we only over-write default locations
     result = False
     if (
@@ -1048,23 +1048,23 @@ def _api_config_regenerate_certs(kwargs: QueryParams) -> Response:
     return report(kwargs, data=result)
 
 
-def _api_config_test_server(kwargs: QueryParams) -> Response:
+def _api_config_test_server(value: str, kwargs: QueryParams) -> Response:
     """API: accepts server-params"""
     result, msg = test_nntp_server_dict(kwargs)
     return report(kwargs, data={"result": result, "message": msg})
 
 
-def _api_config_create_backup(kwargs: QueryParams) -> Response:
+def _api_config_create_backup(value: str, kwargs: QueryParams) -> Response:
     backup_file = config.create_config_backup()
     return report(kwargs, data={"result": bool(backup_file), "message": backup_file})
 
 
-def _api_config_purge_log_files(kwargs: QueryParams) -> Response:
+def _api_config_purge_log_files(value: str, kwargs: QueryParams) -> Response:
     purge_log_files()
     return report(kwargs)
 
 
-def _api_config_undefined(kwargs: QueryParams) -> Response:
+def _api_config_undefined(value: str, kwargs: QueryParams) -> Response:
     return report(kwargs, _MSG_NOT_IMPLEMENTED)
 
 
@@ -1096,113 +1096,99 @@ def _api_gc_stats(name: str, kwargs: QueryParams) -> Response:
 
 
 ##############################################################################
-_api_table = {
-    "server_stats": (_api_server_stats, 2),
-    "get_config": (_api_get_config, 3),
-    "set_config": (_api_set_config, 3),
-    "set_config_default": (_api_set_config_default, 3),
-    "del_config": (_api_del_config, 3),
-    "queue": (_api_queue, 2),
-    "translate": (_api_translate, 2),
-    "addfile": (_api_addfile, 1),
-    "retry": (_api_retry, 2),
-    "cancel_pp": (_api_cancel_pp, 2),
-    "addlocalfile": (_api_addlocalfile, 1),
-    "switch": (_api_switch, 2),
-    "change_cat": (_api_change_cat, 2),
-    "change_script": (_api_change_script, 2),
-    "change_opts": (_api_change_opts, 2),
-    "fullstatus": (_api_fullstatus, 2),
-    "status": (_api_status, 2),
-    "history": (_api_history, 2),
-    "get_files": (_api_get_files, 2),
-    "move_nzf_bulk": (_api_move_nzf_bulk, 2),
-    "addurl": (_api_addurl, 1),
-    "pause": (_api_pause, 2),
-    "resume": (_api_resume, 2),
-    "shutdown": (_api_shutdown, 3),
-    "warnings": (_api_warnings, 2),
-    "showlog": (_api_showlog, 3),
-    "config": (_api_config, 2),
-    "get_cats": (_api_get_cats, 2),
-    "get_scripts": (_api_get_scripts, 2),
-    "version": (_api_version, 1),
-    "auth": (_api_auth, 1),
-    "restart": (_api_restart, 3),
-    "restart_repair": (_api_restart_repair, 3),
-    "disconnect": (_api_disconnect, 2),
-    "gc_stats": (_api_gc_stats, 3),
-    "eval_sort": (_api_eval_sort, 3),
-    "watched_now": (_api_watched_now, 2),
-    "resume_pp": (_api_resume_pp, 2),
-    "pause_pp": (_api_pause_pp, 2),
-    "rss_now": (_api_rss_now, 2),
-    "browse": (_api_browse, 3),
-    "retry_all": (_api_retry_all, 2),
-    "reset_quota": (_api_reset_quota, 3),
-    "test_email": (_api_test_email, 3),
-    "test_windows": (_api_test_windows, 3),
-    "test_notif": (_api_test_notif, 3),
-    "test_osd": (_api_test_osd, 3),
-    "test_pushover": (_api_test_pushover, 3),
-    "test_pushbullet": (_api_test_pushbullet, 3),
-    "test_apprise": (_api_test_apprise, 3),
-    "test_prowl": (_api_test_prowl, 3),
-    "test_nscript": (_api_test_nscript, 3),
-}
+# Fallback for an unrecognised mode. The level matches the most restrictive access,
+# so an unknown call can never be dispatched on looser terms than a known one.
+_API_UNDEFINED = ApiEntry(_api_undefined, 4)
 
-_api_queue_table = {
-    "delete": (_api_queue_delete, 2),
-    "delete_nzf": (_api_queue_delete_nzf, 2),
-    "rename": (_api_queue_rename, 2),
-    "change_complete_action": (_api_queue_change_complete_action, 2),
-    "purge": (_api_queue_purge, 2),
-    "pause": (_api_queue_pause, 2),
-    "resume": (_api_queue_resume, 2),
-    "priority": (_api_queue_priority, 2),
-    "sort": (_api_queue_sort, 2),
-}
-
-_api_history_table = {
-    "delete": (_api_history_delete, 2),
-    "mark_as_completed": (_api_history_mark_as_completed, 2),
-}
-
-
-_api_status_table = {
-    "unblock_server": (_api_unblock_server, 2),
-    "delete_orphan": (_api_delete_orphan, 2),
-    "delete_all_orphan": (_api_delete_all_orphan, 2),
-    "add_orphan": (_api_add_orphan, 2),
-    "add_all_orphan": (_api_add_all_orphan, 2),
-}
-
-_api_config_table = {
-    "speedlimit": (_api_config_speedlimit, 2),
-    "set_pause": (_api_config_set_pause, 2),
-    "set_apikey": (_api_config_set_apikey, 3),
-    "set_nzbkey": (_api_config_set_nzbkey, 3),
-    "regenerate_certs": (_api_config_regenerate_certs, 3),
-    "test_server": (_api_config_test_server, 3),
-    "create_backup": (_api_config_create_backup, 3),
-    "purge_log_files": (_api_config_purge_log_files, 3),
+# Every api-call, keyed on (mode, name). Calls that route on mode alone use an empty
+# name, which also catches an unrecognised name for that mode.
+_api_table: ApiHandlerTable = {
+    ("server_stats", ""): ApiEntry(_api_server_stats, 2),
+    ("get_config", ""): ApiEntry(_api_get_config, 3),
+    ("set_config", ""): ApiEntry(_api_set_config, 3, config_locked=True),
+    ("set_config_default", ""): ApiEntry(_api_set_config_default, 3, config_locked=True),
+    ("del_config", ""): ApiEntry(_api_del_config, 3, config_locked=True),
+    ("translate", ""): ApiEntry(_api_translate, 2),
+    ("addfile", ""): ApiEntry(_api_addfile, 1),
+    ("retry", ""): ApiEntry(_api_retry, 2),
+    ("cancel_pp", ""): ApiEntry(_api_cancel_pp, 2),
+    ("addlocalfile", ""): ApiEntry(_api_addlocalfile, 1),
+    ("switch", ""): ApiEntry(_api_switch, 2),
+    ("change_cat", ""): ApiEntry(_api_change_cat, 2),
+    ("change_script", ""): ApiEntry(_api_change_script, 2),
+    ("change_opts", ""): ApiEntry(_api_change_opts, 2),
+    ("fullstatus", ""): ApiEntry(_api_fullstatus, 2),
+    ("get_files", ""): ApiEntry(_api_get_files, 2),
+    ("move_nzf_bulk", ""): ApiEntry(_api_move_nzf_bulk, 2),
+    ("addurl", ""): ApiEntry(_api_addurl, 1),
+    ("pause", ""): ApiEntry(_api_pause, 2),
+    ("resume", ""): ApiEntry(_api_resume, 2),
+    ("shutdown", ""): ApiEntry(_api_shutdown, 3),
+    ("warnings", ""): ApiEntry(_api_warnings, 2),
+    ("showlog", ""): ApiEntry(_api_showlog, 3),
+    ("get_cats", ""): ApiEntry(_api_get_cats, 2),
+    ("get_scripts", ""): ApiEntry(_api_get_scripts, 2),
+    ("version", ""): ApiEntry(_api_version, 1),
+    ("auth", ""): ApiEntry(_api_auth, 1),
+    ("restart", ""): ApiEntry(_api_restart, 3),
+    ("restart_repair", ""): ApiEntry(_api_restart_repair, 3),
+    ("disconnect", ""): ApiEntry(_api_disconnect, 2),
+    ("gc_stats", ""): ApiEntry(_api_gc_stats, 3),
+    ("eval_sort", ""): ApiEntry(_api_eval_sort, 3),
+    ("watched_now", ""): ApiEntry(_api_watched_now, 2),
+    ("resume_pp", ""): ApiEntry(_api_resume_pp, 2),
+    ("pause_pp", ""): ApiEntry(_api_pause_pp, 2),
+    ("rss_now", ""): ApiEntry(_api_rss_now, 2),
+    ("browse", ""): ApiEntry(_api_browse, 3),
+    ("retry_all", ""): ApiEntry(_api_retry_all, 2),
+    ("reset_quota", ""): ApiEntry(_api_reset_quota, 3),
+    ("test_email", ""): ApiEntry(_api_test_email, 3),
+    ("test_windows", ""): ApiEntry(_api_test_windows, 3),
+    ("test_notif", ""): ApiEntry(_api_test_notif, 3),
+    ("test_osd", ""): ApiEntry(_api_test_osd, 3),
+    ("test_pushover", ""): ApiEntry(_api_test_pushover, 3),
+    ("test_pushbullet", ""): ApiEntry(_api_test_pushbullet, 3),
+    ("test_apprise", ""): ApiEntry(_api_test_apprise, 3),
+    ("test_prowl", ""): ApiEntry(_api_test_prowl, 3),
+    ("test_nscript", ""): ApiEntry(_api_test_nscript, 3),
+    # mode=queue
+    ("queue", ""): ApiEntry(_api_queue_default, 2),
+    ("queue", "delete"): ApiEntry(_api_queue_delete, 2),
+    ("queue", "delete_nzf"): ApiEntry(_api_queue_delete_nzf, 2),
+    ("queue", "rename"): ApiEntry(_api_queue_rename, 2),
+    ("queue", "change_complete_action"): ApiEntry(_api_queue_change_complete_action, 2),
+    ("queue", "purge"): ApiEntry(_api_queue_purge, 2),
+    ("queue", "pause"): ApiEntry(_api_queue_pause, 2),
+    ("queue", "resume"): ApiEntry(_api_queue_resume, 2),
+    ("queue", "priority"): ApiEntry(_api_queue_priority, 2),
+    ("queue", "sort"): ApiEntry(_api_queue_sort, 2),
+    # mode=history
+    ("history", ""): ApiEntry(_api_history_default, 2),
+    ("history", "delete"): ApiEntry(_api_history_delete, 2),
+    ("history", "mark_as_completed"): ApiEntry(_api_history_mark_as_completed, 2),
+    # mode=status
+    ("status", ""): ApiEntry(_api_fullstatus, 2),
+    ("status", "unblock_server"): ApiEntry(_api_unblock_server, 2),
+    ("status", "delete_orphan"): ApiEntry(_api_delete_orphan, 2),
+    ("status", "delete_all_orphan"): ApiEntry(_api_delete_all_orphan, 2),
+    ("status", "add_orphan"): ApiEntry(_api_add_orphan, 2),
+    ("status", "add_all_orphan"): ApiEntry(_api_add_all_orphan, 2),
+    # mode=config, all of which are refused while the config is locked
+    ("config", ""): ApiEntry(_api_config_undefined, 2, config_locked=True),
+    ("config", "speedlimit"): ApiEntry(_api_config_speedlimit, 2, config_locked=True),
+    ("config", "set_pause"): ApiEntry(_api_config_set_pause, 2, config_locked=True),
+    ("config", "set_apikey"): ApiEntry(_api_config_set_apikey, 3, config_locked=True),
+    ("config", "set_nzbkey"): ApiEntry(_api_config_set_nzbkey, 3, config_locked=True),
+    ("config", "regenerate_certs"): ApiEntry(_api_config_regenerate_certs, 3, config_locked=True),
+    ("config", "test_server"): ApiEntry(_api_config_test_server, 3, config_locked=True),
+    ("config", "create_backup"): ApiEntry(_api_config_create_backup, 3, config_locked=True),
+    ("config", "purge_log_files"): ApiEntry(_api_config_purge_log_files, 3, config_locked=True),
 }
 
 
 def api_level(mode: str, name: str) -> int:
     """Return access level required for this API call"""
-    if mode == "queue" and name in _api_queue_table:
-        return _api_queue_table[name][1]
-    if mode == "history" and name in _api_history_table:
-        return _api_history_table[name][1]
-    if mode == "status" and name in _api_status_table:
-        return _api_status_table[name][1]
-    if mode == "config" and name in _api_config_table:
-        return _api_config_table[name][1]
-    if mode in _api_table:
-        return _api_table[mode][1]
-    # It is invalid if it's none of these, but that's is handled somewhere else
-    return 4
+    return _api_lookup(mode, name)[0].access_level
 
 
 def report(

--- a/sabnzbd/bpsmeter.py
+++ b/sabnzbd/bpsmeter.py
@@ -191,7 +191,7 @@ class BPSMeter:
     def defaults(self):
         """Get the latest data from the database and assign to a fake server"""
         logging.debug("Setting default BPS meter values")
-        with sabnzbd.database.HistoryDB() as history_db:
+        with sabnzbd.db_pool.connection() as history_db:
             grand, month, week = history_db.get_history_size()
         self.grand_total = {}
         self.month_total = {}

--- a/sabnzbd/cfg.py
+++ b/sabnzbd/cfg.py
@@ -513,7 +513,6 @@ backup_for_duplicates = OptionBool("misc", "backup_for_duplicates", False)
 wait_for_dfolder = OptionBool("misc", "wait_for_dfolder", False)
 rss_filenames = OptionBool("misc", "rss_filenames", False)
 api_logging = OptionBool("misc", "api_logging", True)
-html_login = OptionBool("misc", "html_login", True)
 disable_archive = OptionBool("misc", "disable_archive", False)
 warn_dupl_jobs = OptionBool("misc", "warn_dupl_jobs", False)
 

--- a/sabnzbd/config.py
+++ b/sabnzbd/config.py
@@ -41,6 +41,7 @@ from sabnzbd.constants import (
     DEFAULT_PRIORITY,
     CONFIG_BACKUP_FILES,
     CONFIG_BACKUP_HTTPS,
+    DB_HISTORY_NAME,
     DEF_INI_FILE,
     DEF_SORTER_RENAME_SIZE,
     DEF_PIPELINING_REQUESTS,
@@ -973,7 +974,21 @@ class SABnzbdConfig(configobj.ConfigObj):
                 with zipfile.ZipFile(zip_buffer, "a", zipfile.ZIP_DEFLATED, False) as zip_ref:
                     for filename in CONFIG_BACKUP_FILES:
                         full_path = os.path.join(admin_path, filename)
-                        if os.path.isfile(full_path):
+                        # A raw copy of the live database file misses un-checkpointed WAL
+                        # transactions and can be inconsistent while SABnzbd runs, so take
+                        # a snapshot through SQLite's online backup instead. Fall back to
+                        # a plain file copy if the file is not the database in active use,
+                        # or the snapshot fails.
+                        snapshot = None
+                        if (
+                            filename == DB_HISTORY_NAME
+                            and sabnzbd.database.HistoryDB.db_path
+                            and full_path == sabnzbd.database.HistoryDB.db_path
+                        ):
+                            snapshot = sabnzbd.database.history_db_snapshot()
+                        if snapshot:
+                            zip_ref.writestr(filename, snapshot)
+                        elif os.path.isfile(full_path):
                             with open(full_path, "rb") as data:
                                 zip_ref.writestr(filename, data.read())
                     for filename, setting in CONFIG_BACKUP_HTTPS.items():
@@ -1033,6 +1048,14 @@ class SABnzbdConfig(configobj.ConfigObj):
                             logging.debug("Writing backup of %s to %s", filename, destination_file)
                             with open(destination_file, "wb") as destination_ref:
                                 destination_ref.write(zip_ref.read(filename))
+                            if filename == DB_HISTORY_NAME:
+                                # Remove any stale WAL sidecar files left by the replaced
+                                # database, so SQLite cannot try to recover the restored
+                                # database with the old write-ahead log
+                                for sidecar in (destination_file + "-wal", destination_file + "-shm"):
+                                    if os.path.isfile(sidecar):
+                                        logging.debug("Removing stale database sidecar %s", sidecar)
+                                        remove_file(sidecar)
                             # For HTTPS config files, point the associated setting to the restored file
                             if setting := CONFIG_BACKUP_HTTPS.get(filename):
                                 logging.debug("Setting value of %s to restored file %s", setting, filename)

--- a/sabnzbd/config.py
+++ b/sabnzbd/config.py
@@ -109,6 +109,10 @@ class Option:
             except KeyError:
                 pass
 
+    def get_from_dict(self, values: dict[str, Any], kw: str) -> Any:
+        """Extract this option's value from a dict by key, raising KeyError if absent"""
+        return values[kw]
+
     def set(self, value: Any):
         """Set new value, no validation"""
         if value is not None:
@@ -330,6 +334,14 @@ class OptionList(Option):
                 super().set(value)
         return error
 
+    def get_from_dict(self, values: dict[str, Any], kw: str) -> Any:
+        """Extract list value using getlist() for MultiDict sources, falling back to plain key access"""
+        if hasattr(values, "getlist"):
+            if lst := values.getlist(kw):
+                return lst
+            raise KeyError(kw)
+        return values[kw]
+
     def get_string(self) -> str:
         """Return the list as a comma-separated string"""
         return ", ".join(self.get())
@@ -486,8 +498,8 @@ class ConfigServer:
             "notes",
         ):
             try:
-                value = values[kw]
-                getattr(self, kw).set(value)
+                attr = getattr(self, kw)
+                attr.set(attr.get_from_dict(values, kw))
             except KeyError:
                 continue
         if not self.displayname():
@@ -552,8 +564,8 @@ class ConfigCat:
         """Set one or more fields, passed as dictionary"""
         for kw in ("order", "pp", "script", "dir", "newzbin", "priority"):
             try:
-                value = values[kw]
-                getattr(self, kw).set(value)
+                attr = getattr(self, kw)
+                attr.set(attr.get_from_dict(values, kw))
             except KeyError:
                 continue
 
@@ -596,8 +608,8 @@ class ConfigSorter:
         """Set one or more fields, passed as dictionary"""
         for kw in ("order", "min_size", "multipart_label", "sort_string", "sort_cats", "sort_type", "is_active"):
             try:
-                value = values[kw]
-                getattr(self, kw).set(value)
+                attr = getattr(self, kw)
+                attr.set(attr.get_from_dict(values, kw))
             except KeyError:
                 continue
 
@@ -708,8 +720,8 @@ class ConfigRSS:
         """Set one or more fields, passed as dictionary"""
         for kw in ("uri", "cat", "pp", "script", "priority", "enable"):
             try:
-                value = values[kw]
-                getattr(self, kw).set(value)
+                attr = getattr(self, kw)
+                attr.set(attr.get_from_dict(values, kw))
             except KeyError:
                 continue
         self.filters.set_dict(values)

--- a/sabnzbd/config.py
+++ b/sabnzbd/config.py
@@ -974,21 +974,15 @@ class SABnzbdConfig(configobj.ConfigObj):
                 with zipfile.ZipFile(zip_buffer, "a", zipfile.ZIP_DEFLATED, False) as zip_ref:
                     for filename in CONFIG_BACKUP_FILES:
                         full_path = os.path.join(admin_path, filename)
+                        if not os.path.isfile(full_path):
+                            continue
                         # A raw copy of the live database file misses un-checkpointed WAL
                         # transactions and can be inconsistent while SABnzbd runs, so take
                         # a snapshot through SQLite's online backup instead. Fall back to
-                        # a plain file copy if the file is not the database in active use,
-                        # or the snapshot fails.
-                        snapshot = None
-                        if (
-                            filename == DB_HISTORY_NAME
-                            and sabnzbd.database.HistoryDB.db_path
-                            and full_path == sabnzbd.database.HistoryDB.db_path
-                        ):
-                            snapshot = sabnzbd.database.history_db_snapshot()
-                        if snapshot:
+                        # a plain file copy if the snapshot fails.
+                        if filename == DB_HISTORY_NAME and (snapshot := sabnzbd.database.history_db_snapshot()):
                             zip_ref.writestr(filename, snapshot)
-                        elif os.path.isfile(full_path):
+                        else:
                             with open(full_path, "rb") as data:
                                 zip_ref.writestr(filename, data.read())
                     for filename, setting in CONFIG_BACKUP_HTTPS.items():

--- a/sabnzbd/constants.py
+++ b/sabnzbd/constants.py
@@ -75,7 +75,6 @@ DEF_PORT = 8080
 DEF_WORKDIR = "sabnzbd"
 DEF_LOG_FILE = "sabnzbd.log"
 DEF_LOG_ERRFILE = "sabnzbd.error.log"
-DEF_LOG_CHERRY = "cherrypy.log"
 DEF_ARTICLE_CACHE_DEFAULT = "500M"
 DEF_ARTICLE_CACHE_MAX = "1G"
 DEF_DOWNLOAD_FREE = DEF_ARTICLE_CACHE_DEFAULT  # So we have at least space for the cache

--- a/sabnzbd/constants.py
+++ b/sabnzbd/constants.py
@@ -75,6 +75,7 @@ DEF_PORT = 8080
 DEF_WORKDIR = "sabnzbd"
 DEF_LOG_FILE = "sabnzbd.log"
 DEF_LOG_ERRFILE = "sabnzbd.error.log"
+DEF_LOG_ACCESSFILE = "access.log"
 DEF_ARTICLE_CACHE_DEFAULT = "500M"
 DEF_ARTICLE_CACHE_MAX = "1G"
 DEF_DOWNLOAD_FREE = DEF_ARTICLE_CACHE_DEFAULT  # So we have at least space for the cache

--- a/sabnzbd/database.py
+++ b/sabnzbd/database.py
@@ -20,6 +20,7 @@ sabnzbd.database - Database Support
 """
 
 import os
+import tempfile
 import time
 import uuid
 import zlib
@@ -882,3 +883,33 @@ def unpack_history_info(item: sqlite3.Row) -> dict[str, Any]:
 def scheduled_history_purge():
     with sabnzbd.db_pool.connection() as history_db:
         history_db.auto_history_purge()
+
+
+def history_db_snapshot() -> Optional[bytes]:
+    """Return a consistent snapshot of the history database as bytes, for backups.
+
+    Under WAL the main database file alone misses any transactions that have not
+    been checkpointed yet, so a raw file copy would silently lose recent history
+    (and could even be inconsistent when copied mid-checkpoint). SQLite's online
+    backup API produces a consistent, checkpointed, single-file copy that is safe
+    to take while other connections are reading or writing.
+    """
+    snapshot_fd, snapshot_path = tempfile.mkstemp(suffix=".db")
+    os.close(snapshot_fd)
+    try:
+        with sabnzbd.db_pool.connection() as history_db:
+            snapshot_connection = sqlite3.connect(snapshot_path)
+            try:
+                history_db.connection.backup(snapshot_connection)
+            finally:
+                snapshot_connection.close()
+        with open(snapshot_path, "rb") as snapshot_data:
+            return snapshot_data.read()
+    except Exception:
+        logging.info("Failed to snapshot history database: ", exc_info=True)
+        return None
+    finally:
+        try:
+            remove_file(snapshot_path)
+        except Exception:
+            pass

--- a/sabnzbd/database.py
+++ b/sabnzbd/database.py
@@ -24,11 +24,13 @@ import time
 import uuid
 import zlib
 import logging
+import queue
 import sys
 import threading
 import sqlite3
+from contextlib import contextmanager
 from sqlite3 import Connection, Cursor
-from typing import Optional, Sequence, Any
+from typing import Optional, Sequence, Any, Iterator
 
 import sabnzbd
 import sabnzbd.cfg
@@ -43,10 +45,12 @@ DB_LOCK = threading.Lock()
 
 
 class HistoryDB:
-    """Class to access the History database
-    Each class-instance will create an access channel that
-    can be used in one thread.
-    Each thread needs its own class-instance!
+    """Class to access the History database.
+    Each class-instance creates its own database connection.
+    Instances may move between threads (check_same_thread=False), but must
+    only ever be used by one thread at a time. Normal code should not create
+    instances directly but borrow one from sabnzbd.db_pool, which guarantees
+    exclusive use through checkout.
     """
 
     # These class attributes will be accessed directly because
@@ -67,10 +71,33 @@ class HistoryDB:
             HistoryDB.db_path = os.path.join(sabnzbd.cfg.admin_dir.get_path(), DB_HISTORY_NAME)
         create_table = not HistoryDB.startup_done and not os.path.exists(HistoryDB.db_path)
 
-        self.connection = sqlite3.connect(HistoryDB.db_path)
+        # Remember which file this connection was opened against, so the pool
+        # can discard it when the database path changes
+        self.db_path_at_connect = HistoryDB.db_path
+
+        # check_same_thread=False so pooled connections can move between threads;
+        # exclusive use is guaranteed by HistoryDBPool checkout
+        self.connection = sqlite3.connect(HistoryDB.db_path, check_same_thread=False)
         self.connection.isolation_level = None  # autocommit attribute only introduced in Python 3.12
         self.connection.row_factory = sqlite3.Row
         self.cursor = self.connection.cursor()
+
+        try:
+            # Multiple readers can work simultaneously with one writer
+            self.cursor.execute("PRAGMA journal_mode = WAL")
+            # Sync to disk at critical moments, not every write
+            self.cursor.execute("PRAGMA synchronous = NORMAL")
+            # Wait for lock instead of failing at once
+            self.cursor.execute("PRAGMA busy_timeout = 5000")
+            # Keep up to ~4MiB in memory per connection
+            self.cursor.execute("PRAGMA cache_size = -4000")
+            # Stores temporary tables, indexes, and sorting operations in RAM
+            self.cursor.execute("PRAGMA temp_store = MEMORY")
+            # Reduce disk access
+            self.cursor.execute("PRAGMA mmap_size = 16777216")
+        except Exception:
+            # Can fail on a readonly database; writes will report the error later
+            logging.debug("Failed to set database pragmas", exc_info=True)
 
         # Perform initialization only once
         if not HistoryDB.startup_done:
@@ -153,7 +180,9 @@ class HistoryDB:
 
     def execute(self, command: str, args: Sequence = (), raise_on_error: bool = False) -> bool:
         """Wrapper for executing SQL commands"""
-        for tries in (4, 3, 2, 1, 0):
+        # Lock contention is normally handled by SQLite itself through the
+        # busy_timeout pragma; a single retry remains as a safety net
+        for tries in (1, 0):
             try:
                 self.cursor.execute(command, args)
                 return True
@@ -179,6 +208,10 @@ class HistoryDB:
                         pass
                     HistoryDB.startup_done = False
                     self.connect()
+                    # Sibling pooled connections hold handles to the deleted file;
+                    # mark them stale so they are discarded instead of reused
+                    if sabnzbd.db_pool:
+                        sabnzbd.db_pool.invalidate(reconnected=self)
                     if raise_on_error:
                         raise sqlite3.DatabaseError(error)
                     # Return False in case of "duplicate column" error
@@ -568,6 +601,142 @@ class HistoryDB:
         self.close()
 
 
+class HistoryDBPool:
+    """Bounded LIFO pool of HistoryDB connections, available as sabnzbd.db_pool.
+
+    Thread-safety comes from exclusive checkout: a connection is only ever used
+    by one borrower at a time. LIFO keeps hot connections hot, and since SQLite
+    serializes writers anyway a handful of connections is plenty. When the pool
+    is exhausted, checkout waits briefly and then falls back to a temporary
+    overflow connection (closed on check-in) so requests degrade instead of
+    deadlocking. Connections are created lazily, so the pool can be constructed
+    before the configuration (database path) is known.
+    """
+
+    def __init__(self, max_connections: int = 5, checkout_timeout: float = 10.0):
+        self.max_connections = max_connections
+        self.checkout_timeout = checkout_timeout
+        self._idle: queue.LifoQueue = queue.LifoQueue()
+        self._lock = threading.Lock()
+        self._created = 0
+        self._generation = 0
+        self._closed = False
+
+    @contextmanager
+    def connection(self) -> Iterator[HistoryDB]:
+        """Borrow a connection for exclusive use: with sabnzbd.db_pool.connection() as history_db"""
+        db, pooled = self._checkout()
+        try:
+            yield db
+        finally:
+            self._checkin(db, pooled)
+
+    def _new_connection(self) -> HistoryDB:
+        db = HistoryDB()
+        db.pool_generation = self._generation
+        return db
+
+    def _is_stale(self, db: HistoryDB) -> bool:
+        """Stale connections predate invalidate(), or hold handles to a
+        replaced database file or a since-changed database path"""
+        return getattr(db, "pool_generation", -1) != self._generation or db.db_path_at_connect != HistoryDB.db_path
+
+    def _discard(self, db: HistoryDB):
+        db.close()
+        with self._lock:
+            self._created -= 1
+
+    def _checkout(self) -> tuple[HistoryDB, bool]:
+        if self._closed:
+            # Shutting down: serve a temporary connection so late requests still work
+            return HistoryDB(), False
+
+        deadline = time.time() + self.checkout_timeout
+        while True:
+            # Prefer an idle pooled connection
+            try:
+                db = self._idle.get_nowait()
+            except queue.Empty:
+                db = None
+            if db is not None:
+                if self._is_stale(db):
+                    self._discard(db)
+                    continue
+                return db, True
+
+            # Nothing idle: create a new one if the pool is not full yet.
+            # Connect outside the pool lock: connecting can trigger schema
+            # migration or corruption recovery, which calls invalidate()
+            with self._lock:
+                create = self._created < self.max_connections
+                if create:
+                    self._created += 1
+            if create:
+                try:
+                    return self._new_connection(), True
+                except Exception:
+                    with self._lock:
+                        self._created -= 1
+                    raise
+
+            # Pool full: wait for a connection to be returned
+            timeout = deadline - time.time()
+            if timeout <= 0:
+                logging.debug("HistoryDB pool exhausted, using overflow connection")
+                return HistoryDB(), False
+            try:
+                db = self._idle.get(timeout=timeout)
+            except queue.Empty:
+                continue
+            if self._is_stale(db):
+                self._discard(db)
+                continue
+            return db, True
+
+    def _checkin(self, db: HistoryDB, pooled: bool):
+        if not pooled:
+            # Overflow connection, never pooled
+            db.close()
+        elif self._closed or self._is_stale(db):
+            self._discard(db)
+        else:
+            self._idle.put(db)
+
+    def invalidate(self, reconnected: Optional[HistoryDB] = None):
+        """Discard all pooled connections, e.g. after the database file was
+        replaced due to corruption. Connections currently checked out are
+        discarded on check-in. The connection that triggered the replacement
+        has already reconnected and stays valid."""
+        with self._lock:
+            self._generation += 1
+            generation = self._generation
+        if reconnected is not None:
+            reconnected.pool_generation = generation
+        # Drain the stale idle connections
+        while True:
+            try:
+                db = self._idle.get_nowait()
+            except queue.Empty:
+                break
+            if self._is_stale(db):
+                self._discard(db)
+            else:
+                self._idle.put(db)
+                break
+
+    def close(self):
+        """Close all idle connections; called at shutdown. Connections still
+        checked out are closed on check-in, later checkouts get temporary
+        overflow connections."""
+        self._closed = True
+        while True:
+            try:
+                db = self._idle.get_nowait()
+            except queue.Empty:
+                break
+            self._discard(db)
+
+
 def convert_search(search: Optional[str]) -> str:
     """Convert classic wildcard to SQL wildcard"""
     if not search or not isinstance(search, str):
@@ -711,5 +880,5 @@ def unpack_history_info(item: sqlite3.Row) -> dict[str, Any]:
 
 
 def scheduled_history_purge():
-    with HistoryDB() as history_db:
+    with sabnzbd.db_pool.connection() as history_db:
         history_db.auto_history_purge()

--- a/sabnzbd/dirscanner.py
+++ b/sabnzbd/dirscanner.py
@@ -128,8 +128,8 @@ class DirScanner(threading.Thread):
     def start_scanner(self):
         """Start the scanner if it is not already running"""
         with DIR_SCANNER_LOCK:
-            if not self.loop:
-                logging.debug("Can not start scanner because loop not found")
+            if not self.loop or self.loop.is_closed():
+                logging.debug("Can not start scanner because loop not found or closed")
                 return
 
             if not self.scanner_task or self.scanner_task.done():

--- a/sabnzbd/encoding.py
+++ b/sabnzbd/encoding.py
@@ -87,15 +87,6 @@ def correct_unknown_encoding(str_or_bytes_in: AnyStr) -> str:
             return unicode_nfc_normalize(str(charset_normalizer.from_bytes(str_or_bytes_in).best()))
 
 
-def correct_cherrypy_encoding(inputstring: str) -> str:
-    """convert inputstring with separate, individual chars (1-255) to valid string (with UTF8 encoding)"""
-    try:
-        return inputstring.encode("raw_unicode_escape").decode("utf8")
-    except Exception:
-        # not possible to convert to UTF8, so don't change anything:
-        return inputstring
-
-
 def xml_name(input_value) -> str:
     """Prepare name for use in HTML/XML context"""
     if input_value is not None:

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -20,8 +20,8 @@ sabnzbd.interface - webinterface
 """
 
 import os
+import threading
 import time
-import cherrypy
 import logging
 import urllib.parse
 import re
@@ -31,9 +31,18 @@ import ssl
 import functools
 import copy
 from random import randint
-from xml.sax.saxutils import escape
+
+import uvicorn
+from starlette.applications import Starlette
+from starlette.datastructures import MultiDict, QueryParams
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, RedirectResponse, PlainTextResponse, Response
+from starlette.middleware import Middleware
+from starlette.middleware.gzip import GZipMiddleware
+from starlette.routing import Mount, Route
+from starlette.staticfiles import StaticFiles
 from Cheetah.Template import Template
-from typing import Optional, Callable, Any
+from typing import Optional, Callable, Any, Collection
 from guessit.api import properties as guessit_properties
 
 import sabnzbd
@@ -54,7 +63,6 @@ from sabnzbd.misc import (
     get_cpu_name,
     clean_comma_separated_list,
 )
-from sabnzbd.get_addrinfo import get_fastest_addrinfo
 from sabnzbd.filesystem import (
     real_path,
     globber,
@@ -63,12 +71,12 @@ from sabnzbd.filesystem import (
     same_directory,
     setname_from_path,
 )
-from sabnzbd.encoding import xml_name, utob
+from sabnzbd.encoding import utob
 import sabnzbd.config as config
 import sabnzbd.cfg as cfg
-import sabnzbd.notifier as notifier
 import sabnzbd.newsunpack
 import sabnzbd.utils.ssdp
+from sabnzbd.get_addrinfo import get_fastest_addrinfo
 from sabnzbd.constants import (
     DEF_STD_CONFIG,
     DEFAULT_PRIORITY,
@@ -80,10 +88,10 @@ from sabnzbd.constants import (
     VALID_NZB_FILES,
     VALID_ARCHIVES,
     DEF_NETWORKING_TEST_TIMEOUT,
-    DEF_PIPELINING_REQUESTS,
 )
 from sabnzbd.lang import list_languages
 from sabnzbd.api import (
+    report,
     list_scripts,
     list_cats,
     del_from_section,
@@ -104,98 +112,75 @@ _MSG_MISSING_AUTH = "Missing authentication"
 _MSG_APIKEY_REQUIRED = "API Key Required"
 _MSG_APIKEY_INCORRECT = "API Key Incorrect"
 
+INTERFACE_ROUTES: list[Route | Mount] = []
+
 
 def secured_expose(
     wrap_func: Optional[Callable] = None,
+    route: Optional[str] = None,
     check_configlock: bool = False,
     check_for_login: bool = True,
     check_api_key: bool = False,
     access_type: int = 4,
+    methods: Collection = ("GET", "POST"),
 ) -> Callable | str:
-    """Wrapper for both cherrypy.expose and login/access check"""
+    """Wrapper for both starlette routing and login/access check"""
     if not wrap_func:
         return functools.partial(
             secured_expose,
+            route=route,
             check_configlock=check_configlock,
             check_for_login=check_for_login,
             check_api_key=check_api_key,
             access_type=access_type,
+            methods=methods,
         )
 
-    # Expose to cherrypy
-    wrap_func.exposed = True
-
     @functools.wraps(wrap_func)
-    def internal_wrap(*args, **kwargs):
-        # Label for logging in this and other functions, handling X-Forwarded-For
-        # The cherrypy.request object allows adding custom attributes
-        if cherrypy.request.headers.get("X-Forwarded-For"):
-            cherrypy.request.remote_label = "%s (X-Forwarded-For: %s) [%s]" % (
-                cherrypy.request.remote.ip,
-                cherrypy.request.headers.get("X-Forwarded-For"),
-                cherrypy.request.headers.get("User-Agent"),
-            )
-        else:
-            cherrypy.request.remote_label = "%s [%s]" % (
-                cherrypy.request.remote.ip,
-                cherrypy.request.headers.get("User-Agent"),
-            )
-
-        # Log all requests
-        if cfg.api_logging():
-            logging.debug(
-                "Request %s %s from %s %s",
-                cherrypy.request.method,
-                cherrypy.request.path_info,
-                cherrypy.request.remote_label,
-                kwargs,
-            )
-
-        # Add X-Frame-Headers headers to page-requests
-        if cfg.x_frame_options():
-            cherrypy.response.headers["X-Frame-Options"] = "SameOrigin"
+    async def internal_wrap(request: Request, *args, **kwargs):
+        # Populate request._query_params from the correct source for this method
+        request._query_params = await get_request_params(request)
 
         # Check if config is locked
         if check_configlock and cfg.configlock():
-            cherrypy.response.status = 403
             if cfg.api_warnings():
-                return _MSG_ACCESS_DENIED_CONFIG_LOCK
-            return
+                return PlainTextResponse(_MSG_ACCESS_DENIED_CONFIG_LOCK, status_code=403)
+            return PlainTextResponse("", status_code=403)
 
         # Check if external access and if it's allowed
-        if not check_access(access_type=access_type, warn_user=True):
-            cherrypy.response.status = 403
+        if not check_access(request, access_type=access_type, warn_user=True):
             if cfg.api_warnings():
-                return _MSG_ACCESS_DENIED
-            return
+                return PlainTextResponse(_MSG_ACCESS_DENIED, status_code=403)
+            return PlainTextResponse("", status_code=403)
 
         # Verify login status, only for non-key pages
-        if check_for_login and not check_api_key and not check_login():
-            raise Raiser("/login/")
+        if check_for_login and not check_api_key and not check_login(request):
+            return RedirectResponse(url=f"{cfg.url_base()}/login")
 
         # Verify host used for the visit
-        if not check_hostname():
-            cherrypy.response.status = 403
+        if not check_hostname(request):
             if cfg.api_warnings():
-                return _MSG_ACCESS_DENIED_HOSTNAME
-            return
+                return PlainTextResponse(_MSG_ACCESS_DENIED_HOSTNAME, status_code=403)
+            return PlainTextResponse("", status_code=403)
 
         # Some pages need correct API key
         if check_api_key:
-            if msg := check_apikey(kwargs):
-                cherrypy.response.status = 403
+            if msg := check_apikey(request):
                 if cfg.api_warnings():
-                    return msg
-                return
+                    return PlainTextResponse(msg, status_code=403)
+                return PlainTextResponse("", status_code=403)
 
         # All good, cool!
-        return wrap_func(*args, **kwargs)
+        return await wrap_func(request, *args, **kwargs)
+
+    if route:
+        INTERFACE_ROUTES.append(Route(route, endpoint=internal_wrap, methods=methods))
 
     return internal_wrap
 
 
-def check_access(access_type: int = 4, warn_user: bool = False) -> bool:
-    """Check if external address is allowed given access_type:
+def check_access(request: Request, access_type: int = 4, warn_user: bool = False) -> bool:
+    """Check if external address is allowed given access_type (Starlette version):
     1=nzb
     2=api
     3=full_api
@@ -206,7 +191,7 @@ def check_access(access_type: int = 4, warn_user: bool = False) -> bool:
     if access_type <= cfg.inet_exposure():
         return True
 
-    remote_ip = cherrypy.request.remote.ip
+    remote_ip = request.client.host
 
     # Check if the client IP is a loopback address or considered local
     is_allowed = is_loopback_addr(remote_ip) or is_local_addr(remote_ip)
@@ -215,19 +200,19 @@ def check_access(access_type: int = 4, warn_user: bool = False) -> bool:
     if (
         is_allowed
         and cfg.verify_xff_header()
-        and (xff_ips := clean_comma_separated_list(cherrypy.request.headers.get("X-Forwarded-For")))
+        and (xff_ips := clean_comma_separated_list(request.headers.get("X-Forwarded-For")))
     ):
         is_allowed = all(is_local_addr(ip) or is_loopback_addr(ip) for ip in xff_ips)
         if not is_allowed:
             logging.debug("Denying access based on X-Forwarded-For IPs '%s'", xff_ips)
 
     if not is_allowed and warn_user:
-        log_warning_and_ip(T("Refused connection from:"))
+        log_warning_and_ip(request, T("Refused connection from:"))
     return is_allowed
 
 
-def check_hostname():
-    """Check if hostname is allowed, to mitigate DNS-rebinding attack.
+def check_hostname(request: Request) -> bool:
+    """Check if hostname is allowed, to mitigate DNS-rebinding attack (Starlette version).
     Similar to CVE-2019-5702, we need to add protection even
     if only allowed to be accessed via localhost.
     """
@@ -236,7 +221,7 @@ def check_hostname():
         return True
 
     # Don't allow requests without Host
-    host = cherrypy.request.headers.get("Host")
+    host = request.headers.get("Host")
     if not host:
         return False
 
@@ -258,7 +243,7 @@ def check_hostname():
         return True
 
     # Ohoh, bad
-    log_warning_and_ip(T('Refused connection with hostname "%s" from:') % host)
+    log_warning_and_ip(request, T('Refused connection with hostname "%s" from:') % host)
     return False
 
 
@@ -279,8 +264,9 @@ def remote_ip_from_xff(xff_ips: list[str]) -> str:
         return xff_ips[0]
 
 
-def set_login_cookie(remove=False, remember_me=False):
-    """We try to set a cookie as unique as possible
+def set_login_cookie(request: Request, response: Response, remove=False, remember_me=False):
+    """Set login cookie for Starlette (updated version)
+    We try to set a cookie as unique as possible
     to the current user. Based on it's IP and the
     current process ID of the SAB instance and a random
     number, so cookies cannot be re-used
@@ -288,97 +274,103 @@ def set_login_cookie(remove=False, remember_me=False):
     salt = randint(1, 1000)
 
     # If we are using XFF headers, get remote IP from XFF if possible
-    if cfg.verify_xff_header() and (
-        xff_ips := clean_comma_separated_list(cherrypy.request.headers.get("X-Forwarded-For"))
-    ):
+    if cfg.verify_xff_header() and (xff_ips := clean_comma_separated_list(request.headers.get("X-Forwarded-For"))):
         remote_ip = remote_ip_from_xff(xff_ips)
     else:
-        remote_ip = cherrypy.request.remote.ip
+        remote_ip = request.client.host
 
     cookie_str = utob(str(salt) + remote_ip + COOKIE_SECRET)
-    cherrypy.response.cookie["login_cookie"] = hashlib.sha1(cookie_str).hexdigest()
-    cherrypy.response.cookie["login_cookie"]["path"] = "/"
-    cherrypy.response.cookie["login_cookie"]["httponly"] = 1
-    cherrypy.response.cookie["login_salt"] = salt
-    cherrypy.response.cookie["login_salt"]["path"] = "/"
-    cherrypy.response.cookie["login_salt"]["httponly"] = 1
+    cookie_value = hashlib.sha1(cookie_str).hexdigest()
 
-    # If we want to be remembered
-    if remember_me:
-        cherrypy.response.cookie["login_cookie"]["max-age"] = 3600 * 24 * 14
-        cherrypy.response.cookie["login_salt"]["max-age"] = 3600 * 24 * 14
-
-    # To remove
+    secure = cfg.enable_https()
     if remove:
-        cherrypy.response.cookie["login_cookie"]["expires"] = 0
-        cherrypy.response.cookie["login_salt"]["expires"] = 0
-
-
-def check_login_cookie():
-    # Do we have everything?
-    if "login_cookie" not in cherrypy.request.cookie or "login_salt" not in cherrypy.request.cookie:
-        return False
-
-    # If we are using XFF headers, get remote IP from XFF if possible
-    if cfg.verify_xff_header() and (
-        xff_ips := clean_comma_separated_list(cherrypy.request.headers.get("X-Forwarded-For"))
-    ):
-        remote_ip = remote_ip_from_xff(xff_ips)
+        # Remove cookies
+        response.set_cookie(
+            "login_cookie",
+            "",
+            path="/",
+            httponly=True,
+            secure=secure,
+            samesite="strict",
+            expires="Thu, 01 Jan 1970 00:00:00 GMT",
+        )
+        response.set_cookie(
+            "login_salt",
+            "",
+            path="/",
+            httponly=True,
+            secure=secure,
+            samesite="strict",
+            expires="Thu, 01 Jan 1970 00:00:00 GMT",
+        )
     else:
-        remote_ip = cherrypy.request.remote.ip
+        # Set cookies
+        max_age = None
+        if remember_me:
+            max_age = 3600 * 24 * 14  # 14 days
 
-    cookie_str = utob(str(cherrypy.request.cookie["login_salt"].value) + remote_ip + COOKIE_SECRET)
-    return cherrypy.request.cookie["login_cookie"].value == hashlib.sha1(cookie_str).hexdigest()
+        response.set_cookie(
+            "login_cookie",
+            cookie_value,
+            path="/",
+            httponly=True,
+            secure=secure,
+            samesite="strict",
+            max_age=max_age,
+        )
+        response.set_cookie(
+            "login_salt",
+            str(salt),
+            path="/",
+            httponly=True,
+            secure=secure,
+            samesite="strict",
+            max_age=max_age,
+        )
 
 
-def check_login():
+def check_login(request: Request) -> bool:
+    """Check if user is logged in (Starlette version)"""
     # Not when no authentication required or basic-auth is on
     if not cfg.html_login() or not cfg.username() or not cfg.password():
         return True
 
     # If we show login for external IP, by using access_type=6 we can check if IP match
-    if cfg.inet_exposure() == 5 and check_access(access_type=6):
+    if cfg.inet_exposure() == 5 and check_access(request, access_type=6):
         return True
 
     # Check the cookie
-    return check_login_cookie()
+    return check_login_cookie(request)
 
 
-def check_basic_auth(_, username, password):
-    """CherryPy basic authentication validation"""
-    return username == cfg.username() and password == cfg.password()
+def check_login_cookie(request: Request) -> bool:
+    """Check login cookie validity (Starlette version)"""
+    # Do we have everything?
+    login_cookie = request.cookies.get("login_cookie")
+    login_salt = request.cookies.get("login_salt")
+    if not login_cookie or not login_salt:
+        return False
 
-
-def set_auth(conf):
-    """Set the authentication for CherryPy"""
-    if cfg.username() and cfg.password() and not cfg.html_login():
-        conf.update(
-            {
-                "tools.auth_basic.on": True,
-                "tools.auth_basic.realm": "SABnzbd",
-                "tools.auth_basic.checkpassword": check_basic_auth,
-            }
-        )
-        conf.update(
-            {
-                "/api": {"tools.auth_basic.on": False},
-                "%s/api" % cfg.url_base(): {"tools.auth_basic.on": False},
-            }
-        )
+    # If we are using XFF headers, get remote IP from XFF if possible
+    if cfg.verify_xff_header() and (xff_ips := clean_comma_separated_list(request.headers.get("X-Forwarded-For"))):
+        remote_ip = remote_ip_from_xff(xff_ips)
     else:
-        conf.update({"tools.auth_basic.on": False})
+        remote_ip = request.client.host
+
+    cookie_str = utob(str(login_salt) + remote_ip + COOKIE_SECRET)
+    return login_cookie == hashlib.sha1(cookie_str).hexdigest()
 
 
-def check_apikey(kwargs):
-    """Check API-key or NZB-key
+def check_apikey(request: Request) -> Optional[str]:
+    """Check API-key or NZB-key (Starlette version)
     Return None when OK, otherwise an error message
     """
-    mode = kwargs.get("mode", "")
-    name = kwargs.get("name", "")
+    mode = request.query_params.get("mode", "")
+    name = request.query_params.get("name", "")
 
     # Lookup required access level for the specific api-call
     req_access = sabnzbd.api.api_level(mode, name)
-    if not check_access(req_access, warn_user=True):
+    if not check_access(request, access_type=req_access, warn_user=True):
         return _MSG_ACCESS_DENIED
 
     # Skip for auth and version calls
@@ -386,10 +378,10 @@ def check_apikey(kwargs):
         return None
 
     # First check API-key, if OK that's sufficient
-    key = kwargs.get("apikey")
+    key = request.query_params.get("apikey")
     if not key:
         log_warning_and_ip(
-            T("API Key missing, please enter the api key from Config->General into your 3rd party program:")
+            request, T("API Key missing, please enter the api key from Config->General into your 3rd party program:")
         )
         return _MSG_APIKEY_REQUIRED
     elif req_access == 1 and key == cfg.nzb_key():
@@ -397,7 +389,9 @@ def check_apikey(kwargs):
     elif key == cfg.api_key():
         return None
     else:
-        log_warning_and_ip(T("API Key incorrect, Use the api key from Config->General in your 3rd party program:"))
+        log_warning_and_ip(
+            request, T("API Key incorrect, Use the api key from Config->General in your 3rd party program:")
+        )
         return _MSG_APIKEY_INCORRECT
 
 
@@ -407,205 +401,225 @@ def template_filtered_response(file: str, search_list: dict[str, Any]):
     search_list_copy = copy.deepcopy(search_list)
     # 'filters' is excluded because the RSS-filters are listed twice
     recursive_html_escape(search_list_copy, exclude_items=("webdir", "filters"))
-    return Template(file=file, searchList=[search_list_copy], compilerSettings=CHEETAH_DIRECTIVES).respond()
+    return HTMLResponse(
+        Template(file=file, searchList=[search_list_copy], compilerSettings=CHEETAH_DIRECTIVES).respond()
+    )
 
 
-def log_warning_and_ip(txt):
-    """Include the IP and the Proxy-IP for warnings"""
+def log_warning_and_ip(request: Request, txt: str):
+    """Include the IP and the Proxy-IP for warnings (Starlette version)"""
     if cfg.api_warnings():
-        logging.warning("%s %s", txt, cherrypy.request.remote_label)
+        remote_info = f"{request.client.host}:{request.client.port}"
+        if cfg.verify_xff_header() and (xff_ips := request.headers.get("X-Forwarded-For")):
+            remote_info += f" (X-Forwarded-For: {xff_ips})"
+        logging.warning("%s %s", txt, remote_info)
+
+
+async def get_request_params(request: Request) -> MultiDict | QueryParams:
+    """Return request parameters as a mutable MultiDict.
+
+    For POST requests the form body is read (both urlencoded and multipart).
+    File uploads in multipart bodies are kept as UploadFile objects.
+
+    For GET (and any non-form POST) only the URL query string is used.
+
+    secured_expose stores the result on request._query_params so that
+    request.query_params returns it in every handler without an extra await.
+    """
+    if request.method == "POST":
+        if request.headers.get("content-type", "").startswith(
+            ("application/x-www-form-urlencoded", "multipart/form-data")
+        ):
+            return MultiDict(await request.form())
+
+    return request.query_params
+
+
+# Disable over-active logging for the form parser
+logging.getLogger("python_multipart.multipart").setLevel(logging.WARNING)
 
 
 ##############################################################################
-# Helper raiser functions
+# Helper redirect functions
 ##############################################################################
-def Raiser(root: str = "", **kwargs):
-    # Add extras
+def BaseRedirectResponse(root: str = "", **kwargs) -> RedirectResponse:
+    """Create a Starlette RedirectResponse with SABnzbd URL base and query parameters"""
+    # Add query parameters if provided
     if kwargs:
         root = "%s?%s" % (root, urllib.parse.urlencode(kwargs))
 
     # Add the leading /sabnzbd/ (or what the user set)
-    root = cfg.url_base() + root
+    url = cfg.url_base() + root
 
-    # Log the redirect
+    # Log the redirect if API logging is enabled
     if cfg.api_logging():
-        logging.debug("Request %s %s redirected to %s", cherrypy.request.method, cherrypy.request.path_info, root)
+        logging.debug("Redirecting to %s", url)
 
-    # Send the redirect
-    return cherrypy.HTTPRedirect(root)
-
-
-def rssRaiser(root, kwargs):
-    return Raiser(root, feed=kwargs.get("feed"))
+    return RedirectResponse(url=url, status_code=302)
 
 
 ##############################################################################
-# Page definitions
+# Page definitions - Main
 ##############################################################################
-class MainPage:
-    def __init__(self):
-        self.__root = "/"
 
-        # Add all sub-pages
-        self.login = LoginPage()
-        self.config = ConfigPage("/config/")
-        self.wizard = Wizard("/wizard/")
 
-    @secured_expose
-    def index(self, **kwargs):
-        # Redirect to wizard if no servers are set
-        if kwargs.get("skip_wizard") or config.get_servers():
-            info = build_header()
+@secured_expose(route="/", methods=["GET"])
+async def main_index(request: Request):
+    # Redirect to wizard if no servers are set
+    if request.query_params.get("skip_wizard") or config.get_servers():
+        info = build_header()
 
-            info["have_rss_defined"] = bool(config.get_rss())
-            info["have_watched_dir"] = bool(cfg.dirscan_dir())
+        info["have_rss_defined"] = bool(config.get_rss())
+        info["have_watched_dir"] = bool(cfg.dirscan_dir())
+        info["cpumodel"] = get_cpu_name()
+        info["cpusimd"] = sabnzbd.decoder.SABCTOOLS_SIMD
+        info["platform"] = sabnzbd.PLATFORM
 
-            info["cpumodel"] = get_cpu_name()
-            info["cpusimd"] = sabnzbd.decoder.SABCTOOLS_SIMD
-            info["platform"] = sabnzbd.PLATFORM
-
-            # Have logout only with HTML and if inet=5, only when we are external
-            info["have_logout"] = (
-                cfg.username()
-                and cfg.password()
-                and (
-                    cfg.html_login()
-                    and (cfg.inet_exposure() < 5 or (cfg.inet_exposure() == 5 and not check_access(access_type=6)))
-                )
+        # Have logout only with HTML and if inet=5, only when we are external
+        info["have_logout"] = (
+            cfg.username()
+            and cfg.password()
+            and (
+                cfg.html_login()
+                and (cfg.inet_exposure() < 5 or (cfg.inet_exposure() == 5 and not check_access(request, access_type=6)))
             )
+        )
 
-            bytespersec_list = sabnzbd.BPSMeter.get_bps_list()
-            info["bytespersec_list"] = ",".join([str(bps) for bps in bytespersec_list])
+        bytespersec_list = sabnzbd.BPSMeter.get_bps_list()
+        info["bytespersec_list"] = ",".join([str(bps) for bps in bytespersec_list])
 
-            return template_filtered_response(file=os.path.join(sabnzbd.WEB_DIR, "main.tmpl"), search_list=info)
-        else:
-            # Redirect to the setup wizard
-            raise cherrypy.HTTPRedirect("%s/wizard/" % cfg.url_base())
+        return template_filtered_response(file=os.path.join(sabnzbd.WEB_DIR, "main.tmpl"), search_list=info)
+    else:
+        # Redirect to the setup wizard
+        return RedirectResponse(url="%s/wizard/" % cfg.url_base())
 
-    @secured_expose(check_api_key=True)
-    def shutdown(self, **kwargs):
-        # Check for PID
-        pid_in = kwargs.get("pid")
-        if pid_in and int(pid_in) != os.getpid():
-            return "Incorrect PID for this instance, remove PID from URL to initiate shutdown."
 
-        sabnzbd.shutdown_program()
-        return T("SABnzbd shutdown finished")
+@secured_expose(route="/shutdown", check_api_key=True)
+async def shutdown(request: Request):
+    # Check for PID
+    pid_in = request.query_params.get("pid")
+    if pid_in and int(pid_in) != os.getpid():
+        return PlainTextResponse("Incorrect PID for this instance, remove PID from URL to initiate shutdown.")
 
-    @secured_expose(check_api_key=True, access_type=1)
-    def api(self, **kwargs):
-        """Redirect to API-handler, we check the access_type in the API-handler"""
-        return api_handler(kwargs)
+    # In separate thread, because the server thread cannot shut down itself
+    threading.Thread(target=sabnzbd.shutdown_program).start()
+    return PlainTextResponse(T("SABnzbd shutdown finished"))
 
-    @secured_expose
-    def scriptlog(self, **kwargs):
-        """Needed for all skins, URL is fixed due to postproc"""
-        # No session key check, due to fixed URLs
-        if name := kwargs.get("name"):
-            history_db = sabnzbd.get_db_connection()
-            return ShowString(history_db.get_name(name), history_db.get_script_log(name))
-        else:
-            raise Raiser(self.__root)
 
-    @secured_expose
-    def robots_txt(self, **kwargs):
-        """Keep web crawlers out"""
-        cherrypy.response.headers["Content-Type"] = "text/plain"
-        return "User-agent: *\nDisallow: /\n"
+@secured_expose(route="/api", check_api_key=True, access_type=1)
+async def api(request: Request):
+    """Redirect to API-handler, we check the access_type in the API-handler"""
+    return api_handler(request.query_params)
 
-    @secured_expose
-    def description_xml(self, **kwargs):
-        """Provide the description.xml which was broadcast via SSDP"""
-        if is_lan_addr(cherrypy.request.remote.ip):
-            cherrypy.response.headers["Content-Type"] = "application/xml"
-            return utob(sabnzbd.utils.ssdp.server_ssdp_xml())
-        else:
-            return None
+
+@secured_expose(route="/scriptlog", methods=["GET"])
+async def scriptlog(request: Request):
+    """Needed for all skins, URL is fixed due to postproc"""
+    # No session key check, due to fixed URLs in history database
+    if name := request.query_params.get("name"):
+        history_db = sabnzbd.get_db_connection()
+        return PlainTextResponse(history_db.get_script_log(name))
+    return PlainTextResponse("")
+
+
+@secured_expose(methods=["GET"])
+async def robots_txt(request: Request):
+    """Keep web crawlers out"""
+    return PlainTextResponse("User-agent: *\nDisallow: /\n")
+
+
+@secured_expose(methods=["GET"])
+async def description_xml(request: Request):
+    """Provide the description.xml which was broadcast via SSDP"""
+    if is_lan_addr(request.client.host):
+        response = Response(content=sabnzbd.utils.ssdp.server_ssdp_xml(), media_type="application/xml")
+        return response
+    else:
+        return Response(status_code=404)
 
 
 ##############################################################################
-class Wizard:
-    def __init__(self, root):
-        self.__root = root
-
-    @secured_expose(check_configlock=True)
-    def index(self, **kwargs):
-        """Show the language selection page"""
-        if sabnzbd.WINDOWS:
-            from sabnzbd.utils.apireg import get_install_lng
-
-            cfg.language.set(get_install_lng())
-            logging.debug('Installer language code "%s"', cfg.language())
-
-        info = build_header(sabnzbd.WIZARD_DIR)
-        info["languages"] = list_languages()
-
-        return template_filtered_response(file=os.path.join(sabnzbd.WIZARD_DIR, "index.html"), search_list=info)
-
-    @secured_expose(check_configlock=True)
-    def one(self, **kwargs):
-        """Accept language and show server page"""
-        if kwargs.get("lang"):
-            cfg.language.set(kwargs.get("lang"))
-
-        info = build_header(sabnzbd.WIZARD_DIR)
-
-        # Just in case, add server
-        servers = config.get_servers()
-        if not servers:
-            info["server"] = ""
-            info["host"] = ""
-            info["port"] = ""
-            info["username"] = ""
-            info["password"] = ""
-            info["connections"] = ""
-            info["ssl"] = 1
-            info["ssl_verify"] = 3
-            info["pipelining_requests"] = DEF_PIPELINING_REQUESTS
-        else:
-            # Sort servers to get the first enabled one
-            server_names = sorted(
-                servers,
-                key=lambda svr: "%d%02d%s"
-                % (int(not servers[svr].enable()), servers[svr].priority(), servers[svr].displayname().lower()),
-            )
-            for server in server_names:
-                # If there are multiple servers, just use the first enabled one
-                s = servers[server]
-                info["server"] = server
-                info["host"] = s.host()
-                info["port"] = s.port()
-                info["username"] = s.username()
-                info["password"] = s.password.get_stars()
-                info["connections"] = s.connections()
-                info["ssl"] = s.ssl()
-                info["ssl_verify"] = s.ssl_verify()
-                info["pipelining_requests"] = s.pipelining_requests()
-                if s.enable():
-                    break
-        return template_filtered_response(file=os.path.join(sabnzbd.WIZARD_DIR, "one.html"), search_list=info)
-
-    @secured_expose(check_configlock=True)
-    def two(self, **kwargs):
-        """Accept server and show the final page for restart"""
-        # Save server details
-        if kwargs:
-            kwargs["enable"] = 1
-            handle_server(kwargs)
-
-        config.save_config()
-
-        # Show Restart screen
-        info = build_header(sabnzbd.WIZARD_DIR)
-
-        info["access_url"], info["urls"] = get_access_info()
-        info["download_dir"] = cfg.download_dir.get_clipped_path()
-        info["complete_dir"] = cfg.complete_dir.get_clipped_path()
-
-        return template_filtered_response(file=os.path.join(sabnzbd.WIZARD_DIR, "two.html"), search_list=info)
+# Page definitions - Wizard
+##############################################################################
 
 
-def get_access_info():
+@secured_expose(route="/wizard/", check_configlock=True, methods=["GET"])
+async def wizard_index(request: Request):
+    """Show the language selection page"""
+    if sabnzbd.WINDOWS:
+        from sabnzbd.utils.apireg import get_install_lng
+
+        cfg.language.set(get_install_lng())
+        logging.debug('Installer language code "%s"', cfg.language())
+
+    info = build_header(sabnzbd.WIZARD_DIR)
+    info["languages"] = list_languages()
+
+    return template_filtered_response(file=os.path.join(sabnzbd.WIZARD_DIR, "index.html"), search_list=info)
+
+
+@secured_expose(route="/wizard/one", check_configlock=True, methods=["GET", "POST"])
+async def wizard_page_one(request: Request):
+    """Accept language and show server page"""
+    if request.query_params.get("lang"):
+        cfg.language.set(request.query_params.get("lang"))
+
+    info = build_header(sabnzbd.WIZARD_DIR)
+
+    # Just in case, add server
+    servers = config.get_servers()
+    if not servers:
+        info["server"] = ""
+        info["host"] = ""
+        info["port"] = ""
+        info["username"] = ""
+        info["password"] = ""
+        info["connections"] = ""
+        info["ssl"] = 1
+        info["ssl_verify"] = 2
+        info["pipelining_requests"] = sabnzbd.constants.DEF_PIPELINING_REQUESTS
+    else:
+        # Sort servers to get the first enabled one
+        server_names = sorted(
+            servers,
+            key=lambda svr: "%d%02d%s"
+            % (int(not servers[svr].enable()), servers[svr].priority(), servers[svr].displayname().lower()),
+        )
+        for server in server_names:
+            # If there are multiple servers, just use the first enabled one
+            s = servers[server]
+            info["server"] = server
+            info["host"] = s.host()
+            info["port"] = s.port()
+            info["username"] = s.username()
+            info["password"] = s.password.get_stars()
+            info["connections"] = s.connections()
+            info["ssl"] = s.ssl()
+            info["ssl_verify"] = s.ssl_verify()
+            info["pipelining_requests"] = s.pipelining_requests()
+            if s.enable():
+                break
+    return template_filtered_response(file=os.path.join(sabnzbd.WIZARD_DIR, "one.html"), search_list=info)
+
+
+@secured_expose(route="/wizard/two", check_configlock=True, methods=["GET", "POST"])
+async def wizard_page_two(request: Request):
+    """Accept server and show the final page for restart"""
+    # Save server details if submitted — no host means the user skipped server setup
+    if request.query_params.get("host"):
+        handle_server(request.query_params)
+
+    # Show Restart screen
+    info = build_header(sabnzbd.WIZARD_DIR)
+
+    info["access_url"], info["urls"] = get_access_info(request)
+    info["download_dir"] = cfg.download_dir.get_clipped_path()
+    info["complete_dir"] = cfg.complete_dir.get_clipped_path()
+
+    return template_filtered_response(file=os.path.join(sabnzbd.WIZARD_DIR, "two.html"), search_list=info)
+
+
+def get_access_info(request: Optional[Request] = None):
     """Build up a list of url's that sabnzbd can be accessed from"""
     # Access_url is used to provide the user a link to SABnzbd depending on the host
     web_host = cfg.web_host()
@@ -640,7 +654,21 @@ def get_access_info():
         socks = [web_host]
 
     # Add the current requested URL as the base
-    access_url = urllib.parse.urljoin(cherrypy.request.base, cfg.url_base())
+    if request:
+        # For Starlette: build URL from request
+        scheme = "https" if cfg.enable_https() else "http"
+        port = cfg.https_port() if cfg.enable_https() else cfg.web_port()
+        host_header = request.headers.get("host", "localhost")
+        if ":" in host_header:
+            host_part = host_header.split(":")[0]
+        else:
+            host_part = host_header
+        access_url = f"{scheme}://{host_part}:{port}{cfg.url_base()}"
+    else:
+        # Fallback for backward compatibility
+        scheme = "https" if cfg.enable_https() else "http"
+        port = cfg.https_port() if cfg.enable_https() else cfg.web_port()
+        access_url = f"{scheme}://localhost:{port}{cfg.url_base()}"
 
     urls = [access_url]
     for sock in socks:
@@ -658,75 +686,84 @@ def get_access_info():
 
 
 ##############################################################################
-class LoginPage:
-    @secured_expose(check_for_login=False)
-    def index(self, **kwargs):
-        # Base output var
-        info = build_header(sabnzbd.WEB_DIR_CONFIG)
-        info["error"] = ""
+# Page definitions - Login
+##############################################################################
 
-        # Logout?
-        if kwargs.get("logout"):
-            set_login_cookie(remove=True)
-            raise Raiser()
 
-        # Check if there's even a username/password set
-        if check_login():
-            raise Raiser("/")
+@secured_expose(route="/login", check_for_login=False)
+async def login_index(request: Request):
+    # Base output var
+    info = build_header(sabnzbd.WEB_DIR_CONFIG)
+    info["error"] = ""
 
-        # Check login info
-        if kwargs.get("username") == cfg.username() and kwargs.get("password") == cfg.password():
-            # Save login cookie
-            set_login_cookie(remember_me=kwargs.get("remember_me", False))
-            # Log the success
-            logging.info("Successful login from %s", cherrypy.request.remote_label)
-            # Notify about new login
-            notifier.send_notification(T("User logged in"), T("User logged in to the web interface"), "new_login")
-            # Redirect
-            raise Raiser("/")
-        elif kwargs.get("username") or kwargs.get("password"):
-            info["error"] = T("Authentication failed, check username/password.")
-            # Warn about the potential security problem
-            logging.warning(T("Unsuccessful login attempt from %s"), cherrypy.request.remote_label)
+    # Use unified params - works for both GET and POST requests
+    username = request.query_params.get("username")
+    password = request.query_params.get("password")
+    remember_me = request.query_params.get("remember_me", False)
 
-        # Show login
-        return template_filtered_response(
-            file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "login", "main.tmpl"),
-            search_list=info,
-        )
+    # Check if there's even a username/password set
+    if check_login(request):
+        return RedirectResponse(url=f"{cfg.url_base()}/", status_code=302)
+
+    # Check login info
+    if username == cfg.username() and password == cfg.password():
+        # Create redirect response
+        response = RedirectResponse(url=f"{cfg.url_base()}/", status_code=302)
+        # Save login cookie
+        set_login_cookie(request, response, remember_me=remember_me)
+        # Log the success
+        remote_info = f"{request.client.host}:{request.client.port}"
+        if cfg.verify_xff_header() and (xff_ips := request.headers.get("X-Forwarded-For")):
+            remote_info += f" (X-Forwarded-For: {xff_ips})"
+        logging.info("Successful login from %s", remote_info)
+        return response
+    elif username or password:
+        info["error"] = T("Authentication failed, check username/password.")
+        # Warn about the potential security problem
+        remote_info = f"{request.client.host}:{request.client.port}"
+        if cfg.verify_xff_header() and (xff_ips := request.headers.get("X-Forwarded-For")):
+            remote_info += f" (X-Forwarded-For: {xff_ips})"
+        logging.warning(T("Unsuccessful login attempt from %s"), remote_info)
+
+    # Show login
+    return template_filtered_response(
+        file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "login", "main.tmpl"),
+        search_list=info,
+    )
+
+
+@secured_expose(route="/logout", check_for_login=False, methods=["GET"])
+async def logout_index(request: Request):
+    response = RedirectResponse(url=f"{cfg.url_base()}/", status_code=302)
+    set_login_cookie(request, response, remove=True)
+    return response
 
 
 ##############################################################################
-class ConfigPage:
-    def __init__(self, root):
-        self.__root = root
-        self.folders = ConfigFolders("/config/folders/")
-        self.notify = ConfigNotify("/config/notify/")
-        self.general = ConfigGeneral("/config/general/")
-        self.rss = ConfigRss("/config/rss/")
-        self.scheduling = ConfigScheduling("/config/scheduling/")
-        self.server = ConfigServer("/config/server/")
-        self.switches = ConfigSwitches("/config/switches/")
-        self.categories = ConfigCats("/config/categories/")
-        self.sorting = ConfigSorting("/config/sorting/")
-        self.special = ConfigSpecial("/config/special/")
-
-    @secured_expose(check_configlock=True)
-    def index(self, **kwargs):
-        conf = build_header(sabnzbd.WEB_DIR_CONFIG)
-        conf["configfn"] = clip_path(config.get_filename())
-        conf["cmdline"] = sabnzbd.CMDLINE
-        conf["build"] = sabnzbd.__baseline__[:7]
-        conf["have_7zip"] = bool(sabnzbd.newsunpack.SEVENZIP_COMMAND)
-        conf["have_par2_turbo"] = sabnzbd.newsunpack.PAR2_TURBO
-        conf["ssl_version"] = ssl.OPENSSL_VERSION
-
-        return template_filtered_response(
-            file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "config.tmpl"),
-            search_list=conf,
-        )
+# Page definitions - Config - General
+##############################################################################
 
 
+@secured_expose(route="/config", check_configlock=True, methods=["GET"])
+async def config_general_index(request: Request):
+    conf = build_header(sabnzbd.WEB_DIR_CONFIG)
+    conf["configfn"] = clip_path(config.get_filename())
+    conf["cmdline"] = sabnzbd.CMDLINE
+    conf["build"] = sabnzbd.__baseline__[:7]
+
+    conf["have_7zip"] = bool(sabnzbd.newsunpack.SEVENZIP_COMMAND)
+    conf["have_sabctools"] = sabnzbd.decoder.SABCTOOLS_ENABLED
+    conf["have_par2_turbo"] = sabnzbd.newsunpack.PAR2_TURBO
+    conf["ssl_version"] = ssl.OPENSSL_VERSION
+
+    return template_filtered_response(
+        file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "config.tmpl"),
+        search_list=conf,
+    )
+
+
+##############################################################################
+# Page definitions - Config - Folders
 ##############################################################################
 LIST_DIRPAGE = (
     "download_dir",
@@ -748,37 +785,32 @@ LIST_DIRPAGE = (
 LIST_BOOL_DIRPAGE = ("fulldisk_autoresume",)
 
 
-class ConfigFolders:
-    def __init__(self, root):
-        self.__root = root
+@secured_expose(route="/config/folders", check_configlock=True, methods=["GET"])
+async def index_config_folders(request: Request):
+    conf = build_header(sabnzbd.WEB_DIR_CONFIG)
+    conf["file_exts"] = ", ".join(VALID_NZB_FILES + VALID_ARCHIVES)
 
-    @secured_expose(check_configlock=True)
-    def index(self, **kwargs):
-        conf = build_header(sabnzbd.WEB_DIR_CONFIG)
+    for kw in LIST_DIRPAGE + LIST_BOOL_DIRPAGE:
+        conf[kw] = config.get_config("misc", kw)()
 
-        conf["file_exts"] = ", ".join(VALID_NZB_FILES + VALID_ARCHIVES)
-
-        for kw in LIST_DIRPAGE + LIST_BOOL_DIRPAGE:
-            conf[kw] = config.get_config("misc", kw)()
-
-        return template_filtered_response(
-            file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "config_folders.tmpl"),
-            search_list=conf,
-        )
-
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def saveDirectories(self, **kwargs):
-        for kw in LIST_DIRPAGE + LIST_BOOL_DIRPAGE:
-            if msg := config.get_config("misc", kw).set(kwargs.get(kw)):
-                return badParameterResponse(msg, kwargs.get("ajax"))
-
-        config.save_config()
-        if kwargs.get("ajax"):
-            return sabnzbd.api.report()
-        else:
-            raise Raiser(self.__root)
+    return template_filtered_response(
+        file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "config_folders.tmpl"),
+        search_list=conf,
+    )
 
 
+@secured_expose(route="/config/folders/save", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_folder_save(request: Request):
+    for kw in LIST_DIRPAGE + LIST_BOOL_DIRPAGE:
+        if msg := config.get_config("misc", kw).set(request.query_params.get(kw)):
+            return report(request.query_params, error=msg)
+
+    config.save_config()
+    return report(request.query_params)
+
+
+##############################################################################
+# Page definitions - Config - Switches
 ##############################################################################
 SWITCH_LIST = (
     "par_option",
@@ -826,41 +858,37 @@ SWITCH_LIST = (
 )
 
 
-class ConfigSwitches:
-    def __init__(self, root):
-        self.__root = root
+@secured_expose(route="/config/switches", check_configlock=True, methods=["GET"])
+async def index_config_switches(request: Request):
+    conf = build_header(sabnzbd.WEB_DIR_CONFIG)
+    conf["have_nice"] = bool(sabnzbd.newsunpack.NICE_COMMAND)
+    conf["have_ionice"] = bool(sabnzbd.newsunpack.IONICE_COMMAND)
 
-    @secured_expose(check_configlock=True)
-    def index(self, **kwargs):
-        conf = build_header(sabnzbd.WEB_DIR_CONFIG)
-        conf["have_nice"] = bool(sabnzbd.newsunpack.NICE_COMMAND)
-        conf["have_ionice"] = bool(sabnzbd.newsunpack.IONICE_COMMAND)
+    for kw in SWITCH_LIST:
+        conf[kw] = config.get_config("misc", kw)()
+    conf["cleanup_list"] = cfg.cleanup_list.get_string()
+    conf["unwanted_extensions"] = cfg.unwanted_extensions.get_string()
 
-        for kw in SWITCH_LIST:
-            conf[kw] = config.get_config("misc", kw)()
-        conf["cleanup_list"] = cfg.cleanup_list.get_string()
-        conf["unwanted_extensions"] = cfg.unwanted_extensions.get_string()
+    conf["scripts"] = list_scripts() or ["None"]
 
-        conf["scripts"] = list_scripts() or ["None"]
-
-        return template_filtered_response(
-            file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "config_switches.tmpl"),
-            search_list=conf,
-        )
-
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def saveSwitches(self, **kwargs):
-        for kw in SWITCH_LIST:
-            if msg := config.get_config("misc", kw).set(kwargs.get(kw)):
-                return badParameterResponse(msg, kwargs.get("ajax"))
-
-        config.save_config()
-        if kwargs.get("ajax"):
-            return sabnzbd.api.report()
-        else:
-            raise Raiser(self.__root)
+    return template_filtered_response(
+        file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "config_switches.tmpl"),
+        search_list=conf,
+    )
 
 
+@secured_expose(route="/config/switches/save", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_switches_save(request: Request):
+    for kw in SWITCH_LIST:
+        if msg := config.get_config("misc", kw).set(request.query_params.get(kw)):
+            return report(request.query_params, error=msg)
+
+    config.save_config()
+    return report(request.query_params)
+
+
+##############################################################################
+# Page definitions - Config - Special
 ##############################################################################
 SPECIAL_BOOL_LIST = (
     "start_paused",
@@ -928,41 +956,40 @@ SPECIAL_LIST_LIST = (
 )
 
 
-class ConfigSpecial:
-    def __init__(self, root):
-        self.__root = root
-
-    @secured_expose(check_configlock=True)
-    def index(self, **kwargs):
-        conf = build_header(sabnzbd.WEB_DIR_CONFIG)
-        conf["switches"] = [
-            (kw, config.get_config("misc", kw)(), config.get_config("misc", kw).default) for kw in SPECIAL_BOOL_LIST
+@secured_expose(route="/config/special", check_configlock=True, methods=["GET"])
+async def index_config_special(request: Request):
+    conf = build_header(sabnzbd.WEB_DIR_CONFIG)
+    conf["switches"] = [
+        (kw, config.get_config("misc", kw)(), config.get_config("misc", kw).default) for kw in SPECIAL_BOOL_LIST
+    ]
+    conf["entries"] = [
+        (kw, config.get_config("misc", kw)(), config.get_config("misc", kw).default) for kw in SPECIAL_VALUE_LIST
+    ]
+    conf["entries"].extend(
+        [
+            (kw, config.get_config("misc", kw).get_string(), config.get_config("misc", kw).default_string())
+            for kw in SPECIAL_LIST_LIST
         ]
-        conf["entries"] = [
-            (kw, config.get_config("misc", kw)(), config.get_config("misc", kw).default) for kw in SPECIAL_VALUE_LIST
-        ]
-        conf["entries"].extend(
-            [
-                (kw, config.get_config("misc", kw).get_string(), config.get_config("misc", kw).default_string())
-                for kw in SPECIAL_LIST_LIST
-            ]
-        )
+    )
 
-        return template_filtered_response(
-            file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "config_special.tmpl"),
-            search_list=conf,
-        )
-
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def saveSpecial(self, **kwargs):
-        for kw in SPECIAL_BOOL_LIST + SPECIAL_VALUE_LIST + SPECIAL_LIST_LIST:
-            if msg := config.get_config("misc", kw).set(kwargs.get(kw)):
-                return badParameterResponse(msg)
-
-        config.save_config()
-        raise Raiser(self.__root)
+    return template_filtered_response(
+        file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "config_special.tmpl"),
+        search_list=conf,
+    )
 
 
+@secured_expose(route="/config/special/save", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_special_save(request: Request):
+    for kw in SPECIAL_BOOL_LIST + SPECIAL_VALUE_LIST + SPECIAL_LIST_LIST:
+        if msg := config.get_config("misc", kw).set(request.query_params.get(kw)):
+            return report(request.query_params, error=msg)
+
+    config.save_config()
+    return report(request.query_params)
+
+
+##############################################################################
+# Page definitions - Config - General
 ##############################################################################
 GENERAL_LIST = (
     "host",
@@ -985,80 +1012,72 @@ GENERAL_LIST = (
 )
 
 
-class ConfigGeneral:
-    def __init__(self, root):
-        self.__root = root
+@secured_expose(route="/config/general", check_configlock=True, methods=["GET"])
+async def index_config_general(request: Request):
+    conf = build_header(sabnzbd.WEB_DIR_CONFIG)
 
-    @secured_expose(check_configlock=True)
-    def index(self, **kwargs):
-        conf = build_header(sabnzbd.WEB_DIR_CONFIG)
+    web_list = []
+    for interface_dir in globber_full(sabnzbd.DIR_INTERFACES):
+        # Ignore the config
+        if not interface_dir.endswith(DEF_STD_CONFIG):
+            # Check the available templates
+            for colorscheme in globber(
+                os.path.join(interface_dir, "templates", "static", "stylesheets", "colorschemes")
+            ):
+                web_list.append("%s - %s" % (setname_from_path(interface_dir), setname_from_path(colorscheme)))
 
-        web_list = []
-        for interface_dir in globber_full(sabnzbd.DIR_INTERFACES):
-            # Ignore the config
-            if not interface_dir.endswith(DEF_STD_CONFIG):
-                # Check the available templates
-                for colorscheme in globber(
-                    os.path.join(interface_dir, "templates", "static", "stylesheets", "colorschemes")
-                ):
-                    web_list.append("%s - %s" % (setname_from_path(interface_dir), setname_from_path(colorscheme)))
+    conf["web_list"] = web_list
+    conf["web_dir"] = "%s - %s" % (cfg.web_dir(), cfg.web_color())
+    conf["password"] = cfg.password.get_stars()
 
-        conf["web_list"] = web_list
-        conf["web_dir"] = "%s - %s" % (cfg.web_dir(), cfg.web_color())
-        conf["password"] = cfg.password.get_stars()
+    conf["language"] = cfg.language()
+    conf["lang_list"] = list_languages()
+    conf["def_https_cert_file"] = DEF_HTTPS_CERT_FILE
 
-        conf["language"] = cfg.language()
-        conf["lang_list"] = list_languages()
-        conf["def_https_cert_file"] = DEF_HTTPS_CERT_FILE
+    for kw in GENERAL_LIST:
+        conf[kw] = config.get_config("misc", kw)()
 
-        for kw in GENERAL_LIST:
-            conf[kw] = config.get_config("misc", kw)()
+    conf["nzb_key"] = cfg.nzb_key()
 
-        conf["nzb_key"] = cfg.nzb_key()
-        conf["caller_url"] = cherrypy.request.base + cfg.url_base()
+    return template_filtered_response(
+        file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "config_general.tmpl"),
+        search_list=conf,
+    )
 
-        return template_filtered_response(
-            file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "config_general.tmpl"),
-            search_list=conf,
-        )
 
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def saveGeneral(self, **kwargs):
-        # Handle general options
-        for kw in GENERAL_LIST:
-            if msg := config.get_config("misc", kw).set(kwargs.get(kw)):
-                return badParameterResponse(msg, ajax=kwargs.get("ajax"))
+@secured_expose(route="/config/general/save", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_general_save(request: Request):
+    # Handle general options
+    for kw in GENERAL_LIST:
+        if msg := config.get_config("misc", kw).set(request.query_params.get(kw)):
+            return report(request.query_params, error=msg)
 
-        # Handle special options
-        cfg.password.set(kwargs.get("password"))
+    # Handle special options
+    cfg.password.set(request.query_params.get("password"))
 
-        web_dir = kwargs.get("web_dir")
-        change_web_dir(web_dir)
+    if web_dir := request.query_params.get("web_dir"):
+        if msg := change_web_dir(web_dir):
+            return report(request.query_params, error=msg)
 
-        config.save_config()
+    config.save_config()
+    return report(request.query_params, data={"success": True, "restart_req": sabnzbd.RESTART_REQ})
 
-        # Update CherryPy authentication
-        set_auth(cherrypy.config)
-        if kwargs.get("ajax"):
-            return sabnzbd.api.report(data={"success": True, "restart_req": sabnzbd.RESTART_REQ})
-        else:
-            raise Raiser(self.__root)
 
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def uploadConfig(self, **kwargs):
-        """Restore a config backup"""
-        config_backup_file = kwargs.get("config_backup_file")
+@secured_expose(route="/config/general/upload_config", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_upload_backup(request: Request):
+    """Restore a config backup"""
+    # secured_expose already parsed the multipart body into request.query_params
+    config_backup_file = request.query_params.get("config_backup_file")
 
-        # Only accept the backup file if it can be opened as a zip archive and only contains a config file
-        try:
-            config_backup_data = config_backup_file.file.read()
-            config_backup_file.file.close()
-            if config.validate_config_backup(config_backup_data):
-                sabnzbd.RESTORE_DATA = config_backup_data
-                return sabnzbd.api.report(data={"success": True, "restart_req": True})
-        except Exception:
-            pass
-        return sabnzbd.api.report(error=T("Invalid backup archive"))
+    # Only accept the backup file if it can be opened as a zip archive and only contains a config file
+    try:
+        config_backup_data = await config_backup_file.read()
+        if config.validate_config_backup(config_backup_data):
+            sabnzbd.RESTORE_DATA = config_backup_data
+            return report(request.query_params, data={"success": True, "restart_req": True})
+    except Exception:
+        pass
+    return report(request.query_params, error=T("Invalid backup archive"))
 
 
 def change_web_dir(web_dir):
@@ -1066,84 +1085,88 @@ def change_web_dir(web_dir):
     web_dir_path = real_path(sabnzbd.DIR_INTERFACES, web_dir)
 
     if not os.path.exists(web_dir_path):
-        return badParameterResponse("Cannot find web template: %s" % web_dir_path)
+        logging.info("Cannot find web template: %s", web_dir_path)
     else:
         cfg.web_dir.set(web_dir)
         cfg.web_color.set(web_color)
 
 
 ##############################################################################
-class ConfigServer:
-    def __init__(self, root):
-        self.__root = root
+# Page definitions - Config - Server
+##############################################################################
 
-    @secured_expose(check_configlock=True)
-    def index(self, **kwargs):
-        conf = build_header(sabnzbd.WEB_DIR_CONFIG)
-        new = []
-        servers = config.get_servers()
-        server_names = sorted(
-            servers,
-            key=lambda svr: "%d%02d%s"
-            % (int(not servers[svr].enable()), servers[svr].priority(), servers[svr].displayname().lower()),
-        )
-        for svr in server_names:
-            new.append(servers[svr].get_dict(for_public_api=True))
-            t, m, w, d, daily, articles_tried, articles_success = sabnzbd.BPSMeter.amounts(svr)
-            if t:
-                new[-1]["amounts"] = (
-                    to_units(t),
-                    to_units(m),
-                    to_units(w),
-                    to_units(d),
-                    daily,
-                    articles_tried,
-                    articles_success,
-                )
-            new[-1]["quota_left"] = to_units(
-                servers[svr].quota.get_int() - sabnzbd.BPSMeter.grand_total.get(svr, 0) + servers[svr].usage_at_start()
+
+@secured_expose(route="/config/server", check_configlock=True, methods=["GET"])
+async def index_config_server(request: Request):
+    conf = build_header(sabnzbd.WEB_DIR_CONFIG)
+    new = []
+    servers = config.get_servers()
+    server_names = sorted(
+        servers,
+        key=lambda svr: "%d%02d%s"
+        % (int(not servers[svr].enable()), servers[svr].priority(), servers[svr].displayname().lower()),
+    )
+    for svr in server_names:
+        new.append(servers[svr].get_dict(for_public_api=True))
+        t, m, w, d, daily, articles_tried, articles_success = sabnzbd.BPSMeter.amounts(svr)
+        if t:
+            new[-1]["amounts"] = (
+                to_units(t),
+                to_units(m),
+                to_units(w),
+                to_units(d),
+                daily,
+                articles_tried,
+                articles_success,
             )
-
-        conf["servers"] = new
-        conf["cats"] = list_cats(default=True)
-
-        return template_filtered_response(
-            file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "config_server.tmpl"),
-            search_list=conf,
+        new[-1]["quota_left"] = to_units(
+            servers[svr].quota.get_int() - sabnzbd.BPSMeter.grand_total.get(svr, 0) + servers[svr].usage_at_start()
         )
 
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def addServer(self, **kwargs):
-        return handle_server(kwargs, self.__root, True)
+    conf["servers"] = new
+    conf["cats"] = list_cats(default=True)
 
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def saveServer(self, **kwargs):
-        return handle_server(kwargs, self.__root)
+    return template_filtered_response(
+        file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "config_server.tmpl"),
+        search_list=conf,
+    )
 
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def delServer(self, **kwargs):
-        kwargs["section"] = "servers"
-        kwargs["keyword"] = kwargs.get("server")
-        del_from_section(kwargs)
-        raise Raiser(self.__root)
 
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def clrServer(self, **kwargs):
-        server = kwargs.get("server")
-        if server:
-            sabnzbd.BPSMeter.clear_server(server)
-        raise Raiser(self.__root)
+@secured_expose(route="/config/server/add_server", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_server_add(request: Request):
+    return handle_server(request.query_params, new_svr=True)
 
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def toggleServer(self, **kwargs):
-        server = kwargs.get("server")
-        if server:
-            svr = config.get_config("servers", server)
-            if svr:
-                svr.enable.set(not svr.enable())
-                config.save_config()
-                sabnzbd.Downloader.update_server(server, server)
-        raise Raiser(self.__root)
+
+@secured_expose(route="/config/server/save_server", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_server_save(request: Request):
+    return handle_server(request.query_params)
+
+
+@secured_expose(route="/config/server/delete_server", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_server_del(request: Request):
+    kw = {"section": "servers", "keyword": request.query_params.get("server")}
+    del_from_section(kw)
+    return BaseRedirectResponse("/config/server")
+
+
+@secured_expose(route="/config/server/clear_server", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_server_clr(request: Request):
+    server = request.query_params.get("server")
+    if server:
+        sabnzbd.BPSMeter.clear_server(server)
+    return BaseRedirectResponse("/config/server")
+
+
+@secured_expose(route="/config/server/toggle_server", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_server_toggle(request: Request):
+    server = request.query_params.get("server")
+    if server:
+        svr = config.get_config("servers", server)
+        if svr:
+            svr.enable.set(not svr.enable())
+            config.save_config()
+            sabnzbd.Downloader.update_server(server, server)
+    return BaseRedirectResponse("/config/server")
 
 
 def unique_svr_name(server):
@@ -1161,35 +1184,34 @@ def unique_svr_name(server):
     return new_name
 
 
-def handle_server(kwargs, root=None, new_svr=False):
-    """Internal server handler"""
-    ajax = kwargs.get("ajax")
-    host = kwargs.get("host", "").strip()
+def handle_server(params, new_svr=False):
+    """Internal server handler, always returns a JSON response"""
+    host = params.get("host", "").strip()
     if not host:
-        return badParameterResponse(T("Server address required"), ajax)
+        return report(params, error=T("Server address required"))
 
-    port = kwargs.get("port", "").strip()
+    port = params.get("port", "").strip()
     if not port:
-        if not kwargs.get("ssl", "").strip():
+        if not params.get("ssl", "").strip():
             port = "119"
         else:
             port = "563"
-        kwargs["port"] = port
+        params["port"] = port
 
-    if kwargs.get("connections", "").strip() == "":
-        kwargs["connections"] = "1"
+    if params.get("connections", "").strip() == "":
+        params["connections"] = "1"
 
-    if kwargs.get("enable") == "1":
+    if params.get("enable") == "1":
         if not get_fastest_addrinfo(
-            host, int_conv(port), int_conv(kwargs.get("timeout"), default=DEF_NETWORKING_TEST_TIMEOUT)
+            host, int_conv(port), int_conv(params.get("timeout"), default=DEF_NETWORKING_TEST_TIMEOUT)
         ):
-            return badParameterResponse(T('Server address "%s:%s" is not valid.') % (host, port), ajax)
+            return report(params, error=T('Server address "%s:%s" is not valid.') % (host, port))
 
     # Default server name is just the host name
     server = host
 
     svr = None
-    old_server = kwargs.get("server")
+    old_server = params.get("server")
     if old_server:
         svr = config.get_config("servers", old_server)
     if svr:
@@ -1201,320 +1223,402 @@ def handle_server(kwargs, root=None, new_svr=False):
         server = unique_svr_name(server)
 
     for kw in ("ssl", "enable", "required", "optional"):
-        if kw not in kwargs.keys():
-            kwargs[kw] = None
+        if kw not in params.keys():
+            params[kw] = None
     if svr and not new_svr:
-        svr.set_dict(kwargs)
+        svr.set_dict(params)
     else:
         old_server = None
-        config.ConfigServer(server, kwargs)
+        config.ConfigServer(server, params)
 
     config.save_config()
     sabnzbd.Downloader.update_server(old_server, server)
-    if root:
-        if ajax:
-            return sabnzbd.api.report()
-        else:
-            raise Raiser(root)
+    return report(params)
 
 
 ##############################################################################
-class ConfigRss:
-    def __init__(self, root):
-        self.__root = root
-        self.__last_msg = ""  # Last error message from RSS reader
+# Standalone RSS filter functions (used by both route handlers and api.py)
+##############################################################################
 
-    def process_feed(
-        self,
-        feed: str,
-        download: bool = False,
-        force: bool = False,
-        ignore_first: bool = False,
-        readout: bool = False,
-    ) -> None:
-        """Process a feed and cache the result message. When readout=True the feed
-        is re-fetched from its URL and the result message is stored for display.
-        When readout=False the cached items are re-evaluated against current filters."""
-        logging.debug(
-            "Processing RSS-feed: %s (download=%s, force=%s, ignore_first=%s, readout=%s)",
-            feed,
-            download,
-            force,
-            ignore_first,
-            readout,
-        )
-        msg = sabnzbd.RSSReader.process_feed(
-            feed,
-            download=download,
-            force=force,
-            ignore_first=ignore_first,
-            readout=readout,
-        )
-        if readout:
-            self.__last_msg = msg
+# Module-level state for RSS page (replaces ConfigRss instance state)
+_rss_refresh_readout = None
+_rss_refresh_download = False
+_rss_refresh_force = False
+_rss_refresh_ignore = False
+_rss_evaluate = False
+_rss_show_eval_button = False
+_rss_last_msg = ""
 
-    @secured_expose(check_configlock=True)
-    def index(self, **kwargs):
-        conf = build_header(sabnzbd.WEB_DIR_CONFIG)
 
-        conf["scripts"] = list_scripts(default=True)
-        pick_script = conf["scripts"] != []
+def do_upd_rss_filter(kwargs):
+    """Update or add an RSS filter. Called by route handler and api.py."""
+    global _rss_evaluate, _rss_show_eval_button
+    try:
+        feed_cfg = config.get_rss()[kwargs.get("feed")]
+    except KeyError:
+        return
 
-        conf["categories"] = list_cats(default=True)
-        pick_cat = conf["categories"] != []
+    pp = kwargs.get("pp", "")
+    if is_none(pp):
+        pp = ""
+    script = ConvertSpecials(kwargs.get("script"))
+    cat = ConvertSpecials(kwargs.get("cat"))
+    prio = ConvertSpecials(kwargs.get("priority"))
+    filt = kwargs.get("filter_text")
+    enabled = kwargs.get("enabled", "0")
 
-        conf["rss_rate"] = cfg.rss_rate()
-
-        rss = {}
-        feeds = config.get_rss()
-        for feed in feeds:
-            rss[feed] = feeds[feed].get_dict()
-            filters = feeds[feed].filters()
-            rss[feed]["filters"] = filters
-            rss[feed]["filter_states"] = [bool(sabnzbd.rss.convert_filter(f[4])) for f in filters]
-            rss[feed]["filtercount"] = len(filters)
-
-            rss[feed]["pick_cat"] = pick_cat
-            rss[feed]["pick_script"] = pick_script
-            rss[feed]["link"] = urllib.parse.quote_plus(feed)
-            rss[feed]["baselink"] = [get_base_url(uri) for uri in rss[feed]["uri"]]
-            rss[feed]["uris"] = feeds[feed].uri.get_string()
-
-        active_feed = kwargs.get("feed", "")
-        conf["active_feed"] = active_feed
-        conf["rss"] = rss
-        conf["rss_next"] = time.strftime(time_format("%H:%M"), time.localtime(sabnzbd.RSSReader.next_run))
-
-        if active_feed:
-            conf["error"] = self.__last_msg
-            conf["downloaded"], conf["matched"], conf["unmatched"] = GetRssLog(active_feed)
-        else:
-            self.__last_msg = ""
-
-        # Find a unique new Feed name
-        unum = 1
-        txt = T("Feed")  # : Used as default Feed name in Config->RSS
-        while txt + str(unum) in feeds:
-            unum += 1
-        conf["feed"] = txt + str(unum)
-
-        return template_filtered_response(
-            file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "config_rss.tmpl"),
-            search_list=conf,
+    if filt:
+        feed_cfg.filters.update(
+            int(kwargs.get("index", 0)),
+            [cat, pp, script, kwargs.get("filter_type"), filt, prio, enabled],
         )
 
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def save_rss_rate(self, **kwargs):
-        """Save changed RSS automatic readout rate"""
-        cfg.rss_rate.set(kwargs.get("rss_rate"))
+        # Move filter if requested
+        index = int_conv(kwargs.get("index", ""))
+        new_index = kwargs.get("new_index", "")
+        if new_index and int_conv(new_index) != index:
+            feed_cfg.filters.move(int(index), int_conv(new_index))
+
         config.save_config()
-        sabnzbd.Scheduler.restart()
-        raise Raiser(self.__root)
+    _rss_evaluate = False
+    _rss_show_eval_button = True
 
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def upd_rss_feed(self, **kwargs):
-        """Update Feed level attributes,
-        legacy version: ignores 'enable' parameter
-        """
-        if kwargs.get("enable") is not None:
-            del kwargs["enable"]
-        try:
-            cf = config.get_rss()[kwargs.get("feed")]
-        except KeyError:
-            cf = None
-        uri = Strip(kwargs.get("uri"))
-        if cf and uri:
-            kwargs["uri"] = uri
-            cf.set_dict(kwargs)
-            config.save_config()
 
-        self.process_feed(kwargs.get("feed"))
-        raise rssRaiser(self.__root, kwargs)
+def do_del_rss_filter(kwargs):
+    """Delete an RSS filter. Called by route handler and api.py."""
+    global _rss_evaluate, _rss_show_eval_button
+    try:
+        feed_cfg = config.get_rss()[kwargs.get("feed")]
+    except KeyError:
+        return
 
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def save_rss_feed(self, **kwargs):
-        """Update Feed level attributes"""
-        feed_name = kwargs.get("feed")
-        try:
-            cf = config.get_rss()[feed_name]
-        except KeyError:
-            cf = None
-        if "enable" not in kwargs:
-            kwargs["enable"] = 0
-        uri = Strip(kwargs.get("uri"))
-        if cf and uri:
-            kwargs["uri"] = uri
-            cf.set_dict(kwargs)
+    feed_cfg.filters.delete(int(kwargs.get("index", 0)))
+    config.save_config()
+    _rss_evaluate = False
+    _rss_show_eval_button = True
 
-            # Did we get a new name for this feed?
-            new_name = kwargs.get("feed_new_name")
-            if new_name and new_name != feed_name:
-                # Update the feed name for the redirect
-                kwargs["feed"] = cf.rename(new_name)
 
-            config.save_config()
+##############################################################################
+# Config - RSS (standalone route functions)
+##############################################################################
 
-        raise rssRaiser(self.__root, kwargs)
 
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def toggle_rss_feed(self, **kwargs):
-        """Toggle automatic read-out flag of Feed"""
-        try:
-            item = config.get_rss()[kwargs.get("feed")]
-        except KeyError:
-            item = None
-        if cfg:
-            item.enable.set(not item.enable())
-            config.save_config()
-        if kwargs.get("table"):
-            raise Raiser(self.__root)
-        else:
-            raise rssRaiser(self.__root, kwargs)
+_RSS_ROOT = "/config/rss"
 
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def add_rss_feed(self, **kwargs):
-        """Add one new RSS feed definition"""
-        feed = Strip(kwargs.get("feed")).strip("[]")
-        uri = Strip(kwargs.get("uri"))
-        if feed and uri:
-            try:
-                rss_cfg = config.get_rss()[feed]
-            except KeyError:
-                rss_cfg = None
-            if not rss_cfg and uri:
-                kwargs["feed"] = feed
-                kwargs["uri"] = uri
-                config.ConfigRSS(feed, kwargs)
-                # Clear out any existing reference to this feed name
-                # Otherwise first-run detection can fail
-                with sabnzbd.rss.rss_repository(sabnzbd.get_db_connection()) as repo:
-                    repo.clear_feed(feed)
-                config.save_config()
-                self.process_feed(feed, readout=True, ignore_first=True)
-                raise rssRaiser(self.__root, kwargs)
-            else:
-                raise Raiser(self.__root)
-        else:
-            raise Raiser(self.__root)
 
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def upd_rss_filter(self, **kwargs):
-        """Wrapper, so we can call from api.py"""
-        self.internal_upd_rss_filter(**kwargs)
+@secured_expose(route="/config/rss", check_configlock=True, methods=["GET"])
+async def config_rss_index(request: Request):
+    global _rss_refresh_readout, _rss_refresh_download, _rss_refresh_force
+    global _rss_refresh_ignore, _rss_evaluate, _rss_show_eval_button, _rss_last_msg
 
-    def internal_upd_rss_filter(self, **kwargs):
-        """Save updated filter definition"""
-        try:
-            feed_cfg = config.get_rss()[kwargs.get("feed")]
-        except KeyError:
-            raise rssRaiser(self.__root, kwargs)
+    conf = build_header(sabnzbd.WEB_DIR_CONFIG)
 
-        pp = kwargs.get("pp", "")
-        if is_none(pp):
-            pp = ""
-        script = ConvertSpecials(kwargs.get("script"))
-        cat = ConvertSpecials(kwargs.get("cat"))
-        prio = ConvertSpecials(kwargs.get("priority"))
-        filt = kwargs.get("filter_text")
-        enabled = kwargs.get("enabled", "0")
+    conf["scripts"] = list_scripts(default=True)
+    pick_script = conf["scripts"] != []
 
-        if filt:
-            feed_cfg.filters.update(
-                int(kwargs.get("index", 0)), [cat, pp, script, kwargs.get("filter_type"), filt, prio, enabled]
+    conf["categories"] = list_cats(default=True)
+    pick_cat = conf["categories"] != []
+
+    conf["rss_rate"] = cfg.rss_rate()
+
+    rss = {}
+    feeds = config.get_rss()
+    for feed in feeds:
+        rss[feed] = feeds[feed].get_dict()
+        filters = feeds[feed].filters()
+        rss[feed]["filters"] = filters
+        rss[feed]["filter_states"] = [bool(sabnzbd.rss.convert_filter(f[4])) for f in filters]
+        rss[feed]["filtercount"] = len(filters)
+
+        rss[feed]["pick_cat"] = pick_cat
+        rss[feed]["pick_script"] = pick_script
+        rss[feed]["link"] = urllib.parse.quote_plus(feed)
+        rss[feed]["baselink"] = [get_base_url(uri) for uri in rss[feed]["uri"]]
+        rss[feed]["uris"] = feeds[feed].uri.get_string()
+
+    active_feed = request.query_params.get("feed", "")
+    conf["active_feed"] = active_feed
+    conf["rss"] = rss
+    conf["rss_next"] = time.strftime(time_format("%H:%M"), time.localtime(sabnzbd.RSSReader.next_run))
+
+    if active_feed:
+        readout = bool(_rss_refresh_readout)
+        logging.debug("RSS READOUT = %s", readout)
+        if not readout:
+            _rss_refresh_download = False
+            _rss_refresh_force = False
+            _rss_refresh_ignore = False
+        if _rss_evaluate:
+            msg = sabnzbd.RSSReader.process_feed(
+                active_feed,
+                download=_rss_refresh_download,
+                force=_rss_refresh_force,
+                ignore_first=_rss_refresh_ignore,
+                readout=readout,
             )
+        else:
+            msg = ""
+        _rss_evaluate = False
+        if readout:
+            _rss_last_msg = msg
+        else:
+            msg = _rss_last_msg
+        _rss_refresh_readout = None
+        conf["evalButton"] = _rss_show_eval_button
+        conf["error"] = msg
 
-            # Move filter if requested
-            index = int_conv(kwargs.get("index", ""))
-            new_index = kwargs.get("new_index", "")
-            if new_index and int_conv(new_index) != index:
-                feed_cfg.filters.move(int(index), int_conv(new_index))
+        conf["downloaded"], conf["matched"], conf["unmatched"] = GetRssLog(active_feed)
+    else:
+        _rss_last_msg = ""
 
-            config.save_config()
-        self.process_feed(kwargs.get("feed"))
-        raise rssRaiser(self.__root, kwargs)
+    # Find a unique new Feed name
+    unum = 1
+    txt = T("Feed")  # : Used as default Feed name in Config->RSS
+    while txt + str(unum) in feeds:
+        unum += 1
+    conf["feed"] = txt + str(unum)
 
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def del_rss_feed(self, *args, **kwargs):
-        """Remove complete RSS feed"""
-        kwargs["section"] = "rss"
-        kwargs["keyword"] = kwargs.get("feed")
-        del_from_section(kwargs)
-        with sabnzbd.rss.rss_repository(sabnzbd.get_db_connection()) as repo:
-            repo.clear_feed(kwargs.get("feed"))
-        raise Raiser(self.__root)
+    return template_filtered_response(
+        file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "config_rss.tmpl"),
+        search_list=conf,
+    )
 
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def del_rss_filter(self, **kwargs):
-        """Wrapper, so we can call from api.py"""
-        self.internal_del_rss_filter(**kwargs)
 
-    def internal_del_rss_filter(self, **kwargs):
-        """Remove one RSS filter"""
-        try:
-            feed_cfg = config.get_rss()[kwargs.get("feed")]
-        except KeyError:
-            raise rssRaiser(self.__root, kwargs)
+@secured_expose(route="/config/rss/save_rss_rate", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_rss_save_rss_rate(request: Request):
+    """Save changed RSS automatic readout rate"""
+    cfg.rss_rate.set(request.query_params.get("rss_rate"))
+    config.save_config()
+    sabnzbd.Scheduler.restart()
+    return BaseRedirectResponse(_RSS_ROOT)
 
-        feed_cfg.filters.delete(int(kwargs.get("index", 0)))
+
+@secured_expose(route="/config/rss/upd_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_rss_upd_rss_feed(request: Request):
+    """Update Feed level attributes,
+    legacy version: ignores 'enable' parameter
+    """
+    global _rss_evaluate, _rss_show_eval_button
+    params = request.query_params
+    kwargs = dict(params)
+    if params.get("enable") is not None:
+        del kwargs["enable"]
+    try:
+        cf = config.get_rss()[params.get("feed")]
+    except KeyError:
+        cf = None
+    uri = Strip(params.get("uri"))
+    if cf and uri:
+        kwargs["uri"] = uri
+        cf.set_dict(kwargs)
         config.save_config()
-        self.process_feed(kwargs.get("feed"))
-        raise rssRaiser(self.__root, kwargs)
 
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def download_rss_feed(self, *args, **kwargs):
-        """Force download of all matching jobs in a feed"""
-        if "feed" in kwargs:
-            self.process_feed(kwargs["feed"], readout=True, download=True, force=True)
-        raise rssRaiser(self.__root, kwargs)
+    _rss_evaluate = False
+    _rss_show_eval_button = True
+    feed = params.get("feed")
+    return BaseRedirectResponse(_RSS_ROOT, feed=feed) if feed else BaseRedirectResponse(_RSS_ROOT)
 
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def clean_rss_jobs(self, *args, **kwargs):
-        """Remove processed RSS jobs from UI"""
+
+@secured_expose(route="/config/rss/save_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_rss_save_rss_feed(request: Request):
+    """Update Feed level attributes"""
+    params = request.query_params
+    kwargs = dict(params)
+    feed_name = params.get("feed")
+    try:
+        cf = config.get_rss()[feed_name]
+    except KeyError:
+        cf = None
+    if "enable" not in kwargs:
+        kwargs["enable"] = 0
+    uri = Strip(params.get("uri"))
+    if cf and uri:
+        kwargs["uri"] = uri
+        cf.set_dict(kwargs)
+
+        # Did we get a new name for this feed?
+        new_name = params.get("feed_new_name")
+        if new_name and new_name != feed_name:
+            feed_name = cf.rename(new_name)
+
+        config.save_config()
+
+    return BaseRedirectResponse(_RSS_ROOT, feed=feed_name) if feed_name else BaseRedirectResponse(_RSS_ROOT)
+
+
+@secured_expose(route="/config/rss/toggle_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_rss_toggle_rss_feed(request: Request):
+    """Toggle automatic read-out flag of Feed"""
+    params = request.query_params
+    try:
+        item = config.get_rss()[params.get("feed")]
+    except KeyError:
+        item = None
+    if item:
+        item.enable.set(not item.enable())
+        config.save_config()
+    if params.get("table"):
+        return BaseRedirectResponse(_RSS_ROOT)
+    else:
+        feed = params.get("feed")
+        return BaseRedirectResponse(_RSS_ROOT, feed=feed) if feed else BaseRedirectResponse(_RSS_ROOT)
+
+
+@secured_expose(route="/config/rss/add_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_rss_add_rss_feed(request: Request):
+    """Add one new RSS feed definition"""
+    global _rss_refresh_readout, _rss_refresh_download, _rss_refresh_force
+    global _rss_refresh_ignore, _rss_evaluate
+    params = request.query_params
+    kwargs = dict(params)
+    feed = Strip(params.get("feed", "")).strip("[]")
+    uri = Strip(params.get("uri"))
+    if feed and uri:
+        try:
+            rss_cfg = config.get_rss()[feed]
+        except KeyError:
+            rss_cfg = None
+        if not rss_cfg and uri:
+            kwargs["feed"] = feed
+            kwargs["uri"] = uri
+            config.ConfigRSS(feed, kwargs)
+            # Clear out any existing reference to this feed name
+            # Otherwise first-run detection can fail
+            with sabnzbd.rss.rss_repository(sabnzbd.get_db_connection()) as repo:
+                repo.clear_feed(feed)
+            config.save_config()
+            _rss_refresh_readout = feed
+            _rss_refresh_download = False
+            _rss_refresh_force = False
+            _rss_refresh_ignore = True
+            _rss_evaluate = True
+            return BaseRedirectResponse(_RSS_ROOT, feed=feed)
+        else:
+            return BaseRedirectResponse(_RSS_ROOT)
+    else:
+        return BaseRedirectResponse(_RSS_ROOT)
+
+
+@secured_expose(route="/config/rss/upd_rss_filter", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_rss_upd_rss_filter(request: Request):
+    """Save updated filter definition"""
+    do_upd_rss_filter(dict(request.query_params))
+    feed = request.query_params.get("feed")
+    return BaseRedirectResponse(_RSS_ROOT, feed=feed) if feed else BaseRedirectResponse(_RSS_ROOT)
+
+
+@secured_expose(route="/config/rss/del_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_rss_del_rss_feed(request: Request):
+    """Remove complete RSS feed"""
+    feed = request.query_params.get("feed")
+    kw = {"section": "rss", "keyword": feed}
+    del_from_section(kw)
+    with sabnzbd.rss.rss_repository(sabnzbd.get_db_connection()) as repo:
+        repo.clear_feed(feed)
+    return BaseRedirectResponse(_RSS_ROOT)
+
+
+@secured_expose(route="/config/rss/del_rss_filter", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_rss_del_rss_filter(request: Request):
+    """Remove one RSS filter"""
+    do_del_rss_filter(dict(request.query_params))
+    feed = request.query_params.get("feed")
+    return BaseRedirectResponse(_RSS_ROOT, feed=feed) if feed else BaseRedirectResponse(_RSS_ROOT)
+
+
+@secured_expose(route="/config/rss/download_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_rss_download_rss_feed(request: Request):
+    """Force download of all matching jobs in a feed"""
+    global _rss_refresh_readout, _rss_refresh_download, _rss_refresh_force
+    global _rss_refresh_ignore, _rss_evaluate
+    feed = request.query_params.get("feed")
+    if feed:
+        _rss_refresh_readout = feed
+        _rss_refresh_download = True
+        _rss_refresh_force = True
+        _rss_refresh_ignore = False
+        _rss_evaluate = True
+    return BaseRedirectResponse(_RSS_ROOT, feed=feed) if feed else BaseRedirectResponse(_RSS_ROOT)
+
+
+@secured_expose(route="/config/rss/clean_rss_jobs", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_rss_clean_rss_jobs(request: Request):
+    """Remove processed RSS jobs from UI"""
+    global _rss_evaluate
+    feed = request.query_params.get("feed")
+    if feed:
         with sabnzbd.rss.rss_repository(sabnzbd.get_db_connection()) as repo:
-            repo.clear_downloaded(kwargs["feed"])
-        self.process_feed(kwargs["feed"])
-        raise rssRaiser(self.__root, kwargs)
+            repo.clear_downloaded(feed)
+    _rss_evaluate = True
+    return BaseRedirectResponse(_RSS_ROOT, feed=feed) if feed else BaseRedirectResponse(_RSS_ROOT)
 
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def test_rss_feed(self, *args, **kwargs):
-        """Read the feed content again and show results"""
-        if "feed" in kwargs:
-            self.process_feed(kwargs["feed"], readout=True, ignore_first=True)
-        raise rssRaiser(self.__root, kwargs)
 
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def download(self, **kwargs):
-        """Download NZB from provider (Download button)"""
-        feed = kwargs.get("feed")
-        url = kwargs.get("url")
-        db = sabnzbd.get_db_connection()
-        repo = sabnzbd.rss.RSSRepository(db)
-        if att := repo.find_job_by_url(feed, url):
-            nzbname = kwargs.get("nzbname")
-            pp = att.pp
-            cat = att.cat
-            script = att.script
-            priority = att.priority
+@secured_expose(route="/config/rss/test_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_rss_test_rss_feed(request: Request):
+    """Read the feed content again and show results"""
+    global _rss_refresh_readout, _rss_refresh_download, _rss_refresh_force
+    global _rss_refresh_ignore, _rss_evaluate, _rss_show_eval_button
+    feed = request.query_params.get("feed")
+    if feed:
+        _rss_refresh_readout = feed
+        _rss_refresh_download = False
+        _rss_refresh_force = False
+        _rss_refresh_ignore = True
+        _rss_evaluate = True
+        _rss_show_eval_button = False
+    return BaseRedirectResponse(_RSS_ROOT, feed=feed) if feed else BaseRedirectResponse(_RSS_ROOT)
 
-            if url:
-                logging.info("Adding %s (%s) to queue", url, nzbname)
-                sabnzbd.urlgrabber.add_url(
-                    url,
-                    pp=pp,
-                    script=script,
-                    cat=cat,
-                    priority=priority,
-                    nzbname=nzbname,
-                    nzo_info=NzoInfo(RSS=feed),
-                )
-            repo.flag_downloaded(feed, url)
-        raise rssRaiser(self.__root, kwargs)
 
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def rss_now(self, *args, **kwargs):
-        """Run an automatic RSS run now"""
-        sabnzbd.Scheduler.force_rss()
-        raise Raiser(self.__root)
+@secured_expose(route="/config/rss/eval_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_rss_eval_rss_feed(request: Request):
+    """Re-apply the filters to the feed"""
+    global _rss_refresh_download, _rss_refresh_force, _rss_refresh_ignore
+    global _rss_show_eval_button, _rss_evaluate
+    feed = request.query_params.get("feed")
+    if feed:
+        _rss_refresh_download = False
+        _rss_refresh_force = False
+        _rss_refresh_ignore = False
+        _rss_show_eval_button = False
+        _rss_evaluate = True
+
+    return BaseRedirectResponse(_RSS_ROOT, feed=feed) if feed else BaseRedirectResponse(_RSS_ROOT)
+
+
+@secured_expose(route="/config/rss/download", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_rss_download(request: Request):
+    """Download NZB from provider (Download button)"""
+    params = request.query_params
+    feed = params.get("feed")
+    url = params.get("url")
+    repo = sabnzbd.rss.RSSRepository(sabnzbd.get_db_connection())
+    if att := repo.find_job_by_url(feed, url):
+        nzbname = params.get("nzbname")
+        pp = att.pp
+        cat = att.cat
+        script = att.script
+        priority = att.priority
+
+        if url:
+            logging.info("Adding %s (%s) to queue", url, nzbname)
+            sabnzbd.urlgrabber.add_url(
+                url,
+                pp=pp,
+                script=script,
+                cat=cat,
+                priority=priority,
+                nzbname=nzbname,
+                nzo_info=NzoInfo(RSS=feed),
+            )
+        repo.flag_downloaded(feed, url)
+    return BaseRedirectResponse(_RSS_ROOT, feed=feed) if feed else BaseRedirectResponse(_RSS_ROOT)
+
+
+@secured_expose(route="/config/rss/rss_now", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_rss_rss_now(request: Request):
+    """Run an automatic RSS run now"""
+    sabnzbd.Scheduler.force_rss()
+    return BaseRedirectResponse(_RSS_ROOT)
 
 
 def ConvertSpecials(p):
@@ -1560,359 +1664,329 @@ _SCHED_ACTIONS = (
 )
 
 
-class ConfigScheduling:
-    def __init__(self, root):
-        self.__root = root
+_SCHED_ROOT = "/config/scheduling"
 
-    @secured_expose(check_configlock=True)
-    def index(self, **kwargs):
-        def get_days():
-            days = {
-                "*": T("Daily"),
-                "1": T("Monday"),
-                "2": T("Tuesday"),
-                "3": T("Wednesday"),
-                "4": T("Thursday"),
-                "5": T("Friday"),
-                "6": T("Saturday"),
-                "7": T("Sunday"),
-            }
-            return days
 
-        conf = build_header(sabnzbd.WEB_DIR_CONFIG)
+@secured_expose(route="/config/scheduling", check_configlock=True, methods=["GET"])
+async def config_scheduling_index(request: Request):
+    def get_days():
+        days = {
+            "*": T("Daily"),
+            "1": T("Monday"),
+            "2": T("Tuesday"),
+            "3": T("Wednesday"),
+            "4": T("Thursday"),
+            "5": T("Friday"),
+            "6": T("Saturday"),
+            "7": T("Sunday"),
+        }
+        return days
 
-        actions = []
-        actions.extend(_SCHED_ACTIONS)
-        day_names = get_days()
-        categories = list_cats(False)
-        snum = 1
-        conf["schedlines"] = []
-        conf["taskinfo"] = []
-        for ev in sabnzbd.scheduler.sort_schedules(all_events=False):
-            line = ev[3]
-            conf["schedlines"].append(line)
-            try:
-                enabled, m, h, day_numbers, action = line.split(" ", 4)
-            except Exception:
-                continue
-            action = action.strip()
-            try:
-                action, value = action.split(" ", 1)
-            except Exception:
-                value = ""
-            value = value.strip()
-            if value and not value.lower().strip("0123456789kmgtp%."):
-                if "%" not in value and from_units(value) < 1.0:
-                    value = T("off")  # : "Off" value for speedlimit in scheduler
-                else:
-                    if "%" not in value and 1 < int_conv(value) < 101:
-                        value += "%"
-                    value = value.upper()
-            if action in actions:
+    conf = build_header(sabnzbd.WEB_DIR_CONFIG)
+
+    actions = []
+    actions.extend(_SCHED_ACTIONS)
+    day_names = get_days()
+    categories = list_cats(False)
+    snum = 1
+    conf["schedlines"] = []
+    conf["taskinfo"] = []
+    for ev in sabnzbd.scheduler.sort_schedules(all_events=False):
+        line = ev[3]
+        conf["schedlines"].append(line)
+        try:
+            enabled, m, h, day_numbers, action = line.split(" ", 4)
+        except Exception:
+            continue
+        action = action.strip()
+        try:
+            action, value = action.split(" ", 1)
+        except Exception:
+            value = ""
+        value = value.strip()
+        if value and not value.lower().strip("0123456789kmgtp%."):
+            if "%" not in value and from_units(value) < 1.0:
+                value = T("off")  # : "Off" value for speedlimit in scheduler
+            else:
+                if "%" not in value and 1 < int_conv(value) < 101:
+                    value += "%"
+                value = value.upper()
+        if action in actions:
+            action = Ttemplate("sch-" + action)
+        else:
+            if action in ("enable_server", "disable_server"):
+                try:
+                    value = '"%s"' % config.get_servers()[value].displayname()
+                except KeyError:
+                    value = '"%s" <<< %s' % (value, T("Undefined server!"))
                 action = Ttemplate("sch-" + action)
-            else:
-                if action in ("enable_server", "disable_server"):
-                    try:
-                        value = '"%s"' % config.get_servers()[value].displayname()
-                    except KeyError:
-                        value = '"%s" <<< %s' % (value, T("Undefined server!"))
-                    action = Ttemplate("sch-" + action)
-                if action in ("pause_cat", "resume_cat"):
-                    action = Ttemplate("sch-" + action)
-                    if value not in categories:
-                        # Category name change
-                        value = '"%s" <<< %s' % (value, T("Incorrect parameter"))
-                    else:
-                        value = '"%s"' % value
-
-            if day_numbers == "1234567":
-                days_of_week = "Daily"
-            elif day_numbers == "12345":
-                days_of_week = "Weekdays"
-            elif day_numbers == "67":
-                days_of_week = "Weekends"
-            else:
-                days_of_week = ", ".join([day_names.get(i, "**") for i in day_numbers])
-
-            item = (snum, "%02d" % int(h), "%02d" % int(m), days_of_week, "%s %s" % (action, value), enabled)
-
-            conf["taskinfo"].append(item)
-            snum += 1
-
-        actions_lng = {}
-        for action in actions:
-            actions_lng[action] = Ttemplate("sch-" + action)
-
-        actions_servers = {}
-        servers = config.get_servers()
-        for srv in servers:
-            actions_servers[srv] = servers[srv].displayname()
-
-        conf["actions_servers"] = actions_servers
-        conf["actions"] = actions
-        conf["actions_lng"] = actions_lng
-        conf["categories"] = categories
-
-        return template_filtered_response(
-            file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "config_scheduling.tmpl"),
-            search_list=conf,
-        )
-
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def addSchedule(self, **kwargs):
-        servers = config.get_servers()
-        minute = kwargs.get("minute")
-        hour = kwargs.get("hour")
-        days_of_week = "".join([str(x) for x in kwargs.get("daysofweek", "")])
-        if not days_of_week:
-            days_of_week = "1234567"
-        action = kwargs.get("action")
-        arguments = kwargs.get("arguments")
-
-        arguments = arguments.strip().lower()
-        if arguments in ("on", "enable"):
-            arguments = "1"
-        elif arguments in ("off", "disable"):
-            arguments = "0"
-
-        if minute and hour and days_of_week and action:
-            if action == "speedlimit":
-                if not arguments or arguments.strip("0123456789kmgtp%."):
-                    arguments = 0
-            elif action in _SCHED_ACTIONS:
-                arguments = ""
-            elif action in servers:
-                if arguments == "1":
-                    arguments = action
-                    action = "enable_server"
+            if action in ("pause_cat", "resume_cat"):
+                action = Ttemplate("sch-" + action)
+                if value not in categories:
+                    value = '"%s" <<< %s' % (value, T("Incorrect parameter"))
                 else:
-                    arguments = action
-                    action = "disable_server"
+                    value = '"%s"' % value
 
-            elif action in ("pause_cat", "resume_cat"):
-                # Need original category name, not lowercased
-                arguments = arguments.strip()
+        if day_numbers == "1234567":
+            days_of_week = "Daily"
+        elif day_numbers == "12345":
+            days_of_week = "Weekdays"
+        elif day_numbers == "67":
+            days_of_week = "Weekends"
+        else:
+            days_of_week = ", ".join([day_names.get(i, "**") for i in day_numbers])
+
+        item = (snum, "%02d" % int(h), "%02d" % int(m), days_of_week, "%s %s" % (action, value), enabled)
+
+        conf["taskinfo"].append(item)
+        snum += 1
+
+    actions_lng = {}
+    for action in actions:
+        actions_lng[action] = Ttemplate("sch-" + action)
+
+    actions_servers = {}
+    servers = config.get_servers()
+    for srv in servers:
+        actions_servers[srv] = servers[srv].displayname()
+
+    conf["actions_servers"] = actions_servers
+    conf["actions"] = actions
+    conf["actions_lng"] = actions_lng
+    conf["categories"] = categories
+
+    return template_filtered_response(
+        file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "config_scheduling.tmpl"),
+        search_list=conf,
+    )
+
+
+@secured_expose(route="/config/scheduling/add_schedule", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_scheduling_add(request: Request):
+    params = request.query_params
+    servers = config.get_servers()
+    minute = params.get("minute")
+    hour = params.get("hour")
+    days_of_week = "".join([str(x) for x in params.get("daysofweek", "")])
+    if not days_of_week:
+        days_of_week = "1234567"
+    action = params.get("action")
+    arguments = params.get("arguments")
+
+    arguments = arguments.strip().lower()
+    if arguments in ("on", "enable"):
+        arguments = "1"
+    elif arguments in ("off", "disable"):
+        arguments = "0"
+
+    if minute and hour and days_of_week and action:
+        if action == "speedlimit":
+            if not arguments or arguments.strip("0123456789kmgtp%."):
+                arguments = 0
+        elif action in _SCHED_ACTIONS:
+            arguments = ""
+        elif action in servers:
+            if arguments == "1":
+                arguments = action
+                action = "enable_server"
             else:
-                # Something else, leave empty
-                action = None
+                arguments = action
+                action = "disable_server"
 
-            if action:
-                sched = cfg.schedules()
-                sched.append("%s %s %s %s %s %s" % (1, minute, hour, days_of_week, action, arguments))
-                cfg.schedules.set(sched)
+        elif action in ("pause_cat", "resume_cat"):
+            # Need original category name, not lowercased
+            arguments = arguments.strip()
+        else:
+            # Something else, leave empty
+            action = None
 
+        if action:
+            sched = cfg.schedules()
+            sched.append("%s %s %s %s %s %s" % (1, minute, hour, days_of_week, action, arguments))
+            cfg.schedules.set(sched)
+
+    config.save_config()
+    sabnzbd.Scheduler.restart()
+    return BaseRedirectResponse(_SCHED_ROOT)
+
+
+@secured_expose(route="/config/scheduling/del_schedule", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_scheduling_del(request: Request):
+    schedules = cfg.schedules()
+    line = request.query_params.get("line")
+    if line and line in schedules:
+        schedules.remove(line)
+        cfg.schedules.set(schedules)
         config.save_config()
         sabnzbd.Scheduler.restart()
-        raise Raiser(self.__root)
+    return BaseRedirectResponse(_SCHED_ROOT)
 
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def delSchedule(self, **kwargs):
-        schedules = cfg.schedules()
-        line = kwargs.get("line")
-        if line and line in schedules:
-            schedules.remove(line)
-            cfg.schedules.set(schedules)
-            config.save_config()
-            sabnzbd.Scheduler.restart()
-        raise Raiser(self.__root)
 
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def toggleSchedule(self, **kwargs):
-        schedules = cfg.schedules()
-        line = kwargs.get("line")
-        if line:
-            for i, schedule in enumerate(schedules):
-                if schedule == line:
-                    # Toggle the schedule
-                    schedule_split = schedule.split()
-                    schedule_split[0] = "%d" % (schedule_split[0] == "0")
-                    schedules[i] = " ".join(schedule_split)
-                    break
-            cfg.schedules.set(schedules)
-            config.save_config()
-            sabnzbd.Scheduler.restart()
-        raise Raiser(self.__root)
+@secured_expose(route="/config/scheduling/toggle_schedule", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_scheduling_toggle(request: Request):
+    schedules = cfg.schedules()
+    line = request.query_params.get("line")
+    if line:
+        for i, schedule in enumerate(schedules):
+            if schedule == line:
+                # Toggle the schedule
+                schedule_split = schedule.split()
+                schedule_split[0] = "%d" % (schedule_split[0] == "0")
+                schedules[i] = " ".join(schedule_split)
+                break
+        cfg.schedules.set(schedules)
+        config.save_config()
+        sabnzbd.Scheduler.restart()
+    return BaseRedirectResponse(_SCHED_ROOT)
 
 
 ##############################################################################
-class ConfigCats:
-    def __init__(self, root):
-        self.__root = root
-
-    @secured_expose(check_configlock=True)
-    def index(self, **kwargs):
-        conf = build_header(sabnzbd.WEB_DIR_CONFIG)
-
-        conf["scripts"] = list_scripts(default=True)
-        conf["defdir"] = cfg.complete_dir.get_clipped_path()
-
-        categories = config.get_ordered_categories()
-        new_cat_order = max(cat["order"] for cat in categories) + 1
-
-        # Add empty line to add new categories
-        empty = {
-            "name": "",
-            "order": str(new_cat_order),
-            "pp": "-1",
-            "script": "",
-            "dir": "",
-            "newzbin": "",
-            "priority": DEFAULT_PRIORITY,
-        }
-        categories.insert(1, empty)
-        conf["slotinfo"] = categories
-
-        return template_filtered_response(
-            file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "config_cat.tmpl"),
-            search_list=conf,
-        )
-
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def delete(self, **kwargs):
-        kwargs["section"] = "categories"
-        kwargs["keyword"] = kwargs.get("name")
-        del_from_section(kwargs)
-        raise Raiser(self.__root)
-
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def save(self, **kwargs):
-        name = kwargs.get("name", "*")
-        newname = kwargs.get("newname", "")
-        if name == "*":
-            newname = name
-
-        if newname:
-            # Check if this cat-dir is not sub-folder of incomplete
-            if same_directory(cfg.download_dir.get_path(), real_path(cfg.complete_dir.get_path(), kwargs["dir"])):
-                return T("Category folder cannot be a subfolder of the Temporary Download Folder.")
-
-            # Delete current one and replace with new one
-            if name:
-                config.delete("categories", name)
-            config.ConfigCat(newname.lower(), kwargs)
-
-        config.save_config()
-        raise Raiser(self.__root)
-
-
+# Page definitions - Config - Categories
 ##############################################################################
-class ConfigSorting:
-    def __init__(self, root):
-        self.__root = root
-
-    @secured_expose(check_configlock=True)
-    def index(self, **kwargs):
-        conf = build_header(sabnzbd.WEB_DIR_CONFIG)
-
-        sorters = config.get_ordered_sorters()
-        # Add empty sorter entry, used as a template at the top of the page
-        empty = {
-            "is_active": "1",
-            "name": "",
-            "order": len(sorters),  # Last in line
-            "min_size": DEF_SORTER_RENAME_SIZE,
-            "sort_string": "",
-            "sort_cats": "",
-            "sort_type": "0,",
-            "multipart_label": "",
-        }
-        sorters.insert(0, empty)
-        conf["slotinfo"] = sorters
-        conf["categories"] = list_cats(False)
-        conf["guessit_properties"] = tuple(
-            prop for prop in guessit_properties().keys() if prop not in EXCLUDED_GUESSIT_PROPERTIES
-        )
-        conf["sort_types"] = GUESSIT_SORT_TYPES
-
-        return template_filtered_response(
-            file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "config_sorting.tmpl"),
-            search_list=conf,
-        )
-
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def delete(self, **kwargs):
-        kwargs["section"] = "sorters"
-        kwargs["keyword"] = kwargs.get("name")
-        del_from_section(kwargs)
-        raise Raiser(self.__root)
-
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def save_sorter(self, **kwargs):
-        name = kwargs.get("name", "*")
-        newname = kwargs.get("newname", "")
-        newname = config.clean_section_name(newname)
-
-        if name == "*":
-            newname = name
-        if newname:
-            # Delete current one and replace with new one
-            if name:
-                config.delete("sorters", name)
-            config.ConfigSorter(newname, kwargs)
-
-        config.save_config()
-        raise Raiser(self.__root)
-
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def toggle_sorter(self, **kwargs):
-        """Toggle is_active flag of a sorter"""
-        try:
-            sorter = config.get_sorters()[kwargs.get("sorter")]
-            sorter.is_active.set(not sorter.is_active())
-            config.save_config()
-        except Exception:
-            pass
-
-        raise Raiser(self.__root)
 
 
-def badParameterResponse(msg, ajax=None):
-    """Return a html page with error message and a 'back' button"""
-    if ajax:
-        return sabnzbd.api.report(error=msg)
-    else:
-        return """
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
-<html>
-<head>
-           <title>SABnzbd %s - %s</title>
-</head>
-<body>
-<h3>%s</h3>
-%s
-<br><br>
-<FORM><INPUT TYPE="BUTTON" VALUE="%s" ONCLICK="history.go(-1)"></FORM>
-</body>
-</html>
-""" % (
-            sabnzbd.__version__,
-            T("ERROR:"),
-            T("Incorrect parameter"),
-            msg,
-            T("Back"),
-        )
+@secured_expose(route="/config/categories", check_configlock=True, methods=["GET"])
+async def index_config_categories(request: Request):
+    conf = build_header(sabnzbd.WEB_DIR_CONFIG)
 
+    conf["scripts"] = list_scripts(default=True)
+    conf["defdir"] = cfg.complete_dir.get_clipped_path()
 
-def ShowString(name, msg):
-    """Return a html page listing a file and a 'back' button"""
-    return """
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
-<html>
-<head>
-           <title>%s</title>
-</head>
-<body>
-           <FORM><INPUT TYPE="BUTTON" VALUE="%s" ONCLICK="history.go(-1)"></FORM>
-           <h3>%s</h3>
-           <code><pre>%s</pre></code>
-</body>
-</html>
-""" % (
-        xml_name(name),
-        T("Back"),
-        xml_name(name),
-        escape(msg),
+    categories = config.get_ordered_categories()
+    new_cat_order = max(cat["order"] for cat in categories) + 1
+
+    # Add empty line to add new categories
+    empty = {
+        "name": "",
+        "order": str(new_cat_order),
+        "pp": "-1",
+        "script": "",
+        "dir": "",
+        "newzbin": "",
+        "priority": DEFAULT_PRIORITY,
+    }
+    categories.insert(1, empty)
+    conf["slotinfo"] = categories
+
+    return template_filtered_response(
+        file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "config_cat.tmpl"),
+        search_list=conf,
     )
+
+
+@secured_expose(route="/config/categories/delete", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_categories_delete(request: Request):
+    kw = {
+        "section": "categories",
+        "keyword": request.query_params.get("name"),
+    }
+    del_from_section(kw)
+    return BaseRedirectResponse("/config/categories")
+
+
+@secured_expose(route="/config/categories/save", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_categories_save(request: Request):
+    name = request.query_params.get("name", "*")
+    newname = request.query_params.get("newname", "")
+    if name == "*":
+        newname = name
+
+    if newname:
+        cat_params = dict(request.query_params)
+        # Validate directory not under incomplete
+        if same_directory(
+            cfg.download_dir.get_path(),
+            real_path(cfg.complete_dir.get_path(), cat_params.get("dir", "")),
+        ):
+            return report(
+                request.query_params,
+                error=T("Category folder cannot be a subfolder of the Temporary Download Folder."),
+            )
+
+        # Delete current one and replace with new one
+        if name:
+            config.delete("categories", name)
+        config.ConfigCat(newname.lower(), cat_params)
+
+    config.save_config()
+    return BaseRedirectResponse("/config/categories")
+
+
+##############################################################################
+# Config - Sorting (standalone route functions)
+##############################################################################
+
+_SORTING_ROOT = "/config/sorting"
+
+
+@secured_expose(route="/config/sorting", check_configlock=True, methods=["GET"])
+async def config_sorting_index(request: Request):
+    conf = build_header(sabnzbd.WEB_DIR_CONFIG)
+
+    sorters = config.get_ordered_sorters()
+    # Add empty sorter entry, used as a template at the top of the page
+    empty = {
+        "is_active": "1",
+        "name": "",
+        "order": len(sorters),  # Last in line
+        "min_size": DEF_SORTER_RENAME_SIZE,
+        "sort_string": "",
+        "sort_cats": "",
+        "sort_type": "0,",
+        "multipart_label": "",
+    }
+    sorters.insert(0, empty)
+    conf["slotinfo"] = sorters
+    conf["categories"] = list_cats(False)
+    conf["guessit_properties"] = tuple(
+        prop for prop in guessit_properties().keys() if prop not in EXCLUDED_GUESSIT_PROPERTIES
+    )
+    conf["sort_types"] = GUESSIT_SORT_TYPES
+
+    return template_filtered_response(
+        file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "config_sorting.tmpl"),
+        search_list=conf,
+    )
+
+
+@secured_expose(route="/config/sorting/delete", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_sorting_delete(request: Request):
+    kw = {"section": "sorters", "keyword": request.query_params.get("name")}
+    del_from_section(kw)
+    return BaseRedirectResponse(_SORTING_ROOT)
+
+
+@secured_expose(route="/config/sorting/save_sorter", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_sorting_save_sorter(request: Request):
+    params = request.query_params
+    kwargs = dict(params)
+    name = params.get("name", "*")
+    newname = params.get("newname", "")
+    newname = config.clean_section_name(newname)
+
+    if name == "*":
+        newname = name
+    if newname:
+        # Delete current one and replace with new one
+        if name:
+            config.delete("sorters", name)
+        config.ConfigSorter(newname, kwargs)
+
+    config.save_config()
+    return BaseRedirectResponse(_SORTING_ROOT)
+
+
+@secured_expose(route="/config/sorting/toggle_sorter", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_sorting_toggle_sorter(request: Request):
+    """Toggle is_active flag of a sorter"""
+    try:
+        sorter = config.get_sorters()[request.query_params.get("sorter")]
+        sorter.is_active.set(not sorter.is_active())
+        config.save_config()
+    except Exception:
+        pass
+
+    return BaseRedirectResponse(_SORTING_ROOT)
 
 
 def GetRssLog(feed):
@@ -2151,39 +2225,83 @@ NOTIFY_OPTIONS = {
 }
 
 
-class ConfigNotify:
-    def __init__(self, root):
-        self.__root = root
+##############################################################################
+# Page definitions - Config - Notify
+##############################################################################
 
-    @secured_expose(check_configlock=True)
-    def index(self, **kwargs):
-        conf = build_header(sabnzbd.WEB_DIR_CONFIG)
-        conf["notify_types"] = sabnzbd.notifier.NOTIFICATION_TYPES
-        conf["categories"] = list_cats(False)
-        conf["have_ntfosd"] = sabnzbd.notifier.have_ntfosd()
-        conf["have_ncenter"] = sabnzbd.MACOS and sabnzbd.FOUNDATION
-        conf["scripts"] = list_scripts(default=False, none=True)
 
-        for section in NOTIFY_OPTIONS:
-            for option in NOTIFY_OPTIONS[section]:
-                conf[option] = config.get_config(section, option)()
+@secured_expose(route="/config/notify", check_configlock=True, methods=["GET"])
+async def index_config_notify(request: Request):
+    conf = build_header(sabnzbd.WEB_DIR_CONFIG)
+    conf["notify_types"] = sabnzbd.notifier.NOTIFICATION_TYPES
+    conf["categories"] = list_cats(False)
+    conf["have_ntfosd"] = sabnzbd.notifier.have_ntfosd()
+    conf["have_ncenter"] = sabnzbd.MACOS and sabnzbd.FOUNDATION
+    conf["scripts"] = list_scripts(default=False, none=True)
 
-        # Use get_string to make sure lists are displayed correctly
-        conf["email_to"] = cfg.email_to.get_string()
+    for section in NOTIFY_OPTIONS:
+        for option in NOTIFY_OPTIONS[section]:
+            conf[option] = config.get_config(section, option)()
 
-        return template_filtered_response(
-            file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "config_notify.tmpl"),
-            search_list=conf,
-        )
+    # Use get_string to make sure lists are displayed correctly
+    conf["email_to"] = cfg.email_to.get_string()
 
-    @secured_expose(check_api_key=True, check_configlock=True)
-    def saveNotify(self, **kwargs):
-        for section in NOTIFY_OPTIONS:
-            for option in NOTIFY_OPTIONS[section]:
-                if msg := config.get_config(section, option).set(kwargs.get(option)):
-                    return badParameterResponse(msg, kwargs.get("ajax"))
-        config.save_config()
-        if kwargs.get("ajax"):
-            return sabnzbd.api.report()
-        else:
-            raise Raiser(self.__root)
+    return template_filtered_response(
+        file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "config_notify.tmpl"),
+        search_list=conf,
+    )
+
+
+@secured_expose(route="/config/notify/save", check_api_key=True, check_configlock=True, methods=["POST"])
+async def config_notify_save(request: Request):
+    for section in NOTIFY_OPTIONS:
+        for option in NOTIFY_OPTIONS[section]:
+            if msg := config.get_config(section, option).set(request.query_params.get(option)):
+                return report(request.query_params, error=msg)
+    config.save_config()
+    return report(request.query_params)
+
+
+##############################################################################
+# New
+##############################################################################
+
+
+class ThreadedServer(uvicorn.Server):
+    def __init__(self, *args, **kwargs):
+        self.thread = None
+        super().__init__(*args, **kwargs)
+
+    def install_signal_handlers(self):
+        pass
+
+    def run_in_thread(self):
+        self.thread = threading.Thread(target=self.run)
+        self.thread.start()
+
+        while not self.started:
+            time.sleep(1e-3)
+
+    def stop(self):
+        self.should_exit = True
+        self.thread.join()
+
+
+INTERFACE_ROUTES.extend(
+    [
+        Route("/sabnzbd", endpoint=main_index, methods=["GET"]),
+        Mount("/static", app=StaticFiles(directory="interfaces/Glitter/templates/static"), name="static"),
+        Mount("/staticcfg", app=StaticFiles(directory="interfaces/Config/templates/staticcfg"), name="staticcfg"),
+        Mount("/wizard/static", app=StaticFiles(directory="interfaces/wizard/static"), name="wizard_static"),
+    ]
+)
+
+routes = [
+    Mount("/sabnzbd", routes=INTERFACE_ROUTES),
+    Mount("/", routes=INTERFACE_ROUTES),
+]
+
+
+middleware = [Middleware(GZipMiddleware, minimum_size=1000, compresslevel=2)]
+
+app = Starlette(middleware=middleware, routes=routes)

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -502,8 +502,8 @@ def scriptlog(request: Request):
     """Needed for all skins, URL is fixed due to postproc"""
     # No session key check, due to fixed URLs in history database
     if name := request_params(request).get("name"):
-        history_db = sabnzbd.get_db_connection()
-        return PlainTextResponse(history_db.get_script_log(name))
+        with sabnzbd.db_pool.connection() as history_db:
+            return PlainTextResponse(history_db.get_script_log(name))
     return PlainTextResponse("")
 
 
@@ -1455,7 +1455,7 @@ def config_rss_add_rss_feed(request: Request):
             config.ConfigRSS(feed, kwargs)
             # Clear out any existing reference to this feed name
             # Otherwise first-run detection can fail
-            with sabnzbd.rss.rss_repository(sabnzbd.get_db_connection()) as repo:
+            with sabnzbd.rss.rss_repository() as repo:
                 repo.clear_feed(feed)
             config.save_config()
             # Read out the new feed now (this handler runs in the threadpool) and
@@ -1481,7 +1481,7 @@ def config_rss_del_rss_feed(request: Request):
     feed = request_params(request).get("feed")
     kw = {"section": "rss", "keyword": feed}
     del_from_section(kw)
-    with sabnzbd.rss.rss_repository(sabnzbd.get_db_connection()) as repo:
+    with sabnzbd.rss.rss_repository() as repo:
         repo.clear_feed(feed)
     return BaseRedirectResponse(_RSS_ROOT)
 
@@ -1509,7 +1509,7 @@ def config_rss_clean_rss_jobs(request: Request):
     """Remove processed RSS jobs from UI"""
     feed = request_params(request).get("feed")
     if feed:
-        with sabnzbd.rss.rss_repository(sabnzbd.get_db_connection()) as repo:
+        with sabnzbd.rss.rss_repository() as repo:
             repo.clear_downloaded(feed)
         # Re-evaluate cached items (no network read-out) so the log refreshes.
         sabnzbd.RSSReader.process_feed(feed, readout=False)
@@ -1543,26 +1543,26 @@ def config_rss_download(request: Request):
     params = request_params(request)
     feed = params.get("feed")
     url = params.get("url")
-    repo = sabnzbd.rss.RSSRepository(sabnzbd.get_db_connection())
-    if att := repo.find_job_by_url(feed, url):
-        nzbname = params.get("nzbname")
-        pp = att.pp
-        cat = att.cat
-        script = att.script
-        priority = att.priority
+    with sabnzbd.rss.rss_repository() as repo:
+        if att := repo.find_job_by_url(feed, url):
+            nzbname = params.get("nzbname")
+            pp = att.pp
+            cat = att.cat
+            script = att.script
+            priority = att.priority
 
-        if url:
-            logging.info("Adding %s (%s) to queue", url, nzbname)
-            sabnzbd.urlgrabber.add_url(
-                url,
-                pp=pp,
-                script=script,
-                cat=cat,
-                priority=priority,
-                nzbname=nzbname,
-                nzo_info=NzoInfo(RSS=feed),
-            )
-        repo.flag_downloaded(feed, url)
+            if url:
+                logging.info("Adding %s (%s) to queue", url, nzbname)
+                sabnzbd.urlgrabber.add_url(
+                    url,
+                    pp=pp,
+                    script=script,
+                    cat=cat,
+                    priority=priority,
+                    nzbname=nzbname,
+                    nzo_info=NzoInfo(RSS=feed),
+                )
+            repo.flag_downloaded(feed, url)
     return _rss_redirect(feed)
 
 
@@ -1987,7 +1987,7 @@ def GetRssLog(feed):
 
         return job
 
-    with sabnzbd.rss.rss_repository(sabnzbd.get_db_connection()) as repo:
+    with sabnzbd.rss.rss_repository() as repo:
         good, bad, done = ([], [], [])
         for job in repo.get_feed_jobs(feed, states=[RSSState.GOOD, RSSState.BAD, RSSState.DOWNLOADED]):
             if job.is_good:

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -1157,15 +1157,17 @@ async def config_upload_backup(request: Request):
     return report(request_params(request), error=T("Invalid backup archive"))
 
 
-def change_web_dir(web_dir):
+def change_web_dir(web_dir: str) -> Optional[str]:
     web_dir, web_color = web_dir.split(" - ")
     web_dir_path = real_path(sabnzbd.DIR_INTERFACES, web_dir)
 
     if not os.path.exists(web_dir_path):
         logging.info("Cannot find web template: %s", web_dir_path)
+        return "Cannot find web template: %s" % web_dir_path
     else:
         cfg.web_dir.set(web_dir)
         cfg.web_color.set(web_color)
+        return None
 
 
 ##############################################################################

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -37,7 +37,7 @@ from random import randint
 import uvicorn
 from starlette.applications import Starlette
 from starlette.concurrency import run_in_threadpool
-from starlette.datastructures import MultiDict, QueryParams
+from starlette.datastructures import Address, MultiDict, QueryParams
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, RedirectResponse, PlainTextResponse, Response, FileResponse
 from starlette.middleware import Middleware
@@ -189,6 +189,13 @@ def secured_expose(
     return internal_wrap
 
 
+def client_address(request: Request) -> Address:
+    """Safe access to request.client, which can be None (e.g. when serving on a
+    unix socket, or with some test clients). Treated as an unknown, non-local
+    client, so access checks fail closed."""
+    return request.client or Address("", 0)
+
+
 def check_access(request: Request, access_type: int = 4, warn_user: bool = False) -> bool:
     """Check if external address is allowed given access_type (Starlette version):
     1=nzb
@@ -205,7 +212,7 @@ def check_access(request: Request, access_type: int = 4, warn_user: bool = False
     # uvicorn.Config in SABnzbd.py): when verify_xff_header is enabled and the
     # connecting peer is a trusted local proxy, request.client already holds the
     # effective client address taken from the XFF chain.
-    remote_ip = request.client.host
+    remote_ip = client_address(request).host
 
     # Check if the client IP is a loopback address or considered local
     is_allowed = is_loopback_addr(remote_ip) or is_local_addr(remote_ip)
@@ -267,7 +274,7 @@ def set_login_cookie(request: Request, response: Response, remove=False, remembe
 
     # request.client is the effective client: uvicorn resolves the XFF header
     # from trusted proxies when verify_xff_header is enabled
-    cookie_str = utob(str(salt) + request.client.host + COOKIE_SECRET)
+    cookie_str = utob(str(salt) + client_address(request).host + COOKIE_SECRET)
     cookie_value = hashlib.sha1(cookie_str).hexdigest()
 
     secure = cfg.enable_https()
@@ -341,7 +348,7 @@ def check_login_cookie(request: Request) -> bool:
 
     # request.client is the effective client: uvicorn resolves the XFF header
     # from trusted proxies when verify_xff_header is enabled
-    cookie_str = utob(str(login_salt) + request.client.host + COOKIE_SECRET)
+    cookie_str = utob(str(login_salt) + client_address(request).host + COOKIE_SECRET)
     return login_cookie == hashlib.sha1(cookie_str).hexdigest()
 
 
@@ -393,7 +400,7 @@ def template_filtered_response(file: str, search_list: dict[str, Any]):
 def log_warning_and_ip(request: Request, txt: str):
     """Include the IP and the Proxy-IP for warnings (Starlette version)"""
     if cfg.api_warnings():
-        remote_info = f"{request.client.host}:{request.client.port}"
+        remote_info = "%s:%s" % client_address(request)
         if cfg.verify_xff_header() and (xff_ips := request.headers.get("X-Forwarded-For")):
             remote_info += f" (X-Forwarded-For: {xff_ips})"
         logging.warning("%s %s", txt, remote_info)
@@ -516,7 +523,7 @@ def robots_txt(request: Request):
 @secured_expose(route="/description.xml", check_for_login=False, methods=["GET"])
 def description_xml(request: Request):
     """Provide the description.xml which was broadcast via SSDP"""
-    if is_lan_addr(request.client.host):
+    if is_lan_addr(client_address(request).host):
         response = Response(content=sabnzbd.utils.ssdp.server_ssdp_xml(), media_type="application/xml")
         return response
     else:
@@ -703,7 +710,7 @@ def login_index(request: Request):
         # Save login cookie
         set_login_cookie(request, response, remember_me=remember_me)
         # Log the success
-        remote_info = f"{request.client.host}:{request.client.port}"
+        remote_info = "%s:%s" % client_address(request)
         if cfg.verify_xff_header() and (xff_ips := request.headers.get("X-Forwarded-For")):
             remote_info += f" (X-Forwarded-For: {xff_ips})"
         logging.info("Successful login from %s", remote_info)
@@ -711,7 +718,7 @@ def login_index(request: Request):
     elif username or password:
         info["error"] = T("Authentication failed, check username/password.")
         # Warn about the potential security problem
-        remote_info = f"{request.client.host}:{request.client.port}"
+        remote_info = "%s:%s" % client_address(request)
         if cfg.verify_xff_header() and (xff_ips := request.headers.get("X-Forwarded-For")):
             remote_info += f" (X-Forwarded-For: {xff_ips})"
         logging.warning(T("Unsuccessful login attempt from %s"), remote_info)

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -140,8 +140,9 @@ def secured_expose(
 
     @functools.wraps(wrap_func)
     async def internal_wrap(request: Request, *args, **kwargs):
-        # Populate request._query_params from the correct source for this method
-        request._query_params = await get_request_params(request)
+        # Store the merged parameters for this method on request.state,
+        # to be retrieved with request_params(request) in the handlers
+        request.state.params = await get_request_params(request)
 
         # Check if config is locked
         if check_configlock and cfg.configlock():
@@ -341,8 +342,8 @@ def check_apikey(request: Request) -> Optional[str]:
     """Check API-key or NZB-key (Starlette version)
     Return None when OK, otherwise an error message
     """
-    mode = request.query_params.get("mode", "")
-    name = request.query_params.get("name", "")
+    mode = request_params(request).get("mode", "")
+    name = request_params(request).get("name", "")
 
     # Lookup required access level for the specific api-call
     req_access = sabnzbd.api.api_level(mode, name)
@@ -354,7 +355,7 @@ def check_apikey(request: Request) -> Optional[str]:
         return None
 
     # First check API-key, if OK that's sufficient
-    key = request.query_params.get("apikey")
+    key = request_params(request).get("apikey")
     if not key:
         log_warning_and_ip(
             request, T("API Key missing, please enter the api key from Config->General into your 3rd party program:")
@@ -399,8 +400,8 @@ async def get_request_params(request: Request) -> MultiDict | QueryParams:
 
     For GET (and any non-form POST) only the URL query string is used.
 
-    secured_expose stores the result on request._query_params so that
-    request.query_params returns it in every handler without an extra await.
+    secured_expose stores the result on request.state.params so that
+    request_params(request) returns it in every handler without an extra await.
     """
     if request.method == "POST":
         if request.headers.get("content-type", "").startswith(
@@ -409,6 +410,11 @@ async def get_request_params(request: Request) -> MultiDict | QueryParams:
             return MultiDict(await request.form())
 
     return request.query_params
+
+
+def request_params(request: Request) -> MultiDict | QueryParams:
+    """Accessor for the merged GET/POST parameters stored by secured_expose"""
+    return request.state.params
 
 
 # Disable over-active logging for the form parser
@@ -442,7 +448,7 @@ def BaseRedirectResponse(root: str = "", **kwargs) -> RedirectResponse:
 @secured_expose(route="/", methods=["GET"])
 async def main_index(request: Request):
     # Redirect to wizard if no servers are set
-    if request.query_params.get("skip_wizard") or config.get_servers():
+    if request_params(request).get("skip_wizard") or config.get_servers():
         info = build_header()
 
         info["have_rss_defined"] = bool(config.get_rss())
@@ -470,7 +476,7 @@ async def main_index(request: Request):
 @secured_expose(route="/shutdown", check_api_key=True)
 async def shutdown(request: Request):
     # Check for PID
-    pid_in = request.query_params.get("pid")
+    pid_in = request_params(request).get("pid")
     if pid_in and int(pid_in) != os.getpid():
         return PlainTextResponse("Incorrect PID for this instance, remove PID from URL to initiate shutdown.")
 
@@ -487,14 +493,14 @@ async def shutdown(request: Request):
 @secured_expose(route="/api", check_api_key=True, access_type=1)
 async def api(request: Request):
     """Redirect to API-handler, we check the access_type in the API-handler"""
-    return api_handler(request.query_params)
+    return api_handler(request_params(request))
 
 
 @secured_expose(route="/scriptlog", methods=["GET"])
 async def scriptlog(request: Request):
     """Needed for all skins, URL is fixed due to postproc"""
     # No session key check, due to fixed URLs in history database
-    if name := request.query_params.get("name"):
+    if name := request_params(request).get("name"):
         history_db = sabnzbd.get_db_connection()
         return PlainTextResponse(history_db.get_script_log(name))
     return PlainTextResponse("")
@@ -545,8 +551,8 @@ async def wizard_index(request: Request):
 @secured_expose(route="/wizard/one", check_configlock=True, methods=["GET", "POST"])
 async def wizard_page_one(request: Request):
     """Accept language and show server page"""
-    if request.query_params.get("lang"):
-        cfg.language.set(request.query_params.get("lang"))
+    if request_params(request).get("lang"):
+        cfg.language.set(request_params(request).get("lang"))
 
     info = build_header(sabnzbd.WIZARD_DIR)
 
@@ -590,8 +596,8 @@ async def wizard_page_one(request: Request):
 async def wizard_page_two(request: Request):
     """Accept server and show the final page for restart"""
     # Save server details if submitted — no host means the user skipped server setup
-    if request.query_params.get("host"):
-        handle_server(request.query_params)
+    if request_params(request).get("host"):
+        handle_server(request_params(request))
 
     # Show Restart screen
     info = build_header(sabnzbd.WIZARD_DIR)
@@ -681,9 +687,9 @@ async def login_index(request: Request):
     info["error"] = ""
 
     # Use unified params - works for both GET and POST requests
-    username = request.query_params.get("username")
-    password = request.query_params.get("password")
-    remember_me = request.query_params.get("remember_me", False)
+    username = request_params(request).get("username")
+    password = request_params(request).get("password")
+    remember_me = request_params(request).get("remember_me", False)
 
     # Check if there's even a username/password set
     if check_login(request):
@@ -786,11 +792,11 @@ async def index_config_folders(request: Request):
 @secured_expose(route="/config/folders/save", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_folder_save(request: Request):
     for kw in LIST_DIRPAGE + LIST_BOOL_DIRPAGE:
-        if msg := config.get_config("misc", kw).set(request.query_params.get(kw)):
-            return report(request.query_params, error=msg)
+        if msg := config.get_config("misc", kw).set(request_params(request).get(kw)):
+            return report(request_params(request), error=msg)
 
     config.save_config()
-    return report(request.query_params)
+    return report(request_params(request))
 
 
 ##############################################################################
@@ -864,11 +870,11 @@ async def index_config_switches(request: Request):
 @secured_expose(route="/config/switches/save", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_switches_save(request: Request):
     for kw in SWITCH_LIST:
-        if msg := config.get_config("misc", kw).set(request.query_params.get(kw)):
-            return report(request.query_params, error=msg)
+        if msg := config.get_config("misc", kw).set(request_params(request).get(kw)):
+            return report(request_params(request), error=msg)
 
     config.save_config()
-    return report(request.query_params)
+    return report(request_params(request))
 
 
 ##############################################################################
@@ -964,11 +970,11 @@ async def index_config_special(request: Request):
 @secured_expose(route="/config/special/save", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_special_save(request: Request):
     for kw in SPECIAL_BOOL_LIST + SPECIAL_VALUE_LIST + SPECIAL_LIST_LIST:
-        if msg := config.get_config("misc", kw).set(request.query_params.get(kw)):
-            return report(request.query_params, error=msg)
+        if msg := config.get_config("misc", kw).set(request_params(request).get(kw)):
+            return report(request_params(request), error=msg)
 
     config.save_config()
-    return report(request.query_params)
+    return report(request_params(request))
 
 
 ##############################################################################
@@ -1032,35 +1038,35 @@ async def index_config_general(request: Request):
 async def config_general_save(request: Request):
     # Handle general options
     for kw in GENERAL_LIST:
-        if msg := config.get_config("misc", kw).set(request.query_params.get(kw)):
-            return report(request.query_params, error=msg)
+        if msg := config.get_config("misc", kw).set(request_params(request).get(kw)):
+            return report(request_params(request), error=msg)
 
     # Handle special options
-    cfg.password.set(request.query_params.get("password"))
+    cfg.password.set(request_params(request).get("password"))
 
-    if web_dir := request.query_params.get("web_dir"):
+    if web_dir := request_params(request).get("web_dir"):
         if msg := change_web_dir(web_dir):
-            return report(request.query_params, error=msg)
+            return report(request_params(request), error=msg)
 
     config.save_config()
-    return report(request.query_params, data={"success": True, "restart_req": sabnzbd.RESTART_REQ})
+    return report(request_params(request), data={"success": True, "restart_req": sabnzbd.RESTART_REQ})
 
 
 @secured_expose(route="/config/general/upload_config", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_upload_backup(request: Request):
     """Restore a config backup"""
-    # secured_expose already parsed the multipart body into request.query_params
-    config_backup_file = request.query_params.get("config_backup_file")
+    # secured_expose already parsed the multipart body into request.state.params
+    config_backup_file = request_params(request).get("config_backup_file")
 
     # Only accept the backup file if it can be opened as a zip archive and only contains a config file
     try:
         config_backup_data = await config_backup_file.read()
         if config.validate_config_backup(config_backup_data):
             sabnzbd.RESTORE_DATA = config_backup_data
-            return report(request.query_params, data={"success": True, "restart_req": True})
+            return report(request_params(request), data={"success": True, "restart_req": True})
     except Exception:
         pass
-    return report(request.query_params, error=T("Invalid backup archive"))
+    return report(request_params(request), error=T("Invalid backup archive"))
 
 
 def change_web_dir(web_dir):
@@ -1117,24 +1123,24 @@ async def index_config_server(request: Request):
 
 @secured_expose(route="/config/server/add_server", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_server_add(request: Request):
-    return handle_server(request.query_params, new_svr=True)
+    return handle_server(request_params(request), new_svr=True)
 
 
 @secured_expose(route="/config/server/save_server", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_server_save(request: Request):
-    return handle_server(request.query_params)
+    return handle_server(request_params(request))
 
 
 @secured_expose(route="/config/server/delete_server", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_server_del(request: Request):
-    kw = {"section": "servers", "keyword": request.query_params.get("server")}
+    kw = {"section": "servers", "keyword": request_params(request).get("server")}
     del_from_section(kw)
     return BaseRedirectResponse("/config/server")
 
 
 @secured_expose(route="/config/server/clear_server", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_server_clr(request: Request):
-    server = request.query_params.get("server")
+    server = request_params(request).get("server")
     if server:
         sabnzbd.BPSMeter.clear_server(server)
     return BaseRedirectResponse("/config/server")
@@ -1142,7 +1148,7 @@ async def config_server_clr(request: Request):
 
 @secured_expose(route="/config/server/toggle_server", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_server_toggle(request: Request):
-    server = request.query_params.get("server")
+    server = request_params(request).get("server")
     if server:
         svr = config.get_config("servers", server)
         if svr:
@@ -1328,7 +1334,7 @@ async def config_rss_index(request: Request):
         rss[feed]["baselink"] = [get_base_url(uri) for uri in rss[feed]["uri"]]
         rss[feed]["uris"] = feeds[feed].uri.get_string()
 
-    active_feed = request.query_params.get("feed", "")
+    active_feed = request_params(request).get("feed", "")
     conf["active_feed"] = active_feed
     conf["rss"] = rss
     conf["rss_next"] = time.strftime(time_format("%H:%M"), time.localtime(sabnzbd.RSSReader.next_run))
@@ -1357,7 +1363,7 @@ async def config_rss_index(request: Request):
 @secured_expose(route="/config/rss/save_rss_rate", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_rss_save_rss_rate(request: Request):
     """Save changed RSS automatic readout rate"""
-    cfg.rss_rate.set(request.query_params.get("rss_rate"))
+    cfg.rss_rate.set(request_params(request).get("rss_rate"))
     config.save_config()
     sabnzbd.Scheduler.restart()
     return BaseRedirectResponse(_RSS_ROOT)
@@ -1368,7 +1374,7 @@ async def config_rss_upd_rss_feed(request: Request):
     """Update Feed level attributes,
     legacy version: ignores 'enable' parameter
     """
-    params = request.query_params
+    params = request_params(request)
     kwargs = dict(params)
     if params.get("enable") is not None:
         del kwargs["enable"]
@@ -1388,7 +1394,7 @@ async def config_rss_upd_rss_feed(request: Request):
 @secured_expose(route="/config/rss/save_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_rss_save_rss_feed(request: Request):
     """Update Feed level attributes"""
-    params = request.query_params
+    params = request_params(request)
     kwargs = dict(params)
     feed_name = params.get("feed")
     try:
@@ -1415,7 +1421,7 @@ async def config_rss_save_rss_feed(request: Request):
 @secured_expose(route="/config/rss/toggle_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_rss_toggle_rss_feed(request: Request):
     """Toggle automatic read-out flag of Feed"""
-    params = request.query_params
+    params = request_params(request)
     try:
         item = config.get_rss()[params.get("feed")]
     except KeyError:
@@ -1433,7 +1439,7 @@ async def config_rss_toggle_rss_feed(request: Request):
 @secured_expose(route="/config/rss/add_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_rss_add_rss_feed(request: Request):
     """Add one new RSS feed definition"""
-    params = request.query_params
+    params = request_params(request)
     kwargs = dict(params)
     feed = Strip(params.get("feed", "")).strip("[]")
     uri = Strip(params.get("uri"))
@@ -1464,14 +1470,14 @@ async def config_rss_add_rss_feed(request: Request):
 @secured_expose(route="/config/rss/upd_rss_filter", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_rss_upd_rss_filter(request: Request):
     """Save updated filter definition"""
-    do_upd_rss_filter(dict(request.query_params))
-    return _rss_redirect(request.query_params.get("feed"))
+    do_upd_rss_filter(dict(request_params(request)))
+    return _rss_redirect(request_params(request).get("feed"))
 
 
 @secured_expose(route="/config/rss/del_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_rss_del_rss_feed(request: Request):
     """Remove complete RSS feed"""
-    feed = request.query_params.get("feed")
+    feed = request_params(request).get("feed")
     kw = {"section": "rss", "keyword": feed}
     del_from_section(kw)
     with sabnzbd.rss.rss_repository(sabnzbd.get_db_connection()) as repo:
@@ -1482,14 +1488,14 @@ async def config_rss_del_rss_feed(request: Request):
 @secured_expose(route="/config/rss/del_rss_filter", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_rss_del_rss_filter(request: Request):
     """Remove one RSS filter"""
-    do_del_rss_filter(dict(request.query_params))
-    return _rss_redirect(request.query_params.get("feed"))
+    do_del_rss_filter(dict(request_params(request)))
+    return _rss_redirect(request_params(request).get("feed"))
 
 
 @secured_expose(route="/config/rss/download_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_rss_download_rss_feed(request: Request):
     """Force download of all matching jobs in a feed"""
-    feed = request.query_params.get("feed")
+    feed = request_params(request).get("feed")
     if not feed:
         return _rss_redirect()
     # Network read-out with forced download; run off the event loop.
@@ -1500,7 +1506,7 @@ async def config_rss_download_rss_feed(request: Request):
 @secured_expose(route="/config/rss/clean_rss_jobs", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_rss_clean_rss_jobs(request: Request):
     """Remove processed RSS jobs from UI"""
-    feed = request.query_params.get("feed")
+    feed = request_params(request).get("feed")
     if feed:
         with sabnzbd.rss.rss_repository(sabnzbd.get_db_connection()) as repo:
             repo.clear_downloaded(feed)
@@ -1512,7 +1518,7 @@ async def config_rss_clean_rss_jobs(request: Request):
 @secured_expose(route="/config/rss/test_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_rss_test_rss_feed(request: Request):
     """Read the feed content again and show results"""
-    feed = request.query_params.get("feed")
+    feed = request_params(request).get("feed")
     if not feed:
         return _rss_redirect()
     # Network read-out; run off the event loop.
@@ -1523,7 +1529,7 @@ async def config_rss_test_rss_feed(request: Request):
 @secured_expose(route="/config/rss/eval_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_rss_eval_rss_feed(request: Request):
     """Re-apply the filters to the feed"""
-    feed = request.query_params.get("feed")
+    feed = request_params(request).get("feed")
     if feed:
         # Re-evaluate cached items against current filters (no network read-out).
         sabnzbd.RSSReader.process_feed(feed, readout=False)
@@ -1533,7 +1539,7 @@ async def config_rss_eval_rss_feed(request: Request):
 @secured_expose(route="/config/rss/download", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_rss_download(request: Request):
     """Download NZB from provider (Download button)"""
-    params = request.query_params
+    params = request_params(request)
     feed = params.get("feed")
     url = params.get("url")
     repo = sabnzbd.rss.RSSRepository(sabnzbd.get_db_connection())
@@ -1708,7 +1714,7 @@ async def config_scheduling_index(request: Request):
 
 @secured_expose(route="/config/scheduling/add_schedule", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_scheduling_add(request: Request):
-    params = request.query_params
+    params = request_params(request)
     servers = config.get_servers()
     minute = params.get("minute")
     hour = params.get("hour")
@@ -1758,7 +1764,7 @@ async def config_scheduling_add(request: Request):
 @secured_expose(route="/config/scheduling/del_schedule", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_scheduling_del(request: Request):
     schedules = cfg.schedules()
-    line = request.query_params.get("line")
+    line = request_params(request).get("line")
     if line and line in schedules:
         schedules.remove(line)
         cfg.schedules.set(schedules)
@@ -1770,7 +1776,7 @@ async def config_scheduling_del(request: Request):
 @secured_expose(route="/config/scheduling/toggle_schedule", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_scheduling_toggle(request: Request):
     schedules = cfg.schedules()
-    line = request.query_params.get("line")
+    line = request_params(request).get("line")
     if line:
         for i, schedule in enumerate(schedules):
             if schedule == line:
@@ -1823,7 +1829,7 @@ async def index_config_categories(request: Request):
 async def config_categories_delete(request: Request):
     kw = {
         "section": "categories",
-        "keyword": request.query_params.get("name"),
+        "keyword": request_params(request).get("name"),
     }
     del_from_section(kw)
     return BaseRedirectResponse("/config/categories")
@@ -1831,20 +1837,20 @@ async def config_categories_delete(request: Request):
 
 @secured_expose(route="/config/categories/save", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_categories_save(request: Request):
-    name = request.query_params.get("name", "*")
-    newname = request.query_params.get("newname", "")
+    name = request_params(request).get("name", "*")
+    newname = request_params(request).get("newname", "")
     if name == "*":
         newname = name
 
     if newname:
-        cat_params = dict(request.query_params)
+        cat_params = dict(request_params(request))
         # Validate directory not under incomplete
         if same_directory(
             cfg.download_dir.get_path(),
             real_path(cfg.complete_dir.get_path(), cat_params.get("dir", "")),
         ):
             return report(
-                request.query_params,
+                request_params(request),
                 error=T("Category folder cannot be a subfolder of the Temporary Download Folder."),
             )
 
@@ -1896,14 +1902,14 @@ async def config_sorting_index(request: Request):
 
 @secured_expose(route="/config/sorting/delete", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_sorting_delete(request: Request):
-    kw = {"section": "sorters", "keyword": request.query_params.get("name")}
+    kw = {"section": "sorters", "keyword": request_params(request).get("name")}
     del_from_section(kw)
     return BaseRedirectResponse(_SORTING_ROOT)
 
 
 @secured_expose(route="/config/sorting/save_sorter", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_sorting_save_sorter(request: Request):
-    params = request.query_params
+    params = request_params(request)
     kwargs = dict(params)
     name = params.get("name", "*")
     newname = params.get("newname", "")
@@ -1925,7 +1931,7 @@ async def config_sorting_save_sorter(request: Request):
 async def config_sorting_toggle_sorter(request: Request):
     """Toggle is_active flag of a sorter"""
     try:
-        sorter = config.get_sorters()[request.query_params.get("sorter")]
+        sorter = config.get_sorters()[request_params(request).get("sorter")]
         sorter.is_active.set(not sorter.is_active())
         config.save_config()
     except Exception:
@@ -2201,10 +2207,10 @@ async def index_config_notify(request: Request):
 async def config_notify_save(request: Request):
     for section in NOTIFY_OPTIONS:
         for option in NOTIFY_OPTIONS[section]:
-            if msg := config.get_config(section, option).set(request.query_params.get(option)):
-                return report(request.query_params, error=msg)
+            if msg := config.get_config(section, option).set(request_params(request).get(option)):
+                return report(request_params(request), error=msg)
     config.save_config()
-    return report(request.query_params)
+    return report(request_params(request))
 
 
 ##############################################################################

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -622,7 +622,6 @@ def get_access_info(request: Optional[Request] = None):
     # Access_url is used to provide the user a link to SABnzbd depending on the host
     web_host = cfg.web_host()
     host = socket.gethostname().lower()
-    logging.info("hostname is", host)
     socks = [host]
 
     try:

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -20,6 +20,7 @@ sabnzbd.interface - webinterface
 """
 
 import os
+import secrets
 import threading
 import time
 import logging
@@ -34,11 +35,13 @@ from random import randint
 
 import uvicorn
 from starlette.applications import Starlette
+from starlette.concurrency import run_in_threadpool
 from starlette.datastructures import MultiDict, QueryParams
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, RedirectResponse, PlainTextResponse, Response
 from starlette.middleware import Middleware
 from starlette.middleware.gzip import GZipMiddleware
+from starlette.middleware.sessions import SessionMiddleware
 from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
 from Cheetah.Template import Template
@@ -249,6 +252,7 @@ def check_hostname(request: Request) -> bool:
 
 # Create a more unique ID for each instance
 COOKIE_SECRET = str(randint(1000, 100000) * os.getpid())
+COOKIE_SESSION = "sabnzbd_session"
 
 
 def remote_ip_from_xff(xff_ips: list[str]) -> str:
@@ -1240,19 +1244,13 @@ def handle_server(params, new_svr=False):
 # Standalone RSS filter functions (used by both route handlers and api.py)
 ##############################################################################
 
-# Module-level state for RSS page (replaces ConfigRss instance state)
-_rss_refresh_readout = None
-_rss_refresh_download = False
-_rss_refresh_force = False
-_rss_refresh_ignore = False
-_rss_evaluate = False
-_rss_show_eval_button = False
-_rss_last_msg = ""
-
 
 def do_upd_rss_filter(kwargs):
-    """Update or add an RSS filter. Called by route handler and api.py."""
-    global _rss_evaluate, _rss_show_eval_button
+    """Update or add an RSS filter. Called by route handler and api.py.
+
+    Performs the config mutation and re-evaluates the feed against the new
+    filters so the cached match log reflects the change. Holds no UI state.
+    """
     try:
         feed_cfg = config.get_rss()[kwargs.get("feed")]
     except KeyError:
@@ -1280,13 +1278,15 @@ def do_upd_rss_filter(kwargs):
             feed_cfg.filters.move(int(index), int_conv(new_index))
 
         config.save_config()
-    _rss_evaluate = False
-    _rss_show_eval_button = True
+    # Re-evaluate cached items against the updated filters (no network read-out)
+    sabnzbd.RSSReader.process_feed(kwargs.get("feed"), readout=False)
 
 
 def do_del_rss_filter(kwargs):
-    """Delete an RSS filter. Called by route handler and api.py."""
-    global _rss_evaluate, _rss_show_eval_button
+    """Delete an RSS filter. Called by route handler and api.py.
+
+    Performs the config mutation and re-evaluates the feed. Holds no UI state.
+    """
     try:
         feed_cfg = config.get_rss()[kwargs.get("feed")]
     except KeyError:
@@ -1294,8 +1294,8 @@ def do_del_rss_filter(kwargs):
 
     feed_cfg.filters.delete(int(kwargs.get("index", 0)))
     config.save_config()
-    _rss_evaluate = False
-    _rss_show_eval_button = True
+    # Re-evaluate cached items against the remaining filters (no network read-out)
+    sabnzbd.RSSReader.process_feed(kwargs.get("feed"), readout=False)
 
 
 ##############################################################################
@@ -1306,11 +1306,24 @@ def do_del_rss_filter(kwargs):
 _RSS_ROOT = "/config/rss"
 
 
+def _rss_redirect(feed: str = "") -> RedirectResponse:
+    """Redirect back to the RSS page, optionally selecting a feed."""
+    if feed:
+        return BaseRedirectResponse(_RSS_ROOT, feed=feed)
+    return BaseRedirectResponse(_RSS_ROOT)
+
+
+def _rss_flash_redirect(request: Request, feed: str, msg: str = "") -> RedirectResponse:
+    """Store a feed read-out result as a one-shot flash in the client session and
+    redirect back to the RSS page. The flash lives in the per-client signed
+    session cookie rather than shared module state, so concurrent requests (other
+    tabs, the API path) can't clobber each other's result."""
+    request.session["rss_flash"] = {"feed": feed, "msg": msg}
+    return _rss_redirect(feed)
+
+
 @secured_expose(route="/config/rss", check_configlock=True, methods=["GET"])
 async def config_rss_index(request: Request):
-    global _rss_refresh_readout, _rss_refresh_download, _rss_refresh_force
-    global _rss_refresh_ignore, _rss_evaluate, _rss_show_eval_button, _rss_last_msg
-
     conf = build_header(sabnzbd.WEB_DIR_CONFIG)
 
     conf["scripts"] = list_scripts(default=True)
@@ -1342,34 +1355,12 @@ async def config_rss_index(request: Request):
     conf["rss_next"] = time.strftime(time_format("%H:%M"), time.localtime(sabnzbd.RSSReader.next_run))
 
     if active_feed:
-        readout = bool(_rss_refresh_readout)
-        logging.debug("RSS READOUT = %s", readout)
-        if not readout:
-            _rss_refresh_download = False
-            _rss_refresh_force = False
-            _rss_refresh_ignore = False
-        if _rss_evaluate:
-            msg = sabnzbd.RSSReader.process_feed(
-                active_feed,
-                download=_rss_refresh_download,
-                force=_rss_refresh_force,
-                ignore_first=_rss_refresh_ignore,
-                readout=readout,
-            )
-        else:
-            msg = ""
-        _rss_evaluate = False
-        if readout:
-            _rss_last_msg = msg
-        else:
-            msg = _rss_last_msg
-        _rss_refresh_readout = None
-        conf["evalButton"] = _rss_show_eval_button
-        conf["error"] = msg
-
+        # This is a plain GET: no feed processing happens here. Any read-out or
+        # re-evaluation is performed by the POST action handler that redirected
+        # us, which leaves its result message as a one-shot flash in the session.
+        flash = request.session.pop("rss_flash", None)
+        conf["error"] = flash["msg"] if flash and flash.get("feed") == active_feed else ""
         conf["downloaded"], conf["matched"], conf["unmatched"] = GetRssLog(active_feed)
-    else:
-        _rss_last_msg = ""
 
     # Find a unique new Feed name
     unum = 1
@@ -1398,7 +1389,6 @@ async def config_rss_upd_rss_feed(request: Request):
     """Update Feed level attributes,
     legacy version: ignores 'enable' parameter
     """
-    global _rss_evaluate, _rss_show_eval_button
     params = request.query_params
     kwargs = dict(params)
     if params.get("enable") is not None:
@@ -1413,10 +1403,7 @@ async def config_rss_upd_rss_feed(request: Request):
         cf.set_dict(kwargs)
         config.save_config()
 
-    _rss_evaluate = False
-    _rss_show_eval_button = True
-    feed = params.get("feed")
-    return BaseRedirectResponse(_RSS_ROOT, feed=feed) if feed else BaseRedirectResponse(_RSS_ROOT)
+    return _rss_redirect(params.get("feed"))
 
 
 @secured_expose(route="/config/rss/save_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
@@ -1467,8 +1454,6 @@ async def config_rss_toggle_rss_feed(request: Request):
 @secured_expose(route="/config/rss/add_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_rss_add_rss_feed(request: Request):
     """Add one new RSS feed definition"""
-    global _rss_refresh_readout, _rss_refresh_download, _rss_refresh_force
-    global _rss_refresh_ignore, _rss_evaluate
     params = request.query_params
     kwargs = dict(params)
     feed = Strip(params.get("feed", "")).strip("[]")
@@ -1487,12 +1472,10 @@ async def config_rss_add_rss_feed(request: Request):
             with sabnzbd.rss.rss_repository(sabnzbd.get_db_connection()) as repo:
                 repo.clear_feed(feed)
             config.save_config()
-            _rss_refresh_readout = feed
-            _rss_refresh_download = False
-            _rss_refresh_force = False
-            _rss_refresh_ignore = True
-            _rss_evaluate = True
-            return BaseRedirectResponse(_RSS_ROOT, feed=feed)
+            # Read out the new feed now (off the event loop) and carry the
+            # result message to the redirected page via the session flash.
+            msg = await run_in_threadpool(sabnzbd.RSSReader.process_feed, feed, readout=True, ignore_first=True)
+            return _rss_flash_redirect(request, feed, msg)
         else:
             return BaseRedirectResponse(_RSS_ROOT)
     else:
@@ -1503,8 +1486,7 @@ async def config_rss_add_rss_feed(request: Request):
 async def config_rss_upd_rss_filter(request: Request):
     """Save updated filter definition"""
     do_upd_rss_filter(dict(request.query_params))
-    feed = request.query_params.get("feed")
-    return BaseRedirectResponse(_RSS_ROOT, feed=feed) if feed else BaseRedirectResponse(_RSS_ROOT)
+    return _rss_redirect(request.query_params.get("feed"))
 
 
 @secured_expose(route="/config/rss/del_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
@@ -1522,67 +1504,51 @@ async def config_rss_del_rss_feed(request: Request):
 async def config_rss_del_rss_filter(request: Request):
     """Remove one RSS filter"""
     do_del_rss_filter(dict(request.query_params))
-    feed = request.query_params.get("feed")
-    return BaseRedirectResponse(_RSS_ROOT, feed=feed) if feed else BaseRedirectResponse(_RSS_ROOT)
+    return _rss_redirect(request.query_params.get("feed"))
 
 
 @secured_expose(route="/config/rss/download_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_rss_download_rss_feed(request: Request):
     """Force download of all matching jobs in a feed"""
-    global _rss_refresh_readout, _rss_refresh_download, _rss_refresh_force
-    global _rss_refresh_ignore, _rss_evaluate
     feed = request.query_params.get("feed")
-    if feed:
-        _rss_refresh_readout = feed
-        _rss_refresh_download = True
-        _rss_refresh_force = True
-        _rss_refresh_ignore = False
-        _rss_evaluate = True
-    return BaseRedirectResponse(_RSS_ROOT, feed=feed) if feed else BaseRedirectResponse(_RSS_ROOT)
+    if not feed:
+        return _rss_redirect()
+    # Network read-out with forced download; run off the event loop.
+    msg = await run_in_threadpool(sabnzbd.RSSReader.process_feed, feed, readout=True, download=True, force=True)
+    return _rss_flash_redirect(request, feed, msg)
 
 
 @secured_expose(route="/config/rss/clean_rss_jobs", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_rss_clean_rss_jobs(request: Request):
     """Remove processed RSS jobs from UI"""
-    global _rss_evaluate
     feed = request.query_params.get("feed")
     if feed:
         with sabnzbd.rss.rss_repository(sabnzbd.get_db_connection()) as repo:
             repo.clear_downloaded(feed)
-    _rss_evaluate = True
-    return BaseRedirectResponse(_RSS_ROOT, feed=feed) if feed else BaseRedirectResponse(_RSS_ROOT)
+        # Re-evaluate cached items (no network read-out) so the log refreshes.
+        sabnzbd.RSSReader.process_feed(feed, readout=False)
+    return _rss_redirect(feed)
 
 
 @secured_expose(route="/config/rss/test_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_rss_test_rss_feed(request: Request):
     """Read the feed content again and show results"""
-    global _rss_refresh_readout, _rss_refresh_download, _rss_refresh_force
-    global _rss_refresh_ignore, _rss_evaluate, _rss_show_eval_button
     feed = request.query_params.get("feed")
-    if feed:
-        _rss_refresh_readout = feed
-        _rss_refresh_download = False
-        _rss_refresh_force = False
-        _rss_refresh_ignore = True
-        _rss_evaluate = True
-        _rss_show_eval_button = False
-    return BaseRedirectResponse(_RSS_ROOT, feed=feed) if feed else BaseRedirectResponse(_RSS_ROOT)
+    if not feed:
+        return _rss_redirect()
+    # Network read-out; run off the event loop.
+    msg = await run_in_threadpool(sabnzbd.RSSReader.process_feed, feed, readout=True, ignore_first=True)
+    return _rss_flash_redirect(request, feed, msg)
 
 
 @secured_expose(route="/config/rss/eval_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_rss_eval_rss_feed(request: Request):
     """Re-apply the filters to the feed"""
-    global _rss_refresh_download, _rss_refresh_force, _rss_refresh_ignore
-    global _rss_show_eval_button, _rss_evaluate
     feed = request.query_params.get("feed")
     if feed:
-        _rss_refresh_download = False
-        _rss_refresh_force = False
-        _rss_refresh_ignore = False
-        _rss_show_eval_button = False
-        _rss_evaluate = True
-
-    return BaseRedirectResponse(_RSS_ROOT, feed=feed) if feed else BaseRedirectResponse(_RSS_ROOT)
+        # Re-evaluate cached items against current filters (no network read-out).
+        sabnzbd.RSSReader.process_feed(feed, readout=False)
+    return _rss_redirect(feed)
 
 
 @secured_expose(route="/config/rss/download", check_api_key=True, check_configlock=True, methods=["POST"])
@@ -1611,7 +1577,7 @@ async def config_rss_download(request: Request):
                 nzo_info=NzoInfo(RSS=feed),
             )
         repo.flag_downloaded(feed, url)
-    return BaseRedirectResponse(_RSS_ROOT, feed=feed) if feed else BaseRedirectResponse(_RSS_ROOT)
+    return _rss_redirect(feed)
 
 
 @secured_expose(route="/config/rss/rss_now", check_api_key=True, check_configlock=True, methods=["POST"])
@@ -2302,6 +2268,18 @@ routes = [
 ]
 
 
-middleware = [Middleware(GZipMiddleware, minimum_size=1000, compresslevel=2)]
+middleware = [
+    Middleware(GZipMiddleware, minimum_size=1000, compresslevel=2),
+    # Signed session cookie, used for short-lived per-client UI state such as the
+    # RSS read-out result message (flash). Secret key is regenerated each run,
+    # so sessions naturally expire on restart, which is fine for flash messages.
+    Middleware(
+        SessionMiddleware,
+        secret_key=secrets.token_hex(),
+        session_cookie=COOKIE_SESSION,
+        same_site="lax",
+        https_only=bool(cfg.enable_https()),
+    ),
+]
 
 app = Starlette(middleware=middleware, routes=routes)

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -332,10 +332,14 @@ def check_apikey(request: Request) -> Optional[str]:
     Return None when OK, otherwise an error message
     """
     mode = request_params(request).get("mode", "")
-    name = request_params(request).get("name", "")
 
-    # Lookup required access level for the specific api-call
-    req_access = sabnzbd.api.api_level(mode, name)
+    # Resolve the call once here and stash it on the request, so the /api route can
+    # dispatch through api_handler without consulting the api table a second time.
+    entry, argument = sabnzbd.api.resolve_api_call(request_params(request))
+    request.state.api_call = (entry, argument)
+
+    # The entry carries the access level required for this specific api-call
+    req_access = entry.access_level
     if not check_access(request, access_type=req_access, warn_user=True):
         return _MSG_ACCESS_DENIED
 
@@ -566,7 +570,7 @@ async def shutdown(request: Request):
 @secured_expose(route="/api", check_api_key=True, access_type=1)
 async def api(request: Request):
     """Redirect to API-handler, we check the access_type in the API-handler"""
-    return await api_handler(request_params(request))
+    return await api_handler(request_params(request), request.state.api_call)
 
 
 @secured_expose(route="/scriptlog", methods=["GET"])

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -502,7 +502,7 @@ def main_index(request: Request):
         return template_filtered_response(file=os.path.join(sabnzbd.WEB_DIR, "main.tmpl"), search_list=info)
     else:
         # Redirect to the setup wizard
-        return BaseRedirectResponse("/wizard/")
+        return BaseRedirectResponse("/wizard")
 
 
 @secured_expose(route="/shutdown", check_api_key=True)
@@ -559,7 +559,7 @@ def favicon_ico(request: Request):
 ##############################################################################
 
 
-@secured_expose(route="/wizard/", check_configlock=True, methods=["GET"])
+@secured_expose(route="/wizard", check_configlock=True, methods=["GET"])
 def wizard_index(request: Request):
     """Show the language selection page"""
     if sabnzbd.WINDOWS:

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -175,8 +175,13 @@ def secured_expose(
                     return PlainTextResponse(msg, status_code=403)
                 return PlainTextResponse("", status_code=403)
 
-        # All good, cool!
-        return await wrap_func(request, *args, **kwargs)
+        # All good, cool! Coroutine handlers are awaited on the event loop, so they
+        # must never block; plain sync handlers are executed in the threadpool so
+        # blocking work (template rendering, disk and database access) cannot stall
+        # the event loop.
+        if inspect.iscoroutinefunction(wrap_func):
+            return await wrap_func(request, *args, **kwargs)
+        return await run_in_threadpool(wrap_func, request, *args, **kwargs)
 
     if route:
         INTERFACE_ROUTES.append(Route(route, endpoint=internal_wrap, methods=methods))
@@ -448,7 +453,7 @@ def BaseRedirectResponse(root: str = "", **kwargs) -> RedirectResponse:
 
 
 @secured_expose(route="/", methods=["GET"])
-async def main_index(request: Request):
+def main_index(request: Request):
     # Redirect to wizard if no servers are set
     if request_params(request).get("skip_wizard") or config.get_servers():
         info = build_header()
@@ -489,15 +494,11 @@ async def shutdown(request: Request):
 @secured_expose(route="/api", check_api_key=True, access_type=1)
 async def api(request: Request):
     """Redirect to API-handler, we check the access_type in the API-handler"""
-    response = api_handler(request_params(request))
-    # Some API functions (e.g. shutdown) are coroutine functions
-    if inspect.isawaitable(response):
-        response = await response
-    return response
+    return await api_handler(request_params(request))
 
 
 @secured_expose(route="/scriptlog", methods=["GET"])
-async def scriptlog(request: Request):
+def scriptlog(request: Request):
     """Needed for all skins, URL is fixed due to postproc"""
     # No session key check, due to fixed URLs in history database
     if name := request_params(request).get("name"):
@@ -507,13 +508,13 @@ async def scriptlog(request: Request):
 
 
 @secured_expose(route="/robots.txt", check_for_login=False, methods=["GET"])
-async def robots_txt(request: Request):
+def robots_txt(request: Request):
     """Keep web crawlers out"""
     return PlainTextResponse("User-agent: *\nDisallow: /\n")
 
 
 @secured_expose(route="/description.xml", check_for_login=False, methods=["GET"])
-async def description_xml(request: Request):
+def description_xml(request: Request):
     """Provide the description.xml which was broadcast via SSDP"""
     if is_lan_addr(request.client.host):
         response = Response(content=sabnzbd.utils.ssdp.server_ssdp_xml(), media_type="application/xml")
@@ -523,7 +524,7 @@ async def description_xml(request: Request):
 
 
 @secured_expose(route="/favicon.ico", check_for_login=False, methods=["GET"])
-async def favicon_ico(request: Request):
+def favicon_ico(request: Request):
     """Provide the favicon.ico"""
     return FileResponse(os.path.join(sabnzbd.WEB_DIR_CONFIG, "staticcfg", "ico", "favicon.ico"))
 
@@ -534,7 +535,7 @@ async def favicon_ico(request: Request):
 
 
 @secured_expose(route="/wizard/", check_configlock=True, methods=["GET"])
-async def wizard_index(request: Request):
+def wizard_index(request: Request):
     """Show the language selection page"""
     if sabnzbd.WINDOWS:
         from sabnzbd.utils.apireg import get_install_lng
@@ -549,7 +550,7 @@ async def wizard_index(request: Request):
 
 
 @secured_expose(route="/wizard/one", check_configlock=True, methods=["GET", "POST"])
-async def wizard_page_one(request: Request):
+def wizard_page_one(request: Request):
     """Accept language and show server page"""
     if request_params(request).get("lang"):
         cfg.language.set(request_params(request).get("lang"))
@@ -593,7 +594,7 @@ async def wizard_page_one(request: Request):
 
 
 @secured_expose(route="/wizard/two", check_configlock=True, methods=["GET", "POST"])
-async def wizard_page_two(request: Request):
+def wizard_page_two(request: Request):
     """Accept server and show the final page for restart"""
     # Save server details if submitted — no host means the user skipped server setup
     if request_params(request).get("host"):
@@ -681,7 +682,7 @@ def get_access_info(request: Optional[Request] = None):
 
 
 @secured_expose(route="/login", check_for_login=False)
-async def login_index(request: Request):
+def login_index(request: Request):
     # Base output var
     info = build_header(sabnzbd.WEB_DIR_CONFIG)
     info["error"] = ""
@@ -723,7 +724,7 @@ async def login_index(request: Request):
 
 
 @secured_expose(route="/logout", check_for_login=False, methods=["GET"])
-async def logout_index(request: Request):
+def logout_index(request: Request):
     response = RedirectResponse(url=f"{cfg.url_base()}/", status_code=302)
     set_login_cookie(request, response, remove=True)
     return response
@@ -735,7 +736,7 @@ async def logout_index(request: Request):
 
 
 @secured_expose(route="/config", check_configlock=True, methods=["GET"])
-async def config_general_index(request: Request):
+def config_general_index(request: Request):
     conf = build_header(sabnzbd.WEB_DIR_CONFIG)
     conf["configfn"] = clip_path(config.get_filename())
     conf["cmdline"] = sabnzbd.CMDLINE
@@ -776,7 +777,7 @@ LIST_BOOL_DIRPAGE = ("fulldisk_autoresume",)
 
 
 @secured_expose(route="/config/folders", check_configlock=True, methods=["GET"])
-async def index_config_folders(request: Request):
+def index_config_folders(request: Request):
     conf = build_header(sabnzbd.WEB_DIR_CONFIG)
     conf["file_exts"] = ", ".join(VALID_NZB_FILES + VALID_ARCHIVES)
 
@@ -790,7 +791,7 @@ async def index_config_folders(request: Request):
 
 
 @secured_expose(route="/config/folders/save", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_folder_save(request: Request):
+def config_folder_save(request: Request):
     for kw in LIST_DIRPAGE + LIST_BOOL_DIRPAGE:
         if msg := config.get_config("misc", kw).set(request_params(request).get(kw)):
             return report(request_params(request), error=msg)
@@ -849,7 +850,7 @@ SWITCH_LIST = (
 
 
 @secured_expose(route="/config/switches", check_configlock=True, methods=["GET"])
-async def index_config_switches(request: Request):
+def index_config_switches(request: Request):
     conf = build_header(sabnzbd.WEB_DIR_CONFIG)
     conf["have_nice"] = bool(sabnzbd.newsunpack.NICE_COMMAND)
     conf["have_ionice"] = bool(sabnzbd.newsunpack.IONICE_COMMAND)
@@ -868,7 +869,7 @@ async def index_config_switches(request: Request):
 
 
 @secured_expose(route="/config/switches/save", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_switches_save(request: Request):
+def config_switches_save(request: Request):
     for kw in SWITCH_LIST:
         if msg := config.get_config("misc", kw).set(request_params(request).get(kw)):
             return report(request_params(request), error=msg)
@@ -946,7 +947,7 @@ SPECIAL_LIST_LIST = (
 
 
 @secured_expose(route="/config/special", check_configlock=True, methods=["GET"])
-async def index_config_special(request: Request):
+def index_config_special(request: Request):
     conf = build_header(sabnzbd.WEB_DIR_CONFIG)
     conf["switches"] = [
         (kw, config.get_config("misc", kw)(), config.get_config("misc", kw).default) for kw in SPECIAL_BOOL_LIST
@@ -968,7 +969,7 @@ async def index_config_special(request: Request):
 
 
 @secured_expose(route="/config/special/save", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_special_save(request: Request):
+def config_special_save(request: Request):
     for kw in SPECIAL_BOOL_LIST + SPECIAL_VALUE_LIST + SPECIAL_LIST_LIST:
         if msg := config.get_config("misc", kw).set(request_params(request).get(kw)):
             return report(request_params(request), error=msg)
@@ -1002,7 +1003,7 @@ GENERAL_LIST = (
 
 
 @secured_expose(route="/config/general", check_configlock=True, methods=["GET"])
-async def index_config_general(request: Request):
+def index_config_general(request: Request):
     conf = build_header(sabnzbd.WEB_DIR_CONFIG)
 
     web_list = []
@@ -1035,7 +1036,7 @@ async def index_config_general(request: Request):
 
 
 @secured_expose(route="/config/general/save", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_general_save(request: Request):
+def config_general_save(request: Request):
     # Handle general options
     for kw in GENERAL_LIST:
         if msg := config.get_config("misc", kw).set(request_params(request).get(kw)):
@@ -1086,7 +1087,7 @@ def change_web_dir(web_dir):
 
 
 @secured_expose(route="/config/server", check_configlock=True, methods=["GET"])
-async def index_config_server(request: Request):
+def index_config_server(request: Request):
     conf = build_header(sabnzbd.WEB_DIR_CONFIG)
     new = []
     servers = config.get_servers()
@@ -1122,24 +1123,24 @@ async def index_config_server(request: Request):
 
 
 @secured_expose(route="/config/server/add_server", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_server_add(request: Request):
+def config_server_add(request: Request):
     return handle_server(request_params(request), new_svr=True)
 
 
 @secured_expose(route="/config/server/save_server", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_server_save(request: Request):
+def config_server_save(request: Request):
     return handle_server(request_params(request))
 
 
 @secured_expose(route="/config/server/delete_server", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_server_del(request: Request):
+def config_server_del(request: Request):
     kw = {"section": "servers", "keyword": request_params(request).get("server")}
     del_from_section(kw)
     return BaseRedirectResponse("/config/server")
 
 
 @secured_expose(route="/config/server/clear_server", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_server_clr(request: Request):
+def config_server_clr(request: Request):
     server = request_params(request).get("server")
     if server:
         sabnzbd.BPSMeter.clear_server(server)
@@ -1147,7 +1148,7 @@ async def config_server_clr(request: Request):
 
 
 @secured_expose(route="/config/server/toggle_server", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_server_toggle(request: Request):
+def config_server_toggle(request: Request):
     server = request_params(request).get("server")
     if server:
         svr = config.get_config("servers", server)
@@ -1308,7 +1309,7 @@ def _rss_flash_redirect(request: Request, feed: str, msg: str = "") -> RedirectR
 
 
 @secured_expose(route="/config/rss", check_configlock=True, methods=["GET"])
-async def config_rss_index(request: Request):
+def config_rss_index(request: Request):
     conf = build_header(sabnzbd.WEB_DIR_CONFIG)
 
     conf["scripts"] = list_scripts(default=True)
@@ -1361,7 +1362,7 @@ async def config_rss_index(request: Request):
 
 
 @secured_expose(route="/config/rss/save_rss_rate", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_rss_save_rss_rate(request: Request):
+def config_rss_save_rss_rate(request: Request):
     """Save changed RSS automatic readout rate"""
     cfg.rss_rate.set(request_params(request).get("rss_rate"))
     config.save_config()
@@ -1370,7 +1371,7 @@ async def config_rss_save_rss_rate(request: Request):
 
 
 @secured_expose(route="/config/rss/upd_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_rss_upd_rss_feed(request: Request):
+def config_rss_upd_rss_feed(request: Request):
     """Update Feed level attributes,
     legacy version: ignores 'enable' parameter
     """
@@ -1392,7 +1393,7 @@ async def config_rss_upd_rss_feed(request: Request):
 
 
 @secured_expose(route="/config/rss/save_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_rss_save_rss_feed(request: Request):
+def config_rss_save_rss_feed(request: Request):
     """Update Feed level attributes"""
     params = request_params(request)
     kwargs = dict(params)
@@ -1419,7 +1420,7 @@ async def config_rss_save_rss_feed(request: Request):
 
 
 @secured_expose(route="/config/rss/toggle_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_rss_toggle_rss_feed(request: Request):
+def config_rss_toggle_rss_feed(request: Request):
     """Toggle automatic read-out flag of Feed"""
     params = request_params(request)
     try:
@@ -1437,7 +1438,7 @@ async def config_rss_toggle_rss_feed(request: Request):
 
 
 @secured_expose(route="/config/rss/add_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_rss_add_rss_feed(request: Request):
+def config_rss_add_rss_feed(request: Request):
     """Add one new RSS feed definition"""
     params = request_params(request)
     kwargs = dict(params)
@@ -1457,9 +1458,9 @@ async def config_rss_add_rss_feed(request: Request):
             with sabnzbd.rss.rss_repository(sabnzbd.get_db_connection()) as repo:
                 repo.clear_feed(feed)
             config.save_config()
-            # Read out the new feed now (off the event loop) and carry the
-            # result message to the redirected page via the session flash.
-            msg = await run_in_threadpool(sabnzbd.RSSReader.process_feed, feed, readout=True, ignore_first=True)
+            # Read out the new feed now (this handler runs in the threadpool) and
+            # carry the result message to the redirected page via the session flash.
+            msg = sabnzbd.RSSReader.process_feed(feed, readout=True, ignore_first=True)
             return _rss_flash_redirect(request, feed, msg)
         else:
             return BaseRedirectResponse(_RSS_ROOT)
@@ -1468,14 +1469,14 @@ async def config_rss_add_rss_feed(request: Request):
 
 
 @secured_expose(route="/config/rss/upd_rss_filter", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_rss_upd_rss_filter(request: Request):
+def config_rss_upd_rss_filter(request: Request):
     """Save updated filter definition"""
     do_upd_rss_filter(dict(request_params(request)))
     return _rss_redirect(request_params(request).get("feed"))
 
 
 @secured_expose(route="/config/rss/del_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_rss_del_rss_feed(request: Request):
+def config_rss_del_rss_feed(request: Request):
     """Remove complete RSS feed"""
     feed = request_params(request).get("feed")
     kw = {"section": "rss", "keyword": feed}
@@ -1486,25 +1487,25 @@ async def config_rss_del_rss_feed(request: Request):
 
 
 @secured_expose(route="/config/rss/del_rss_filter", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_rss_del_rss_filter(request: Request):
+def config_rss_del_rss_filter(request: Request):
     """Remove one RSS filter"""
     do_del_rss_filter(dict(request_params(request)))
     return _rss_redirect(request_params(request).get("feed"))
 
 
 @secured_expose(route="/config/rss/download_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_rss_download_rss_feed(request: Request):
+def config_rss_download_rss_feed(request: Request):
     """Force download of all matching jobs in a feed"""
     feed = request_params(request).get("feed")
     if not feed:
         return _rss_redirect()
-    # Network read-out with forced download; run off the event loop.
-    msg = await run_in_threadpool(sabnzbd.RSSReader.process_feed, feed, readout=True, download=True, force=True)
+    # Network read-out with forced download; this handler runs in the threadpool.
+    msg = sabnzbd.RSSReader.process_feed(feed, readout=True, download=True, force=True)
     return _rss_flash_redirect(request, feed, msg)
 
 
 @secured_expose(route="/config/rss/clean_rss_jobs", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_rss_clean_rss_jobs(request: Request):
+def config_rss_clean_rss_jobs(request: Request):
     """Remove processed RSS jobs from UI"""
     feed = request_params(request).get("feed")
     if feed:
@@ -1516,18 +1517,18 @@ async def config_rss_clean_rss_jobs(request: Request):
 
 
 @secured_expose(route="/config/rss/test_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_rss_test_rss_feed(request: Request):
+def config_rss_test_rss_feed(request: Request):
     """Read the feed content again and show results"""
     feed = request_params(request).get("feed")
     if not feed:
         return _rss_redirect()
-    # Network read-out; run off the event loop.
-    msg = await run_in_threadpool(sabnzbd.RSSReader.process_feed, feed, readout=True, ignore_first=True)
+    # Network read-out; this handler runs in the threadpool.
+    msg = sabnzbd.RSSReader.process_feed(feed, readout=True, ignore_first=True)
     return _rss_flash_redirect(request, feed, msg)
 
 
 @secured_expose(route="/config/rss/eval_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_rss_eval_rss_feed(request: Request):
+def config_rss_eval_rss_feed(request: Request):
     """Re-apply the filters to the feed"""
     feed = request_params(request).get("feed")
     if feed:
@@ -1537,7 +1538,7 @@ async def config_rss_eval_rss_feed(request: Request):
 
 
 @secured_expose(route="/config/rss/download", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_rss_download(request: Request):
+def config_rss_download(request: Request):
     """Download NZB from provider (Download button)"""
     params = request_params(request)
     feed = params.get("feed")
@@ -1566,7 +1567,7 @@ async def config_rss_download(request: Request):
 
 
 @secured_expose(route="/config/rss/rss_now", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_rss_rss_now(request: Request):
+def config_rss_rss_now(request: Request):
     """Run an automatic RSS run now"""
     sabnzbd.Scheduler.force_rss()
     return BaseRedirectResponse(_RSS_ROOT)
@@ -1619,7 +1620,7 @@ _SCHED_ROOT = "/config/scheduling"
 
 
 @secured_expose(route="/config/scheduling", check_configlock=True, methods=["GET"])
-async def config_scheduling_index(request: Request):
+def config_scheduling_index(request: Request):
     def get_days():
         days = {
             "*": T("Daily"),
@@ -1713,7 +1714,7 @@ async def config_scheduling_index(request: Request):
 
 
 @secured_expose(route="/config/scheduling/add_schedule", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_scheduling_add(request: Request):
+def config_scheduling_add(request: Request):
     params = request_params(request)
     servers = config.get_servers()
     minute = params.get("minute")
@@ -1762,7 +1763,7 @@ async def config_scheduling_add(request: Request):
 
 
 @secured_expose(route="/config/scheduling/del_schedule", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_scheduling_del(request: Request):
+def config_scheduling_del(request: Request):
     schedules = cfg.schedules()
     line = request_params(request).get("line")
     if line and line in schedules:
@@ -1774,7 +1775,7 @@ async def config_scheduling_del(request: Request):
 
 
 @secured_expose(route="/config/scheduling/toggle_schedule", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_scheduling_toggle(request: Request):
+def config_scheduling_toggle(request: Request):
     schedules = cfg.schedules()
     line = request_params(request).get("line")
     if line:
@@ -1797,7 +1798,7 @@ async def config_scheduling_toggle(request: Request):
 
 
 @secured_expose(route="/config/categories", check_configlock=True, methods=["GET"])
-async def index_config_categories(request: Request):
+def index_config_categories(request: Request):
     conf = build_header(sabnzbd.WEB_DIR_CONFIG)
 
     conf["scripts"] = list_scripts(default=True)
@@ -1826,7 +1827,7 @@ async def index_config_categories(request: Request):
 
 
 @secured_expose(route="/config/categories/delete", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_categories_delete(request: Request):
+def config_categories_delete(request: Request):
     kw = {
         "section": "categories",
         "keyword": request_params(request).get("name"),
@@ -1836,7 +1837,7 @@ async def config_categories_delete(request: Request):
 
 
 @secured_expose(route="/config/categories/save", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_categories_save(request: Request):
+def config_categories_save(request: Request):
     name = request_params(request).get("name", "*")
     newname = request_params(request).get("newname", "")
     if name == "*":
@@ -1871,7 +1872,7 @@ _SORTING_ROOT = "/config/sorting"
 
 
 @secured_expose(route="/config/sorting", check_configlock=True, methods=["GET"])
-async def config_sorting_index(request: Request):
+def config_sorting_index(request: Request):
     conf = build_header(sabnzbd.WEB_DIR_CONFIG)
 
     sorters = config.get_ordered_sorters()
@@ -1901,14 +1902,14 @@ async def config_sorting_index(request: Request):
 
 
 @secured_expose(route="/config/sorting/delete", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_sorting_delete(request: Request):
+def config_sorting_delete(request: Request):
     kw = {"section": "sorters", "keyword": request_params(request).get("name")}
     del_from_section(kw)
     return BaseRedirectResponse(_SORTING_ROOT)
 
 
 @secured_expose(route="/config/sorting/save_sorter", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_sorting_save_sorter(request: Request):
+def config_sorting_save_sorter(request: Request):
     params = request_params(request)
     kwargs = dict(params)
     name = params.get("name", "*")
@@ -1928,7 +1929,7 @@ async def config_sorting_save_sorter(request: Request):
 
 
 @secured_expose(route="/config/sorting/toggle_sorter", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_sorting_toggle_sorter(request: Request):
+def config_sorting_toggle_sorter(request: Request):
     """Toggle is_active flag of a sorter"""
     try:
         sorter = config.get_sorters()[request_params(request).get("sorter")]
@@ -2182,7 +2183,7 @@ NOTIFY_OPTIONS = {
 
 
 @secured_expose(route="/config/notify", check_configlock=True, methods=["GET"])
-async def index_config_notify(request: Request):
+def index_config_notify(request: Request):
     conf = build_header(sabnzbd.WEB_DIR_CONFIG)
     conf["notify_types"] = sabnzbd.notifier.NOTIFICATION_TYPES
     conf["categories"] = list_cats(False)
@@ -2204,7 +2205,7 @@ async def index_config_notify(request: Request):
 
 
 @secured_expose(route="/config/notify/save", check_api_key=True, check_configlock=True, methods=["POST"])
-async def config_notify_save(request: Request):
+def config_notify_save(request: Request):
     for section in NOTIFY_OPTIONS:
         for option in NOTIFY_OPTIONS[section]:
             if msg := config.get_config(section, option).set(request_params(request).get(option)):

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -178,7 +178,7 @@ def secured_expose(
 
         # Verify login status, only for non-key pages
         if check_for_login and not check_api_key and not check_login(request):
-            return RedirectResponse(url=f"{cfg.url_base()}/login")
+            return BaseRedirectResponse("/login")
 
         # Verify host used for the visit
         if not check_hostname(request):
@@ -502,7 +502,7 @@ def main_index(request: Request):
         return template_filtered_response(file=os.path.join(sabnzbd.WEB_DIR, "main.tmpl"), search_list=info)
     else:
         # Redirect to the setup wizard
-        return RedirectResponse(url="%s/wizard/" % cfg.url_base())
+        return BaseRedirectResponse("/wizard/")
 
 
 @secured_expose(route="/shutdown", check_api_key=True)
@@ -709,7 +709,7 @@ def get_access_info(request: Optional[Request] = None):
 async def login_index(request: Request):
     # Already logged in, or no username/password set at all
     if check_login(request):
-        return RedirectResponse(url=f"{cfg.url_base()}/", status_code=302)
+        return BaseRedirectResponse("/")
 
     # Base output var
     info = build_header(sabnzbd.WEB_DIR_CONFIG)
@@ -722,7 +722,7 @@ async def login_index(request: Request):
 
         if username == cfg.username() and password == cfg.password():
             # Create redirect response
-            response = RedirectResponse(url=f"{cfg.url_base()}/", status_code=302)
+            response = BaseRedirectResponse("/")
             # Save login cookie
             set_login_cookie(request, response, remember_me=remember_me)
             # Log the success
@@ -748,7 +748,7 @@ async def login_index(request: Request):
 
 @secured_expose(route="/logout", check_for_login=False, methods=["GET"])
 def logout_index(request: Request):
-    response = RedirectResponse(url=f"{cfg.url_base()}/", status_code=302)
+    response = BaseRedirectResponse("/")
     set_login_cookie(request, response, remove=True)
     return response
 

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -38,7 +38,7 @@ from starlette.applications import Starlette
 from starlette.concurrency import run_in_threadpool
 from starlette.datastructures import MultiDict, QueryParams
 from starlette.requests import Request
-from starlette.responses import HTMLResponse, RedirectResponse, PlainTextResponse, Response
+from starlette.responses import HTMLResponse, RedirectResponse, PlainTextResponse, Response, FileResponse
 from starlette.middleware import Middleware
 from starlette.middleware.gzip import GZipMiddleware
 from starlette.middleware.sessions import SessionMiddleware
@@ -531,13 +531,13 @@ async def scriptlog(request: Request):
     return PlainTextResponse("")
 
 
-@secured_expose(methods=["GET"])
+@secured_expose(route="/robots.txt", check_for_login=False, methods=["GET"])
 async def robots_txt(request: Request):
     """Keep web crawlers out"""
     return PlainTextResponse("User-agent: *\nDisallow: /\n")
 
 
-@secured_expose(methods=["GET"])
+@secured_expose(route="/description.xml", check_for_login=False, methods=["GET"])
 async def description_xml(request: Request):
     """Provide the description.xml which was broadcast via SSDP"""
     if is_lan_addr(request.client.host):
@@ -545,6 +545,12 @@ async def description_xml(request: Request):
         return response
     else:
         return Response(status_code=404)
+
+
+@secured_expose(route="/favicon.ico", check_for_login=False, methods=["GET"])
+async def favicon_ico(request: Request):
+    """Provide the favicon.ico"""
+    return FileResponse(os.path.join(sabnzbd.WEB_DIR_CONFIG, "staticcfg", "ico", "favicon.ico"))
 
 
 ##############################################################################

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -20,7 +20,6 @@ sabnzbd.interface - webinterface
 """
 
 import os
-import inspect
 import secrets
 import threading
 import time
@@ -130,8 +129,8 @@ def secured_expose(
     check_api_key: bool = False,
     access_type: int = 4,
     methods: Collection = ("GET", "POST"),
-) -> Callable | str:
-    """Wrapper for both starlette routing and login/access check"""
+) -> Callable:
+    """Register a handler as a Starlette route and attach its access controls"""
     if not wrap_func:
         return functools.partial(
             secured_expose,
@@ -143,17 +142,11 @@ def secured_expose(
             methods=methods,
         )
 
-    @functools.wraps(wrap_func)
-    async def internal_wrap(request: Request, *args, **kwargs):
-        if inspect.iscoroutinefunction(wrap_func):
-            return await wrap_func(request, *args, **kwargs)
-        return await run_in_threadpool(wrap_func, request, *args, **kwargs)
-
     if route:
         INTERFACE_ROUTES.append(
             Route(
                 route,
-                endpoint=internal_wrap,
+                endpoint=wrap_func,
                 methods=methods,
                 middleware=[
                     Middleware(ParamsMiddleware, merge_query=check_api_key),
@@ -168,7 +161,7 @@ def secured_expose(
             )
         )
 
-    return internal_wrap
+    return wrap_func
 
 
 def client_address(request: Request) -> Address:

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -146,6 +146,24 @@ def secured_expose(
         # to be retrieved with request_params(request) in the handlers
         request.state.params = await get_request_params(request)
 
+        # Log all requests
+        if cfg.api_logging():
+            if xff_ips := request.headers.get("X-Forwarded-For"):
+                remote_label = "%s (X-Forwarded-For: %s) [%s]" % (
+                    client_address(request).host,
+                    xff_ips,
+                    request.headers.get("User-Agent"),
+                )
+            else:
+                remote_label = "%s [%s]" % (client_address(request).host, request.headers.get("User-Agent"))
+            logging.debug(
+                "Request %s %s from %s %s",
+                request.method,
+                request.url.path,
+                remote_label,
+                dict(request.state.params),
+            )
+
         # Check if config is locked
         if check_configlock and cfg.configlock():
             if cfg.api_warnings():

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -64,7 +64,6 @@ from sabnzbd.misc import (
     recursive_html_escape,
     is_none,
     get_cpu_name,
-    clean_comma_separated_list,
 )
 from sabnzbd.filesystem import (
     real_path,
@@ -194,20 +193,14 @@ def check_access(request: Request, access_type: int = 4, warn_user: bool = False
     if access_type <= cfg.inet_exposure():
         return True
 
+    # X-Forwarded-For is resolved by uvicorn's ProxyHeadersMiddleware (see the
+    # uvicorn.Config in SABnzbd.py): when verify_xff_header is enabled and the
+    # connecting peer is a trusted local proxy, request.client already holds the
+    # effective client address taken from the XFF chain.
     remote_ip = request.client.host
 
     # Check if the client IP is a loopback address or considered local
     is_allowed = is_loopback_addr(remote_ip) or is_local_addr(remote_ip)
-
-    # Never check the XFF header unless access would have been granted based on the remote IP alone!
-    if (
-        is_allowed
-        and cfg.verify_xff_header()
-        and (xff_ips := clean_comma_separated_list(request.headers.get("X-Forwarded-For")))
-    ):
-        is_allowed = all(is_local_addr(ip) or is_loopback_addr(ip) for ip in xff_ips)
-        if not is_allowed:
-            logging.debug("Denying access based on X-Forwarded-For IPs '%s'", xff_ips)
 
     if not is_allowed and warn_user:
         log_warning_and_ip(request, T("Refused connection from:"))
@@ -255,19 +248,6 @@ COOKIE_SECRET = str(randint(1000, 100000) * os.getpid())
 COOKIE_SESSION = "sabnzbd_session"
 
 
-def remote_ip_from_xff(xff_ips: list[str]) -> str:
-    # Per MDN docs, the first non-local/non-trusted IP (rtl) is our "client"
-    # However, it's possible that all IPs are local/trusted, so we may also
-    # return the first ip in the list as it "should" be the client
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For#selecting_an_ip_address
-    for ip in reversed(xff_ips):
-        if not is_local_addr(ip) and not is_loopback_addr(ip):
-            return ip
-    else:
-        # If no non-local/non-trusted IPs found, return the first IP in the list
-        return xff_ips[0]
-
-
 def set_login_cookie(request: Request, response: Response, remove=False, remember_me=False):
     """Set login cookie for Starlette (updated version)
     We try to set a cookie as unique as possible
@@ -277,13 +257,9 @@ def set_login_cookie(request: Request, response: Response, remove=False, remembe
     """
     salt = randint(1, 1000)
 
-    # If we are using XFF headers, get remote IP from XFF if possible
-    if cfg.verify_xff_header() and (xff_ips := clean_comma_separated_list(request.headers.get("X-Forwarded-For"))):
-        remote_ip = remote_ip_from_xff(xff_ips)
-    else:
-        remote_ip = request.client.host
-
-    cookie_str = utob(str(salt) + remote_ip + COOKIE_SECRET)
+    # request.client is the effective client: uvicorn resolves the XFF header
+    # from trusted proxies when verify_xff_header is enabled
+    cookie_str = utob(str(salt) + request.client.host + COOKIE_SECRET)
     cookie_value = hashlib.sha1(cookie_str).hexdigest()
 
     secure = cfg.enable_https()
@@ -355,13 +331,9 @@ def check_login_cookie(request: Request) -> bool:
     if not login_cookie or not login_salt:
         return False
 
-    # If we are using XFF headers, get remote IP from XFF if possible
-    if cfg.verify_xff_header() and (xff_ips := clean_comma_separated_list(request.headers.get("X-Forwarded-For"))):
-        remote_ip = remote_ip_from_xff(xff_ips)
-    else:
-        remote_ip = request.client.host
-
-    cookie_str = utob(str(login_salt) + remote_ip + COOKIE_SECRET)
+    # request.client is the effective client: uvicorn resolves the XFF header
+    # from trusted proxies when verify_xff_header is enabled
+    cookie_str = utob(str(login_salt) + request.client.host + COOKIE_SECRET)
     return login_cookie == hashlib.sha1(cookie_str).hexdigest()
 
 

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -509,7 +509,7 @@ def main_index(request: Request):
 async def shutdown(request: Request):
     # Check for PID
     pid_in = request_params(request).get("pid")
-    if pid_in and int(pid_in) != os.getpid():
+    if pid_in and int_conv(pid_in) != os.getpid():
         return PlainTextResponse("Incorrect PID for this instance, remove PID from URL to initiate shutdown.")
 
     await halt_and_shutdown()

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -145,14 +145,6 @@ def secured_expose(
 
     @functools.wraps(wrap_func)
     async def internal_wrap(request: Request, *args, **kwargs):
-        # Store the parameters for this method on request.state, to be retrieved
-        # with request_params(request) in the handlers.Page routes are strict:
-        # GET reads the query string and POST reads the form body only. The /api
-        # route merges the query string with the form body (body wins), which
-        # third-party API clients rely on (e.g. multipart NZB uploads with
-        # mode/apikey in the URL).
-        request.state.params = await get_request_params(request, merge_query=check_api_key)
-
         # Check if config is locked
         if check_configlock and cfg.configlock():
             if cfg.api_warnings():
@@ -185,7 +177,14 @@ def secured_expose(
         return await run_in_threadpool(wrap_func, request, *args, **kwargs)
 
     if route:
-        INTERFACE_ROUTES.append(Route(route, endpoint=internal_wrap, methods=methods))
+        INTERFACE_ROUTES.append(
+            Route(
+                route,
+                endpoint=internal_wrap,
+                methods=methods,
+                middleware=[Middleware(ParamsMiddleware, merge_query=check_api_key)],
+            )
+        )
 
     return internal_wrap
 
@@ -425,7 +424,7 @@ async def get_request_params(request: Request, merge_query: bool = False) -> Mul
     An /api POST without a form body uses the query string alone, returned as
     the immutable QueryParams.
 
-    secured_expose stores the result on request.state.params so that
+    ParamsMiddleware stores the result on request.state.params so that
     request_params(request) returns it in every handler without an extra await.
     """
     if request.method == "POST":
@@ -446,11 +445,30 @@ async def get_request_params(request: Request, merge_query: bool = False) -> Mul
 
 
 def request_params(request: Request) -> MultiDict | QueryParams:
-    """The request's parameters, parsed once by secured_expose: the query
+    """The request's parameters, parsed once by ParamsMiddleware: the query
     string for a GET, the form body for a page POST, or the form body merged
     with the query string for an /api POST. See get_request_params for the
     exact rules and the returned types."""
     return request.state.params
+
+
+class ParamsMiddleware:
+    """Parse a request's parameters onto request.state.params before the handler
+    runs, so request_params(request) returns them without a further await. Attached
+    per route by secured_expose because the merge behavior is route-specific:
+    merge_query follows check_api_key (the /api and *_save routes that accept
+    mode/apikey in the query string alongside a form body). Pure ASGI, and the
+    request body is read once here; handlers only ever read the parsed params."""
+
+    def __init__(self, app, merge_query: bool = False):
+        self.app = app
+        self.merge_query = merge_query
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http":
+            request = Request(scope, receive)
+            request.state.params = await get_request_params(request, merge_query=self.merge_query)
+        await self.app(scope, receive, send)
 
 
 # Disable over-active logging for the form parser
@@ -1071,7 +1089,6 @@ def config_general_save(request: Request):
 @secured_expose(route="/config/general/upload_config", check_api_key=True, check_configlock=True, methods=["POST"])
 async def config_upload_backup(request: Request):
     """Restore a config backup"""
-    # secured_expose already parsed the multipart body into request.state.params
     config_backup_file = request_params(request).get("config_backup_file")
 
     # Only accept the backup file if it can be opened as a zip archive and only contains a config file

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -153,24 +153,6 @@ def secured_expose(
         # mode/apikey in the URL).
         request.state.params = await get_request_params(request, merge_query=check_api_key)
 
-        # Log all requests
-        if cfg.api_logging():
-            if xff_ips := request.headers.get("X-Forwarded-For"):
-                remote_label = "%s (X-Forwarded-For: %s) [%s]" % (
-                    client_address(request).host,
-                    xff_ips,
-                    request.headers.get("User-Agent"),
-                )
-            else:
-                remote_label = "%s [%s]" % (client_address(request).host, request.headers.get("User-Agent"))
-            logging.debug(
-                "Request %s %s from %s %s",
-                request.method,
-                request.url.path,
-                remote_label,
-                dict(request.state.params),
-            )
-
         # Check if config is locked
         if check_configlock and cfg.configlock():
             if cfg.api_warnings():
@@ -2298,6 +2280,43 @@ class HostnameCheckMiddleware:
         await self.app(scope, receive, send)
 
 
+class RequestLoggingMiddleware:
+    """Log every request when cfg.api_logging is enabled. The line is emitted after
+    the handler runs, once the request's parameters have been parsed onto
+    request.state; requests that never reach a secured handler (e.g. static files)
+    have no parsed params and are skipped, matching the previous
+    behavior. Pure ASGI to leave streaming responses untouched."""
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            # request.state stores params in scope["state"]; a missing key means the
+            # request did not pass through secured_expose, so there is nothing to log.
+            if cfg.api_logging() and (params := scope.get("state", {}).get("params")) is not None:
+                request = Request(scope)
+                if xff_ips := request.headers.get("X-Forwarded-For"):
+                    remote_label = "%s (X-Forwarded-For: %s) [%s]" % (
+                        client_address(request).host,
+                        xff_ips,
+                        request.headers.get("User-Agent"),
+                    )
+                else:
+                    remote_label = "%s [%s]" % (client_address(request).host, request.headers.get("User-Agent"))
+                logging.debug(
+                    "Request %s %s from %s %s",
+                    request.method,
+                    request.url.path,
+                    remote_label,
+                    dict(params),
+                )
+
+
 class ThreadedServer(uvicorn.Server):
     """uvicorn server running in a background thread, so the main thread stays
     free for the SABnzbd main loop."""
@@ -2386,6 +2405,7 @@ def create_app() -> Starlette:
     middleware = [
         Middleware(XFrameOptionsMiddleware),
         Middleware(HostnameCheckMiddleware),
+        Middleware(RequestLoggingMiddleware),
         Middleware(GZipMiddleware, minimum_size=1000, compresslevel=2),
         # Signed session cookie, used for short-lived per-client UI state such as the
         # RSS read-out result message (flash). Secret key is regenerated each run,

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -1563,7 +1563,13 @@ def config_rss_test_rss_feed(request: Request):
         return _rss_redirect()
     # Network read-out; this handler runs in the threadpool.
     msg = sabnzbd.RSSReader.process_feed(feed, readout=True, ignore_first=True)
-    return _rss_flash_redirect(request, feed, msg)
+    # This endpoint is only called via AJAX; the client navigates to the feed
+    # page itself once we return. Returning a redirect here would make the XHR
+    # follow it transparently and consume the one-shot session flash before the
+    # browser navigation can read it, so store the flash and return a plain
+    # response instead.
+    request.session["rss_flash"] = {"feed": feed, "msg": msg}
+    return PlainTextResponse(msg)
 
 
 @secured_expose(route="/config/rss/eval_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -101,6 +101,9 @@ from sabnzbd.api import (
     api_handler,
     halt_and_shutdown,
     build_header,
+    url_for,
+    url_origin,
+    url_netloc,
     Ttemplate,
 )
 from sabnzbd.nzb import NzoInfo
@@ -458,12 +461,10 @@ logging.getLogger("python_multipart.multipart").setLevel(logging.WARNING)
 ##############################################################################
 def BaseRedirectResponse(root: str = "", **kwargs) -> RedirectResponse:
     """Create a Starlette RedirectResponse with SABnzbd URL base and query parameters"""
-    # Add query parameters if provided
-    if kwargs:
-        root = "%s?%s" % (root, urllib.parse.urlencode(kwargs))
-
-    # Add the leading /sabnzbd/ (or what the user set)
-    url = cfg.url_base() + root
+    # Shares url_for with the templates so redirect targets and links stay in step.
+    # Root-relative on purpose: a Location header should send the client back to the
+    # host it just used, not to whatever origin this process thinks it is on.
+    url = url_for(root, absolute=False, **kwargs)
 
     # Log the redirect if API logging is enabled
     if cfg.api_logging():
@@ -481,7 +482,7 @@ def BaseRedirectResponse(root: str = "", **kwargs) -> RedirectResponse:
 def main_index(request: Request):
     # Redirect to wizard if no servers are set
     if request_params(request).get("skip_wizard") or config.get_servers():
-        info = build_header()
+        info = build_header(request=request)
 
         info["have_rss_defined"] = bool(config.get_rss())
         info["have_watched_dir"] = bool(cfg.dirscan_dir())
@@ -568,7 +569,7 @@ def wizard_index(request: Request):
         cfg.language.set(get_install_lng())
         logging.debug('Installer language code "%s"', cfg.language())
 
-    info = build_header(sabnzbd.WIZARD_DIR)
+    info = build_header(sabnzbd.WIZARD_DIR, request=request)
     info["languages"] = list_languages()
 
     return template_filtered_response(file=os.path.join(sabnzbd.WIZARD_DIR, "index.html"), search_list=info)
@@ -580,7 +581,7 @@ def wizard_page_one(request: Request):
     if request_params(request).get("lang"):
         cfg.language.set(request_params(request).get("lang"))
 
-    info = build_header(sabnzbd.WIZARD_DIR)
+    info = build_header(sabnzbd.WIZARD_DIR, request=request)
 
     # Just in case, add server
     servers = config.get_servers()
@@ -626,18 +627,17 @@ def wizard_page_two(request: Request):
         handle_server(request_params(request))
 
     # Show Restart screen
-    info = build_header(sabnzbd.WIZARD_DIR)
+    info = build_header(sabnzbd.WIZARD_DIR, request=request)
 
-    info["access_url"], info["urls"] = get_access_info(request)
+    info["urls"] = get_access_info(request)
     info["download_dir"] = cfg.download_dir.get_clipped_path()
     info["complete_dir"] = cfg.complete_dir.get_clipped_path()
 
     return template_filtered_response(file=os.path.join(sabnzbd.WIZARD_DIR, "two.html"), search_list=info)
 
 
-def get_access_info(request: Optional[Request] = None):
+def get_access_info(request: Optional[Request] = None) -> set[str]:
     """Build up a list of url's that sabnzbd can be accessed from"""
-    # Access_url is used to provide the user a link to SABnzbd depending on the host
     web_host = cfg.web_host()
     host = socket.gethostname().lower()
     socks = [host]
@@ -668,36 +668,24 @@ def get_access_info(request: Optional[Request] = None):
     elif web_host:
         socks = [web_host]
 
-    # Add the current requested URL as the base
-    if request:
-        # For Starlette: build URL from request
-        scheme = "https" if cfg.enable_https() else "http"
-        port = cfg.https_port() if cfg.enable_https() else cfg.web_port()
-        host_header = request.headers.get("host", "localhost")
-        if ":" in host_header:
-            host_part = host_header.split(":")[0]
-        else:
-            host_part = host_header
-        access_url = f"{scheme}://{host_part}:{port}{cfg.url_base()}"
-    else:
-        # Fallback for backward compatibility
-        scheme = "https" if cfg.enable_https() else "http"
-        port = cfg.https_port() if cfg.enable_https() else cfg.web_port()
-        access_url = f"{scheme}://localhost:{port}{cfg.url_base()}"
+    # Lead with the URL this page was actually reached by, which is the one we know works.
+    # Built from the origin rather than url_for() so it matches the bare "scheme://host+base"
+    # shape of the entries below and dedupes against them.
+    urls = [url_origin(request) + cfg.url_base()]
 
-    urls = [access_url]
+    if cfg.enable_https():
+        scheme = "https"
+        port = cfg.https_port() or cfg.web_port()
+    else:
+        scheme = "http"
+        port = cfg.web_port()
+
     for sock in socks:
         if sock:
-            if cfg.enable_https() and cfg.https_port():
-                url = "https://%s:%s%s" % (sock, cfg.https_port(), cfg.url_base())
-            elif cfg.enable_https():
-                url = "https://%s:%s%s" % (sock, cfg.web_port(), cfg.url_base())
-            else:
-                url = "http://%s:%s%s" % (sock, cfg.web_port(), cfg.url_base())
-            urls.append(url)
+            urls.append("%s://%s%s" % (scheme, url_netloc(sock, scheme, port), cfg.url_base()))
 
     # Return a unique list
-    return access_url, set(urls)
+    return set(urls)
 
 
 ##############################################################################
@@ -711,10 +699,7 @@ async def login_index(request: Request):
     if check_login(request):
         return BaseRedirectResponse("/")
 
-    # Base output var
-    info = build_header(sabnzbd.WEB_DIR_CONFIG)
-    info["error"] = ""
-
+    error = None
     if request.method == "POST":
         username = request_params(request).get("username")
         password = request_params(request).get("password")
@@ -732,18 +717,24 @@ async def login_index(request: Request):
             logging.info("Successful login from %s", remote_info)
             return response
         elif username or password:
-            info["error"] = T("Authentication failed, check username/password.")
+            error = T("Authentication failed, check username/password.")
             # Warn about the potential security problem
             remote_info = "%s:%s" % client_address(request)
             if cfg.verify_xff_header() and (xff_ips := request.headers.get("X-Forwarded-For")):
                 remote_info += f" (X-Forwarded-For: {xff_ips})"
             logging.warning(T("Unsuccessful login attempt from %s"), remote_info)
 
-    # Show login
-    return template_filtered_response(
-        file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "login", "main.tmpl"),
-        search_list=info,
-    )
+    # Show login. Building the header and rendering the Cheetah template are
+    # blocking work, so keep them off the event loop.
+    def render_login_page():
+        info = build_header(sabnzbd.WEB_DIR_CONFIG, request=request)
+        info["error"] = error
+        return template_filtered_response(
+            file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "login", "main.tmpl"),
+            search_list=info,
+        )
+
+    return await run_in_threadpool(render_login_page)
 
 
 @secured_expose(route="/logout", check_for_login=False, methods=["GET"])
@@ -760,7 +751,7 @@ def logout_index(request: Request):
 
 @secured_expose(route="/config", check_configlock=True, methods=["GET"])
 def config_general_index(request: Request):
-    conf = build_header(sabnzbd.WEB_DIR_CONFIG)
+    conf = build_header(sabnzbd.WEB_DIR_CONFIG, request=request)
     conf["configfn"] = clip_path(config.get_filename())
     conf["cmdline"] = sabnzbd.CMDLINE
     conf["build"] = sabnzbd.__baseline__[:7]
@@ -801,7 +792,7 @@ LIST_BOOL_DIRPAGE = ("fulldisk_autoresume",)
 
 @secured_expose(route="/config/folders", check_configlock=True, methods=["GET"])
 def index_config_folders(request: Request):
-    conf = build_header(sabnzbd.WEB_DIR_CONFIG)
+    conf = build_header(sabnzbd.WEB_DIR_CONFIG, request=request)
     conf["file_exts"] = ", ".join(VALID_NZB_FILES + VALID_ARCHIVES)
 
     for kw in LIST_DIRPAGE + LIST_BOOL_DIRPAGE:
@@ -874,7 +865,7 @@ SWITCH_LIST = (
 
 @secured_expose(route="/config/switches", check_configlock=True, methods=["GET"])
 def index_config_switches(request: Request):
-    conf = build_header(sabnzbd.WEB_DIR_CONFIG)
+    conf = build_header(sabnzbd.WEB_DIR_CONFIG, request=request)
     conf["have_nice"] = bool(sabnzbd.newsunpack.NICE_COMMAND)
     conf["have_ionice"] = bool(sabnzbd.newsunpack.IONICE_COMMAND)
 
@@ -971,7 +962,7 @@ SPECIAL_LIST_LIST = (
 
 @secured_expose(route="/config/special", check_configlock=True, methods=["GET"])
 def index_config_special(request: Request):
-    conf = build_header(sabnzbd.WEB_DIR_CONFIG)
+    conf = build_header(sabnzbd.WEB_DIR_CONFIG, request=request)
     conf["switches"] = [
         (kw, config.get_config("misc", kw)(), config.get_config("misc", kw).default) for kw in SPECIAL_BOOL_LIST
     ]
@@ -1027,7 +1018,7 @@ GENERAL_LIST = (
 
 @secured_expose(route="/config/general", check_configlock=True, methods=["GET"])
 def index_config_general(request: Request):
-    conf = build_header(sabnzbd.WEB_DIR_CONFIG)
+    conf = build_header(sabnzbd.WEB_DIR_CONFIG, request=request)
 
     web_list = []
     for interface_dir in globber_full(sabnzbd.DIR_INTERFACES):
@@ -1111,7 +1102,7 @@ def change_web_dir(web_dir):
 
 @secured_expose(route="/config/server", check_configlock=True, methods=["GET"])
 def index_config_server(request: Request):
-    conf = build_header(sabnzbd.WEB_DIR_CONFIG)
+    conf = build_header(sabnzbd.WEB_DIR_CONFIG, request=request)
     new = []
     servers = config.get_servers()
     server_names = sorted(
@@ -1333,7 +1324,7 @@ def _rss_flash_redirect(request: Request, feed: str, msg: str = "") -> RedirectR
 
 @secured_expose(route="/config/rss", check_configlock=True, methods=["GET"])
 def config_rss_index(request: Request):
-    conf = build_header(sabnzbd.WEB_DIR_CONFIG)
+    conf = build_header(sabnzbd.WEB_DIR_CONFIG, request=request)
 
     conf["scripts"] = list_scripts(default=True)
     pick_script = conf["scripts"] != []
@@ -1657,7 +1648,7 @@ def config_scheduling_index(request: Request):
         }
         return days
 
-    conf = build_header(sabnzbd.WEB_DIR_CONFIG)
+    conf = build_header(sabnzbd.WEB_DIR_CONFIG, request=request)
 
     actions = []
     actions.extend(_SCHED_ACTIONS)
@@ -1822,7 +1813,7 @@ def config_scheduling_toggle(request: Request):
 
 @secured_expose(route="/config/categories", check_configlock=True, methods=["GET"])
 def index_config_categories(request: Request):
-    conf = build_header(sabnzbd.WEB_DIR_CONFIG)
+    conf = build_header(sabnzbd.WEB_DIR_CONFIG, request=request)
 
     conf["scripts"] = list_scripts(default=True)
     conf["defdir"] = cfg.complete_dir.get_clipped_path()
@@ -1896,7 +1887,7 @@ _SORTING_ROOT = "/config/sorting"
 
 @secured_expose(route="/config/sorting", check_configlock=True, methods=["GET"])
 def config_sorting_index(request: Request):
-    conf = build_header(sabnzbd.WEB_DIR_CONFIG)
+    conf = build_header(sabnzbd.WEB_DIR_CONFIG, request=request)
 
     sorters = config.get_ordered_sorters()
     # Add empty sorter entry, used as a template at the top of the page
@@ -2207,7 +2198,7 @@ NOTIFY_OPTIONS = {
 
 @secured_expose(route="/config/notify", check_configlock=True, methods=["GET"])
 def index_config_notify(request: Request):
-    conf = build_header(sabnzbd.WEB_DIR_CONFIG)
+    conf = build_header(sabnzbd.WEB_DIR_CONFIG, request=request)
     conf["notify_types"] = sabnzbd.notifier.NOTIFICATION_TYPES
     conf["categories"] = list_cats(False)
     conf["have_ntfosd"] = sabnzbd.notifier.have_ntfosd()

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -2321,6 +2321,11 @@ class ThreadedServer(uvicorn.Server):
             self.thread.join()
 
 
+async def not_found_redirect(request: Request, exc):
+    """Catch-all for unknown URLs: redirect to the UI root"""
+    return BaseRedirectResponse("/")
+
+
 def create_app() -> Starlette:
     """Build the Starlette application"""
     interface_routes = [
@@ -2359,4 +2364,8 @@ def create_app() -> Starlette:
         ),
     ]
 
-    return Starlette(middleware=middleware, routes=routes)
+    return Starlette(
+        middleware=middleware,
+        routes=routes,
+        exception_handlers={404: not_found_redirect},
+    )

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -187,12 +187,6 @@ def secured_expose(
         if check_for_login and not check_api_key and not check_login(request):
             return BaseRedirectResponse("/login")
 
-        # Verify host used for the visit
-        if not check_hostname(request):
-            if cfg.api_warnings():
-                return PlainTextResponse(_MSG_ACCESS_DENIED_HOSTNAME, status_code=403)
-            return PlainTextResponse("", status_code=403)
-
         # Some pages need correct API key
         if check_api_key:
             if msg := check_apikey(request):
@@ -2286,6 +2280,24 @@ class XFrameOptionsMiddleware:
         await self.app(scope, receive, send_with_header)
 
 
+class HostnameCheckMiddleware:
+    """Reject requests whose Host header is not allowed (DNS-rebinding mitigation).
+    Applied as global middleware rather than in secured_expose so a single place
+    guards every route, including the static mounts and error responses. The setting
+    is read per request, and check_hostname short-circuits to allow when a
+    username/password is configured. Pure ASGI, and no request body is consumed."""
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http" and not check_hostname(Request(scope, receive)):
+            message = _MSG_ACCESS_DENIED_HOSTNAME if cfg.api_warnings() else ""
+            response = PlainTextResponse(message, status_code=403)
+            return await response(scope, receive, send)
+        await self.app(scope, receive, send)
+
+
 class ThreadedServer(uvicorn.Server):
     """uvicorn server running in a background thread, so the main thread stays
     free for the SABnzbd main loop."""
@@ -2373,6 +2385,7 @@ def create_app() -> Starlette:
 
     middleware = [
         Middleware(XFrameOptionsMiddleware),
+        Middleware(HostnameCheckMiddleware),
         Middleware(GZipMiddleware, minimum_size=1000, compresslevel=2),
         # Signed session cookie, used for short-lived per-client UI state such as the
         # RSS read-out result message (flash). Secret key is regenerated each run,

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -2260,33 +2260,41 @@ class ThreadedServer(uvicorn.Server):
         self.thread.join()
 
 
-INTERFACE_ROUTES.extend(
-    [
-        Route("/sabnzbd", endpoint=main_index, methods=["GET"]),
-        Mount("/static", app=StaticFiles(directory="interfaces/Glitter/templates/static"), name="static"),
-        Mount("/staticcfg", app=StaticFiles(directory="interfaces/Config/templates/staticcfg"), name="staticcfg"),
-        Mount("/wizard/static", app=StaticFiles(directory="interfaces/wizard/static"), name="wizard_static"),
+def create_app() -> Starlette:
+    """Build the Starlette application"""
+    interface_routes = [
+        *INTERFACE_ROUTES,
+        Mount("/static", app=StaticFiles(directory=os.path.join(sabnzbd.WEB_DIR, "static")), name="static"),
+        Mount(
+            "/staticcfg", app=StaticFiles(directory=os.path.join(sabnzbd.WEB_DIR_CONFIG, "staticcfg")), name="staticcfg"
+        ),
+        Mount(
+            "/wizard/static",
+            app=StaticFiles(directory=os.path.join(sabnzbd.WIZARD_DIR, "static")),
+            name="wizard_static",
+        ),
     ]
-)
 
-routes = [
-    Mount("/sabnzbd", routes=INTERFACE_ROUTES),
-    Mount("/", routes=INTERFACE_ROUTES),
-]
+    # Always serve at the root, and when a URL base is configured (e.g. behind a
+    # reverse proxy) additionally under that base.The base mount must come
+    # first so it is matched before the catch-all root mount.
+    routes = []
+    if url_base := cfg.url_base():
+        routes.append(Mount(url_base, routes=interface_routes))
+    routes.append(Mount("/", routes=interface_routes))
 
+    middleware = [
+        Middleware(GZipMiddleware, minimum_size=1000, compresslevel=2),
+        # Signed session cookie, used for short-lived per-client UI state such as the
+        # RSS read-out result message (flash). Secret key is regenerated each run,
+        # so sessions naturally expire on restart, which is fine for flash messages.
+        Middleware(
+            SessionMiddleware,
+            secret_key=secrets.token_hex(),
+            session_cookie=COOKIE_SESSION,
+            same_site="lax",
+            https_only=bool(cfg.enable_https()),
+        ),
+    ]
 
-middleware = [
-    Middleware(GZipMiddleware, minimum_size=1000, compresslevel=2),
-    # Signed session cookie, used for short-lived per-client UI state such as the
-    # RSS read-out result message (flash). Secret key is regenerated each run,
-    # so sessions naturally expire on restart, which is fine for flash messages.
-    Middleware(
-        SessionMiddleware,
-        secret_key=secrets.token_hex(),
-        session_cookie=COOKIE_SESSION,
-        same_site="lax",
-        https_only=bool(cfg.enable_https()),
-    ),
-]
-
-app = Starlette(middleware=middleware, routes=routes)
+    return Starlette(middleware=middleware, routes=routes)

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -510,7 +510,7 @@ class SecurityMiddleware:
 
         # Verify login status, only for non-key pages
         if self.check_for_login and not self.check_api_key and not check_login(request):
-            return BaseRedirectResponse("/login")
+            return base_redirect_response("/login")
 
         # Some pages need the correct API key
         if self.check_api_key and (msg := check_apikey(request)):
@@ -531,7 +531,9 @@ logging.getLogger("python_multipart.multipart").setLevel(logging.WARNING)
 ##############################################################################
 # Helper redirect functions
 ##############################################################################
-def BaseRedirectResponse(root: str = "", **kwargs) -> RedirectResponse:
+
+
+def base_redirect_response(root: str = "", **kwargs) -> RedirectResponse:
     """Create a Starlette RedirectResponse with SABnzbd URL base and query parameters"""
     # Shares url_for with the templates so redirect targets and links stay in step.
     # Root-relative on purpose: a Location header should send the client back to the
@@ -575,7 +577,7 @@ def main_index(request: Request):
         return template_filtered_response(file=os.path.join(sabnzbd.WEB_DIR, "main.tmpl"), search_list=info)
     else:
         # Redirect to the setup wizard
-        return BaseRedirectResponse("/wizard")
+        return base_redirect_response("/wizard")
 
 
 @secured_expose(route="/shutdown", check_api_key=True)
@@ -769,7 +771,7 @@ def get_access_info(request: Optional[Request] = None) -> set[str]:
 async def login_index(request: Request):
     # Already logged in, or no username/password set at all
     if check_login(request):
-        return BaseRedirectResponse("/")
+        return base_redirect_response("/")
 
     error = None
     if request.method == "POST":
@@ -779,7 +781,7 @@ async def login_index(request: Request):
 
         if username == cfg.username() and password == cfg.password():
             # Create redirect response
-            response = BaseRedirectResponse("/")
+            response = base_redirect_response("/")
             # Save login cookie
             set_login_cookie(request, response, remember_me=remember_me)
             # Log the success
@@ -811,7 +813,7 @@ async def login_index(request: Request):
 
 @secured_expose(route="/logout", check_for_login=False, methods=["GET"])
 def logout_index(request: Request):
-    response = BaseRedirectResponse("/")
+    response = base_redirect_response("/")
     set_login_cookie(request, response, remove=True)
     return response
 
@@ -1221,7 +1223,7 @@ def config_server_save(request: Request):
 def config_server_del(request: Request):
     kw = {"section": "servers", "keyword": request_params(request).get("server")}
     del_from_section(kw)
-    return BaseRedirectResponse("/config/server")
+    return base_redirect_response("/config/server")
 
 
 @secured_expose(route="/config/server/clear_server", check_api_key=True, check_configlock=True, methods=["POST"])
@@ -1229,7 +1231,7 @@ def config_server_clr(request: Request):
     server = request_params(request).get("server")
     if server:
         sabnzbd.BPSMeter.clear_server(server)
-    return BaseRedirectResponse("/config/server")
+    return base_redirect_response("/config/server")
 
 
 @secured_expose(route="/config/server/toggle_server", check_api_key=True, check_configlock=True, methods=["POST"])
@@ -1241,7 +1243,7 @@ def config_server_toggle(request: Request):
             svr.enable.set(not svr.enable())
             config.save_config()
             sabnzbd.Downloader.update_server(server, server)
-    return BaseRedirectResponse("/config/server")
+    return base_redirect_response("/config/server")
 
 
 def unique_svr_name(server):
@@ -1380,8 +1382,8 @@ _RSS_ROOT = "/config/rss"
 def _rss_redirect(feed: str = "") -> RedirectResponse:
     """Redirect back to the RSS page, optionally selecting a feed."""
     if feed:
-        return BaseRedirectResponse(_RSS_ROOT, feed=feed)
-    return BaseRedirectResponse(_RSS_ROOT)
+        return base_redirect_response(_RSS_ROOT, feed=feed)
+    return base_redirect_response(_RSS_ROOT)
 
 
 def _rss_flash_redirect(request: Request, feed: str, msg: str = "") -> RedirectResponse:
@@ -1452,7 +1454,7 @@ def config_rss_save_rss_rate(request: Request):
     cfg.rss_rate.set(request_params(request).get("rss_rate"))
     config.save_config()
     sabnzbd.Scheduler.restart()
-    return BaseRedirectResponse(_RSS_ROOT)
+    return base_redirect_response(_RSS_ROOT)
 
 
 @secured_expose(route="/config/rss/upd_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
@@ -1501,7 +1503,7 @@ def config_rss_save_rss_feed(request: Request):
 
         config.save_config()
 
-    return BaseRedirectResponse(_RSS_ROOT, feed=feed_name) if feed_name else BaseRedirectResponse(_RSS_ROOT)
+    return base_redirect_response(_RSS_ROOT, feed=feed_name) if feed_name else base_redirect_response(_RSS_ROOT)
 
 
 @secured_expose(route="/config/rss/toggle_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
@@ -1516,10 +1518,10 @@ def config_rss_toggle_rss_feed(request: Request):
         item.enable.set(not item.enable())
         config.save_config()
     if params.get("table"):
-        return BaseRedirectResponse(_RSS_ROOT)
+        return base_redirect_response(_RSS_ROOT)
     else:
         feed = params.get("feed")
-        return BaseRedirectResponse(_RSS_ROOT, feed=feed) if feed else BaseRedirectResponse(_RSS_ROOT)
+        return base_redirect_response(_RSS_ROOT, feed=feed) if feed else base_redirect_response(_RSS_ROOT)
 
 
 @secured_expose(route="/config/rss/add_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
@@ -1548,9 +1550,9 @@ def config_rss_add_rss_feed(request: Request):
             msg = sabnzbd.RSSReader.process_feed(feed, readout=True, ignore_first=True)
             return _rss_flash_redirect(request, feed, msg)
         else:
-            return BaseRedirectResponse(_RSS_ROOT)
+            return base_redirect_response(_RSS_ROOT)
     else:
-        return BaseRedirectResponse(_RSS_ROOT)
+        return base_redirect_response(_RSS_ROOT)
 
 
 @secured_expose(route="/config/rss/upd_rss_filter", check_api_key=True, check_configlock=True, methods=["POST"])
@@ -1568,7 +1570,7 @@ def config_rss_del_rss_feed(request: Request):
     del_from_section(kw)
     with sabnzbd.rss.rss_repository() as repo:
         repo.clear_feed(feed)
-    return BaseRedirectResponse(_RSS_ROOT)
+    return base_redirect_response(_RSS_ROOT)
 
 
 @secured_expose(route="/config/rss/del_rss_filter", check_api_key=True, check_configlock=True, methods=["POST"])
@@ -1661,7 +1663,7 @@ def config_rss_download(request: Request):
 def config_rss_rss_now(request: Request):
     """Run an automatic RSS run now"""
     sabnzbd.Scheduler.force_rss()
-    return BaseRedirectResponse(_RSS_ROOT)
+    return base_redirect_response(_RSS_ROOT)
 
 
 def ConvertSpecials(p):
@@ -1850,7 +1852,7 @@ def config_scheduling_add(request: Request):
 
     config.save_config()
     sabnzbd.Scheduler.restart()
-    return BaseRedirectResponse(_SCHED_ROOT)
+    return base_redirect_response(_SCHED_ROOT)
 
 
 @secured_expose(route="/config/scheduling/del_schedule", check_api_key=True, check_configlock=True, methods=["POST"])
@@ -1862,7 +1864,7 @@ def config_scheduling_del(request: Request):
         cfg.schedules.set(schedules)
         config.save_config()
         sabnzbd.Scheduler.restart()
-    return BaseRedirectResponse(_SCHED_ROOT)
+    return base_redirect_response(_SCHED_ROOT)
 
 
 @secured_expose(route="/config/scheduling/toggle_schedule", check_api_key=True, check_configlock=True, methods=["POST"])
@@ -1880,7 +1882,7 @@ def config_scheduling_toggle(request: Request):
         cfg.schedules.set(schedules)
         config.save_config()
         sabnzbd.Scheduler.restart()
-    return BaseRedirectResponse(_SCHED_ROOT)
+    return base_redirect_response(_SCHED_ROOT)
 
 
 ##############################################################################
@@ -1924,7 +1926,7 @@ def config_categories_delete(request: Request):
         "keyword": request_params(request).get("name"),
     }
     del_from_section(kw)
-    return BaseRedirectResponse("/config/categories")
+    return base_redirect_response("/config/categories")
 
 
 @secured_expose(route="/config/categories/save", check_api_key=True, check_configlock=True, methods=["POST"])
@@ -1952,7 +1954,7 @@ def config_categories_save(request: Request):
         config.ConfigCat(newname.lower(), cat_params)
 
     config.save_config()
-    return BaseRedirectResponse("/config/categories")
+    return base_redirect_response("/config/categories")
 
 
 ##############################################################################
@@ -1996,7 +1998,7 @@ def config_sorting_index(request: Request):
 def config_sorting_delete(request: Request):
     kw = {"section": "sorters", "keyword": request_params(request).get("name")}
     del_from_section(kw)
-    return BaseRedirectResponse(_SORTING_ROOT)
+    return base_redirect_response(_SORTING_ROOT)
 
 
 @secured_expose(route="/config/sorting/save_sorter", check_api_key=True, check_configlock=True, methods=["POST"])
@@ -2016,7 +2018,7 @@ def config_sorting_save_sorter(request: Request):
         config.ConfigSorter(newname, kwargs)
 
     config.save_config()
-    return BaseRedirectResponse(_SORTING_ROOT)
+    return base_redirect_response(_SORTING_ROOT)
 
 
 @secured_expose(route="/config/sorting/toggle_sorter", check_api_key=True, check_configlock=True, methods=["POST"])
@@ -2029,7 +2031,7 @@ def config_sorting_toggle_sorter(request: Request):
     except Exception:
         pass
 
-    return BaseRedirectResponse(_SORTING_ROOT)
+    return base_redirect_response(_SORTING_ROOT)
 
 
 def GetRssLog(feed):
@@ -2461,7 +2463,7 @@ class ThreadedServer(uvicorn.Server):
 
 async def not_found_redirect(request: Request, exc):
     """Catch-all for unknown URLs: redirect to the UI root"""
-    return BaseRedirectResponse("/")
+    return base_redirect_response("/")
 
 
 def create_app() -> Starlette:

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -1733,7 +1733,7 @@ def config_scheduling_add(request: Request):
     servers = config.get_servers()
     minute = params.get("minute")
     hour = params.get("hour")
-    days_of_week = "".join([str(x) for x in params.get("daysofweek", "")])
+    days_of_week = "".join([str(x) for x in params.getlist("daysofweek")])
     if not days_of_week:
         days_of_week = "1234567"
     action = params.get("action")

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -399,14 +399,6 @@ def log_warning_and_ip(request: Request, txt: str):
 API_FIRST_WINS_KEYS = ("mode", "name", "value", "value2", "value3", "start", "limit", "search")
 
 
-def first_wins(params: MultiDict) -> MultiDict:
-    """Collapse the CherryPy API scalar keys to their first value, in place."""
-    for key in API_FIRST_WINS_KEYS:
-        if len(values := params.getlist(key)) > 1:
-            params[key] = values[0]
-    return params
-
-
 def is_form_post(request: Request) -> bool:
     return request.method == "POST" and request.headers.get("content-type", "").startswith(
         ("application/x-www-form-urlencoded", "multipart/form-data")
@@ -447,7 +439,12 @@ async def get_request_params(request: Request, merge_query: bool = False) -> Mul
     for key, value in request.query_params.multi_items():
         if key not in body_keys:
             params.append(key, value)
-    return first_wins(params)
+
+    # Collapse the API scalar keys to their first value
+    for key in API_FIRST_WINS_KEYS:
+        if len(values := params.getlist(key)) > 1:
+            params[key] = values[0]
+    return params
 
 
 def request_params(request: Request) -> MultiDict | QueryParams:
@@ -507,11 +504,11 @@ class SecurityMiddleware:
         """Return the response to send when a check fails, or None when allowed."""
         # Check if config is locked
         if self.check_configlock and cfg.configlock():
-            return forbidden(_MSG_ACCESS_DENIED_CONFIG_LOCK)
+            return PlainTextResponse(_MSG_ACCESS_DENIED_CONFIG_LOCK if cfg.api_warnings() else "", status_code=403)
 
         # Check if external access and if it's allowed
         if not check_access(request, access_type=self.access_type, warn_user=True):
-            return forbidden(_MSG_ACCESS_DENIED)
+            return PlainTextResponse(_MSG_ACCESS_DENIED if cfg.api_warnings() else "", status_code=403)
 
         # Verify login status, only for non-key pages
         if self.check_for_login and not self.check_api_key and not check_login(request):
@@ -519,7 +516,7 @@ class SecurityMiddleware:
 
         # Some pages need the correct API key
         if self.check_api_key and (msg := check_apikey(request)):
-            return forbidden(msg)
+            return PlainTextResponse(msg if cfg.api_warnings() else "", status_code=403)
 
         return None
 
@@ -1721,24 +1718,21 @@ _SCHED_ROOT = "/config/scheduling"
 
 @secured_expose(route="/config/scheduling", check_configlock=True, methods=["GET"])
 def config_scheduling_index(request: Request):
-    def get_days():
-        days = {
-            "*": T("Daily"),
-            "1": T("Monday"),
-            "2": T("Tuesday"),
-            "3": T("Wednesday"),
-            "4": T("Thursday"),
-            "5": T("Friday"),
-            "6": T("Saturday"),
-            "7": T("Sunday"),
-        }
-        return days
-
     conf = build_header(sabnzbd.WEB_DIR_CONFIG, request=request)
 
     actions = []
     actions.extend(_SCHED_ACTIONS)
-    day_names = get_days()
+    # Translated per request, so the names follow the currently active language
+    day_names = {
+        "*": T("Daily"),
+        "1": T("Monday"),
+        "2": T("Tuesday"),
+        "3": T("Wednesday"),
+        "4": T("Thursday"),
+        "5": T("Friday"),
+        "6": T("Saturday"),
+        "7": T("Sunday"),
+    }
     categories = list_cats(False)
     snum = 1
     conf["schedlines"] = []
@@ -2367,20 +2361,18 @@ class SecureSessionCookieMiddleware:
             # Runs after SessionMiddleware appended its Set-Cookie, since the send of
             # an inner middleware is called before that of the ones wrapping it
             if message["type"] == "http.response.start" and use_secure_cookies(Request(scope)):
-                message["headers"] = [
-                    (key, self.mark_secure(value)) if key.lower() == b"set-cookie" else (key, value)
-                    for key, value in message["headers"]
-                ]
+                headers = message["headers"]
+                for index, (key, value) in enumerate(headers):
+                    # Append the Secure attribute to the session cookie, if not already set
+                    if (
+                        key.lower() == b"set-cookie"
+                        and value.startswith(self.COOKIE_PREFIX)
+                        and b"secure" not in value.lower().split(b"; ")
+                    ):
+                        headers[index] = (key, value + b"; secure")
             await send(message)
 
         await self.app(scope, receive, send_with_secure_cookie)
-
-    @classmethod
-    def mark_secure(cls, cookie: bytes) -> bytes:
-        """Append the Secure attribute to the session cookie, if not already set"""
-        if cookie.startswith(cls.COOKIE_PREFIX) and b"secure" not in cookie.lower().split(b"; "):
-            return cookie + b"; secure"
-        return cookie
 
 
 class HostnameCheckMiddleware:

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -20,6 +20,7 @@ sabnzbd.interface - webinterface
 """
 
 import os
+import inspect
 import secrets
 import threading
 import time
@@ -98,6 +99,7 @@ from sabnzbd.api import (
     list_cats,
     del_from_section,
     api_handler,
+    halt_and_shutdown,
     build_header,
     Ttemplate,
 )
@@ -480,20 +482,18 @@ async def shutdown(request: Request):
     if pid_in and int(pid_in) != os.getpid():
         return PlainTextResponse("Incorrect PID for this instance, remove PID from URL to initiate shutdown.")
 
-    if not sabnzbd.SABSTOP:
-        # Persist all state before replying, matching the pre-uvicorn behaviour where
-        # the request blocked until shutdown had saved everything. Run halt() off the
-        # event loop so we don't block it. The web server itself cannot be stopped from
-        # within its own event loop, so that part is deferred to a separate thread.
-        await run_in_threadpool(sabnzbd.halt)
-        threading.Thread(target=sabnzbd.shutdown_program).start()
+    await halt_and_shutdown()
     return PlainTextResponse(T("SABnzbd shutdown finished"))
 
 
 @secured_expose(route="/api", check_api_key=True, access_type=1)
 async def api(request: Request):
     """Redirect to API-handler, we check the access_type in the API-handler"""
-    return api_handler(request_params(request))
+    response = api_handler(request_params(request))
+    # Some API functions (e.g. shutdown) are coroutine functions
+    if inspect.isawaitable(response):
+        response = await response
+    return response
 
 
 @secured_expose(route="/scriptlog", methods=["GET"])

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -335,8 +335,8 @@ def set_login_cookie(request: Request, response: Response, remove=False, remembe
 
 def check_login(request: Request) -> bool:
     """Check if user is logged in (Starlette version)"""
-    # Not when no authentication required or basic-auth is on
-    if not cfg.html_login() or not cfg.username() or not cfg.password():
+    # No authentication required when no username/password is set
+    if not cfg.username() or not cfg.password():
         return True
 
     # If we show login for external IP, by using access_type=6 we can check if IP match
@@ -479,14 +479,11 @@ async def main_index(request: Request):
         info["cpusimd"] = sabnzbd.decoder.SABCTOOLS_SIMD
         info["platform"] = sabnzbd.PLATFORM
 
-        # Have logout only with HTML and if inet=5, only when we are external
+        # Have logout only if inet=5, only when we are external
         info["have_logout"] = (
             cfg.username()
             and cfg.password()
-            and (
-                cfg.html_login()
-                and (cfg.inet_exposure() < 5 or (cfg.inet_exposure() == 5 and not check_access(request, access_type=6)))
-            )
+            and (cfg.inet_exposure() < 5 or (cfg.inet_exposure() == 5 and not check_access(request, access_type=6)))
         )
 
         bytespersec_list = sabnzbd.BPSMeter.get_bps_list()
@@ -931,7 +928,6 @@ SPECIAL_BOOL_LIST = (
     "ipv6_hosting",
     "keep_awake",
     "new_nzb_on_failure",
-    "html_login",
     "disable_archive",
     "wait_for_dfolder",
     "enable_broadcast",

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -145,9 +145,13 @@ def secured_expose(
 
     @functools.wraps(wrap_func)
     async def internal_wrap(request: Request, *args, **kwargs):
-        # Store the merged parameters for this method on request.state,
-        # to be retrieved with request_params(request) in the handlers
-        request.state.params = await get_request_params(request)
+        # Store the parameters for this method on request.state, to be retrieved
+        # with request_params(request) in the handlers.Page routes are strict:
+        # GET reads the query string and POST reads the form body only. The /api
+        # route merges the query string with the form body (body wins), which
+        # third-party API clients rely on (e.g. multipart NZB uploads with
+        # mode/apikey in the URL).
+        request.state.params = await get_request_params(request, merge_query=check_api_key)
 
         # Log all requests
         if cfg.api_logging():
@@ -427,22 +431,36 @@ def log_warning_and_ip(request: Request, txt: str):
         logging.warning("%s %s", txt, remote_info)
 
 
-async def get_request_params(request: Request) -> MultiDict | QueryParams:
+async def get_request_params(request: Request, merge_query: bool = False) -> MultiDict | QueryParams:
     """Return request parameters as a mutable MultiDict.
 
     For POST requests the form body is read (both urlencoded and multipart).
-    File uploads in multipart bodies are kept as UploadFile objects.
+    File uploads in multipart bodies are kept as UploadFile objects. A page
+    POST never reads the query string, so parameters cannot be smuggled into
+    form handlers via the URL.
 
-    For GET (and any non-form POST) only the URL query string is used.
+    The /api route (merge_query) keeps the CherryPy behavior instead: the
+    query string and the form body are merged, with the body winning per key.
+    3rd-party clients traditionally POST an NZB as a multipart body while
+    passing mode/apikey/output in the query string, or POST with all
+    parameters in the query string and no form body at all.
 
     secured_expose stores the result on request.state.params so that
     request_params(request) returns it in every handler without an extra await.
     """
     if request.method == "POST":
-        if request.headers.get("content-type", "").startswith(
+        is_form = request.headers.get("content-type", "").startswith(
             ("application/x-www-form-urlencoded", "multipart/form-data")
-        ):
-            return MultiDict(await request.form())
+        )
+        if not merge_query:
+            return MultiDict(await request.form()) if is_form else MultiDict()
+        if is_form:
+            # Body values replace query values for the same key
+            params = MultiDict(await request.form())
+            for key, value in request.query_params.multi_items():
+                if key not in params:
+                    params.append(key, value)
+            return params
 
     return request.query_params
 

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -505,8 +505,13 @@ async def shutdown(request: Request):
     if pid_in and int(pid_in) != os.getpid():
         return PlainTextResponse("Incorrect PID for this instance, remove PID from URL to initiate shutdown.")
 
-    # In separate thread, because the server thread cannot shut down itself
-    threading.Thread(target=sabnzbd.shutdown_program).start()
+    if not sabnzbd.SABSTOP:
+        # Persist all state before replying, matching the pre-uvicorn behaviour where
+        # the request blocked until shutdown had saved everything. Run halt() off the
+        # event loop so we don't block it. The web server itself cannot be stopped from
+        # within its own event loop, so that part is deferred to a separate thread.
+        await run_in_threadpool(sabnzbd.halt)
+        threading.Thread(target=sabnzbd.shutdown_program).start()
     return PlainTextResponse(T("SABnzbd shutdown finished"))
 
 

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -706,39 +706,38 @@ def get_access_info(request: Optional[Request] = None):
 
 
 @secured_expose(route="/login", check_for_login=False)
-def login_index(request: Request):
+async def login_index(request: Request):
+    # Already logged in, or no username/password set at all
+    if check_login(request):
+        return RedirectResponse(url=f"{cfg.url_base()}/", status_code=302)
+
     # Base output var
     info = build_header(sabnzbd.WEB_DIR_CONFIG)
     info["error"] = ""
 
-    # Use unified params - works for both GET and POST requests
-    username = request_params(request).get("username")
-    password = request_params(request).get("password")
-    remember_me = request_params(request).get("remember_me", False)
+    if request.method == "POST":
+        username = request_params(request).get("username")
+        password = request_params(request).get("password")
+        remember_me = bool(request_params(request).get("remember_me", False))
 
-    # Check if there's even a username/password set
-    if check_login(request):
-        return RedirectResponse(url=f"{cfg.url_base()}/", status_code=302)
-
-    # Check login info
-    if username == cfg.username() and password == cfg.password():
-        # Create redirect response
-        response = RedirectResponse(url=f"{cfg.url_base()}/", status_code=302)
-        # Save login cookie
-        set_login_cookie(request, response, remember_me=remember_me)
-        # Log the success
-        remote_info = "%s:%s" % client_address(request)
-        if cfg.verify_xff_header() and (xff_ips := request.headers.get("X-Forwarded-For")):
-            remote_info += f" (X-Forwarded-For: {xff_ips})"
-        logging.info("Successful login from %s", remote_info)
-        return response
-    elif username or password:
-        info["error"] = T("Authentication failed, check username/password.")
-        # Warn about the potential security problem
-        remote_info = "%s:%s" % client_address(request)
-        if cfg.verify_xff_header() and (xff_ips := request.headers.get("X-Forwarded-For")):
-            remote_info += f" (X-Forwarded-For: {xff_ips})"
-        logging.warning(T("Unsuccessful login attempt from %s"), remote_info)
+        if username == cfg.username() and password == cfg.password():
+            # Create redirect response
+            response = RedirectResponse(url=f"{cfg.url_base()}/", status_code=302)
+            # Save login cookie
+            set_login_cookie(request, response, remember_me=remember_me)
+            # Log the success
+            remote_info = "%s:%s" % client_address(request)
+            if cfg.verify_xff_header() and (xff_ips := request.headers.get("X-Forwarded-For")):
+                remote_info += f" (X-Forwarded-For: {xff_ips})"
+            logging.info("Successful login from %s", remote_info)
+            return response
+        elif username or password:
+            info["error"] = T("Authentication failed, check username/password.")
+            # Warn about the potential security problem
+            remote_info = "%s:%s" % client_address(request)
+            if cfg.verify_xff_header() and (xff_ips := request.headers.get("X-Forwarded-For")):
+                remote_info += f" (X-Forwarded-For: {xff_ips})"
+            logging.warning(T("Unsuccessful login attempt from %s"), remote_info)
 
     # Show login
     return template_filtered_response(

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -145,33 +145,6 @@ def secured_expose(
 
     @functools.wraps(wrap_func)
     async def internal_wrap(request: Request, *args, **kwargs):
-        # Check if config is locked
-        if check_configlock and cfg.configlock():
-            if cfg.api_warnings():
-                return PlainTextResponse(_MSG_ACCESS_DENIED_CONFIG_LOCK, status_code=403)
-            return PlainTextResponse("", status_code=403)
-
-        # Check if external access and if it's allowed
-        if not check_access(request, access_type=access_type, warn_user=True):
-            if cfg.api_warnings():
-                return PlainTextResponse(_MSG_ACCESS_DENIED, status_code=403)
-            return PlainTextResponse("", status_code=403)
-
-        # Verify login status, only for non-key pages
-        if check_for_login and not check_api_key and not check_login(request):
-            return BaseRedirectResponse("/login")
-
-        # Some pages need correct API key
-        if check_api_key:
-            if msg := check_apikey(request):
-                if cfg.api_warnings():
-                    return PlainTextResponse(msg, status_code=403)
-                return PlainTextResponse("", status_code=403)
-
-        # All good, cool! Coroutine handlers are awaited on the event loop, so they
-        # must never block; plain sync handlers are executed in the threadpool so
-        # blocking work (template rendering, disk and database access) cannot stall
-        # the event loop.
         if inspect.iscoroutinefunction(wrap_func):
             return await wrap_func(request, *args, **kwargs)
         return await run_in_threadpool(wrap_func, request, *args, **kwargs)
@@ -182,7 +155,16 @@ def secured_expose(
                 route,
                 endpoint=internal_wrap,
                 methods=methods,
-                middleware=[Middleware(ParamsMiddleware, merge_query=check_api_key)],
+                middleware=[
+                    Middleware(ParamsMiddleware, merge_query=check_api_key),
+                    Middleware(
+                        SecurityMiddleware,
+                        check_configlock=check_configlock,
+                        check_for_login=check_for_login,
+                        check_api_key=check_api_key,
+                        access_type=access_type,
+                    ),
+                ],
             )
         )
 
@@ -469,6 +451,58 @@ class ParamsMiddleware:
             request = Request(scope, receive)
             request.state.params = await get_request_params(request, merge_query=self.merge_query)
         await self.app(scope, receive, send)
+
+
+class SecurityMiddleware:
+    """Enforce a route's access rules before its handler runs: config lock, local vs
+    external access, login, and API key. Attached per route by secured_expose with
+    that route's flags, and ordered after ParamsMiddleware so the API-key check can
+    read the parsed request_params. Pure ASGI; a failed check answers with a 403 (or
+    a redirect to /login) without ever invoking the handler."""
+
+    def __init__(
+        self,
+        app,
+        check_configlock: bool = False,
+        check_for_login: bool = True,
+        check_api_key: bool = False,
+        access_type: int = 4,
+    ):
+        self.app = app
+        self.check_configlock = check_configlock
+        self.check_for_login = check_for_login
+        self.check_api_key = check_api_key
+        self.access_type = access_type
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http" and (response := self.denied_response(Request(scope, receive))):
+            return await response(scope, receive, send)
+        await self.app(scope, receive, send)
+
+    def denied_response(self, request: Request) -> Optional[Response]:
+        """Return the response to send when a check fails, or None when allowed."""
+        # Check if config is locked
+        if self.check_configlock and cfg.configlock():
+            return forbidden(_MSG_ACCESS_DENIED_CONFIG_LOCK)
+
+        # Check if external access and if it's allowed
+        if not check_access(request, access_type=self.access_type, warn_user=True):
+            return forbidden(_MSG_ACCESS_DENIED)
+
+        # Verify login status, only for non-key pages
+        if self.check_for_login and not self.check_api_key and not check_login(request):
+            return BaseRedirectResponse("/login")
+
+        # Some pages need the correct API key
+        if self.check_api_key and (msg := check_apikey(request)):
+            return forbidden(msg)
+
+        return None
+
+
+def forbidden(message: str) -> PlainTextResponse:
+    """403 response, carrying the reason only when api_warnings is enabled."""
+    return PlainTextResponse(message if cfg.api_warnings() else "", status_code=403)
 
 
 # Disable over-active logging for the form parser

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -252,7 +252,7 @@ def set_login_cookie(request: Request, response: Response, remove=False, remembe
     cookie_str = utob(str(salt) + client_address(request).host + COOKIE_SECRET)
     cookie_value = hashlib.sha1(cookie_str).hexdigest()
 
-    secure = cfg.enable_https()
+    secure = cfg.enable_https() or request.url.scheme == "https"
     if remove:
         # Remove cookies
         response.set_cookie(

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -2241,23 +2241,60 @@ async def config_notify_save(request: Request):
 
 
 class ThreadedServer(uvicorn.Server):
+    """uvicorn server running in a background thread, so the main thread stays
+    free for the SABnzbd main loop."""
+
+    # Give up on a server that has not reached the serving state by then
+    STARTUP_TIMEOUT = 30.0
+
     def __init__(self, *args, **kwargs):
-        self.thread = None
+        self.thread: Optional[threading.Thread] = None
+        self._startup_exc: Optional[BaseException] = None
+        # Set once the server is either serving or done trying
+        self._startup_done = threading.Event()
         super().__init__(*args, **kwargs)
 
-    def install_signal_handlers(self):
-        pass
+    async def startup(self, sockets=None):
+        await super().startup(sockets=sockets)
+        # Only signal here on success, a failure is signalled by _run() so that
+        # the exception is always recorded before run_in_thread() wakes up
+        self._startup_done.set()
+
+    def _run(self):
+        # Capture any start-up failure (bad cert, port grabbed after the free
+        # check, bad host, etc.) so run_in_thread() can report it. uvicorn raises
+        # SystemExit on a bind error, so catch BaseException rather than Exception.
+        try:
+            self.run()
+        except BaseException as exc:
+            self._startup_exc = exc
+        finally:
+            # No-op after a successful start-up, but releases run_in_thread()
+            # when the thread dies before it ever started serving
+            self._startup_done.set()
 
     def run_in_thread(self):
-        self.thread = threading.Thread(target=self.run)
+        """Start the server in a background thread and block until it is serving.
+
+        Raises RuntimeError if the server thread exits before signalling that it
+        has started, or if it takes too long, so the caller can abort instead of
+        waiting forever.
+        """
+        self.thread = threading.Thread(target=self._run, name="WebServer")
         self.thread.start()
 
-        while not self.started:
-            time.sleep(1e-3)
+        if not self._startup_done.wait(self.STARTUP_TIMEOUT):
+            raise RuntimeError("Web server did not start within %s seconds" % self.STARTUP_TIMEOUT)
+
+        if not self.started:
+            raise RuntimeError("Web server failed to start") from self._startup_exc
 
     def stop(self):
+        """Ask the server to shut down and wait for the thread to finish.
+        Safe to call more than once and before the server was ever started."""
         self.should_exit = True
-        self.thread.join()
+        if self.thread and self.thread is not threading.current_thread():
+            self.thread.join()
 
 
 def create_app() -> Starlette:

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -432,18 +432,22 @@ def log_warning_and_ip(request: Request, txt: str):
 
 
 async def get_request_params(request: Request, merge_query: bool = False) -> MultiDict | QueryParams:
-    """Return request parameters as a mutable MultiDict.
+    """Parse the request's parameters.
 
-    For POST requests the form body is read (both urlencoded and multipart).
-    File uploads in multipart bodies are kept as UploadFile objects. A page
-    POST never reads the query string, so parameters cannot be smuggled into
-    form handlers via the URL.
+    A GET renders a page and never changes state, so only the URL query
+    string is used, returned as the request's immutable QueryParams.
 
-    The /api route (merge_query) keeps the CherryPy behavior instead: the
-    query string and the form body are merged, with the body winning per key.
+    A page POST reads the form body only (urlencoded or multipart, with file
+    uploads kept as UploadFile objects) into a mutable MultiDict; the query
+    string is ignored, so parameters cannot be smuggled into form handlers
+    via the URL. A POST without a form body yields an empty MultiDict.
+
+    The /api route (merge_query) keeps the CherryPy behavior instead:
     3rd-party clients traditionally POST an NZB as a multipart body while
-    passing mode/apikey/output in the query string, or POST with all
-    parameters in the query string and no form body at all.
+    passing mode/apikey/output in the query string, so a form body is merged
+    with the query string into a mutable MultiDict, the body winning per key.
+    An /api POST without a form body uses the query string alone, returned as
+    the immutable QueryParams.
 
     secured_expose stores the result on request.state.params so that
     request_params(request) returns it in every handler without an extra await.
@@ -466,7 +470,10 @@ async def get_request_params(request: Request, merge_query: bool = False) -> Mul
 
 
 def request_params(request: Request) -> MultiDict | QueryParams:
-    """Accessor for the merged GET/POST parameters stored by secured_expose"""
+    """The request's parameters, parsed once by secured_expose: the query
+    string for a GET, the form body for a page POST, or the form body merged
+    with the query string for an /api POST. See get_request_params for the
+    exact rules and the returned types."""
     return request.state.params
 
 

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -238,6 +238,11 @@ COOKIE_SECRET = str(randint(1000, 100000) * os.getpid())
 COOKIE_SESSION = "sabnzbd_session"
 
 
+def use_secure_cookies(request: Request) -> bool:
+    """Whether cookies for this request should carry the Secure attribute"""
+    return request.url.scheme == "https" or bool(cfg.enable_https())
+
+
 def set_login_cookie(request: Request, response: Response, remove=False, remember_me=False):
     """Set login cookie for Starlette (updated version)
     We try to set a cookie as unique as possible
@@ -252,7 +257,7 @@ def set_login_cookie(request: Request, response: Response, remove=False, remembe
     cookie_str = utob(str(salt) + client_address(request).host + COOKIE_SECRET)
     cookie_value = hashlib.sha1(cookie_str).hexdigest()
 
-    secure = cfg.enable_https() or request.url.scheme == "https"
+    secure = use_secure_cookies(request)
     if remove:
         # Remove cookies
         response.set_cookie(
@@ -2336,6 +2341,48 @@ class XFrameOptionsMiddleware:
         await self.app(scope, receive, send_with_header)
 
 
+class SecureSessionCookieMiddleware:
+    """Add the Secure attribute to the session cookie when the connection warrants it.
+
+    SessionMiddleware builds its cookie flags once at construction, so it cannot know
+    that TLS was terminated at a reverse proxy, which is only visible per request. It
+    is therefore mounted without https_only and wrapped by this middleware, which
+    flags the cookie using the same rule as set_login_cookie. Any other Set-Cookie
+    header is passed through untouched: the login cookies are already flagged where
+    they are set. Pure ASGI (not BaseHTTPMiddleware) to keep streaming responses
+    untouched."""
+
+    # Matches the cookie emitted by SessionMiddleware, which is mounted with
+    # session_cookie=COOKIE_SESSION
+    COOKIE_PREFIX = utob(COOKIE_SESSION + "=")
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+
+        async def send_with_secure_cookie(message):
+            # Runs after SessionMiddleware appended its Set-Cookie, since the send of
+            # an inner middleware is called before that of the ones wrapping it
+            if message["type"] == "http.response.start" and use_secure_cookies(Request(scope)):
+                message["headers"] = [
+                    (key, self.mark_secure(value)) if key.lower() == b"set-cookie" else (key, value)
+                    for key, value in message["headers"]
+                ]
+            await send(message)
+
+        await self.app(scope, receive, send_with_secure_cookie)
+
+    @classmethod
+    def mark_secure(cls, cookie: bytes) -> bytes:
+        """Append the Secure attribute to the session cookie, if not already set"""
+        if cookie.startswith(cls.COOKIE_PREFIX) and b"secure" not in cookie.lower().split(b"; "):
+            return cookie + b"; secure"
+        return cookie
+
+
 class HostnameCheckMiddleware:
     """Reject requests whose Host header is not allowed (DNS-rebinding mitigation).
     Applied as global middleware rather than in secured_expose so a single place
@@ -2496,15 +2543,18 @@ def create_app() -> Starlette:
         Middleware(HostnameCheckMiddleware),
         Middleware(RequestLoggingMiddleware),
         Middleware(GZipMiddleware, minimum_size=1000, compresslevel=2),
+        Middleware(SecureSessionCookieMiddleware),
         # Signed session cookie, used for short-lived per-client UI state such as the
         # RSS read-out result message (flash). Secret key is regenerated each run,
         # so sessions naturally expire on restart, which is fine for flash messages.
+        # The Secure attribute is left to SecureSessionCookieMiddleware, which decides
+        # it per request instead of once at start-up.
         Middleware(
             SessionMiddleware,
             secret_key=secrets.token_hex(),
             session_cookie=COOKIE_SESSION,
             same_site="lax",
-            https_only=bool(cfg.enable_https()),
+            https_only=False,
         ),
     ]
 

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -37,7 +37,7 @@ from random import randint
 import uvicorn
 from starlette.applications import Starlette
 from starlette.concurrency import run_in_threadpool
-from starlette.datastructures import Address, MultiDict, QueryParams
+from starlette.datastructures import Address, MultiDict, MutableHeaders, QueryParams
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, RedirectResponse, PlainTextResponse, Response, FileResponse
 from starlette.middleware import Middleware
@@ -2226,6 +2226,28 @@ def config_notify_save(request: Request):
 ##############################################################################
 
 
+class XFrameOptionsMiddleware:
+    """Add X-Frame-Options to every response when cfg.x_frame_options is enabled,
+    mitigating clickjacking. Applied as middleware rather than in secured_expose so
+    it also covers static file mounts, redirects, the login page and error responses.
+    The setting is read per request, so toggling it needs no restart. Implemented as
+    pure ASGI (not BaseHTTPMiddleware) to keep streaming responses untouched."""
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http" or not cfg.x_frame_options():
+            return await self.app(scope, receive, send)
+
+        async def send_with_header(message):
+            if message["type"] == "http.response.start":
+                MutableHeaders(scope=message)["X-Frame-Options"] = "SAMEORIGIN"
+            await send(message)
+
+        await self.app(scope, receive, send_with_header)
+
+
 class ThreadedServer(uvicorn.Server):
     """uvicorn server running in a background thread, so the main thread stays
     free for the SABnzbd main loop."""
@@ -2307,6 +2329,7 @@ def create_app() -> Starlette:
     routes.append(Mount("/", routes=interface_routes))
 
     middleware = [
+        Middleware(XFrameOptionsMiddleware),
         Middleware(GZipMiddleware, minimum_size=1000, compresslevel=2),
         # Signed session cookie, used for short-lived per-client UI state such as the
         # RSS read-out result message (flash). Secret key is regenerated each run,

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -385,49 +385,71 @@ def log_warning_and_ip(request: Request, txt: str):
         logging.warning("%s %s", txt, remote_info)
 
 
+# CherryPy collapsed these API routing/scalar keys to their first value when a key
+# was supplied more than once (e.g. ?mode=queue&mode=version resolved to "queue"),
+# whereas Starlette's .get() would otherwise return the last. Dispatch and the
+# handlers still assume a single value, so the merged API routes reproduce this.
+# Genuinely multi-valued keys (keyword, file uploads) are left alone so getlist()
+# still sees every value.
+API_FIRST_WINS_KEYS = ("mode", "name", "value", "value2", "value3", "start", "limit", "search")
+
+
+def first_wins(params: MultiDict) -> MultiDict:
+    """Collapse the CherryPy API scalar keys to their first value, in place."""
+    for key in API_FIRST_WINS_KEYS:
+        if len(values := params.getlist(key)) > 1:
+            params[key] = values[0]
+    return params
+
+
+def is_form_post(request: Request) -> bool:
+    return request.method == "POST" and request.headers.get("content-type", "").startswith(
+        ("application/x-www-form-urlencoded", "multipart/form-data")
+    )
+
+
 async def get_request_params(request: Request, merge_query: bool = False) -> MultiDict | QueryParams:
     """Parse the request's parameters.
 
-    A GET renders a page and never changes state, so only the URL query
-    string is used, returned as the request's immutable QueryParams.
+    A page GET renders a page and never changes state, so only the URL query
+    string is used, returned as the request's immutable QueryParams. A page POST
+    reads the form body only (urlencoded or multipart, with file uploads kept as
+    UploadFile objects) into a mutable MultiDict; the query string is ignored, so
+    parameters cannot be smuggled into form handlers via the URL. A POST without a
+    form body yields an empty MultiDict.
 
-    A page POST reads the form body only (urlencoded or multipart, with file
-    uploads kept as UploadFile objects) into a mutable MultiDict; the query
-    string is ignored, so parameters cannot be smuggled into form handlers
-    via the URL. A POST without a form body yields an empty MultiDict.
-
-    The /api route (merge_query) keeps the CherryPy behavior instead:
-    3rd-party clients traditionally POST an NZB as a multipart body while
-    passing mode/apikey/output in the query string, so a form body is merged
-    with the query string into a mutable MultiDict, the body winning per key.
-    An /api POST without a form body uses the query string alone, returned as
-    the immutable QueryParams.
+    The merged API routes (merge_query, i.e. /api and the api-key protected
+    *_save routes) keep the CherryPy behavior instead: 3rd-party clients
+    traditionally POST an NZB as a multipart body while passing mode/apikey/output
+    in the query string, so the form body and query string are merged into a
+    mutable MultiDict, the body winning per key. A key supplied only in the query
+    string keeps all of its values. GET, form POST and bodyless POST all take this
+    same path, so a duplicated key resolves identically regardless of method, and
+    the API scalar keys collapse to their first value exactly as CherryPy did.
 
     ParamsMiddleware stores the result on request.state.params so that
     request_params(request) returns it in every handler without an extra await.
     """
-    if request.method == "POST":
-        is_form = request.headers.get("content-type", "").startswith(
-            ("application/x-www-form-urlencoded", "multipart/form-data")
-        )
-        if not merge_query:
-            return MultiDict(await request.form()) if is_form else MultiDict()
-        if is_form:
-            # Body values replace query values for the same key
-            params = MultiDict(await request.form())
-            for key, value in request.query_params.multi_items():
-                if key not in params:
-                    params.append(key, value)
-            return params
+    if not merge_query:
+        if is_form_post(request):
+            return MultiDict(await request.form())
+        return MultiDict() if request.method == "POST" else request.query_params
 
-    return request.query_params
+    # Start from the form body (if any) so it wins per key, then add query-string
+    # values for keys the body did not set.
+    params = MultiDict(await request.form()) if is_form_post(request) else MultiDict()
+    body_keys = set(params.keys())
+    for key, value in request.query_params.multi_items():
+        if key not in body_keys:
+            params.append(key, value)
+    return first_wins(params)
 
 
 def request_params(request: Request) -> MultiDict | QueryParams:
     """The request's parameters, parsed once by ParamsMiddleware: the query
-    string for a GET, the form body for a page POST, or the form body merged
-    with the query string for an /api POST. See get_request_params for the
-    exact rules and the returned types."""
+    string for a page GET, the form body for a page POST, or the form body
+    merged with the query string for the API routes. See get_request_params
+    for the exact rules and the returned types."""
     return request.state.params
 
 

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -2421,6 +2421,18 @@ class ThreadedServer(uvicorn.Server):
         if self.thread and self.thread is not threading.current_thread():
             self.thread.join()
 
+    def stop_accepting_connections(self):
+        """Close the listening sockets so no new connections are accepted, while
+        in-flight requests (including the caller's own response) still complete.
+
+        Must be called from the event-loop thread, i.e. from within an async
+        request handler, so touching the asyncio Server objects needs no
+        cross-thread scheduling. Safe before start-up (uvicorn only sets `servers`
+        once serving) and after a previous close (uvicorn's own shutdown closes
+        them again, idempotently)."""
+        for server in getattr(self, "servers", []):
+            server.close()
+
 
 async def not_found_redirect(request: Request, exc):
     """Catch-all for unknown URLs: redirect to the UI root"""

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -2394,9 +2394,12 @@ class ThreadedServer(uvicorn.Server):
     # Give up on a server that has not reached the serving state by then
     STARTUP_TIMEOUT = 30.0
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, sockets: Optional[list[socket.socket]] = None, **kwargs):
         self.thread: Optional[threading.Thread] = None
         self._startup_exc: Optional[BaseException] = None
+        # Pre-bound listening sockets, so the port cannot be taken between the
+        # moment we claim it and the moment uvicorn starts serving on it
+        self._sockets = sockets
         # Set once the server is either serving or done trying
         self._startup_done = threading.Event()
         super().__init__(*args, **kwargs)
@@ -2408,11 +2411,11 @@ class ThreadedServer(uvicorn.Server):
         self._startup_done.set()
 
     def _run(self):
-        # Capture any start-up failure (bad cert, port grabbed after the free
-        # check, bad host, etc.) so run_in_thread() can report it. uvicorn raises
-        # SystemExit on a bind error, so catch BaseException rather than Exception.
+        # Capture any start-up failure (bad cert, bad host, etc.) so
+        # run_in_thread() can report it. uvicorn raises SystemExit on a bind
+        # error, so catch BaseException rather than Exception.
         try:
-            self.run()
+            self.run(sockets=self._sockets)
         except BaseException as exc:
             self._startup_exc = exc
         finally:

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -19,6 +19,7 @@
 sabnzbd.misc - misc classes
 """
 
+import errno
 import os
 import platform
 import ssl
@@ -743,16 +744,24 @@ def split_host(srv: Optional[str]) -> tuple[Optional[str], Optional[int]]:
     return out[0], port
 
 
-def port_is_free(host: str, port: int) -> bool:
-    """Return True if host:port can be bound.
+class HostNotAvailableError(OSError):
+    """The address is not one of ours, so no port on it can ever be bound"""
 
-    Deliberately mirrors how uvicorn builds its listening socket (see
-    uvicorn.Config.bind_socket) so the answer predicts whether the web server
-    will actually come up, rather than merely whether something answers there.
 
-    Raises PermissionError when the port may not be bound at all, which is a
-    different problem from the port being taken and cannot be worked around by
-    picking a nearby port.
+# "Cannot assign requested address" is errno 99 on Linux but 49 on macOS/BSD,
+# and Winsock reports its own value, so collect whichever names exist here
+ADDRESS_NOT_AVAILABLE = {getattr(errno, name) for name in ("EADDRNOTAVAIL", "WSAEADDRNOTAVAIL") if hasattr(errno, name)}
+
+
+def bind_web_socket(host: str, port: int) -> socket.socket:
+    """Return a listening socket on host:port, ready to be served on.
+
+    Built the way uvicorn would (see uvicorn.Config.bind_socket) so it can be
+    handed straight to the server. Doing that removes the window between finding
+    a port free and actually claiming it.
+
+    Raises PermissionError if the port may not be used and HostNotAvailableError
+    if the address is not ours. Neither is solved by trying a different port.
     """
     # uvicorn derives the family from the shape of the host string, so match it
     family = socket.AF_INET6 if host and ":" in host else socket.AF_INET
@@ -761,29 +770,52 @@ def port_is_free(host: str, port: int) -> bool:
         # uvicorn sets this before binding, so a port held in TIME_WAIT is free
         # to us too. Skipped on Windows, where SO_REUSEADDR instead permits
         # taking over a port another process is actively listening on, which
-        # would make every probe succeed.
+        # would make every bind succeed.
         if not sabnzbd.WINDOWS:
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         sock.bind((host, port))
-        return True
+        # Binding alone does not reserve the port: another SO_REUSEADDR socket
+        # can still bind it until someone listens. asyncio calls listen() again
+        # with its own backlog when it takes the socket over, which is harmless.
+        sock.listen(socket.SOMAXCONN)
     except PermissionError:
         # Where the privileged range starts is configurable on Linux and does
         # not exist on Windows, so react to the error rather than comparing
         # the port against 1024
+        sock.close()
         logging.debug("Not allowed to bind %s:%s", host, port)
+        raise
+    except OSError as err:
+        sock.close()
+        if err.errno in ADDRESS_NOT_AVAILABLE:
+            logging.debug("Address %s is not available", host)
+            raise HostNotAvailableError(err.errno, "Host address not available: %s" % host) from err
+        raise
+    return sock
+
+
+def port_is_free(host: str, port: int) -> bool:
+    """Return True if host:port can be bound.
+
+    Binds and immediately releases, so the answer predicts whether the web
+    server will actually come up rather than merely whether something answers
+    there. Propagates the errors that no other port would avoid.
+    """
+    try:
+        bind_web_socket(host, port).close()
+        return True
+    except (PermissionError, HostNotAvailableError):
         raise
     except OSError as err:
         logging.debug("Cannot bind %s:%s (%s)", host, port, err)
         return False
-    finally:
-        sock.close()
 
 
 def find_free_port(host: str, currentport: int) -> Optional[int]:
     """Return the first bindable port at or above currentport, None if there is none.
 
-    Propagates PermissionError from port_is_free, so a caller can report that a
-    port is barred instead of a fruitless search for a free one.
+    Propagates PermissionError and HostNotAvailableError from port_is_free, so a
+    caller can report those instead of a fruitless search for a free port.
     """
     for _ in range(10):
         # Port 0 would have the OS hand out an arbitrary port, and 49152 and up

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -1335,6 +1335,35 @@ def is_local_addr(ip: str) -> bool:
         return is_lan_addr(ip)
 
 
+def xff_trusted_networks() -> list[str]:
+    """Networks from which the X-Forwarded-For header may be trusted, for use as
+    uvicorn's forwarded_allow_ips. Mirrors is_loopback_addr plus is_local_addr:
+    loopback and the user-defined local_ranges, or the private LAN address space
+    when no local_ranges are set.
+
+    Uvicorn compares the raw peer address without normalization, so for every
+    IPv4 entry the IPv4-mapped IPv6 form (::ffff:a.b.c.d) is added as well.
+    """
+    networks = ["127.0.0.0/8", "::1"]
+    if local_ranges := cfg.local_ranges():
+        networks.extend(local_ranges)
+    else:
+        # Private address space, matching is_lan_addr()
+        networks.extend(["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "169.254.0.0/16", "fc00::/7", "fe80::/10"])
+
+    # Add IPv4-mapped IPv6 equivalents of all IPv4 entries
+    mapped = []
+    for network in networks:
+        try:
+            net = ipaddress.ip_network(network, strict=False)
+        except ValueError:
+            # Not a valid IP or network; leave it to uvicorn as a literal
+            continue
+        if net.version == 4:
+            mapped.append("::ffff:%s/%d" % (net.network_address, net.prefixlen + 96))
+    return networks + mapped
+
+
 def ip_extract() -> list[str]:
     """Return list of IP addresses of this system"""
     ips = []

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -743,6 +743,34 @@ def split_host(srv: Optional[str]) -> tuple[Optional[str], Optional[int]]:
     return out[0], port
 
 
+def port_is_free(host: str, port: int, timeout: float = 0.1) -> bool:
+    """Return True if nothing is listening on host:port.
+
+    Probes by attempting a TCP connection.  A refused or timed-out connection
+    means the port is free; a successful connection means it is occupied.
+    Bind-all addresses (0.0.0.0 / ::) are remapped to localhost so the probe
+    has a concrete target.
+    """
+    if host in ("0.0.0.0", "::", ""):
+        host = "127.0.0.1"
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return False  # connection succeeded → port is occupied
+    except OSError:
+        return True  # connection refused / timed-out → port is free
+
+
+def find_free_port(host: str, currentport: int) -> int:
+    """Return the first free port at or above currentport, 0 if none found."""
+    n = 0
+    while n < 10 and currentport <= 49151:
+        if port_is_free(host, currentport, timeout=0.025):
+            return currentport
+        currentport += 5
+        n += 1
+    return 0
+
+
 def get_cache_limit() -> str:
     """Depending on OS, calculate cache limits.
     In ArticleCache it will make sure we stay

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -743,32 +743,57 @@ def split_host(srv: Optional[str]) -> tuple[Optional[str], Optional[int]]:
     return out[0], port
 
 
-def port_is_free(host: str, port: int, timeout: float = 0.1) -> bool:
-    """Return True if nothing is listening on host:port.
+def port_is_free(host: str, port: int) -> bool:
+    """Return True if host:port can be bound.
 
-    Probes by attempting a TCP connection.  A refused or timed-out connection
-    means the port is free; a successful connection means it is occupied.
-    Bind-all addresses (0.0.0.0 / ::) are remapped to localhost so the probe
-    has a concrete target.
+    Deliberately mirrors how uvicorn builds its listening socket (see
+    uvicorn.Config.bind_socket) so the answer predicts whether the web server
+    will actually come up, rather than merely whether something answers there.
+
+    Raises PermissionError when the port may not be bound at all, which is a
+    different problem from the port being taken and cannot be worked around by
+    picking a nearby port.
     """
-    if host in ("0.0.0.0", "::", ""):
-        host = "127.0.0.1"
+    # uvicorn derives the family from the shape of the host string, so match it
+    family = socket.AF_INET6 if host and ":" in host else socket.AF_INET
+    sock = socket.socket(family, socket.SOCK_STREAM)
     try:
-        with socket.create_connection((host, port), timeout=timeout):
-            return False  # connection succeeded → port is occupied
-    except OSError:
-        return True  # connection refused / timed-out → port is free
+        # uvicorn sets this before binding, so a port held in TIME_WAIT is free
+        # to us too. Skipped on Windows, where SO_REUSEADDR instead permits
+        # taking over a port another process is actively listening on, which
+        # would make every probe succeed.
+        if not sabnzbd.WINDOWS:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind((host, port))
+        return True
+    except PermissionError:
+        # Where the privileged range starts is configurable on Linux and does
+        # not exist on Windows, so react to the error rather than comparing
+        # the port against 1024
+        logging.debug("Not allowed to bind %s:%s", host, port)
+        raise
+    except OSError as err:
+        logging.debug("Cannot bind %s:%s (%s)", host, port, err)
+        return False
+    finally:
+        sock.close()
 
 
-def find_free_port(host: str, currentport: int) -> int:
-    """Return the first free port at or above currentport, 0 if none found."""
-    n = 0
-    while n < 10 and currentport <= 49151:
-        if port_is_free(host, currentport, timeout=0.025):
+def find_free_port(host: str, currentport: int) -> Optional[int]:
+    """Return the first bindable port at or above currentport, None if there is none.
+
+    Propagates PermissionError from port_is_free, so a caller can report that a
+    port is barred instead of a fruitless search for a free one.
+    """
+    for _ in range(10):
+        # Port 0 would have the OS hand out an arbitrary port, and 49152 and up
+        # is the dynamic range that outgoing connections draw from
+        if currentport < 1 or currentport > 49151:
+            break
+        if port_is_free(host, currentport):
             return currentport
         currentport += 5
-        n += 1
-    return 0
+    return None
 
 
 def get_cache_limit() -> str:

--- a/sabnzbd/nzb/object.py
+++ b/sabnzbd/nzb/object.py
@@ -96,7 +96,6 @@ from sabnzbd.decorators import synchronized
 import sabnzbd.config as config
 import sabnzbd.cfg as cfg
 from sabnzbd.downloader import Server
-from sabnzbd.database import HistoryDB
 from sabnzbd.deobfuscate_filenames import is_probably_obfuscated
 
 # Fixed types for the bad-article counter keys
@@ -1648,7 +1647,7 @@ class NzbObject(TryList):
         duplicate_in_history = smart_duplicate_in_history = False
         duplicate_in_queue = smart_duplicate_in_queue = False
 
-        with HistoryDB() as history_db:
+        with sabnzbd.db_pool.connection() as history_db:
             # Dupe check off just name or nzb contents
             if cfg.no_dupes():
                 logging.debug("Duplicate checking NZB %s (md5sum=%s)", self.final_name, self.md5sum)

--- a/sabnzbd/nzbparser.py
+++ b/sabnzbd/nzbparser.py
@@ -30,8 +30,8 @@ import datetime
 import zipfile
 import tempfile
 
-import cherrypy._cpreqbody
-from typing import Optional
+from typing import Optional, Any
+from starlette.datastructures import UploadFile
 
 import sabnzbd
 from sabnzbd.nzb import (
@@ -44,7 +44,7 @@ from sabnzbd.nzb import (
     NzbFile,
     SkippedNzbFile,
 )
-from sabnzbd.encoding import utob, correct_cherrypy_encoding
+from sabnzbd.encoding import utob
 from sabnzbd.filesystem import (
     get_filename,
     get_ext,
@@ -58,14 +58,14 @@ import rarfile
 
 
 def add_nzbfile(
-    nzbfile: str | cherrypy._cpreqbody.Part,
+    nzbfile: str | UploadFile,
     pp: Optional[int | str] = None,
     script: Optional[str] = None,
     cat: Optional[str] = None,
     catdir: Optional[str] = None,
     priority: Optional[int | str] = DEFAULT_PRIORITY,
     nzbname: Optional[str] = None,
-    nzo_info=None,
+    nzo_info: Optional[dict[str, Any]] = None,
     url: Optional[str] = None,
     keep: Optional[bool] = None,
     reuse: Optional[str] = None,
@@ -91,13 +91,11 @@ def add_nzbfile(
         logging.info("Attempting to add %s [%s]", filename, path)
     else:
         # File from file-upload object
-        # CherryPy mangles unicode-filenames: https://github.com/cherrypy/cherrypy/issues/1766
-        filename = correct_cherrypy_encoding(nzbfile.filename)
+        filename = nzbfile.filename
         logging.info("Attempting to add %s", filename)
         keep_default = False
         try:
-            # We have to create a copy, because we can't re-use the CherryPy temp-file
-            # Just to be sure we add the extension to detect file type later on
+            # We have to create a temp file copy; just to be sure we add the extension to detect file type later on
             nzb_temp_file, path = tempfile.mkstemp(suffix=get_ext(filename))
             os.write(nzb_temp_file, nzbfile.file.read())
             os.close(nzb_temp_file)

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -32,7 +32,6 @@ from sabnzbd.filesystem import get_admin_path, remove_all, globber_full, remove_
 from sabnzbd.nzbparser import process_single_nzb
 from sabnzbd.panic import panic_queue
 from sabnzbd.decorators import NzbQueueLocker
-from sabnzbd.database import HistoryDB
 from sabnzbd.constants import (
     QUEUE_FILE_NAME,
     QUEUE_VERSION,
@@ -149,7 +148,7 @@ class NzbQueue:
             registered = {nzo.work_name for nzo in self.__nzo_list}
 
         # Retryable folders from History
-        with HistoryDB() as history_db:
+        with sabnzbd.db_pool.connection() as history_db:
             registered.update(os.path.basename(job["path"]) for job in history_db.get_retryable_jobs())
 
         # Anything waiting or active in post-processing is also a known item

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -23,7 +23,6 @@ import os
 import logging
 import time
 import uuid
-import cherrypy._cpreqbody
 from typing import Optional
 
 import sabnzbd
@@ -169,9 +168,7 @@ class NzbQueue:
                     logging.info("Skipping repair for job %s", folder)
         return result
 
-    def repair_job(
-        self, repair_folder: str, new_nzb: Optional[cherrypy._cpreqbody.Part] = None, password: Optional[str] = None
-    ) -> Optional[str]:
+    def repair_job(self, repair_folder: str, new_nzb=None, password: Optional[str] = None) -> Optional[str]:
         """Reconstruct admin for a single job folder, optionally with new NZB"""
         # Check if folder exists
         if not repair_folder or not os.path.exists(repair_folder):

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -25,6 +25,8 @@ import time
 import uuid
 from typing import Optional
 
+from starlette.datastructures import UploadFile
+
 import sabnzbd
 from sabnzbd.nzb import Article, NzbObject
 from sabnzbd.misc import exit_sab, cat_to_opts, int_conv, caller_name, safe_lower, duplicate_warning
@@ -167,7 +169,9 @@ class NzbQueue:
                     logging.info("Skipping repair for job %s", folder)
         return result
 
-    def repair_job(self, repair_folder: str, new_nzb=None, password: Optional[str] = None) -> Optional[str]:
+    def repair_job(
+        self, repair_folder: str, new_nzb: Optional[UploadFile] = None, password: Optional[str] = None
+    ) -> Optional[str]:
         """Reconstruct admin for a single job folder, optionally with new NZB"""
         # Check if folder exists
         if not repair_folder or not os.path.exists(repair_folder):

--- a/sabnzbd/panic.py
+++ b/sabnzbd/panic.py
@@ -246,39 +246,3 @@ def show_error_dialog(msg):
     if sabnzbd.WINDOWS:
         ctypes.windll.user32.MessageBoxW(0, msg, T("Fatal error"), 0)
     print(msg)
-
-
-def error_page_401(status, message, traceback, version):
-    """Custom handler for 401 error"""
-    title = T("Access denied")
-    body = T("Error %s: You need to provide a valid username and password.") % status
-    return r"""
-<html>
-    <head>
-    <title>%s</title>
-    </head>
-    <body>
-    <br/><br/>
-    <font color="#0000FF">%s</font>
-    </body>
-</html>
-""" % (
-        title,
-        body,
-    )
-
-
-def error_page_404(status, message, traceback, version):
-    """Custom handler for 404 error, redirect to main page"""
-    return r"""
-<html>
-    <head>
-      <script type="text/javascript">
-      <!--
-      location.href = location.protocol + '//' + location.hostname + (location.port ? ':' + location.port : '') + '%s' ;
-      //-->
-      </script>
-    </head>
-    <body><br/></body>
-</html>
-""" % cfg.url_base()

--- a/sabnzbd/panic.py
+++ b/sabnzbd/panic.py
@@ -31,6 +31,7 @@ except ImportError:
 
 import sabnzbd
 import sabnzbd.cfg as cfg
+from sabnzbd.constants import DEF_PORT
 from sabnzbd.encoding import utob
 
 PANIC_PORT = 1
@@ -39,6 +40,7 @@ PANIC_QUEUE = 3
 PANIC_OTHER = 5
 PANIC_SQLITE = 7
 PANIC_HOST = 8
+PANIC_PORT_PERMISSION = 9
 
 
 def MSG_BAD_NEWS():
@@ -78,6 +80,24 @@ def MSG_BAD_PORT():
       &nbsp;&nbsp;&nbsp;&nbsp;%s --server %s:%s<br>
     <br>"""
         + T(r"If you get this error message again, please try a different number.<br>")
+    )
+
+
+def MSG_PORT_PERMISSION():
+    return (
+        T(r"""
+    SABnzbd is not allowed to use port %s on %s.<br>
+    Low port numbers are reserved for privileged processes on most systems,
+    so the port itself is available but cannot be claimed.<br>
+    <br>
+    Either run SABnzbd with the privileges needed for that port, or restart it
+    with a port number of 1024 or higher.""")
+        + """<br>
+    <br>
+    %s<br>
+      &nbsp;&nbsp;&nbsp;&nbsp;%s --server %s:%s<br>
+    <br>"""
+        + T(r"To keep using the low port, put a reverse proxy in front of SABnzbd instead.<br>")
     )
 
 
@@ -158,6 +178,8 @@ def panic_message(panic_code, a=None, b=None):
         msg = MSG_SQLITE()
     elif panic_code == PANIC_HOST:
         msg = MSG_BAD_HOST() % (os_str, prog_path, "localhost", b)
+    elif panic_code == PANIC_PORT_PERMISSION:
+        msg = MSG_PORT_PERMISSION() % (b, a, os_str, prog_path, a, DEF_PORT)
     else:
         msg = MSG_OTHER() % (a, b)
 
@@ -192,6 +214,17 @@ def panic_port(host, port):
         )
     )
     launch_a_browser(panic_message(PANIC_PORT, host, port))
+
+
+def panic_port_permission(host, port):
+    show_error_dialog(
+        "\n%s:\n  %s"
+        % (
+            T("Fatal error"),
+            T("Not allowed to bind to port %s on %s. Low ports need elevated privileges.") % (port, host),
+        )
+    )
+    launch_a_browser(panic_message(PANIC_PORT_PERMISSION, host, port))
 
 
 def panic_host(host, port):

--- a/sabnzbd/postproc.py
+++ b/sabnzbd/postproc.py
@@ -95,7 +95,6 @@ from sabnzbd.decorators import synchronized
 import sabnzbd.emailer as emailer
 import sabnzbd.config as config
 import sabnzbd.cfg as cfg
-import sabnzbd.database as database
 import sabnzbd.notifier as notifier
 import sabnzbd.utils.rarvolinfo as rarvolinfo
 import sabnzbd.utils.checkdir
@@ -362,7 +361,7 @@ class PostProcessor(Thread):
             process_job(nzo)
 
             if nzo.to_be_removed:
-                with database.HistoryDB() as history_db:
+                with sabnzbd.db_pool.connection() as history_db:
                     history_db.remove(nzo.nzo_id)
                 nzo.purge_data()
 
@@ -726,7 +725,7 @@ def process_job(nzo: NzbObject) -> bool:
     # Log the overall time taken for postprocessing
     postproc_time = int(time.time() - start)
 
-    with database.HistoryDB() as history_db:
+    with sabnzbd.db_pool.connection() as history_db:
         # Add the nzo to the database. Only the path, script and time taken is passed
         # Other information is obtained from the nzo
         history_db.add_history_db(nzo, workdir_complete, postproc_time, script_log, script_line)

--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -1275,7 +1275,7 @@ def expired_purge():
 @contextmanager
 def rss_repository(db: Optional[sabnzbd.database.HistoryDB] = None):
     if db is None:
-        with HistoryDB() as db:
+        with sabnzbd.db_pool.connection() as db:
             yield RSSRepository(db)
     else:
         yield RSSRepository(db)

--- a/sabnzbd/skintext.py
+++ b/sabnzbd/skintext.py
@@ -274,7 +274,6 @@ SKIN_TEXT = {
     "opt-port": TT("SABnzbd Port"),
     "explain-port": TT("Port SABnzbd should listen on."),
     "opt-web_dir": TT("Web Interface Theme"),
-    "explain-web_dir": TT("Choose a theme."),
     "opt-web_username": TT("SABnzbd Username"),
     "explain-web_username": TT("Optional authentication username."),
     "opt-web_password": TT("SABnzbd Password"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,7 @@ from tests.testhelper import (
     SABnzbdBaseTest,
     get_api_result,
     get_url_result,
+    wait_for,
 )
 
 # Re-export the shared fixtures so they are registered suite-wide. These are
@@ -102,27 +103,17 @@ def _port_is_open(host, port):
         return sock.connect_ex((host, port)) == 0
 
 
-def _wait_for_port_release(host, port, timeout=30):
-    """Block until nothing is listening on host:port, returns False on timeout"""
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        if not _port_is_open(host, port):
-            return True
-        time.sleep(0.1)
-    return False
-
-
 @pytest.fixture(scope="module")
 def clean_cache_dir(request):
-    # Remove cache if already there
+    # Remove cache if already there. PermissionError is retried (not swallowed):
+    # on Windows a just-stopped instance can hold file handles for a moment, and
+    # skipping the clean-up would leave a previous module's state behind.
     for x in range(100):
         try:
             if os.path.exists(SAB_CACHE_DIR):
                 shutil.rmtree(SAB_CACHE_DIR)
             # Create an empty placeholder
             os.makedirs(SAB_CACHE_DIR)
-            break
-        except PermissionError:
             break
         except OSError:
             time.sleep(0.1)
@@ -163,12 +154,13 @@ def run_sabnzbd(clean_cache_dir, compiled_language_files, request):
             sabnzbd_process.kill()
             sabnzbd_process.communicate(timeout=30)
 
-        # The tracked PID exiting is not proof the instance is gone. Within a single
-        # worker the port and cache dir are reused by every module, so a lingering
-        # instance (slow shutdown, re-exec, orphaned worker) can keep re-saving its
-        # own config over the cache dir.
+        # The tracked PID exiting is not proof the instance is gone: SAB_PORT is a
+        # single random port reused by every module in the session, and a lingering
+        # instance (slow shutdown, re-exec, orphaned worker) keeps re-saving its own
+        # config over the shared cache dir. That is what intermittently wipes the
+        # freshly-copied module ini (e.g. dropping the converted [sorters] section).
         # Block until the port is actually free so the next module starts clean.
-        if not _wait_for_port_release(SAB_HOST, SAB_PORT):
+        if not wait_for(lambda: not _port_is_open(SAB_HOST, SAB_PORT), timeout=15):
             sabnzbd_process.kill()
             warn("Port %s:%s still in use after SABnzbd shutdown" % (SAB_HOST, SAB_PORT))
 
@@ -195,8 +187,11 @@ def run_sabnzbd(clean_cache_dir, compiled_language_files, request):
         ]
     )
 
-    # Wait for SAB to respond
+    # Wait for SAB to respond. Also bail out early if the process died during
+    # start-up, otherwise we'd keep polling a port that a stale instance may own.
     for _ in range(600):
+        if sabnzbd_process.poll() is not None:
+            pytest.fail("SABnzbd exited during start-up (code %s)" % sabnzbd_process.returncode)
         try:
             get_url_result()
             # Woohoo, we're up!

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,10 +150,6 @@ def run_sabnzbd(clean_cache_dir, compiled_language_files, request):
             get_url_result("shutdown", SAB_HOST, SAB_PORT)
         except requests.ConnectionError:
             sabnzbd_process.kill()
-            sabnzbd_process.communicate(timeout=30)
-        except requests.exceptions.ChunkedEncodingError:
-            # Occurs when the server disappears while responding
-            pass
         except Exception as err:
             warn("Failed to shutdown the sabnzbd process: %s" % err)
 

--- a/tests/data/tavern/api_get_files_format.yaml
+++ b/tests/data/tavern/api_get_files_format.yaml
@@ -18,6 +18,7 @@ stages:
       headers:
         content-type: !re_match "application/json"
         content-type: !re_search "charset=(UTF|utf)-8"
+        cache-control: "no-store"
         pragma: "no-cache"
         access-control-allow-origin: "*"
       json:
@@ -51,6 +52,7 @@ stages:
       headers:
         content-type: !re_match "text/xml"
         content-type: !re_search "charset=(UTF|utf)-8"
+        cache-control: "no-store"
         pragma: "no-cache"
         access-control-allow-origin: "*"
         content-length: !re_match "[0-9]+"

--- a/tests/data/tavern/api_history_empty.yaml
+++ b/tests/data/tavern/api_history_empty.yaml
@@ -17,6 +17,7 @@ stages:
       headers:
         content-type: !re_match "application/json"
         content-type: !re_search "charset=(UTF|utf)-8"
+        cache-control: "no-store"
         pragma: "no-cache"
         access-control-allow-origin: "*"
       json:
@@ -49,6 +50,7 @@ stages:
       headers:
         content-type: !re_match "text/xml"
         content-type: !re_search "charset=(UTF|utf)-8"
+        cache-control: "no-store"
         pragma: "no-cache"
         access-control-allow-origin: "*"
         content-length: !re_match "[0-9]+"

--- a/tests/data/tavern/api_history_format.yaml
+++ b/tests/data/tavern/api_history_format.yaml
@@ -18,6 +18,7 @@ stages:
       headers:
         content-type: !re_match "application/json"
         content-type: !re_search "charset=(UTF|utf)-8"
+        cache-control: "no-store"
         pragma: "no-cache"
         access-control-allow-origin: "*"
       json:
@@ -83,6 +84,7 @@ stages:
       headers:
         content-type: !re_match "text/xml"
         content-type: !re_search "charset=(UTF|utf)-8"
+        cache-control: "no-store"
         pragma: "no-cache"
         access-control-allow-origin: "*"
         content-length: !re_match "[0-9]+"

--- a/tests/data/tavern/api_queue_empty.yaml
+++ b/tests/data/tavern/api_queue_empty.yaml
@@ -17,6 +17,7 @@ stages:
       headers:
         content-type: !re_match "application/json"
         content-type: !re_search "charset=(UTF|utf)-8"
+        cache-control: "no-store"
         pragma: "no-cache"
         access-control-allow-origin: "*"
       json:
@@ -72,6 +73,7 @@ stages:
       headers:
         content-type: !re_match "text/xml"
         content-type: !re_search "charset=(UTF|utf)-8"
+        cache-control: "no-store"
         pragma: "no-cache"
         access-control-allow-origin: "*"
         content-length: !re_match "[0-9]+"

--- a/tests/data/tavern/api_queue_format.yaml
+++ b/tests/data/tavern/api_queue_format.yaml
@@ -18,6 +18,7 @@ stages:
       headers:
         content-type: !re_match "application/json"
         content-type: !re_search "charset=(UTF|utf)-8"
+        cache-control: "no-store"
         pragma: "no-cache"
         access-control-allow-origin: "*"
       json:
@@ -94,6 +95,7 @@ stages:
       headers:
         content-type: !re_match "text/xml"
         content-type: !re_search "charset=(UTF|utf)-8"
+        cache-control: "no-store"
         pragma: "no-cache"
         access-control-allow-origin: "*"
         content-length: !re_match "[0-9]+"

--- a/tests/data/tavern/api_server_stats.yaml
+++ b/tests/data/tavern/api_server_stats.yaml
@@ -41,6 +41,7 @@ stages:
       headers:
         content-type: !re_match "text/xml"
         content-type: !re_search "charset=(UTF|utf)-8"
+        cache-control: "no-store"
         pragma: "no-cache"
         access-control-allow-origin: "*"
         content-length: !re_match "[0-9]+"

--- a/tests/test_api_and_interface.py
+++ b/tests/test_api_and_interface.py
@@ -35,6 +35,7 @@ import sabnzbd.database as db
 from sabnzbd.constants import DB_HISTORY_NAME, DEF_ADMIN_DIR, PP_LOOKUP
 from sabnzbd.misc import pp_to_opts
 from tests.testhelper import FakeHistoryDB, SAB_CACHE_DIR
+from tests.test_interface import resolve_client
 
 
 class TestApiInternals:
@@ -423,22 +424,29 @@ class TestSecuredExpose:
 
     @pytest.mark.config({"inet_exposure": 2, "verify_xff_header": True})
     def test_inet_exposure_with_xff_headers(self):
-        """Test inet_exposure behavior with X-Forwarded-For headers"""
-        # XFF is only checked when remote IP is local/loopback but XFF contains non-local IPs
-        # Test with local remote IP but external XFF
+        """Test inet_exposure behavior with X-Forwarded-For headers.
+
+        The XFF chain is resolved by uvicorn's ProxyHeadersMiddleware before
+        check_access sees the request (see tests/test_interface.py), so
+        request.client already holds the effective client address here.
+        """
+        # Local remote IP with external XFF: uvicorn rewrites the client to the
+        # external XFF address, which should be denied
         local_request_external_xff = create_mock_request(
-            remote_ip="192.168.1.1", headers={"X-Forwarded-For": "8.8.8.8"}
+            remote_ip=resolve_client(remote_ip="192.168.1.1", xff_header="8.8.8.8").host
         )
 
-        # Test with local remote IP and local XFF
+        # Local remote IP with local XFF: effective client is the (local) XFF address
         local_request_local_xff = create_mock_request(
-            remote_ip="192.168.1.1", headers={"X-Forwarded-For": "192.168.1.10"}
+            remote_ip=resolve_client(remote_ip="192.168.1.1", xff_header="192.168.1.10").host
         )
 
-        # Test with external remote IP (XFF should be ignored)
-        external_request = create_mock_request(remote_ip="8.8.8.8", headers={"X-Forwarded-For": "192.168.1.10"})
+        # External remote IP: untrusted peer, XFF is ignored and the client is untouched
+        external_request = create_mock_request(
+            remote_ip=resolve_client(remote_ip="8.8.8.8", xff_header="192.168.1.10").host
+        )
 
-        # Local IP with external XFF should be denied (XFF verification fails)
+        # Local IP with external XFF should be denied
         assert interface.check_access(local_request_external_xff, access_type=4) is False
 
         # Local IP with local XFF should be allowed

--- a/tests/test_api_and_interface.py
+++ b/tests/test_api_and_interface.py
@@ -21,18 +21,17 @@ tests.test_api - Tests for API functions
 
 import os
 from functools import cached_property
+import pytest
 from random import choice, randint
 from unittest import mock
+from unittest.mock import Mock, patch
+from starlette.requests import Request
+from starlette.datastructures import Headers, Address, QueryParams
 
-import cherrypy
-import pytest
-
-import sabnzbd
 import sabnzbd.api as api
-import sabnzbd.cfg
-import sabnzbd.config
-import sabnzbd.database as db
 import sabnzbd.interface as interface
+import sabnzbd
+import sabnzbd.database as db
 from sabnzbd.constants import DB_HISTORY_NAME, DEF_ADMIN_DIR, PP_LOOKUP
 from sabnzbd.misc import pp_to_opts
 from tests.testhelper import FakeHistoryDB, SAB_CACHE_DIR
@@ -42,19 +41,23 @@ class TestApiInternals:
     """Test internal functions of the API"""
 
     def test_empty(self):
-        with pytest.raises(TypeError):
-            api.api_handler(None)
         with pytest.raises(AttributeError):
-            api.api_handler("")
+            api.api_handler(None)
+        # Empty string should work but result in undefined mode
+        result = api.api_handler(QueryParams({}))
+        assert "not implemented" in result.body.decode()
 
     def test_mode_invalid(self):
-        assert "not implemented" in str(api.api_handler({"mode": "invalid"}))
+        result = api.api_handler(QueryParams({"mode": "invalid"}))
+        assert "not implemented" in result.body.decode()
 
     def test_version(self):
-        assert sabnzbd.__version__ in str(api.api_handler({"mode": "version"}))
+        result = api.api_handler(QueryParams({"mode": "version"}))
+        assert sabnzbd.__version__ in result.body.decode()
 
     def test_auth(self):
-        assert "apikey" in str(api.api_handler({"mode": "auth"}))
+        result = api.api_handler(QueryParams({"mode": "auth"}))
+        assert "apikey" in result.body.decode()
 
     @pytest.mark.parametrize(
         "line,ip",
@@ -156,6 +159,28 @@ class TestApiInternals:
         )
 
 
+def create_mock_request(
+    hostname: str = "localhost",
+    remote_ip: str = "127.0.0.1",
+    headers: dict | None = None,
+    query_params: dict | None = None,
+):
+    """Create a mock Starlette Request object for testing"""
+    mock_request = Mock(spec=Request)
+    mock_request.client = Address(remote_ip, 12345)
+
+    # Set up headers
+    request_headers = {"Host": hostname}
+    if headers:
+        request_headers.update(headers)
+    mock_request.headers = Headers(request_headers)
+
+    # Set up query params
+    mock_request.query_params = QueryParams(query_params or {})
+
+    return mock_request
+
+
 class TestOrphanPathTraversal:
     """Orphaned-job handlers must not allow deleting/adding paths outside the download folder"""
 
@@ -200,72 +225,106 @@ class TestOrphanPathTraversal:
             nzbqueue_mock.repair_job.assert_called_once_with(os.path.join(download_dir, "myjob"), None, None)
 
 
-def set_remote_host_or_ip(hostname: str = "localhost", remote_ip: str = "127.0.0.1"):
-    """Change CherryPy's "Host" and "remote.ip"-values"""
-    cherrypy.request.headers["Host"] = hostname
-    cherrypy.request.remote.ip = remote_ip
-
-
 class TestSecuredExpose:
-    """Test the security handling"""
+    """Test the security handling for Starlette interface"""
 
     @cached_property
     def main_page(self):
         return sabnzbd.interface.MainPage()
 
-    @pytest.fixture(autouse=True)
-    def setup(self, monkeypatch):
-        monkeypatch.setattr(cherrypy.request, "headers", {})
-        monkeypatch.setattr(cherrypy.request.remote, "ip", "127.0.0.1")
-        yield
+    def setup_method(self):
+        """Set up mocks for SABnzbd components before each test"""
+        # Instead of mocking every individual component, let's mock the main API functions
+        # that are used in testing to return simple, predictable responses
 
-    def api_wrapper(self, *args, **kwargs):
-        """Wrapper to convert bytes to str"""
-        if api_response := self.main_page.api(*args, **kwargs):
-            return str(api_response)
+        # Mock build_queue to return a simple queue response
+        mock_queue_response = {
+            "version": "test-version",
+            "paused": False,
+            "slots": [],
+            "noofslots": 0,
+            "limit": 0,
+            "start": 0,
+            "finish": 0,
+            "cache_art": "0",
+            "cache_size": "0 B",
+            "kbpersec": "0.00",
+            "speed": "0 B/s",
+            "mbleft": "0.00",
+            "mb": "0.00",
+            "sizeleft": "0 B",
+            "size": "0 B",
+            "timeleft": "0:00:00",
+            "eta": "unknown",
+        }
 
-    def check_full_access(self, redirect_match: str = r".*wizard.*"):
+        # Apply patches for main API functions
+        self.build_queue_patch = patch("sabnzbd.api.build_queue", return_value=mock_queue_response)
+
+        # Start all patches
+        self.build_queue_patch.start()
+
+    def teardown_method(self):
+        """Clean up mocks after each test"""
+        self.build_queue_patch.stop()
+
+    async def call_api_endpoint(self, request: Request):
+        """Call the API endpoint directly"""
+        return await interface.api(request)
+
+    async def call_main_endpoint(self, request: Request):
+        """Call the main endpoint directly"""
+        return await interface.main_index(request)
+
+    def api_wrapper(self, **kwargs):
+        """Wrapper to test API calls with query parameters"""
+        request = create_mock_request(query_params=kwargs)
+        return api.api_handler(request.query_params)
+
+    def check_full_access(self, hostname="localhost", remote_ip="127.0.0.1"):
         """Basic test if we have full access to API and interface"""
-        assert sabnzbd.__version__ in self.api_wrapper(mode="version")
-        # Passed authentication
-        assert api._MSG_NOT_IMPLEMENTED in self.api_wrapper(apikey=sabnzbd.cfg.api_key())
-        # Raises a redirect to the wizard
-        with pytest.raises(cherrypy._cperror.HTTPRedirect, match=redirect_match):
-            self.main_page.index()
+        # Test API access
+        result = self.api_wrapper(mode="version")
+        assert sabnzbd.__version__ in result.body.decode()
+        # Test API with correct key
+        result = self.api_wrapper(mode="queue", apikey=sabnzbd.cfg.api_key())
+        assert "queue" in result.body.decode()  # Should return queue data
 
     def test_basic(self):
-        set_remote_host_or_ip()
+        """Test basic API access functionality"""
         self.check_full_access()
 
     def test_api_no_or_wrong_api_key(self):
-        set_remote_host_or_ip()
-        # Get blocked
-        assert interface._MSG_APIKEY_REQUIRED in self.api_wrapper()
-        assert interface._MSG_APIKEY_REQUIRED in self.api_wrapper(mode="queue")
+        """Test API key validation through direct API handler calls"""
         # Allowed to access "auth" and "version" without key
-        assert "apikey" in self.api_wrapper(mode="auth")
-        assert sabnzbd.__version__ in self.api_wrapper(mode="version")
-        # Blocked when you do something wrong
-        assert interface._MSG_APIKEY_INCORRECT in self.api_wrapper(mode="queue", apikey="wrong")
+        result = self.api_wrapper(mode="auth")
+        assert "apikey" in result.body.decode()
+        result = self.api_wrapper(mode="version")
+        assert sabnzbd.__version__ in result.body.decode()
+
+        # Other modes should work with correct API key
+        result = self.api_wrapper(mode="queue", apikey=sabnzbd.cfg.api_key())
+        assert "queue" in result.body.decode()
 
     def test_api_nzb_key(self):
-        set_remote_host_or_ip()
-        # It should only access the nzb-functions, nothing else
-        assert api._MSG_NO_VALUE in self.api_wrapper(mode="addfile", apikey=sabnzbd.cfg.nzb_key())
-        assert interface._MSG_APIKEY_INCORRECT in self.api_wrapper(mode="set_config", apikey=sabnzbd.cfg.nzb_key())
-        assert interface._MSG_APIKEY_INCORRECT in self.main_page.shutdown(apikey=sabnzbd.cfg.nzb_key())
+        """Test NZB key functionality"""
+        # NZB key should work for addfile (level 1 access)
+        result = self.api_wrapper(mode="addfile", apikey=sabnzbd.cfg.nzb_key())
+        assert api._MSG_NO_VALUE in result.body.decode()  # No file provided, but key was accepted
 
     def test_check_hostname_basic(self):
-        # Block bad host
-        set_remote_host_or_ip(hostname="not_me")
-        assert interface._MSG_ACCESS_DENIED_HOSTNAME in self.api_wrapper()
-        assert interface._MSG_ACCESS_DENIED_HOSTNAME in self.main_page.index()
-        # Block empty value
-        set_remote_host_or_ip(hostname="")
-        assert interface._MSG_ACCESS_DENIED_HOSTNAME in self.api_wrapper()
-        assert interface._MSG_ACCESS_DENIED_HOSTNAME in self.main_page.index()
+        """Test hostname checking functionality"""
+        # Test the check_hostname_starlette function directly
 
-        # Fine if ip-address
+        # Block bad host
+        bad_request = create_mock_request(hostname="not_me")
+        assert interface.check_hostname(bad_request) is False
+
+        # Block empty hostname
+        empty_request = create_mock_request(hostname="")
+        assert interface.check_hostname(empty_request) is False
+
+        # Allow valid hostnames/IPs
         for test_hostname in (
             "100.100.100.100",
             "100.100.100.100:8080",
@@ -274,121 +333,183 @@ class TestSecuredExpose:
             "test.local",
             "test.local:8080",
             "test.local.",
+            "localhost",
         ):
-            set_remote_host_or_ip(hostname=test_hostname)
-            self.check_full_access()
+            good_request = create_mock_request(hostname=test_hostname)
+            assert interface.check_hostname(good_request) is True
 
     @pytest.mark.config({"username": "foo", "password": "bar"})
-    def test_check_hostname_not_user_password(self):
-        set_remote_host_or_ip(hostname="not_me")
-        self.check_full_access(redirect_match=r".*login.*")
+    def test_check_hostname_with_auth(self):
+        """Test hostname checking with authentication enabled"""
+        # With username/password set, hostname check should always pass
+        bad_request = create_mock_request(hostname="not_me")
+        assert interface.check_hostname(bad_request) is True
 
     @pytest.mark.config({"host_whitelist": "test.com, not_evil"})
     def test_check_hostname_whitelist(self):
-        set_remote_host_or_ip(hostname="test.com")
-        self.check_full_access()
-        set_remote_host_or_ip(hostname="not_evil")
-        self.check_full_access()
+        """Test hostname whitelist functionality"""
+        # Whitelisted hostnames should be allowed
+        request1 = create_mock_request(hostname="test.com")
+        assert interface.check_hostname(request1) is True
+
+        request2 = create_mock_request(hostname="not_evil")
+        assert interface.check_hostname(request2) is True
+
+        # Non-whitelisted hostname should be blocked
+        request3 = create_mock_request(hostname="evil.com")
+        assert interface.check_hostname(request3) is False
 
     def test_dual_stack(self):
-        set_remote_host_or_ip(remote_ip="::ffff:192.168.0.10")
-        self.check_full_access()
+        """Test IPv6 dual stack functionality"""
+        request = create_mock_request(remote_ip="::ffff:192.168.0.10")
+        # Dual stack IPs should be treated as local
+        assert interface.check_access(request, access_type=4) is True
 
     @pytest.mark.config({"local_ranges": "132.10."})
     def test_dual_stack_local_ranges(self):
-        # Without custom local_ranges this one would be allowed
-        set_remote_host_or_ip(remote_ip="::ffff:192.168.0.10")
-        self.check_inet_blocks(inet_exposure=0)
-        # But now we only allow the custom ones
-        set_remote_host_or_ip(remote_ip="::ffff:132.10.0.10")
-        self.check_full_access()
+        """Test custom local ranges"""
+        # IP not in custom local_ranges should be blocked
+        request1 = create_mock_request(remote_ip="::ffff:192.168.0.10")
+        assert interface.check_access(request1, access_type=5) is False
 
-    def check_inet_allows(self, inet_exposure: int):
-        """Each should allow all previous ones and the current one"""
-        # Level 1: nzb
-        if inet_exposure >= 1:
-            assert api._MSG_NO_VALUE in self.api_wrapper(mode="addfile", apikey=sabnzbd.cfg.nzb_key())
-            assert api._MSG_NO_VALUE in self.api_wrapper(mode="addfile", apikey=sabnzbd.cfg.api_key())
+        # IP in custom local_ranges should be allowed
+        request2 = create_mock_request(remote_ip="::ffff:132.10.0.10")
+        assert interface.check_access(request2, access_type=4) is True
 
-        # Level 2: basic API
-        if inet_exposure >= 2:
-            assert api._MSG_NO_VALUE in self.api_wrapper(mode="get_files", apikey=sabnzbd.cfg.api_key())
-            assert api._MSG_NO_VALUE in self.api_wrapper(mode="change_script", apikey=sabnzbd.cfg.api_key())
-            # Sub-function
-            assert "status" in self.api_wrapper(mode="queue", name="resume", apikey=sabnzbd.cfg.api_key())
+    @pytest.mark.config({"inet_exposure": 2})
+    def test_inet_exposure_basic(self):
+        """Test basic inet exposure functionality"""
+        # Test with external IP (should be blocked for high access levels)
+        external_request = create_mock_request(remote_ip="11.11.11.11")
 
-        # Level 3: full API
-        if inet_exposure >= 3:
-            assert "misc" in self.api_wrapper(mode="get_config", apikey=sabnzbd.cfg.api_key())
-            # Sub-function
-            assert "The hostname is not set" in self.api_wrapper(
-                mode="config", name="test_server", apikey=sabnzbd.cfg.api_key()
-            )
+        # Level 1-2 should be allowed
+        assert interface.check_access(external_request, access_type=1) is True
+        assert interface.check_access(external_request, access_type=2) is True
+        # Level 3+ should be blocked
+        assert interface.check_access(external_request, access_type=3) is False
+        assert interface.check_access(external_request, access_type=4) is False
 
-        # Level 4: full interface
-        if inet_exposure >= 4:
-            self.check_full_access()
+    @pytest.mark.config({"inet_exposure": 0})
+    def test_local_access_always_allowed(self):
+        """Test that local IPs are always allowed regardless of inet_exposure"""
+        local_request = create_mock_request(remote_ip="127.0.0.1")
 
-    def check_inet_blocks(self, inet_exposure: int):
-        """We count from the most exposure down"""
-        # Level 4: full interface, no blocking
-        # Level 3: full API
-        if inet_exposure <= 3:
-            assert interface._MSG_ACCESS_DENIED in self.main_page.index()
+        # Even with minimal exposure, local IPs should be allowed
+        assert interface.check_access(local_request, access_type=4) is True
+        assert interface.check_access(local_request, access_type=5) is True
 
-        # Level 2: basic API
-        if inet_exposure <= 2:
-            assert interface._MSG_ACCESS_DENIED in self.api_wrapper(mode="get_config", apikey=sabnzbd.cfg.api_key())
-            assert interface._MSG_ACCESS_DENIED in self.api_wrapper(
-                mode="config", name="set_nzbkey", apikey=sabnzbd.cfg.api_key()
-            )
-        # Level 1: nzb
-        if inet_exposure <= 1:
-            assert interface._MSG_ACCESS_DENIED in self.api_wrapper(mode="get_scripts", apikey=sabnzbd.cfg.api_key())
-            assert interface._MSG_ACCESS_DENIED in self.api_wrapper(
-                mode="queue", name="resume", apikey=sabnzbd.cfg.api_key()
-            )
+    @pytest.mark.parametrize("inet_exposure", [0, 1, 2, 3, 4, 5])
+    @pytest.mark.parametrize("access_type", [1, 2, 3, 4, 5, 6])
+    @pytest.mark.parametrize(
+        "remote_ip,expected_local",
+        [
+            ("192.168.1.10", True),  # Local IP
+            ("127.0.0.1", True),  # Loopback IP
+            ("8.8.8.8", False),  # External IP
+        ],
+    )
+    @pytest.mark.config(lambda params: {"inet_exposure": params["inet_exposure"]})
+    def test_inet_exposure_levels_comprehensive(self, inet_exposure, access_type, remote_ip, expected_local):
+        """Test all inet_exposure levels with different access types and IP types"""
+        request = create_mock_request(remote_ip=remote_ip)
 
-        # Level 0: nothing, already checked above, but just to be sure
-        if inet_exposure <= 0:
-            assert interface._MSG_ACCESS_DENIED in self.api_wrapper(mode="addfile", apikey=sabnzbd.cfg.api_key())
-            # Check with or without API-key
-            assert interface._MSG_ACCESS_DENIED in self.api_wrapper(mode="auth", apikey=sabnzbd.cfg.api_key())
-            assert interface._MSG_ACCESS_DENIED in self.api_wrapper(mode="auth")
+        if expected_local:
+            # Local and loopback IPs should always be allowed
+            assert interface.check_access(request, access_type) is True
+        else:
+            # External IPs should follow inet_exposure rules
+            expected_allowed = access_type <= inet_exposure
+            assert interface.check_access(request, access_type) is expected_allowed
 
-    def test_inet_exposure(self):
-        # Run all tests as external user
-        set_remote_host_or_ip(hostname="100.100.100.100", remote_ip="11.11.11.11")
+    @pytest.mark.config({"inet_exposure": 2, "verify_xff_header": True})
+    def test_inet_exposure_with_xff_headers(self):
+        """Test inet_exposure behavior with X-Forwarded-For headers"""
+        # XFF is only checked when remote IP is local/loopback but XFF contains non-local IPs
+        # Test with local remote IP but external XFF
+        local_request_external_xff = create_mock_request(
+            remote_ip="192.168.1.1", headers={"X-Forwarded-For": "8.8.8.8"}
+        )
 
-        # We don't use the wrapper, it would require creating many extra functions
-        # Option 5 is special, so it also gets it's own special test
-        for inet_exposure in range(6):
-            sabnzbd.cfg.inet_exposure.set(inet_exposure)
-            self.check_inet_allows(inet_exposure=inet_exposure)
-            self.check_inet_blocks(inet_exposure=inet_exposure)
+        # Test with local remote IP and local XFF
+        local_request_local_xff = create_mock_request(
+            remote_ip="192.168.1.1", headers={"X-Forwarded-For": "192.168.1.10"}
+        )
 
-        # Reset it
-        sabnzbd.cfg.inet_exposure.set(sabnzbd.cfg.inet_exposure.default)
+        # Test with external remote IP (XFF should be ignored)
+        external_request = create_mock_request(remote_ip="8.8.8.8", headers={"X-Forwarded-For": "192.168.1.10"})
 
-    @pytest.mark.config({"inet_exposure": 5, "username": "foo", "password": "bar"})
-    def test_inet_exposure_login_for_external(self):
-        # Local user: full access
-        set_remote_host_or_ip()
-        self.check_full_access()
+        # Local IP with external XFF should be denied (XFF verification fails)
+        assert interface.check_access(local_request_external_xff, access_type=4) is False
 
-        # Remote user: redirect to login
-        set_remote_host_or_ip(hostname="100.100.100.100", remote_ip="11.11.11.11")
-        self.check_full_access(redirect_match=r".*login.*")
+        # Local IP with local XFF should be allowed
+        assert interface.check_access(local_request_local_xff, access_type=4) is True
 
-    @pytest.mark.config({"api_warnings": False})
-    def test_no_text_warnings(self):
-        assert self.main_page.index() is None
-        assert cherrypy.response.status == 403
-        assert self.api_wrapper(mode="queue") is None
-        assert cherrypy.response.status == 403
-        set_remote_host_or_ip(hostname="not_me")
-        assert self.api_wrapper() is None
-        assert cherrypy.response.status == 403
+        # External IP should follow inet_exposure rules (XFF ignored for external IPs)
+        assert interface.check_access(external_request, access_type=1) is True
+        assert interface.check_access(external_request, access_type=2) is True
+        assert interface.check_access(external_request, access_type=3) is False
+
+    # Note: The comprehensive parametrized test above covers all these scenarios,
+    # but this test provides explicit documentation of the API access level meanings
+    @pytest.mark.config({"inet_exposure": 2})
+    def test_inet_exposure_api_levels_documentation(self):
+        """Document the different API access levels with inet_exposure"""
+        external_request = create_mock_request(remote_ip="8.8.8.8")
+
+        # access_type = 1: NZB upload access
+        assert interface.check_access(external_request, access_type=1) is True
+        # access_type = 2: Basic API access
+        assert interface.check_access(external_request, access_type=2) is True
+        # access_type = 3: Full API access (blocked with inet_exposure=2)
+        assert interface.check_access(external_request, access_type=3) is False
+        # access_type = 4: WebUI access (blocked with inet_exposure=2)
+        assert interface.check_access(external_request, access_type=4) is False
+
+    @pytest.mark.config({"inet_exposure": 1})
+    def test_inet_exposure_ipv6(self):
+        """Test IPv6 edge cases for inet_exposure"""
+        # Test IPv6 addresses
+        ipv6_external_request = create_mock_request(remote_ip="2001:4860:4860::8888")
+        ipv6_local_request = create_mock_request(remote_ip="::1")
+
+        # Test dual-stack (IPv4-mapped IPv6)
+        dual_stack_request = create_mock_request(remote_ip="::ffff:192.168.1.10")
+
+        # IPv6 loopback should always be allowed
+        assert interface.check_access(ipv6_local_request, access_type=4) is True
+
+        # IPv6 external should follow inet_exposure rules
+        assert interface.check_access(ipv6_external_request, access_type=1) is True
+        assert interface.check_access(ipv6_external_request, access_type=2) is False
+
+        # Dual-stack should be treated as local
+        assert interface.check_access(dual_stack_request, access_type=4) is True
+
+    @pytest.mark.config({"inet_exposure": 1, "local_ranges": ["4.4.4.0/24"]})
+    def test_inet_exposure_custom_local_ranges(self):
+        """Test custom local ranges for inet_exposure"""
+        # Test with custom local ranges
+        custom_local_request = create_mock_request(remote_ip="4.4.4.10")
+
+        # IP in custom local range should be treated as local
+        assert interface.check_access(custom_local_request, access_type=4) is True
+
+    # Note: Boundary conditions are covered by the comprehensive parametrized test
+    # These tests serve as explicit documentation of the most restrictive/permissive settings
+    @pytest.mark.config({"inet_exposure": 0})
+    def test_inet_exposure_most_restrictive(self):
+        """Document the most restrictive inet_exposure setting"""
+        external_request = create_mock_request(remote_ip="1.1.1.1")
+        # inet_exposure=0: No external access allowed for any access type
+        assert interface.check_access(external_request, access_type=1) is False
+
+    @pytest.mark.config({"inet_exposure": 5})
+    def test_inet_exposure_most_permissive(self):
+        """Document the most permissive inet_exposure setting"""
+        external_request = create_mock_request(remote_ip="1.1.1.1")
+        # inet_exposure=5: External access allowed for access_type 1-5, but not 6
+        assert interface.check_access(external_request, access_type=5) is True
+        assert interface.check_access(external_request, access_type=6) is False
 
 
 class TestHistory:

--- a/tests/test_api_and_interface.py
+++ b/tests/test_api_and_interface.py
@@ -19,6 +19,7 @@
 tests.test_api - Tests for API functions
 """
 
+import asyncio
 import os
 from functools import cached_property
 import pytest
@@ -26,6 +27,7 @@ from random import choice, randint
 from unittest import mock
 from unittest.mock import Mock, patch
 from starlette.requests import Request
+from starlette.responses import Response
 from starlette.datastructures import Headers, Address, QueryParams, State
 
 import sabnzbd.api as api
@@ -38,26 +40,31 @@ from tests.testhelper import FakeHistoryDB, SAB_CACHE_DIR
 from tests.test_interface import resolve_client
 
 
+def run_api_handler(kwargs) -> Response:
+    """Run the (async) api_handler to completion, like the /api route does"""
+    return asyncio.run(api.api_handler(kwargs))
+
+
 class TestApiInternals:
     """Test internal functions of the API"""
 
     def test_empty(self):
         with pytest.raises(AttributeError):
-            api.api_handler(None)
+            run_api_handler(None)
         # Empty string should work but result in undefined mode
-        result = api.api_handler(QueryParams({}))
+        result = run_api_handler(QueryParams({}))
         assert "not implemented" in result.body.decode()
 
     def test_mode_invalid(self):
-        result = api.api_handler(QueryParams({"mode": "invalid"}))
+        result = run_api_handler(QueryParams({"mode": "invalid"}))
         assert "not implemented" in result.body.decode()
 
     def test_version(self):
-        result = api.api_handler(QueryParams({"mode": "version"}))
+        result = run_api_handler(QueryParams({"mode": "version"}))
         assert sabnzbd.__version__ in result.body.decode()
 
     def test_auth(self):
-        result = api.api_handler(QueryParams({"mode": "auth"}))
+        result = run_api_handler(QueryParams({"mode": "auth"}))
         assert "apikey" in result.body.decode()
 
     @pytest.mark.parametrize(
@@ -283,7 +290,7 @@ class TestSecuredExpose:
     def api_wrapper(self, **kwargs):
         """Wrapper to test API calls with query parameters"""
         request = create_mock_request(query_params=kwargs)
-        return api.api_handler(request.query_params)
+        return run_api_handler(request.query_params)
 
     def check_full_access(self, hostname="localhost", remote_ip="127.0.0.1"):
         """Basic test if we have full access to API and interface"""

--- a/tests/test_api_and_interface.py
+++ b/tests/test_api_and_interface.py
@@ -34,7 +34,7 @@ import sabnzbd.api as api
 import sabnzbd.interface as interface
 import sabnzbd
 import sabnzbd.database as db
-from sabnzbd.constants import DB_HISTORY_NAME, DEF_ADMIN_DIR, PP_LOOKUP
+from sabnzbd.constants import DB_HISTORY_NAME, DEF_ADMIN_DIR, PP_LOOKUP, AddNzbFileResult, Status
 from sabnzbd.misc import pp_to_opts
 from tests.testhelper import FakeHistoryDB, SAB_CACHE_DIR
 from tests.test_interface import resolve_client
@@ -298,6 +298,71 @@ class TestOrphanPathTraversal:
         with mock.patch.object(sabnzbd, "NzbQueue", create=True) as nzbqueue_mock:
             api._api_add_orphan("myjob", {})
             nzbqueue_mock.repair_job.assert_called_once_with(os.path.join(download_dir, "myjob"), None, None)
+
+
+class TestRetryJobFuturetype:
+    """A futuretype job never got past fetching its URL, so there is nothing on disk to
+    repair: retry_job() has to re-fetch the URL instead of going through repair_job()"""
+
+    @pytest.fixture
+    def history_db(self, tmp_path, monkeypatch):
+        """A real history database, also served by the pool that retry_job() borrows from"""
+        monkeypatch.setattr(db.HistoryDB, "db_path", str(tmp_path / DB_HISTORY_NAME))
+        monkeypatch.setattr(db.HistoryDB, "startup_done", False)
+        pool = db.HistoryDBPool(max_connections=1)
+        monkeypatch.setattr(sabnzbd, "db_pool", pool)
+        fake_history_db = FakeHistoryDB(db.HistoryDB.db_path)
+        yield fake_history_db
+        fake_history_db.close()
+        pool.close()
+
+    @staticmethod
+    def _add_futuretype_job(history_db) -> tuple[str, tuple]:
+        """Add a failed URL-fetch to the history, return its nzo_id and stored settings"""
+        nzo_id = history_db.add_fake_history_job(
+            "Ubuntu.Linux.ISO-Usenet", status=Status.FAILED, category="catA", futuretype=True
+        )
+        stored_settings = history_db.get_other(nzo_id)
+        assert stored_settings[0] == "future"
+        return nzo_id, stored_settings
+
+    def test_futuretype_job_url_is_refetched(self, history_db):
+        nzo_id, (_, url, pp, script, cat) = self._add_futuretype_job(history_db)
+
+        with (
+            mock.patch.object(
+                sabnzbd.urlgrabber, "add_url", return_value=(AddNzbFileResult.OK, ["new_nzo_id"])
+            ) as add_url_mock,
+            mock.patch.object(sabnzbd, "NzbQueue", create=True) as nzbqueue_mock,
+        ):
+            assert api.retry_job(nzo_id) == "new_nzo_id"
+
+        # Retried with the settings stored in the history, but without the duplicate check:
+        # the job that is being retried is still in the history at that point
+        add_url_mock.assert_called_once_with(url, pp, script, cat, dup_check=False)
+        # There is no incomplete folder to repair
+        nzbqueue_mock.repair_job.assert_not_called()
+        # The old entry is gone, the re-added job will create its own
+        assert history_db.get_other(nzo_id) == ("", "", "", "", "")
+
+    @pytest.mark.parametrize(
+        "add_url_result",
+        [
+            (AddNzbFileResult.NO_FILES_FOUND, []),
+            (AddNzbFileResult.ERROR, []),
+            (AddNzbFileResult.RETRY, []),
+            (AddNzbFileResult.PREQUEUE_REJECTED, []),
+        ],
+    )
+    def test_futuretype_job_kept_in_history_when_refetch_fails(self, history_db, add_url_result):
+        """Only a job that was actually re-added may leave the history, otherwise the
+        failure disappears without anything taking its place"""
+        nzo_id, stored_settings = self._add_futuretype_job(history_db)
+
+        with mock.patch.object(sabnzbd.urlgrabber, "add_url", return_value=add_url_result):
+            assert api.retry_job(nzo_id) is None
+
+        assert history_db.get_other(nzo_id) == stored_settings
 
 
 class TestSecuredExpose:

--- a/tests/test_api_and_interface.py
+++ b/tests/test_api_and_interface.py
@@ -192,6 +192,70 @@ def create_mock_request(
     return mock_request
 
 
+def run_get_request_params(method, query_string="", body=b"", content_type=None, merge_query=False):
+    """Drive interface.get_request_params with a real Starlette Request"""
+    headers = [(b"content-type", content_type.encode())] if content_type else []
+    scope = {
+        "type": "http",
+        "method": method,
+        "query_string": query_string.encode(),
+        "headers": headers,
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    request = Request(scope, receive)
+    return asyncio.run(interface.get_request_params(request, merge_query=merge_query))
+
+
+FORM = "application/x-www-form-urlencoded"
+
+
+class TestGetRequestParams:
+    """The /api route must expose GET and POST arguments identically to CherryPy"""
+
+    def test_api_duplicate_scalar_key_first_wins(self):
+        """A repeated routing/scalar key resolves to its first value, as CherryPy did"""
+        params = run_get_request_params("GET", "mode=queue&mode=version", merge_query=True)
+        assert params.get("mode") == "queue"
+
+    def test_api_get_and_post_resolve_duplicates_identically(self):
+        """GET and a form POST must dispatch a duplicated key the same way"""
+        get_params = run_get_request_params("GET", "mode=queue&mode=version", merge_query=True)
+        post_params = run_get_request_params(
+            "POST", "mode=queue&mode=version", body=b"nzbname=x", content_type=FORM, merge_query=True
+        )
+        assert get_params.get("mode") == post_params.get("mode") == "queue"
+
+    def test_api_body_wins_over_query(self):
+        """On a form POST the body value replaces the query value for the same key"""
+        params = run_get_request_params(
+            "POST", "mode=version&apikey=K", body=b"mode=addfile", content_type=FORM, merge_query=True
+        )
+        assert params.get("mode") == "addfile"
+        assert params.get("apikey") == "K"
+
+    def test_api_query_only_multi_value_key_preserved(self):
+        """A genuinely multi-valued key supplied only in the query keeps every value"""
+        params = run_get_request_params(
+            "POST", "keyword=a&keyword=b", body=b"section=misc", content_type=FORM, merge_query=True
+        )
+        assert params.getlist("keyword") == ["a", "b"]
+
+    def test_api_bodyless_post_uses_query(self):
+        """An /api POST without a form body falls back to the query string"""
+        params = run_get_request_params("POST", "mode=queue&apikey=K", merge_query=True)
+        assert params.get("mode") == "queue"
+        assert params.get("apikey") == "K"
+
+    def test_page_post_ignores_query_string(self):
+        """A page POST (no merge) reads the form body only; the query is not merged in"""
+        params = run_get_request_params("POST", "smuggled=1", body=b"field=value", content_type=FORM, merge_query=False)
+        assert params.get("field") == "value"
+        assert params.get("smuggled") is None
+
+
 class TestOrphanPathTraversal:
     """Orphaned-job handlers must not allow deleting/adding paths outside the download folder"""
 

--- a/tests/test_api_and_interface.py
+++ b/tests/test_api_and_interface.py
@@ -26,7 +26,7 @@ from random import choice, randint
 from unittest import mock
 from unittest.mock import Mock, patch
 from starlette.requests import Request
-from starlette.datastructures import Headers, Address, QueryParams
+from starlette.datastructures import Headers, Address, QueryParams, State
 
 import sabnzbd.api as api
 import sabnzbd.interface as interface
@@ -176,8 +176,11 @@ def create_mock_request(
         request_headers.update(headers)
     mock_request.headers = Headers(request_headers)
 
-    # Set up query params
+    # Set up query params, both on the Request itself and on request.state.params,
+    # where secured_expose stores the merged GET/POST params (see request_params)
     mock_request.query_params = QueryParams(query_params or {})
+    mock_request.state = State()
+    mock_request.state.params = mock_request.query_params
 
     return mock_request
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,10 +29,12 @@ import pytest
 
 import sabnzbd
 import sabnzbd.cfg
+import sabnzbd.database
 from sabnzbd import config, filesystem
 from sabnzbd.constants import (
     CONFIG_BACKUP_FILES,
     CONFIG_BACKUP_HTTPS,
+    DB_HISTORY_NAME,
     DEF_HTTPS_CERT_FILE,
     DEF_HTTPS_KEY_FILE,
     DEF_INI_FILE,
@@ -41,6 +43,12 @@ from sabnzbd.filesystem import long_path
 from tests.testhelper import SAB_CACHE_DIR, SAB_COMPLETE_DIR, SAB_DATA_DIR
 
 DEF_CHAIN_FILE = "server.chain"
+
+# Stand-in for the SQLite online backup of the history database. This test only
+# fabricates history1.db as a file, while a real snapshot needs a live database
+# and connection pool, so history_db_snapshot is patched to return these bytes.
+# The snapshot itself is tested in tests/test_database.py.
+FAKE_HISTORY_SNAPSHOT = b"fake history database snapshot"
 
 
 class TestOptions:
@@ -101,6 +109,9 @@ class TestConfig:
             with zipfile.ZipFile(fp, "r") as zip:
                 for basename in must_haves:
                     assert zip.getinfo(basename)
+                # The history database is stored as an online snapshot, not a raw file copy
+                if DB_HISTORY_NAME in must_haves:
+                    assert zip.read(DB_HISTORY_NAME) == FAKE_HISTORY_SNAPSHOT
                 # Make sure there's nothing else in the zip
                 assert (zip_len := len(zip.filelist)) == len(must_haves)
 
@@ -179,6 +190,8 @@ class TestConfig:
     def test_config_backup(self, monkeypatch):
         """Combined tests for the config.{create,validate,restore}_config_backup functions"""
         monkeypatch.setattr(sabnzbd, "CONFIG_BACKUP_HTTPS_OK", [])
+        monkeypatch.setattr(sabnzbd.database, "history_db_snapshot", lambda: FAKE_HISTORY_SNAPSHOT)
+
         # Prepare the basics
         admin_dir = sabnzbd.cfg.admin_dir.get_path()
         sabnzbd.cfg.set_root_folders2()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,120 @@
+#!/usr/bin/python3 -OO
+# Copyright 2007-2026 by The SABnzbd-Team (sabnzbd.org)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+tests.test_database - Testing the HistoryDB connection pool
+"""
+
+import threading
+
+import pytest
+
+import sabnzbd.database as db
+
+
+@pytest.fixture
+def pool(tmp_path):
+    """Fresh pool against a fresh database file"""
+    db.HistoryDB.db_path = str(tmp_path / "history1.db")
+    db.HistoryDB.startup_done = False
+    pool = db.HistoryDBPool(max_connections=2, checkout_timeout=0.2)
+    yield pool
+    pool.close()
+
+
+class TestHistoryDBPool:
+    def test_lifo_reuse(self, pool):
+        with pool.connection() as first:
+            assert first.execute("SELECT COUNT(*) FROM history")
+        with pool.connection() as second:
+            # The returned connection is reused, not a new one
+            assert second is first
+        assert pool._created == 1
+
+    def test_exclusive_checkout_and_bounded(self, pool):
+        with pool.connection() as first, pool.connection() as second:
+            assert first is not second
+            assert pool._created == 2
+            # Third concurrent checkout exceeds max_connections: served by a
+            # temporary overflow connection instead of blocking forever
+            with pool.connection() as third:
+                assert third is not first
+                assert third is not second
+                assert pool._created == 2
+            # Overflow connection was closed on check-in, not pooled
+            assert pool._idle.qsize() == 0
+
+    def test_returned_connections_reused_when_full(self, pool):
+        with pool.connection() as first:
+            with pool.connection() as second:
+                pass
+        with pool.connection() as reused:
+            assert reused in (first, second)
+        assert pool._created == 2
+
+    def test_invalidate_discards_pooled_connections(self, pool):
+        with pool.connection() as first:
+            pass
+        pool.invalidate()
+        with pool.connection() as second:
+            assert second is not first
+            # Still works after replacement
+            assert second.execute("SELECT COUNT(*) FROM history")
+        assert pool._created == 1
+
+    def test_invalidate_spares_reconnected_instance(self, pool):
+        with pool.connection() as first:
+            pool.invalidate(reconnected=first)
+        # The reconnected instance survives and is pooled again
+        with pool.connection() as second:
+            assert second is first
+
+    def test_close_discards_and_serves_overflow(self, pool):
+        with pool.connection() as first:
+            pass
+        pool.close()
+        assert pool._idle.qsize() == 0
+        # Late checkout after shutdown still works, via a temporary connection
+        with pool.connection() as late:
+            assert late is not first
+            assert late.execute("SELECT COUNT(*) FROM history")
+        assert pool._idle.qsize() == 0
+
+    def test_connection_usable_across_threads(self, pool):
+        """Pooled connections move between (e.g. AnyIO worker) threads"""
+        with pool.connection() as history_db:
+            pass
+
+        result = {}
+
+        def worker():
+            with pool.connection() as history_db2:
+                result["same"] = history_db2 is history_db
+                history_db2.execute("SELECT COUNT(*) FROM history")
+                result["count"] = history_db2.cursor.fetchone()[0]
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        thread.join()
+
+        assert result["same"] is True
+        assert result["count"] == 0
+
+    def test_wal_mode_enabled(self, pool):
+        with pool.connection() as history_db:
+            history_db.execute("PRAGMA journal_mode;")
+            assert history_db.cursor.fetchone()[0] == "wal"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -19,10 +19,13 @@
 tests.test_database - Testing the HistoryDB connection pool
 """
 
+import sqlite3
 import threading
+from unittest import mock
 
 import pytest
 
+import sabnzbd
 import sabnzbd.database as db
 
 
@@ -118,3 +121,48 @@ class TestHistoryDBPool:
         with pool.connection() as history_db:
             history_db.execute("PRAGMA journal_mode;")
             assert history_db.cursor.fetchone()[0] == "wal"
+
+
+class TestHistoryDBSnapshot:
+    @staticmethod
+    def _count_history_rows(db_file: str) -> int:
+        connection = sqlite3.connect(db_file)
+        try:
+            return connection.execute("SELECT COUNT(*) FROM history").fetchone()[0]
+        except sqlite3.Error:
+            # Empty or inconsistent database
+            return 0
+        finally:
+            connection.close()
+
+    def test_snapshot_includes_uncheckpointed_wal_data(self, pool, tmp_path, monkeypatch):
+        """The snapshot must contain transactions still in the WAL, which a
+        raw copy of the main database file misses"""
+        monkeypatch.setattr(sabnzbd, "db_pool", pool)
+        with pool.connection() as history_db:
+            assert history_db.execute(
+                "INSERT INTO history (completed, name, nzb_name) VALUES (?, ?, ?)", (123, "job", "job.nzb")
+            )
+
+        # Snapshot sees the row
+        snapshot = db.history_db_snapshot()
+        assert snapshot
+        snapshot_file = str(tmp_path / "snapshot.db")
+        with open(snapshot_file, "wb") as snapshot_ref:
+            snapshot_ref.write(snapshot)
+        assert self._count_history_rows(snapshot_file) == 1
+
+        # While the row is not in the main database file yet: it is in the WAL
+        raw_file = str(tmp_path / "raw_copy.db")
+        with open(db.HistoryDB.db_path, "rb") as source_ref, open(raw_file, "wb") as raw_ref:
+            raw_ref.write(source_ref.read())
+        assert self._count_history_rows(raw_file) == 0
+
+    def test_snapshot_failure_returns_none(self, pool, monkeypatch):
+        monkeypatch.setattr(sabnzbd, "db_pool", pool)
+        with pool.connection() as history_db:
+            pass
+        # sqlite3.Connection attributes are read-only, so replace the HistoryDB
+        # instance attribute with a mock whose backup() fails
+        monkeypatch.setattr(history_db, "connection", mock.Mock(backup=mock.Mock(side_effect=sqlite3.Error)))
+        assert db.history_db_snapshot() is None

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -30,10 +30,10 @@ import sabnzbd.database as db
 
 
 @pytest.fixture
-def pool(tmp_path):
+def pool(tmp_path, monkeypatch):
     """Fresh pool against a fresh database file"""
-    db.HistoryDB.db_path = str(tmp_path / "history1.db")
-    db.HistoryDB.startup_done = False
+    monkeypatch.setattr(db.HistoryDB, "db_path", str(tmp_path / "history1.db"))
+    monkeypatch.setattr(db.HistoryDB, "startup_done", False)
     pool = db.HistoryDBPool(max_connections=2, checkout_timeout=0.2)
     yield pool
     pool.close()

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -57,46 +57,6 @@ class TestEncoding:
         # Confirm NFD input was different at the byte level before normalization
         assert nfd_bytes != nfc_string.encode("utf-8")
 
-    def test_correct_cherrypy_encoding(self):
-        raw_input = "aaazzz"  # correct UTF8
-        corrected_output = enc.correct_cherrypy_encoding(raw_input)
-        assert corrected_output == "aaazzz"
-
-        # Let's create some "manual" strings of separate chars:
-
-        # typical use case: raw chars in a string: 2-byte UTF8
-        # Ω (capital omega) in UTF8: 0xCE 0xA9
-        raw_input = "aaa" + chr(0xCE) + chr(0xA9) + "zzz"  # Ω (capital omega)
-        corrected_output = enc.correct_cherrypy_encoding(raw_input)
-        assert corrected_output == "aaaΩzzz"
-
-        # typical use case: raw chars in a string: 3-byte UTF8
-        # ∇ (nabla) in UTF8: 0xE2 0x88 0x87
-        raw_input = "aaa" + chr(0xE2) + chr(0x88) + chr(0x87) + "zzz"  # ∇ (nabla)
-        corrected_output = enc.correct_cherrypy_encoding(raw_input)
-        assert corrected_output == "aaa∇zzz"
-
-        # typical use case: raw chars in a string: 4-byte UTF8
-        raw_input = "aaa" + chr(0xF0) + chr(0x9F) + chr(0x9A) + chr(0x80) + "zzz"  # "correct" 4-byte UTF8 for "rocket"
-        corrected_output = enc.correct_cherrypy_encoding(raw_input)
-        assert corrected_output == "aaa🚀zzz"
-
-        # and now more automatic: craft from utf8
-
-        nice_utf8_string = "aaa你好🚀🤔zzzαβγ"  # correct UTF8  # noqa: RUF001
-        # now break it
-        raw_input = ""
-        for i in nice_utf8_string.encode("utf-8"):
-            raw_input += chr(i)
-        assert raw_input != nice_utf8_string
-        corrected_output = enc.correct_cherrypy_encoding(raw_input)
-        assert corrected_output == nice_utf8_string
-
-        # this is not valid UTF8, so string cannot be repaired, so stay the same
-        raw_input = "aaa" + chr(0xF0) + chr(0x9F) + "zzz"  # two bytes (instead of four) ... not valid UTF8
-        corrected_output = enc.correct_cherrypy_encoding(raw_input)
-        assert corrected_output == raw_input  # check nothing changed
-
     def test_limit_encoded_length(self):
         # Test with empty string
         assert enc.limit_encoded_length("", 10) == "", "Empty string should return empty string"

--- a/tests/test_functional_config.py
+++ b/tests/test_functional_config.py
@@ -117,8 +117,8 @@ class TestConfigLogin(SABnzbdBaseTest):
                 pass
 
         # Open any page and check if we get redirected
-        self.open_page("http://%s:%s/general" % (SAB_HOST, SAB_PORT))
-        assert "/login/" in self.driver.current_url
+        self.open_page("http://%s:%s/config/general" % (SAB_HOST, SAB_PORT))
+        assert "/login" in self.driver.current_url
 
         # Fill nonsense and submit
         username_login = self.selenium_wrapper(self.driver.find_element, By.CSS_SELECTOR, "input[name='username']")
@@ -146,7 +146,7 @@ class TestConfigLogin(SABnzbdBaseTest):
 
         # Can we now go to the page and empty the settings again?
         self.open_page("http://%s:%s/config/general" % (SAB_HOST, SAB_PORT))
-        assert "/login/" not in self.driver.current_url
+        assert "/login" not in self.driver.current_url
 
         # Set the username and password
         username_imp = self.selenium_wrapper(self.driver.find_element, By.CSS_SELECTOR, "input[data-hide='username']")
@@ -166,9 +166,9 @@ class TestConfigLogin(SABnzbdBaseTest):
             except NoAlertPresentException:
                 pass
 
-        # Open any page and check if we get redirected
-        self.open_page("http://%s:%s/general" % (SAB_HOST, SAB_PORT))
-        assert "/login/" not in self.driver.current_url
+        # Open any page and check we are NOT redirected to login (no credentials set)
+        self.open_page("http://%s:%s/config/general" % (SAB_HOST, SAB_PORT))
+        assert "/login" not in self.driver.current_url
 
 
 class TestConfigCategories(SABnzbdBaseTest):
@@ -208,17 +208,17 @@ class TestConfigRSS(SABnzbdBaseTest):
 
         # Uncheck enabled-checkbox for new feeds
         self.selenium_wrapper(
-            self.driver.find_element, By.XPATH, '//form[@action="add_rss_feed"]//input[@name="enable"]'
+            self.driver.find_element, By.XPATH, '//form[@action="rss/add_rss_feed"]//input[@name="enable"]'
         ).click()
         input_name = self.selenium_wrapper(
-            self.driver.find_element, By.XPATH, '//form[@action="add_rss_feed"]//input[@name="feed"]'
+            self.driver.find_element, By.XPATH, '//form[@action="rss/add_rss_feed"]//input[@name="feed"]'
         )
         input_name.clear()
         input_name.send_keys(self.rss_name)
         self.selenium_wrapper(
-            self.driver.find_element, By.XPATH, '//form[@action="add_rss_feed"]//input[@name="uri"]'
+            self.driver.find_element, By.XPATH, '//form[@action="rss/add_rss_feed"]//input[@name="uri"]'
         ).send_keys(rss_url)
-        self.selenium_wrapper(self.driver.find_element, By.XPATH, '//form[@action="add_rss_feed"]//button').click()
+        self.selenium_wrapper(self.driver.find_element, By.XPATH, '//form[@action="rss/add_rss_feed"]//button').click()
 
         # Check if we have results
         tab_results = int(

--- a/tests/test_functional_config.py
+++ b/tests/test_functional_config.py
@@ -208,17 +208,17 @@ class TestConfigRSS(SABnzbdBaseTest):
 
         # Uncheck enabled-checkbox for new feeds
         self.selenium_wrapper(
-            self.driver.find_element, By.XPATH, '//form[@action="rss/add_rss_feed"]//input[@name="enable"]'
+            self.driver.find_element, By.XPATH, '//form[@data-form="add-rss-feed"]//input[@name="enable"]'
         ).click()
         input_name = self.selenium_wrapper(
-            self.driver.find_element, By.XPATH, '//form[@action="rss/add_rss_feed"]//input[@name="feed"]'
+            self.driver.find_element, By.XPATH, '//form[@data-form="add-rss-feed"]//input[@name="feed"]'
         )
         input_name.clear()
         input_name.send_keys(self.rss_name)
         self.selenium_wrapper(
-            self.driver.find_element, By.XPATH, '//form[@action="rss/add_rss_feed"]//input[@name="uri"]'
+            self.driver.find_element, By.XPATH, '//form[@data-form="add-rss-feed"]//input[@name="uri"]'
         ).send_keys(rss_url)
-        self.selenium_wrapper(self.driver.find_element, By.XPATH, '//form[@action="rss/add_rss_feed"]//button').click()
+        self.selenium_wrapper(self.driver.find_element, By.XPATH, '//form[@data-form="add-rss-feed"]//button').click()
 
         # Check if we have results
         tab_results = int(

--- a/tests/test_functional_config.py
+++ b/tests/test_functional_config.py
@@ -19,7 +19,7 @@
 tests.test_functional_config - Basic testing if Config pages work
 """
 
-from selenium.common.exceptions import NoSuchElementException, UnexpectedAlertPresentException, NoAlertPresentException
+from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from pytest_httpserver import HTTPServer
@@ -70,14 +70,10 @@ class TestBasicPages(SABnzbdBaseTest):
             # Click the right button
             submit_btn.click()
 
-            try:
-                self.wait_for_ajax()
-            except UnexpectedAlertPresentException:
-                try:
-                    # Ignore restart-request due to empty sabnzbd.ini in tests
-                    self.driver.switch_to.alert.dismiss()
-                except NoAlertPresentException:
-                    pass
+            # Saving here may or may not raise a restart-request (depends on whether
+            # an option actually changed against the test ini), so dismiss it only
+            # if it appears. Cancel = no restart, so the process keeps serving.
+            self.dismiss_alert_if_present()
 
             # For Specials page we get redirected after save, so check for no crash
             if "special" in test_url:
@@ -104,17 +100,9 @@ class TestConfigLogin(SABnzbdBaseTest):
         pass_inp.clear()
         pass_inp.send_keys("test_password")
 
-        # Submit and ignore alert
+        # Submit and dismiss the restart-request (cancel, so no restart happens)
         self.selenium_wrapper(self.driver.find_element, By.CLASS_NAME, "saveButton").click()
-
-        try:
-            self.wait_for_ajax()
-        except UnexpectedAlertPresentException:
-            try:
-                # Ignore restart-request
-                self.driver.switch_to.alert.dismiss()
-            except NoAlertPresentException:
-                pass
+        self.dismiss_restart_prompt()
 
         # Open any page and check if we get redirected
         self.open_page("http://%s:%s/config/general" % (SAB_HOST, SAB_PORT))
@@ -154,17 +142,9 @@ class TestConfigLogin(SABnzbdBaseTest):
         pass_inp = self.selenium_wrapper(self.driver.find_element, By.CSS_SELECTOR, "input[data-hide='password']")
         pass_inp.clear()
 
-        # Submit and ignore alert
+        # Submit and dismiss the restart-request (cancel, so no restart happens)
         self.selenium_wrapper(self.driver.find_element, By.CLASS_NAME, "saveButton").click()
-
-        try:
-            self.wait_for_ajax()
-        except UnexpectedAlertPresentException:
-            try:
-                # Ignore restart-request
-                self.driver.switch_to.alert.dismiss()
-            except NoAlertPresentException:
-                pass
+        self.dismiss_restart_prompt()
 
         # Open any page and check we are NOT redirected to login (no credentials set)
         self.open_page("http://%s:%s/config/general" % (SAB_HOST, SAB_PORT))
@@ -311,9 +291,11 @@ class TestConfigServers(SABnzbdBaseTest):
         self.selenium_wrapper(self.driver.find_element, By.CLASS_NAME, "showserver").click()
 
     def remove_server(self):
-        # Remove the first server and accept the confirmation
+        # Remove the first server and accept the confirmation. The confirm() is
+        # opened synchronously by the click handler, but Selenium's click() can
+        # return before it is registered, so wait for it rather than racing.
         self.selenium_wrapper(self.driver.find_element, By.CLASS_NAME, "delServer").click()
-        self.driver.switch_to.alert.accept()
+        self.wait_for_alert().accept()
 
         # Check that it's gone
         wait_for(

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -19,13 +19,15 @@
 tests.test_interface - Testing functions in interface.py
 """
 
+import asyncio
 import pytest
 from unittest.mock import Mock
 from starlette.requests import Request
 from starlette.datastructures import Headers, Address
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 from sabnzbd import interface
-from sabnzbd.misc import is_local_addr, is_loopback_addr
+from sabnzbd.misc import is_local_addr, is_loopback_addr, xff_trusted_networks
 
 
 def create_mock_request(remote_ip: str = "127.0.0.1", headers: dict | None = None, remote_port: int = 12345):
@@ -36,6 +38,23 @@ def create_mock_request(remote_ip: str = "127.0.0.1", headers: dict | None = Non
     return mock_request
 
 
+def resolve_client(remote_ip: str, xff_header: str | None = None, remote_port: int = 12345) -> Address:
+    """Pass a connection through uvicorn's ProxyHeadersMiddleware, configured
+    exactly like SABnzbd.py does, and return the resulting effective client."""
+    captured = {}
+
+    async def asgi_app(scope, receive, send):
+        captured["client"] = scope.get("client")
+
+    middleware = ProxyHeadersMiddleware(asgi_app, trusted_hosts=xff_trusted_networks())
+    headers = []
+    if xff_header:
+        headers.append((b"x-forwarded-for", xff_header.encode("latin1")))
+    scope = {"type": "http", "client": (remote_ip, remote_port), "headers": headers}
+    asyncio.run(middleware(scope, None, None))
+    return Address(*captured["client"])
+
+
 class TestInterfaceFunctions:
     @pytest.mark.parametrize(
         "remote_ip, local_ranges, xff_header, result_with_xff",
@@ -43,10 +62,10 @@ class TestInterfaceFunctions:
             ("10.11.12.13", None, None, True),
             ("10.11.12.13", None, "127.0.0.1", True),
             ("10.11.12.13", None, "127.1.2.3", True),
-            ("10.11.12.13", None, "127.0.0.1:8080", False),  # Port number in XFF
+            ("10.11.12.13", None, "127.0.0.1:8080", True),  # Port stripped from XFF, leaving loopback
             ("10.11.12.13", None, "::1", True),
             ("10.11.12.13", None, "[::1]", True),
-            ("10.11.12.13", None, "[::1]:8080", False),  # Port number in XFF
+            ("10.11.12.13", None, "[::1]:8080", True),  # Port stripped from XFF, leaving loopback
             ("10.11.12.13", None, "localhost", False),  # Hostname in XFF
             ("10.11.12.13", None, "example.org", False),  # Hostname in XFF
             ("10.11.12.13", None, "192.168.1.1", True),
@@ -92,10 +111,10 @@ class TestInterfaceFunctions:
             ("127.6.6.6", None, None, True),
             ("127.6.6.6", None, "127.0.0.1", True),
             ("127.6.6.6", None, "127.1.2.3", True),
-            ("127.6.6.6", None, "127.0.0.1:8080", False),  # Port number in XFF
+            ("127.6.6.6", None, "127.0.0.1:8080", True),  # Port stripped from XFF, leaving loopback
             ("127.6.6.6", None, "::1", True),
             ("127.6.6.6", None, "[::1]", True),
-            ("127.6.6.6", None, "[::1]:8080", False),  # Port number in XFF
+            ("127.6.6.6", None, "[::1]:8080", True),  # Port stripped from XFF, leaving loopback
             ("127.6.6.6", None, "localhost", False),  # Hostname in XFF
             ("127.6.6.6", None, "example.org", False),  # Hostname in XFF
             ("127.6.6.6", None, "192.168.1.1", True),
@@ -165,17 +184,19 @@ class TestInterfaceFunctions:
         monkeypatch,
     ):
         def _func():
-            # Create mock Starlette request with test data
-            headers = {}
-            if xff_header:
-                headers["X-Forwarded-For"] = xff_header
-            request = create_mock_request(remote_ip=remote_ip, headers=headers)
-
+            # With verify_xff_header enabled, SABnzbd.py runs uvicorn with
+            # proxy_headers=True, so the XFF chain is resolved into the
+            # effective client before check_access ever sees the request.
+            # With it disabled the header is ignored entirely.
             if verify_xff_header:
+                client = resolve_client(remote_ip=remote_ip, xff_header=xff_header)
                 result = result_with_xff
             else:
+                client = Address(remote_ip, 12345)
                 # Without XFF, only the remote IP and the local ranges setting matter
                 result = is_loopback_addr(remote_ip) or is_local_addr(remote_ip)
+
+            request = create_mock_request(remote_ip=client.host, remote_port=client.port)
 
             if access_type <= inet_exposure:
                 assert interface.check_access(request, access_type) is True
@@ -232,7 +253,7 @@ class TestInterfaceFunctions:
             (["666::/48"], ["4.3.2.1", "192.168.0.1", "10.10.10.10", "127.0.0.1"], "10.10.10.10"),
             (["8.8.8.8"], ["4.3.2.1", "192.168.0.1", "10.10.10.10", "::1"], "10.10.10.10"),
             (["666::/48"], ["4.3.2.1", "192.168.0.1", "10.10.10.10", "::1"], "10.10.10.10"),
-            ([], ["4.3.2.1:56789"], "4.3.2.1:56789"),  # Garbage in, garbage out.
+            ([], ["4.3.2.1:56789"], "4.3.2.1"),  # Port stripped from XFF entry
         ],
     )
     @pytest.mark.config(
@@ -240,11 +261,39 @@ class TestInterfaceFunctions:
             "local_ranges": params["local_ranges"],
         }
     )
-    def test_remote_ip_from_xff(self, local_ranges, xff_ips, expected_result, monkeypatch):
+    def test_effective_client_from_xff(self, local_ranges, xff_ips, expected_result):
         def _func():
-            # The remote_ip_from_xff function doesn't depend on request objects,
-            # it only takes the xff_ips list as parameter
+            # The effective client IP (used for login-cookie binding and access
+            # checks) is selected by uvicorn's ProxyHeadersMiddleware: the last
+            # XFF entry that is not a trusted (local) proxy, or the first entry
+            # when the whole chain is trusted. Connect from loopback, which is
+            # always a trusted peer.
             assert xff_ips
-            assert interface.remote_ip_from_xff(xff_ips) is expected_result
+            client = resolve_client(remote_ip="127.0.0.1", xff_header=", ".join(xff_ips))
+            assert client.host == expected_result
+
+        _func()
+
+    @pytest.mark.parametrize(
+        "local_ranges, expected_networks, unexpected_networks",
+        [
+            # Without local_ranges: loopback plus all private address space
+            (None, ["127.0.0.0/8", "::1", "10.0.0.0/8", "192.168.0.0/16", "::ffff:10.0.0.0/104"], []),
+            # With local_ranges: loopback plus the configured ranges only
+            (
+                "192.168.1.0/24",
+                ["127.0.0.0/8", "::1", "192.168.1.0/24", "::ffff:192.168.1.0/120"],
+                ["10.0.0.0/8", "172.16.0.0/12"],
+            ),
+        ],
+    )
+    @pytest.mark.config(lambda params: {"local_ranges": params["local_ranges"]})
+    def test_xff_trusted_networks(self, local_ranges, expected_networks, unexpected_networks):
+        def _func():
+            networks = xff_trusted_networks()
+            for network in expected_networks:
+                assert network in networks
+            for network in unexpected_networks:
+                assert network not in networks
 
         _func()

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -274,6 +274,19 @@ class TestInterfaceFunctions:
 
         _func()
 
+    @pytest.mark.parametrize("access_type", [1, 2, 3, 4, 5, 6])
+    @pytest.mark.parametrize("inet_exposure", [0, 2, 4])
+    @pytest.mark.config(lambda params: {"inet_exposure": params["inet_exposure"], "api_warnings": True})
+    def test_check_access_without_client(self, access_type, inet_exposure):
+        # request.client can be None (e.g. unix sockets or some test clients);
+        # this must not raise and must fail closed for restricted access types
+        request = create_mock_request()
+        request.client = None
+
+        assert interface.check_access(request, access_type, warn_user=True) is (access_type <= inet_exposure)
+        # The logging helpers must not raise either
+        interface.log_warning_and_ip(request, "txt")
+
     @pytest.mark.parametrize(
         "local_ranges, expected_networks, unexpected_networks",
         [

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -19,11 +19,21 @@
 tests.test_interface - Testing functions in interface.py
 """
 
-import cherrypy
 import pytest
+from unittest.mock import Mock
+from starlette.requests import Request
+from starlette.datastructures import Headers, Address
 
 from sabnzbd import interface
 from sabnzbd.misc import is_local_addr, is_loopback_addr
+
+
+def create_mock_request(remote_ip: str = "127.0.0.1", headers: dict | None = None, remote_port: int = 12345):
+    """Create a mock Starlette Request object for testing"""
+    mock_request = Mock(spec=Request)
+    mock_request.client = Address(remote_ip, remote_port)
+    mock_request.headers = Headers(headers or {})
+    return mock_request
 
 
 class TestInterfaceFunctions:
@@ -155,9 +165,11 @@ class TestInterfaceFunctions:
         monkeypatch,
     ):
         def _func():
-            # Insert fake request data
-            monkeypatch.setitem(cherrypy.request.headers, "X-Forwarded-For", xff_header)
-            monkeypatch.setattr(cherrypy.request.remote, "ip", remote_ip)
+            # Create mock Starlette request with test data
+            headers = {}
+            if xff_header:
+                headers["X-Forwarded-For"] = xff_header
+            request = create_mock_request(remote_ip=remote_ip, headers=headers)
 
             if verify_xff_header:
                 result = result_with_xff
@@ -166,9 +178,9 @@ class TestInterfaceFunctions:
                 result = is_loopback_addr(remote_ip) or is_local_addr(remote_ip)
 
             if access_type <= inet_exposure:
-                assert interface.check_access(access_type) is True
+                assert interface.check_access(request, access_type) is True
             else:
-                assert interface.check_access(access_type) is result
+                assert interface.check_access(request, access_type) is result
 
         _func()
 
@@ -230,8 +242,8 @@ class TestInterfaceFunctions:
     )
     def test_remote_ip_from_xff(self, local_ranges, xff_ips, expected_result, monkeypatch):
         def _func():
-            # Insert fake request data; should *not* influence the results of the tested function
-            monkeypatch.setattr(cherrypy.request.remote, "ip", "6.6.6.6")
+            # The remote_ip_from_xff function doesn't depend on request objects,
+            # it only takes the xff_ips list as parameter
             assert xff_ips
             assert interface.remote_ip_from_xff(xff_ips) is expected_result
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1217,12 +1217,37 @@ class TestPortIsFree:
         with self._listener("127.0.0.1") as port:
             assert misc.port_is_free("::1", port) is True
 
-    def test_non_local_host_returns_false(self):
-        """An address that is not ours cannot be bound (192.0.2.0/24 is TEST-NET-1)."""
-        assert misc.port_is_free("192.0.2.1", 8080) is False
+    def test_non_local_host_raises(self):
+        """An address that is not ours cannot be bound on any port, so it must not
+        look like an ordinary busy port (192.0.2.0/24 is TEST-NET-1)."""
+        with pytest.raises(misc.HostNotAvailableError):
+            misc.port_is_free("192.0.2.1", 8080)
+
+    def test_find_free_port_propagates_host_not_available(self):
+        with pytest.raises(misc.HostNotAvailableError):
+            misc.find_free_port("192.0.2.1", 8080)
 
     def test_unresolvable_host_returns_false(self):
         assert misc.port_is_free("no-such-host.invalid", 8080) is False
+
+    def test_bind_web_socket_reserves_the_port(self):
+        """The whole point of handing uvicorn a ready-made socket: from here on
+        nothing else can take the port. Binding alone is not enough for that, a
+        socket only reserves a port once it listens."""
+        sock = misc.bind_web_socket("127.0.0.1", 0)
+        try:
+            host, port = sock.getsockname()[:2]
+            assert host == "127.0.0.1"
+            assert port > 0
+            assert misc.port_is_free("127.0.0.1", port) is False
+        finally:
+            sock.close()
+
+    def test_bind_web_socket_closes_socket_on_failure(self):
+        """A failed bind must not leak the file descriptor."""
+        with self._listener() as port:
+            with pytest.raises(OSError):
+                misc.bind_web_socket("127.0.0.1", port)
 
     @staticmethod
     def _barred_socket():

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -28,7 +28,7 @@ import subprocess
 import sys
 import tempfile
 import wave
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from functools import cached_property
 from random import randint, sample
 from unittest import mock
@@ -1091,86 +1091,182 @@ class TestMisc:
         assert misc.subject_name_extractor(subject) == filename
 
 
+def ipv6_loopback_available() -> bool:
+    """Not every CI runner can bind ::1, so check instead of assuming"""
+    if not socket.has_ipv6:
+        return False
+    try:
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as sock:
+            sock.bind(("::1", 0))
+        return True
+    except OSError:
+        return False
+
+
+skip_without_ipv6 = pytest.mark.skipif(not ipv6_loopback_available(), reason="No usable IPv6 loopback")
+
+
+def low_ports_are_privileged() -> bool:
+    """Whether binding port 80 needs privileges for the user running the tests"""
+    if sys.platform.startswith("win") or not hasattr(os, "geteuid") or os.geteuid() == 0:
+        return False
+    try:
+        # Linux allows the privileged range to be moved, including down to nothing
+        with open("/proc/sys/net/ipv4/ip_unprivileged_port_start") as sysctl:
+            return int(sysctl.read().strip()) > 80
+    except OSError:
+        return True
+
+
+skip_without_privileged_ports = pytest.mark.skipif(
+    not low_ports_are_privileged(), reason="Low ports are not privileged for this user"
+)
+
+
 class TestPortIsFree:
-    """Tests for misc.port_is_free() and misc.find_free_local_port()"""
+    """Tests for misc.port_is_free() and misc.find_free_port()"""
 
     @staticmethod
-    def _listening_socket() -> tuple[socket.socket, int]:
-        """Return a listening socket bound to an OS-assigned port."""
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.bind(("127.0.0.1", 0))
-        s.listen(1)
-        return s, s.getsockname()[1]
+    @contextmanager
+    def _listener(host: str = "127.0.0.1", family: int = socket.AF_INET):
+        """Listen on an OS-assigned port on host, yielding that port."""
+        sock = socket.socket(family, socket.SOCK_STREAM)
+        # Match port_is_free, so a port left in TIME_WAIT by an earlier test
+        # cannot make this bind fail
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind((host, 0))
+            sock.listen(1)
+            yield sock.getsockname()[1]
+        finally:
+            sock.close()
+
+    @staticmethod
+    @contextmanager
+    def _listener_in_scan_range():
+        """Listen on a port low enough for find_free_port() to scan onwards from.
+        OS-assigned ports land in the dynamic range, above its 49151 ceiling."""
+        for port in range(10000, 10500, 5):
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                sock.bind(("127.0.0.1", port))
+                sock.listen(1)
+            except OSError:
+                sock.close()
+                continue
+            try:
+                yield port
+            finally:
+                sock.close()
+            return
+        pytest.skip("No free port available in the scan range")
+
+    @staticmethod
+    def _released_port(host: str = "127.0.0.1", family: int = socket.AF_INET) -> int:
+        """Return a port that was bindable a moment ago."""
+        with socket.socket(family, socket.SOCK_STREAM) as sock:
+            sock.bind((host, 0))
+            return sock.getsockname()[1]
 
     def test_free_port_returns_true(self):
-        """A port with no listener is reported as free."""
-        port = misc.find_free_port("127.0.0.1", 10000)
-        assert misc.port_is_free("127.0.0.1", port) is True
+        assert misc.port_is_free("127.0.0.1", self._released_port()) is True
 
     def test_occupied_port_returns_false(self):
-        """A port with an active listener is reported as occupied."""
-        s, port = self._listening_socket()
-        try:
+        with self._listener() as port:
             assert misc.port_is_free("127.0.0.1", port) is False
-        finally:
-            s.close()
 
-    def test_bind_all_ipv4_remapped(self):
-        """0.0.0.0 is remapped to 127.0.0.1 so the probe has a concrete target."""
-        s, port = self._listening_socket()
-        try:
-            assert misc.port_is_free("0.0.0.0", port) is False
-        finally:
-            s.close()
+    @pytest.mark.parametrize(
+        "host, family",
+        [
+            ("0.0.0.0", socket.AF_INET),
+            ("", socket.AF_INET),
+            ("127.0.0.1", socket.AF_INET),
+            ("::", socket.AF_INET6),
+            ("::1", socket.AF_INET6),
+        ],
+    )
+    def test_binds_the_host_it_was_given(self, host, family):
+        """The previous version remapped the bind-all addresses to 127.0.0.1, so
+        it probed the wrong address and, for ::, the wrong family as well.
 
-    def test_bind_all_ipv6_remapped(self):
-        """:: is remapped to 127.0.0.1 for the probe."""
-        s, port = self._listening_socket()
-        try:
-            assert misc.port_is_free("::", port) is False
-        finally:
-            s.close()
+        Asserted against the bind call rather than by watching two sockets fight
+        over a port, because whether a wildcard and a specific address may share
+        one is decided by the kernel and differs on Linux, macOS and Windows."""
+        with mock.patch("sabnzbd.misc.socket.socket") as fake_socket:
+            misc.port_is_free(host, 8080)
+        assert fake_socket.call_args.args[0] == family
+        fake_socket.return_value.bind.assert_called_once_with((host, 8080))
 
-    def test_empty_host_remapped(self):
-        """Empty string host is remapped to 127.0.0.1."""
-        s, port = self._listening_socket()
-        try:
-            assert misc.port_is_free("", port) is False
-        finally:
-            s.close()
-
-    def test_custom_timeout_respected(self):
-        """A very short timeout still works for a local free port."""
-        port = misc.find_free_port("127.0.0.1", 10000)
-        assert misc.port_is_free("127.0.0.1", port, timeout=0.01) is True
-
-    def test_find_free_port_returns_valid_port(self):
-        """find_free_port() returns a port in the valid range."""
-        port = misc.find_free_port("127.0.0.1", 10000)
-        assert 1 <= port <= 65535
-
-    def test_find_free_port_is_actually_free(self):
-        """The port returned by find_free_port() is not occupied."""
-        port = misc.find_free_port("127.0.0.1", 10000)
+    def test_free_port_is_actually_bindable(self):
+        """The property that matters: True has to mean uvicorn can bind it."""
+        port = self._released_port()
         assert misc.port_is_free("127.0.0.1", port) is True
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind(("127.0.0.1", port))
+
+    @skip_without_ipv6
+    def test_occupied_ipv6_port_returns_false(self):
+        with self._listener("::1", socket.AF_INET6) as port:
+            assert misc.port_is_free("::1", port) is False
+
+    @skip_without_ipv6
+    def test_ipv4_listener_does_not_block_ipv6(self):
+        """A port held on 127.0.0.1 says nothing about the same port on ::1."""
+        with self._listener("127.0.0.1") as port:
+            assert misc.port_is_free("::1", port) is True
+
+    def test_non_local_host_returns_false(self):
+        """An address that is not ours cannot be bound (192.0.2.0/24 is TEST-NET-1)."""
+        assert misc.port_is_free("192.0.2.1", 8080) is False
+
+    def test_unresolvable_host_returns_false(self):
+        assert misc.port_is_free("no-such-host.invalid", 8080) is False
+
+    @staticmethod
+    def _barred_socket():
+        """Patch the probe's socket so binding is refused for lack of privileges."""
+        sock = mock.MagicMock()
+        sock.bind.side_effect = PermissionError("Permission denied")
+        return mock.patch("sabnzbd.misc.socket.socket", return_value=sock)
+
+    def test_barred_port_raises(self):
+        """A port we may not use is a different problem from an occupied one, so
+        it must not come back as a plain False."""
+        with self._barred_socket(), pytest.raises(PermissionError):
+            misc.port_is_free("0.0.0.0", 80)
+
+    @skip_without_privileged_ports
+    def test_low_port_raises_permission_error(self):
+        """Guards the premise: the platform really does report this as EACCES."""
+        with pytest.raises(PermissionError):
+            misc.port_is_free("127.0.0.1", 80)
+
+    def test_find_free_port_propagates_permission_error(self):
+        """Scanning on past a barred port could only end in a misleading answer."""
+        with self._barred_socket(), pytest.raises(PermissionError):
+            misc.find_free_port("0.0.0.0", 80)
+
+    def test_find_free_port_returns_port_in_scan_range(self):
+        port = misc.find_free_port("127.0.0.1", 10000)
+        assert port is not None
+        assert 10000 <= port <= 10045
 
     def test_find_free_port_skips_occupied(self):
-        """find_free_port() moves past an occupied port."""
-        # Find a port in the scan range, then occupy it
-        start = misc.find_free_port("127.0.0.1", 10000)
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.bind(("127.0.0.1", start))
-        s.listen(1)
-        try:
-            free = misc.find_free_port("127.0.0.1", start)
-            assert free != start
-            assert free > start
-        finally:
-            s.close()
+        with self._listener_in_scan_range() as port:
+            free = misc.find_free_port("127.0.0.1", port)
+            assert free is not None
+            assert free > port
+            assert misc.port_is_free("127.0.0.1", free) is True
 
-    def test_find_free_port_returns_zero_when_exhausted(self):
-        """find_free_port() returns 0 when starting above the scan ceiling."""
-        assert misc.find_free_port("127.0.0.1", 49200) == 0
+    def test_find_free_port_above_ceiling(self):
+        """49152 and up is the dynamic range, so it is never scanned."""
+        assert misc.find_free_port("127.0.0.1", 49200) is None
+
+    def test_find_free_port_rejects_port_zero(self):
+        """Binding port 0 always succeeds, which would return a misleading 0."""
+        assert misc.find_free_port("127.0.0.1", 0) is None
 
 
 class TestBuildAndRunCommand:

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -23,6 +23,7 @@ import builtins
 import datetime
 import functools
 import os
+import socket
 import subprocess
 import sys
 import tempfile
@@ -1088,6 +1089,88 @@ class TestMisc:
     )
     def test_name_extractor(self, subject, filename):
         assert misc.subject_name_extractor(subject) == filename
+
+
+class TestPortIsFree:
+    """Tests for misc.port_is_free() and misc.find_free_local_port()"""
+
+    @staticmethod
+    def _listening_socket() -> tuple[socket.socket, int]:
+        """Return a listening socket bound to an OS-assigned port."""
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.bind(("127.0.0.1", 0))
+        s.listen(1)
+        return s, s.getsockname()[1]
+
+    def test_free_port_returns_true(self):
+        """A port with no listener is reported as free."""
+        port = misc.find_free_port("127.0.0.1", 10000)
+        assert misc.port_is_free("127.0.0.1", port) is True
+
+    def test_occupied_port_returns_false(self):
+        """A port with an active listener is reported as occupied."""
+        s, port = self._listening_socket()
+        try:
+            assert misc.port_is_free("127.0.0.1", port) is False
+        finally:
+            s.close()
+
+    def test_bind_all_ipv4_remapped(self):
+        """0.0.0.0 is remapped to 127.0.0.1 so the probe has a concrete target."""
+        s, port = self._listening_socket()
+        try:
+            assert misc.port_is_free("0.0.0.0", port) is False
+        finally:
+            s.close()
+
+    def test_bind_all_ipv6_remapped(self):
+        """:: is remapped to 127.0.0.1 for the probe."""
+        s, port = self._listening_socket()
+        try:
+            assert misc.port_is_free("::", port) is False
+        finally:
+            s.close()
+
+    def test_empty_host_remapped(self):
+        """Empty string host is remapped to 127.0.0.1."""
+        s, port = self._listening_socket()
+        try:
+            assert misc.port_is_free("", port) is False
+        finally:
+            s.close()
+
+    def test_custom_timeout_respected(self):
+        """A very short timeout still works for a local free port."""
+        port = misc.find_free_port("127.0.0.1", 10000)
+        assert misc.port_is_free("127.0.0.1", port, timeout=0.01) is True
+
+    def test_find_free_port_returns_valid_port(self):
+        """find_free_port() returns a port in the valid range."""
+        port = misc.find_free_port("127.0.0.1", 10000)
+        assert 1 <= port <= 65535
+
+    def test_find_free_port_is_actually_free(self):
+        """The port returned by find_free_port() is not occupied."""
+        port = misc.find_free_port("127.0.0.1", 10000)
+        assert misc.port_is_free("127.0.0.1", port) is True
+
+    def test_find_free_port_skips_occupied(self):
+        """find_free_port() moves past an occupied port."""
+        # Find a port in the scan range, then occupy it
+        start = misc.find_free_port("127.0.0.1", 10000)
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.bind(("127.0.0.1", start))
+        s.listen(1)
+        try:
+            free = misc.find_free_port("127.0.0.1", start)
+            assert free != start
+            assert free > start
+        finally:
+            s.close()
+
+    def test_find_free_port_returns_zero_when_exhausted(self):
+        """find_free_port() returns 0 when starting above the scan ceiling."""
+        assert misc.find_free_port("127.0.0.1", 49200) == 0
 
 
 class TestBuildAndRunCommand:

--- a/tests/test_newswrapper.py
+++ b/tests/test_newswrapper.py
@@ -36,7 +36,6 @@ from functools import cached_property
 from typing import Optional
 from unittest import mock
 
-import portend
 import pytest
 from flaky import flaky
 
@@ -46,7 +45,7 @@ from sabnzbd.get_addrinfo import AddrInfo
 
 TEST_HOST = "127.0.0.1"
 TEST_HOST_IPV6 = "::1"
-TEST_PORT = portend.find_available_local_port()
+TEST_PORT = misc.find_free_port(TEST_HOST, 10000)
 TEST_DATA = b"connection_test"
 
 

--- a/tests/test_postproc.py
+++ b/tests/test_postproc.py
@@ -142,6 +142,11 @@ class TestPostProc:
     def test_prepare_extraction_path(
         self, category, has_jobdir, has_catdir, has_active_sorter, sort_string, marker_file, do_folder_rename
     ):
+        # Every parametrization asserts on the exact directory name that comes out, but that
+        # name depends on what's already on disk. Best effort cleanup.
+        shutil.rmtree(SAB_CACHE_DIR, ignore_errors=True)
+        os.makedirs(SAB_CACHE_DIR, exist_ok=True)
+
         # Ensure global CFG_ vars are initialised
         sabnzbd.config.read_config(os.devnull)
 

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -35,6 +35,7 @@ from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 from string import ascii_lowercase, digits
 from unittest import mock
 from urllib3.exceptions import ProtocolError
@@ -440,6 +441,45 @@ class SABnzbdBaseTest:
             wait.until(lambda driver_wait: self.driver.execute_script("return window.scrollY") == 0)
         except RemoteDisconnected:
             pass
+
+    def wait_for_alert(self, timeout=15):
+        """Wait for a JS confirm()/alert dialog and return it.
+
+        Selenium's click() can return before a dialog opened synchronously in the
+        click handler is registered, and a confirm() raised from an AJAX success
+        callback only appears once the request settles. Waiting explicitly avoids
+        both races. Use this only where a dialog is guaranteed."""
+        WebDriverWait(self.driver, timeout).until(EC.alert_is_present())
+        return self.driver.switch_to.alert
+
+    def dismiss_restart_prompt(self, timeout=15):
+        """Dismiss the "restart required" confirmation raised after saving.
+
+        Changing username/password (and other guarded options) sets RESTART_REQ,
+        so the save callback always pops a confirm() dialog. Cancel it (= no
+        restart). The alert is guaranteed here, so wait for it deterministically."""
+        self.wait_for_alert(timeout).dismiss()
+
+    def dismiss_alert_if_present(self, timeout=15):
+        """Wait until a submitted save settles, dismissing a restart-request
+        confirm() only if one is raised.
+
+        Use where the dialog is conditional (a save that may or may not change a
+        guarded option), so its absence must not fail the test. The alert, if any,
+        is popped in the same JS turn that completes the request, so poll for either
+        terminal state and return as soon as one is reached."""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if EC.alert_is_present()(self.driver):
+                self.driver.switch_to.alert.dismiss()
+                return
+            try:
+                if self.driver.execute_script("return jQuery.active") == 0:
+                    return
+            except (RemoteDisconnected, ProtocolError):
+                return
+            time.sleep(0.1)
+        pytest.fail("Config save did not settle within %s seconds" % timeout)
 
     def wait_for_ajax(self):
         # We catch common nonsense errors from Selenium


### PR DESCRIPTION
This builds upon the work done in #3373

The first commit combines all the work from #3373 with a few unrelated changes left out.
Each of the many following commits fix or reimplement some missing feature.
I tried really hard but there are a few new features that are either required or worth adding and are related to the PR I promise!

You won't like one part where I used `data-form` I couldn't decide what approach you would prefer, maybe classes since id couldn't be used without creating unique ones - the same form is on a page multiple times.

I purposely made as few changes as possible to the api route implementations themselves, except preparing them for a future when they may be async but it requires more changes than I felt comfortable with, better to land this first. This means Uvicorn delegates almost everything to it's threadpool to run them async, note Uvicorn by default can use 40 threads - I've not checked how it works but I presume it typically uses far fewer.

The main thing to be aware of is there is one async loop, so if you do something synchronous you block all other requests; for example if you do a DB query, or try to grab an RSS feed you block every other request unless you use async methods. So for now pretty much everything runs in the threadpool.

Given our performance requirements I didn't bother adding uvloop.
For anyone wondering, Starlette is used instead of FastAPI because the existing API is not rest routing so you don't gain any of the auto-documentation or validation benefits.

Missing features/changes:

- The dual-server http and https is gone; single uvicorn.Config that is either HTTPS with a dedicated https_port, HTTPS on web_port, or HTTP on web_port - note https_port could be removed but i didn't want to break existing configs
- Basic authentication is removed
- Uvicorn can't be shutdown from its own thread, so such requests are async: you send a restart request via the api and it starts a BackgroundTask actioned after a response is sent to the browser, I made the webserver stop accepting new connections so you can't immediately connect to the shutting down server
- secure cookies if request was served over https or enable_https, the XFF middleware proxies the request scheme. Note I have not made this quite correct for `SessionMiddleware` yet
- I need to check 'Fix return type of retry job for future types'

New features:

- Fixed existing global RSS state shared between webserver threads without locking - uses a session cookie to flash data
- Pool database connections; previously each webserver thread (10) would open a database connection, Uvicorn could use 40 for its threadpool for handling sync requests. The previous threadlocal approach was a bit messy and you still had other areas creating short-lived connections. Therefore there is now `with sabnzbd.db_pool.connection() as history_db` used throughout, it manages a pool of 5 connections but more can still be requested they're just not returned to the pool. This may result in lower memory usage because idle connections are not sat in webserver threads.
- SQLite PRAGMA tweaks to compliment the pool changes; see `database.py` for explanation tl;dr journal_mode=WAL,synchronous=NORMAL,busy_timeout=5000,cache_size=-4000,temp_store=MEMORY,mmap_size=16777216
- Backup changes to facilitate database WAL changes; note WAL won't play nice over the network, but if someone has their config directory on a network share they've got bigger problems
- $url helper in interfaces, a lot nicer to work with from nested routes and required because Uvicorn/Starlette changes removed the trailing slashes - accounts for ~300 line changes

Future:

There are loads of future changes this opens up, some not strickly unlocked by this PR but I thought of having looked at webserver/interface/api code:

- Pydantic validation of api requests, like FastAPI would provide - I'm imagining passing models to `ApiEntry` and also using it to generate API documentation
- Config changes without restart; all but about 2 usages of the `guard_restart` callback can be replaced with live changes to the webserver, without restarting the whole application
- Database-backed sessions for cookie authentication and removing apikey usage from the frontend - use aiosqlite, can resolve some issues with cookies in containers
- Constant time comparison of login credentials - prevent timing based leaks of credentials
- add_nzbfile by processing UploadFile without a temporary file (except 7zip)
- SQLite incremental vacuum upon DELETE operations
- UI state via SSE or WebSockets (probably SSE), perhaps in-browser log output via SSE
- I left it out of these changes but add trigger_shutdown() and act on it from the main thread, with careful use of a wait_for_shutdown() from threads that require it, for now I kept it as is and spawned threads
- ~~Detect network filesystems and disable WAL~~

Probably some things I've forgotten so I'll probably edit this message.