### PR TITLE
use XDG_CURRENT_DESKTOP as an alternative GUI indicator

### DIFF
--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1172,7 +1172,7 @@ def main():
     if sabnzbd.cfg.tray_icon() and not sabnzbd.DAEMON and not sabnzbd.WIN_SERVICE:
         if sabnzbd.WINDOWS:
             sabnzbd.WINTRAY = sabnzbd.sabtraywin.SABTrayThread()
-        elif sabnzbd.LINUX_POWER and os.environ.get("DISPLAY"):
+        elif sabnzbd.LINUX_POWER and (os.environ.get("DISPLAY") or os.environ.get("XDG_CURRENT_DESKTOP")):
             try:
                 import gi
 


### PR DESCRIPTION
some environment such as flatpak don't set DISPLAY, which can throw off detection of a graphical environment when determining whether or not to enable the tray icon. XDG_CURRENT_DESKTOP is part of freedesktop.org's [Desktop Entry Specification](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html) and widely supported by desktop environments.