### PR TITLE
Persistent sessions, CSRF tokens, and no apikey in the web interface

### DIFF
--- a/builder/package.py
+++ b/builder/package.py
@@ -246,7 +246,7 @@ def test_sab_binary(binary_path: str):
 
         # Parse API-key so we can do a graceful shutdown
         sab_config = configobj.ConfigObj(os.path.join(config_dir, "sabnzbd.ini"))
-        urllib.request.urlopen(base_url + "shutdown/?apikey=" + sab_config["misc"]["api_key"], timeout=10)
+        urllib.request.urlopen(base_url + "api?mode=shutdown&apikey=" + sab_config["misc"]["api_key"], timeout=10)
         sabnzbd_process.wait()
 
         # Print logs for verification

--- a/interfaces/Config/templates/_inc_header_uc.tmpl
+++ b/interfaces/Config/templates/_inc_header_uc.tmpl
@@ -41,10 +41,10 @@
         var formWasSubmitted = false;
 
         // Information we need
-        var sabSession = '$apikey';
+        var csrfToken = '$csrf_token';
         var rootURL = '$url()'
         var urlBase = '${url_base}'
-        var folderBrowseUrl = "$url('api', mode='browse', output='json', apikey=$apikey)";
+        var folderBrowseUrl = "$url('api', mode='browse', output='json')";
         var folderSeperator = '#if $os.sep == '\\' then '\\\\' else '/'#'
 
         // Translations

--- a/interfaces/Config/templates/config_cat.tmpl
+++ b/interfaces/Config/templates/config_cat.tmpl
@@ -28,7 +28,6 @@
                                 <span class="glyphicon glyphicon-option-vertical"></span>
                             </td>
                             <td>
-                                <input type="hidden" name="apikey" value="$apikey" />
                                 <input type="hidden" name="order" value="$slot.order" />
                                 <input type="hidden" value="$slot.name" name="name" />
                                 <!--#if $slot.name != '*'#-->

--- a/interfaces/Config/templates/config_folders.tmpl
+++ b/interfaces/Config/templates/config_folders.tmpl
@@ -9,7 +9,6 @@
         </label>
     </div>
     <form action="$url('config/folders/save')" method="post" class="fullform" autocomplete="off">
-    <input type="hidden" id="apikey" name="apikey" value="$apikey" />
     <input type="hidden" name="output" value="json" />
     <div class="section">
         <div class="col2">
@@ -139,7 +138,7 @@
                 $.ajax({
                     type: "POST",
                     url: "$url('api')",
-                    data: {mode: 'config', name: 'purge_log_files', output: 'json', apikey: jQuery('#apikey').val()}
+                    data: {mode: 'config', name: 'purge_log_files', output: 'json'}
                 })
             } else {
                 return false;

--- a/interfaces/Config/templates/config_general.tmpl
+++ b/interfaces/Config/templates/config_general.tmpl
@@ -9,7 +9,6 @@
         </label>
     </div>
     <form action="$url('config/general/save')" method="post" class="fullform" autocomplete="off">
-        <input type="hidden" id="apikey" name="apikey" value="$apikey" />
         <input type="hidden" name="output" value="json" />
         <div class="section">
             <div class="col2">
@@ -222,7 +221,6 @@
     </form>
 
     <form action="$url('config/general/upload_config')" method="post" class="fullform" autocomplete="off" enctype="multipart/form-data">
-        <input type="hidden" name="apikey" value="$apikey" />
         <input type="hidden" name="output" value="json" />
         <div class="section">
             <div class="col2">
@@ -307,17 +305,16 @@ jQuery(document).ready(function(){
     safeCheck.on('change', checkSafety)
 
     // Click functions
-    jQuery('#apikey, #nzbkey').click(function () { jQuery(this).select() });
+    jQuery('#apikey_display, #nzbkey').click(function () { jQuery(this).select() });
 
     jQuery('#generate_new_apikey').click(function () {
       if (confirm("$T('confirm')")) {
         $.ajax({
           type: "POST",
           url: "$url('api')",
-          data: {mode:'config', name:'set_apikey', apikey: jQuery('#apikey').val()},
+          data: { mode: 'config', name: 'set_apikey' },
           success: function(msg){
-            jQuery('#apikey').val(msg);
-            document.location = document.location;
+            jQuery('#apikey_display').val(msg.apikey);
           }
         });
       }
@@ -327,10 +324,9 @@ jQuery(document).ready(function(){
         $.ajax({
           type: "POST",
           url: "$url('api')",
-          data: { mode:'config', name:'set_nzbkey', apikey: jQuery('#apikey').val() },
-          success: function(msg){
-            jQuery('#nzbkey').val(msg);
-            document.location = document.location;
+          data: { mode: 'config', name: 'set_nzbkey' },
+          success: function(msg) {
+            jQuery('#nzbkey').val(msg.nzbkey);
           }
         });
       }
@@ -362,7 +358,7 @@ jQuery(document).ready(function(){
         $.ajax({
             type: "POST",
             url: "$url('api')",
-            data: { mode: 'config', name: 'regenerate_certs', apikey: jQuery('#apikey').val() },
+            data: { mode: 'config', name: 'regenerate_certs' },
             success: function(msg) {
                 do_restart()
             }
@@ -400,7 +396,7 @@ jQuery(document).ready(function(){
         $.ajax({
           type: "POST",
           url: "$url('api')",
-          data: {mode:'config', name:'create_backup', output:'json', apikey: jQuery('#apikey').val()},
+          data: { mode: 'config', name: 'create_backup', output: 'json' },
           success: function(data) {
               if(data.value.result) {
                   alert("$T('backup'):\n" + data.value.message)

--- a/interfaces/Config/templates/config_notify.tmpl
+++ b/interfaces/Config/templates/config_notify.tmpl
@@ -31,7 +31,6 @@
 
 <div class="colmask">
     <form action="$url('config/notify/save')" method="post" class="fullform" autocomplete="off">
-    <input type="hidden" id="apikey" name="apikey" value="$apikey" />
     <input type="hidden" name="output" value="json" />
     <div class="section" id="email">
         <div class="col2">
@@ -447,7 +446,7 @@ jQuery(document).ready(function(){
         jQuery(buttonObj).attr("disabled", "disabled")
         jQuery(buttonObj).attr("aria-busy", "true")
         jQuery(buttonObj).find('span').toggleClass('glyphicon-comment glyphicon-refresh spin-glyphicon')
-        var data = { mode: buttonObj.id, apikey: '$apikey', output: 'json' };
+        var data = { mode: buttonObj.id, output: 'json' };
         jQuery(buttonObj).parents('.section').extractFormDataTo(data);
 
         // Clear up the box
@@ -455,7 +454,7 @@ jQuery(document).ready(function(){
 
         // Get the request
         jQuery.ajax({
-            type: "GET",
+            type: "POST",
             url: "$url('api')",
             data: data
         }).then(function(data) {

--- a/interfaces/Config/templates/config_rss.tmpl
+++ b/interfaces/Config/templates/config_rss.tmpl
@@ -9,7 +9,6 @@
             <a class="main-helplink" href="$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a>
             <p>$T('explain-RSS')</p>
             <form data-form="add-rss-feed" action="$url('config/rss/add_rss_feed')" method="post" autocomplete="off">
-                <input type="hidden" name="apikey" value="$apikey" />
                 <table class="catTable addRssTable">
                     <tr>
                         <th>&nbsp;</th>
@@ -39,7 +38,6 @@
     <div class="section">
         <div class="padTable">
             <form action="$url('config/rss/save_rss_feed')" method="post" autocomplete="off">
-                <input type="hidden" name="apikey" value="$apikey" />
                 <table id="subscriptions">
                     <tbody>
                         <!--#set $feeds = sorted($rss.keys(), key=lambda x: x.lower())#-->
@@ -76,7 +74,6 @@
             <!--#if $feeds#-->
             <br/>
             <form action="$url('config/rss/rss_now')" method="post" autocomplete="off">
-                <input type="hidden" name="apikey" value="$apikey" />
                 <button type="submit" class="btn btn-default readAll"><span class="glyphicon glyphicon-sort"></span> $T('button-rssNow')</button>
             </form>
             <!--#end if#-->
@@ -85,7 +82,6 @@
     <!--#end if#-->
     <div class="section">
         <form action="$url('config/rss/save_rss_rate')" method="post" autocomplete="off">
-            <input type="hidden" name="apikey" value="$apikey" />
             <div class="col1">
                 <fieldset>
                     <div class="field-pair">
@@ -117,7 +113,6 @@
             </div>
             <!--#end if#-->
             <form action="$url('config/rss/upd_rss_feed')" method="post">
-                <input type="hidden" name="apikey" value="$apikey" />
                 <input type="hidden" name="feed" value="$active_feed" />
                 <input type="hidden" name="uri" value="$rss[$feed]['uris']" />
                 <table class="catTable">
@@ -209,7 +204,6 @@
             </form>
             <!-- add new filter -->
             <form data-form="update-rss-filter" action="$url('config/rss/upd_rss_filter')" method="post">
-                <input type="hidden" name="apikey" value="$apikey" />
                 <input type="hidden" name="index" value="$rss[$feed]['filtercount']" />
                 <input type="hidden" name="feed" value="$active_feed" />
                 <table class="catTable">
@@ -286,7 +280,6 @@
             <!--#for $filter in $rss[$feed].filters#-->
                 <!--#set $odd = not $odd#-->
                 <form data-form="update-rss-filter" action="$url('config/rss/upd_rss_filter')" method="post" autocomplete="off">
-                    <input type="hidden" name="apikey" value="$apikey" />
                     <input type="hidden" name="index" value="$fnum" />
                     <input type="hidden" name="feed" value="$active_feed" />
                     <table class="catTable">
@@ -365,7 +358,6 @@
                 <!--#set $fnum = $fnum+1#-->
             <!--#end for#-->
             <form action="$url('config/rss/download_rss_feed')" method="post">
-                <input type="hidden" name="apikey" value="$apikey" />
                 <input type="hidden" name="feed" value="$active_feed" />
                 <div class="padding">
                     <button type="button" class="btn btn-default testFeed" rel="$active_feed"><span class="glyphicon glyphicon-sort"></span> $T('button-preFeed')</button>
@@ -402,7 +394,6 @@
                             <td>
                                 <form data-form="download-rss-job" action="$url('config/rss/download')" method="post">
                                     <input type="hidden" value="$active_feed" name="feed" />
-                                    <input type="hidden" name="apikey" value="$apikey" />
                                     <input type="hidden" name="url" value="$job['url']" />
                                     <input type="hidden" name="nzbname" value="$job['nzbname']" />
                                     <button type="submit" class="btn btn-default"><span class="glyphicon glyphicon-plus-sign"></span> $T('link-download')</button>
@@ -446,7 +437,6 @@
                             <td>
                                 <form data-form="download-rss-job" action="$url('config/rss/download')" method="post">
                                     <input type="hidden" value="$active_feed" name="feed" />
-                                    <input type="hidden" name="apikey" value="$apikey" />
                                     <input type="hidden" name="url" value="$job['url']" />
                                     <input type="hidden" name="nzbname" value="$job['nzbname']" />
                                     <button type="submit" class="btn btn-default"><span class="glyphicon glyphicon-plus-sign"></span> $T('link-download')</button>
@@ -475,7 +465,6 @@
                 <!--#if $downloaded#-->
                 <form action="$url('config/rss/clean_rss_jobs')" method="post">
                     <input type="hidden" value="$active_feed" name="feed" />
-                    <input type="hidden" name="apikey" value="$apikey" />
                     <table class="catTable">
                         <thead>
                             <tr>
@@ -535,7 +524,6 @@
                     <span class="help-block">$T('addMultipleFeeds')</span>
                 </div>
                 <input type="hidden" name="feed" id="feed_edit_old_name" />
-                <input type="hidden" name="apikey" value="$apikey" />
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-danger" data-dismiss="modal"><span class="glyphicon glyphicon-remove"></span> $T('cancel')</button>
@@ -590,7 +578,7 @@ jQuery(document).ready(function(){
             jQuery.ajax({
                 type: "POST",
                 url: "$url('config/rss/del_rss_feed')",
-                data: {feed: whichFeed, apikey: "$apikey" }
+                data: {feed: whichFeed }
             }).done(function( msg ) {
                 // Let us leave!
                 formWasSubmitted = true;
@@ -605,7 +593,7 @@ jQuery(document).ready(function(){
         jQuery.ajax({
             type: "POST",
             url: "$url('config/rss/toggle_rss_feed')",
-            data: {feed: whichFeed, apikey: "$apikey" }
+            data: {feed: whichFeed }
         }).done(function() {
             // Let us leave!
             formWasSubmitted = true;
@@ -645,7 +633,7 @@ jQuery(document).ready(function(){
         jQuery.ajax({
             type: "POST",
             url: "$url('config/rss/test_rss_feed')",
-            data: {feed: whichFeed, apikey: "$apikey" }
+            data: {feed: whichFeed }
         }).done(function( msg ) {
             // Let us leave!
             formWasSubmitted = true;

--- a/interfaces/Config/templates/config_scheduling.tmpl
+++ b/interfaces/Config/templates/config_scheduling.tmpl
@@ -18,7 +18,6 @@ else:
             <h3>$T('addSchedule') <a href="$help_uri" target="_blank"><span class="glyphicon glyphicon-question-sign"></span></a></h3>
         </div><!-- /col2 -->
         <form data-form="add-schedule" action="$url('config/scheduling/add_schedule')" method="post" autocomplete="off">
-        <input type="hidden" id="apikey" name="apikey" value="$apikey" />
         <div class="col1">
             <fieldset>
                 <div class="field-pair">
@@ -91,7 +90,6 @@ else:
                         <!--#for $schednum, $line in enumerate($schedlines)#-->
                             <!--#set $odd = not $odd#-->
                             <form data-form="del-schedule" action="$url('config/scheduling/del_schedule')" method="post">
-                                <input type="hidden" name="apikey" value="$apikey"/>
                                 <input type="hidden" name="line" value="$line"/>
                                 <div class="field-pair infoTableSeperator <!--#if $odd then "" else " alt"#-->">
                                     <input type="checkbox" name="schedenabled" value="$line" aria-label="$T('enabled')" aria-describedby="schedule-description-$schednum" <!--#if int($taskinfo[$schednum][5]) > 0 then 'checked="checked"' else ""#-->>
@@ -137,7 +135,7 @@ else:
         jQuery.ajax({
             type: "POST",
             url: "$url('config/scheduling/toggle_schedule')",
-            data: {line: jQuery(this).val(), apikey: "$apikey" }
+            data: {line: jQuery(this).val() }
         }).done(function() {
             // Let us leave!
             formWasSubmitted = true;

--- a/interfaces/Config/templates/config_server.tmpl
+++ b/interfaces/Config/templates/config_server.tmpl
@@ -41,7 +41,6 @@
         </div>
         <div class="col1">
             <form data-form="add-server" action="$url('config/server/add_server')" method="post" autocomplete="off">
-                <input type="hidden" name="apikey" value="$apikey" />
                 <input type="hidden" name="output" value="json" />
                 <fieldset>
                     <div class="field-pair">
@@ -154,7 +153,6 @@
     <!--#set $last_prio = -1 #-->
     <!--#for $cur, $server in enumerate($servers) #-->
         <form action="$url('config/server/save_server')" method="post" class="fullform" autocomplete="off">
-            <input type="hidden" name="apikey" value="$apikey" />
             <input type="hidden" name="output" value="json" />
             <input type="hidden" name="server" value="$server['name']" />
 
@@ -644,7 +642,7 @@
             jQuery.ajax({
                 type: "POST",
                 url: "$url('config/server/toggle_server')",
-                data: {server: whichServer, apikey: "$apikey" }
+                data: {server: whichServer }
             }).done(function() {
                 // Let us leave!
                 formWasSubmitted = true;

--- a/interfaces/Config/templates/config_sorting.tmpl
+++ b/interfaces/Config/templates/config_sorting.tmpl
@@ -21,7 +21,6 @@
         <!-- SORTER $cur -->
         <div class="section <!--#if $cur != 0#-->sorter<!--#end if#-->" id="sorter_$cur" <!--#if $cur == 0#-->style="display: none;"<!--#end if#-->>
             <form action="$url('config/sorting/save_sorter')" method="post" autocomplete="off" <!--#if $cur != 0#-->class="sorting-row"<!--#end if#-->>
-                <input type="hidden" name="apikey" value="$apikey" />
                 <input type="hidden" name="order" value="$slot.order" />
                 <input type="hidden" value="$slot.name" name="name" />
                 <!--#if $cur == 0#-->
@@ -348,7 +347,6 @@
         <h3>$T('sort-quick-add'):</h3>
         <!--#if "tv" in $categories#-->
         <form action="$url('config/sorting/save_sorter')" method="post" autocomplete="off">
-            <input type="hidden" name="apikey" value="$apikey" />
             <input type="hidden" name="order" value="0" />
             <input type="hidden" name="is_active" value="1" />
             <input type="hidden" name="name" value="">
@@ -367,7 +365,6 @@
         <!--#end if#-->
         <!--#if "movies" in $categories#-->
         <form action="$url('config/sorting/save_sorter')" method="post" autocomplete="off">
-            <input type="hidden" name="apikey" value="$apikey" />
             <input type="hidden" name="order" value="0" />
             <input type="hidden" name="is_active" value="1" />
             <input type="hidden" name="name" value="">
@@ -420,7 +417,6 @@
                         job_name: jQuery('#preview_name_' + sort_nr).val(),
                         sort_string: preview_sort_string,
                         multipart_label: jQuery('#multipart_label_' + sort_nr).val(),
-                        apikey: '$apikey',
                         output: 'json'
                     },
                     success: function(data) {
@@ -510,7 +506,7 @@
             jQuery.ajax({
                 type: "POST",
                 url: "$url('config/sorting/toggle_sorter')",
-                data: {sorter: whichSorter, apikey: "$apikey" }
+                data: {sorter: whichSorter }
             }).done(function() {
                 formWasSubmitted = true;
                 formHasChanged = false;

--- a/interfaces/Config/templates/config_special.tmpl
+++ b/interfaces/Config/templates/config_special.tmpl
@@ -4,7 +4,6 @@
 
 <div class="colmask">
     <form action="$url('config/special/save')" method="post" class="fullform" autocomplete="off">
-        <input type="hidden" id="apikey" name="apikey" value="$apikey" />
         <div class="padTable">
             <h4 class="darkred nomargin">$T('explain-special')</h4>
         </div>

--- a/interfaces/Config/templates/config_switches.tmpl
+++ b/interfaces/Config/templates/config_switches.tmpl
@@ -9,7 +9,6 @@
         </label>
     </div>
     <form action="$url('config/switches/save')" method="post" class="fullform" autocomplete="off">
-        <input type="hidden" id="apikey" name="apikey" value="$apikey" />
         <input type="hidden" name="output" value="json" />
         <div class="section advanced-settings">
             <div class="col2">
@@ -394,9 +393,9 @@ jQuery(document).ready(function() {
 
         // Send request
         jQuery.ajax({
-            type: "GET",
+            type: "POST",
             url: "$url('api')",
-            data: "mode=set_config_default&apikey=${apikey}&output=json&keyword=" + key_container.join('&keyword=')
+            data: "mode=set_config_default&output=json&keyword=" + key_container.join('&keyword=')
         }).then(function(data) {
             // Reload page
             document.location = document.location

--- a/interfaces/Config/templates/staticcfg/js/script.js
+++ b/interfaces/Config/templates/staticcfg/js/script.js
@@ -243,6 +243,11 @@ $.fn.extractFormDataTo = function(target) {
  *
  * (c) 2015 SABnzbd Team, Inc. All rights reserved.
  */
+
+$.ajaxSetup({
+    headers: { "X-SABnzbd-CSRF": csrfToken }
+});
+
 function config_success() {
     $('.saveButton[disabled=disabled]').each(function () {
         $(this).removeAttr("disabled").html('<span class="glyphicon glyphicon-ok"></span> '+configTranslate.saveChanges);
@@ -291,7 +296,7 @@ function do_restart() {
     $('.main-restarting .restarting-url').text(urlTotal)
 
     // Initiate restart
-    $.ajax({ url: '../../api?mode=restart&apikey=' + sabSession,
+    $.ajax({ url: '../../api?mode=restart', type: 'POST',
         complete: function() {
             // Keep counter of failures
             var loopCounter = 0;
@@ -371,6 +376,8 @@ jQuery.extend(jQuery.fn.typeahead.defaults, {
 })
 
 $(document).ready(function () {
+    $('form').append('<input type="hidden" name="csrf_token" value="' + csrfToken + '">');
+
     /**
         Restart function
     **/

--- a/interfaces/Glitter/templates/include_menu.tmpl
+++ b/interfaces/Glitter/templates/include_menu.tmpl
@@ -91,14 +91,28 @@
                     <li><a href="#modal-help" data-toggle="modal"><span class="glyphicon glyphicon-question-sign"></span> $T('menu-help')</a></li>
                     <li><a href="https://sabnzbd.org/donate" target="_blank"><span class="glyphicon glyphicon-heart"></span> $T('menu-donate')</a></li>
                     <!--#if $have_logout or $have_quota or $have_rss_defined or $have_watched_dir or $pp_pause_event#--><li class="divider"></li><!--#end if#-->
-                    <!--#if $have_logout#--><li><a href="$url('logout')"><span class="glyphicon glyphicon-log-out"></span> $T('logout')</a></li><!--#end if#-->
+                    <!--#if $have_logout#--><li>
+                        <form method="post" action="$url('logout')">
+                            <input type="hidden" name="csrf_token" value="$csrf_token" />
+                            <button type="submit"><span class="glyphicon glyphicon-log-out"></span> $T('logout')</button>
+                        </form>
+                    </li><!--#end if#-->
                     <!--#if $have_quota#--><li><a href="#" data-bind="click: doQueueAction" data-mode="reset_quota">$T('link-resetQuota')</a></li><!--#end if#-->
                     <!--#if $have_rss_defined#--><li><a href="#" data-bind="click: doQueueAction" data-mode="rss_now">$T('button-rssNow')</a></li><!--#end if#-->
                     <!--#if $have_watched_dir#--><li><a href="#" data-bind="click: doQueueAction" data-mode="watched_now">$T('sch-scan_folder')</a></li><!--#end if#-->
                     <!--#if $pp_pause_event#--><li><a href="#" data-bind="click: doQueueAction" data-mode="resume_pp">$T('sch-resume_post')</a></li><!--#end if#-->
                     <li class="divider"></li>
-                    <li><a href="$url('shutdown', apikey=$apikey, pid=$pid)" data-bind="click: shutdownSAB">$T('shutdownSab')</a></li>
-                    <li><a href="#" data-bind="click: restartSAB">$T('Glitter-restartSab')</a></li>
+                    <li>
+                        <form method="post" action="$url('shutdown')" data-bind="submit: shutdownSAB">
+                            <input type="hidden" name="csrf_token" value="$csrf_token" />
+                            <button type="submit">$T('shutdownSab')</button>
+                        </form>
+                    </li>
+                    <li>
+                        <form data-bind="submit: restartSAB">
+                            <button type="submit">$T('Glitter-restartSab')</button>
+                        </form>
+                    </li>
                     <li class="divider"></li>
                     <li class="dropdown-header"><span class="glyphicon glyphicon-off"></span> $T('Glitter-onFinish'):</li>
                     <li>

--- a/interfaces/Glitter/templates/include_overlays.tmpl
+++ b/interfaces/Glitter/templates/include_overlays.tmpl
@@ -197,9 +197,12 @@
                         </div>
                         <div class="row options-function-box">
                             <div class="col-sm-6">
-                                <a href="$url('api', mode='showlog', apikey=$apikey)" target="_blank" class="btn btn-default" data-tooltip="true" data-placement="top" title="$T('Glitter-logText')">
-                                    <span class="glyphicon glyphicon-file"></span> $T('link-showLog')
-                                </a>
+                                <form method="post" action="$url('log')" target="_blank">
+                                    <input type="hidden" name="csrf_token" value="$csrf_token" />
+                                    <button type="submit" class="btn btn-default" data-tooltip="true" data-placement="top" title="$T('Glitter-logText')">
+                                        <span class="glyphicon glyphicon-file"></span> $T('link-showLog')
+                                    </button>
+                                </form>
                             </div>
                             <div class="col-sm-6">
                                 <div class="input-group" data-tooltip="true" data-placement="top" title="$T('logging')">

--- a/interfaces/Glitter/templates/main.tmpl
+++ b/interfaces/Glitter/templates/main.tmpl
@@ -42,7 +42,7 @@
 
         <!-- Make translations available in scripts -->
         <script type="text/javascript">
-            var apiKey = "$apikey";
+            var csrfToken = "$csrf_token";
             var displayLang = "$active_lang";
             var sabSpeedHistory = [$bytespersec_list];
             var newRelease = "$new_release";

--- a/interfaces/Glitter/templates/static/javascripts/glitter.basic.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.basic.js
@@ -23,15 +23,17 @@ if(isMobile) {
     });
 }
 
+$.ajaxSetup({
+    headers: { "X-SABnzbd-CSRF": csrfToken }
+});
+
 // Basic API-call
 function callAPI(data, timeout = 10000) {
     // Fill basis var's
     data.output = "json";
-    data.apikey = apiKey;
     var ajaxQuery = $.ajax({
         url: "./api",
-        type: "GET",
-        cache: false,
+        type: "POST",
         data: data,
         timeout: timeout
     });

--- a/interfaces/Glitter/templates/static/javascripts/glitter.history.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.history.js
@@ -150,7 +150,6 @@ function HistoryListModel(parent) {
         data.append("nzbfile", $(form.nzbFile)[0].files[0]);
         data.append("value", $('#modal-retry-job input[name="retry_job_id"]').val());
         data.append("password", $('#retry_job_password').val());
-        data.append("apikey", apiKey);
 
         // Add
         $.ajax({

--- a/interfaces/Glitter/templates/static/javascripts/glitter.main.js
+++ b/interfaces/Glitter/templates/static/javascripts/glitter.main.js
@@ -702,7 +702,6 @@ function ViewModel() {
         data.append("priority", $('#modal-add-nzb select[name="Priority"]').val())
         data.append("pp", $('#modal-add-nzb select[name="Processing"]').val())
         data.append("script", $('#modal-add-nzb select[name="Post-processing"]').val())
-        data.append("apikey", apiKey);
 
         // Add this one
         $.ajax({

--- a/interfaces/Glitter/templates/static/stylesheets/glitter.css
+++ b/interfaces/Glitter/templates/static/stylesheets/glitter.css
@@ -89,12 +89,27 @@ h2 {
 }
 
 .navbar-collapse.in .dropdown-menu a,
-.navbar-collapse.in .dropdown-menu a:hover {
+.navbar-collapse.in .dropdown-menu a:hover,
+.navbar-collapse.in .dropdown-menu form button,
+.navbar-collapse.in .dropdown-menu form button:hover {
     color: black !important;
 }
 
 .navbar-collapse.in .dropdown-menu a.active-on-queue-finish {
     color: white !important;
+}
+
+.dropdown-menu > li > form > button {
+    display: block;
+    width: 100%;
+    padding: 3px 20px;
+    border: 0;
+    background: transparent;
+    text-align: left;
+    font-weight: normal;
+    line-height: 1.42857143;
+    color: var(--clr-text);
+    white-space: nowrap;
 }
 
 .navbar-nav>li>a {
@@ -2409,7 +2424,9 @@ hr {
 }
 
 .dropdown-menu>li>a:hover,
-.dropdown-menu>li>a:focus {
+.dropdown-menu>li>a:focus,
+.dropdown-menu>li>form>button:hover,
+.dropdown-menu>li>form>button:focus {
     background-color: var(--clr-surface-hover);
     color: var(--clr-text);
 }

--- a/interfaces/wizard/inc_top.tmpl
+++ b/interfaces/wizard/inc_top.tmpl
@@ -11,6 +11,12 @@
         <link rel="shortcut icon" href="$url('staticcfg/ico/favicon.ico', v=$cache_buster)" />
         <script type="text/javascript" src="$url('staticcfg/js/jquery-3.5.1.min.js', v=$cache_buster)"></script>
         <script type="text/javascript" src="$url('staticcfg/bootstrap/js/bootstrap.min.js', v=$cache_buster)"></script>
+        <script type="text/javascript">
+            var csrfToken = "$csrf_token";
+            $.ajaxSetup({
+                headers: { "X-SABnzbd-CSRF": csrfToken }
+            });
+        </script>
     </head>
     <body>
         <div id="logo">

--- a/interfaces/wizard/index.html
+++ b/interfaces/wizard/index.html
@@ -1,5 +1,6 @@
 <!--#include $webdir + "/inc_top.tmpl"#-->
 <form action="$url('wizard/one')" method="post">
+<input type="hidden" name="csrf_token" value="$csrf_token" />
     <div class="container">
         <div id="inner">
             <div id="content" class="bigger">
@@ -27,7 +28,7 @@
             <hr />
             <div class="row">
                 <div class="col-md-4 text-center">
-                    <a class="btn btn-danger" href="$url('shutdown', apikey=$apikey, pid=$pid)"><span class="glyphicon glyphicon-remove"></span> $T('wizard-exit')</a>
+                    <button class="btn btn-danger" type="submit" form="shutdown-form"><span class="glyphicon glyphicon-remove"></span> $T('wizard-exit')</button>
                 </div>
                 <div class="col-md-4 text-center">
                     <a class="btn btn-default" href="$url('config/general#config_backup_file')"><span class="glyphicon glyphicon-open"></span> $T('restore-backup')</a>
@@ -39,4 +40,5 @@
         </div>
     </div>
 </form>
+<form id="shutdown-form" method="post" action="$url('shutdown')"><input type="hidden" name="csrf_token" value="$csrf_token" /></form>
 <!--#include $webdir + "/inc_bottom.tmpl"#-->

--- a/interfaces/wizard/one.html
+++ b/interfaces/wizard/one.html
@@ -1,5 +1,6 @@
 <!--#include $webdir + "/inc_top.tmpl"#-->
 <form action="$url('wizard/two')" method="post" autocomplete="off">
+<input type="hidden" name="csrf_token" value="$csrf_token" />
     <div class="container">
         <div id="inner">
             <div id="content" class="bigger">
@@ -103,7 +104,6 @@
                     </div>
                 </div>
                 <input type="hidden" name="enable" value="1">
-                <input type="hidden" name="apikey" value="$apikey" />
             </div>
             <hr />
             <div class="row">

--- a/interfaces/wizard/static/javascript/checkserver.js
+++ b/interfaces/wizard/static/javascript/checkserver.js
@@ -43,10 +43,11 @@ $(document).ready(function() {
         
         $('#serverTest').attr('aria-busy', 'true');
         $('#serverResponse').html(txtChecking);
-        $.getJSON(
-            "../api?mode=config&name=test_server&output=json",
-            $("form").serialize(),
-            function(result) {
+        $.ajax({
+            type: 'POST',
+            url: "../api?mode=config&name=test_server&output=json",
+            data: $("form").serialize(),
+            success: function(result) {
                 if (result.value.result) {
                     r = '<span class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span> ' + result.value.message + '</span>';
                     setTestResult(true);
@@ -58,7 +59,7 @@ $(document).ready(function() {
                 $('#serverResponse').html(r);
                 $('#serverTest').attr('aria-busy', 'false');
             }
-        );
+        });
         return false;
     });
 

--- a/interfaces/wizard/two.html
+++ b/interfaces/wizard/two.html
@@ -38,7 +38,6 @@
         <hr />
         <div class="row">
             <div class="col-xs-12 text-center">
-                <input type="hidden" name="apikey" id="apikey" value="$apikey"/>
                 <a class="btn btn-success" href="$url()">$T('wizard-goto') <span class="glyphicon glyphicon-chevron-right"></span></a>
             </div>
         </div>

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -88,6 +88,7 @@ import sabnzbd.encoding as encoding
 import sabnzbd.config as config
 import sabnzbd.cfg as cfg
 import sabnzbd.database
+import sabnzbd.sessionstore
 import sabnzbd.lang as lang
 import sabnzbd.nzb
 import sabnzbd.nzbparser as nzbparser
@@ -128,6 +129,7 @@ DirScanner: sabnzbd.dirscanner.DirScanner
 BPSMeter: sabnzbd.bpsmeter.BPSMeter
 RSSReader: sabnzbd.rss.RSSReader
 Scheduler: sabnzbd.scheduler.Scheduler
+SessionStore: sabnzbd.sessionstore.SessionStore
 
 # For backwards compatibility with pre-5.0 queue files
 sys.modules["sabnzbd.nzbstuff"] = sabnzbd.nzb
@@ -303,6 +305,7 @@ def initialize(pause_downloader=False, clean_up=False, repair=0):
     sabnzbd.URLGrabber = sabnzbd.urlgrabber.URLGrabber()
     sabnzbd.RSSReader = sabnzbd.rss.RSSReader()
     sabnzbd.Scheduler = sabnzbd.scheduler.Scheduler()
+    sabnzbd.SessionStore = sabnzbd.sessionstore.SessionStore()
 
     # Run startup tasks
     sabnzbd.NzbQueue.read_queue(repair)

--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -36,7 +36,7 @@ from starlette.background import BackgroundTask
 from starlette.concurrency import run_in_threadpool
 from starlette.datastructures import QueryParams, UploadFile
 from starlette.requests import Request
-from starlette.responses import Response, StreamingResponse
+from starlette.responses import RedirectResponse, Response, StreamingResponse
 
 # For json.dumps, orjson is magnitudes faster than ujson, but it is harder to
 # compile due to Rust dependency. Since the output is the same, we support all modules.
@@ -786,7 +786,7 @@ def sanitize_line(line: bytes, cur_user_bytes: Optional[bytes] = None) -> bytes:
     return line
 
 
-def _api_showlog(name: str, kwargs: QueryParams) -> StreamingResponse:
+def build_log_response() -> StreamingResponse:
     """Fetch the INI and the log-data and add a message at the top"""
 
     def _generate_log():
@@ -827,6 +827,10 @@ def _api_showlog(name: str, kwargs: QueryParams) -> StreamingResponse:
         media_type="application/x-download;charset=utf-8",
         headers={"Content-Disposition": 'attachment;filename="sabnzbd.log"', "Cache-Control": "no-store"},
     )
+
+
+def _api_showlog(name: str, kwargs: QueryParams) -> StreamingResponse:
+    return build_log_response()
 
 
 def _api_get_cats(name: str, kwargs: QueryParams) -> Response:
@@ -1920,6 +1924,14 @@ def clear_trans_cache():
     sabnzbd.WEBUI_READY = True
 
 
+def base_redirect_response(root: str = "", **kwargs) -> RedirectResponse:
+    """Create a Starlette RedirectResponse with SABnzbd URL base and query parameters"""
+    url = url_for(root, **kwargs)
+    if cfg.api_logging():
+        logging.debug("Redirecting to %s", url)
+    return RedirectResponse(url=url, status_code=302)
+
+
 def url_for(path: str = "", **kwargs) -> str:
     """Build an absolute URL below the configured URL base.
 
@@ -1983,6 +1995,9 @@ def build_header(
         header["color_scheme"] = sabnzbd.WEB_COLOR or ""
         header["confighelpuri"] = f"https://sabnzbd.org/wiki/configuration/{sabnzbd.__version__[:3]}/"
 
+        if request:
+            header["csrf_token"] = getattr(request.state, "csrf_token", "")
+
         header["pid"] = os.getpid()
         header["active_lang"] = cfg.language()
         header["rtl"] = is_rtl(header["active_lang"])
@@ -1998,7 +2013,6 @@ def build_header(
         header["power_options"] = sabnzbd.WINDOWS or sabnzbd.MACOS or sabnzbd.LINUX_POWER
         header["pp_pause_event"] = sabnzbd.Scheduler.pp_pause_event
 
-        header["apikey"] = cfg.api_key()
         header["new_release"], header["new_rel_url"] = sabnzbd.NEW_VERSION
 
         # Add the commit hash so static files are refreshed on nightly/development builds

--- a/sabnzbd/constants.py
+++ b/sabnzbd/constants.py
@@ -58,6 +58,9 @@ SABCTOOLS_VERSION_REQUIRED = "9.7.0"
 DB_HISTORY_VERSION = 1
 DB_HISTORY_NAME = "history%s.db" % DB_HISTORY_VERSION
 
+SESSIONS_VERSION = 1
+SESSIONS_FILE_NAME = "sessions.sab"
+
 DEF_DOWNLOAD_DIR = os.path.normpath("Downloads/incomplete")
 DEF_COMPLETE_DIR = os.path.normpath("Downloads/complete")
 DEF_ADMIN_DIR = "admin"

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -20,23 +20,21 @@ sabnzbd.interface - webinterface
 """
 
 import os
+import re
 import secrets
 import threading
 import time
 import logging
 import urllib.parse
-import re
-import hashlib
 import socket
 import ssl
 import functools
 import copy
-from random import randint
 
 import uvicorn
 from starlette.applications import Starlette
 from starlette.concurrency import run_in_threadpool
-from starlette.datastructures import Address, MultiDict, MutableHeaders, QueryParams
+from starlette.datastructures import MultiDict, MutableHeaders, QueryParams
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, RedirectResponse, PlainTextResponse, Response, FileResponse
 from starlette.middleware import Middleware
@@ -59,8 +57,6 @@ from sabnzbd.misc import (
     is_ipv4_addr,
     is_ipv6_addr,
     is_lan_addr,
-    is_local_addr,
-    is_loopback_addr,
     recursive_html_escape,
     is_none,
     get_cpu_name,
@@ -93,6 +89,7 @@ from sabnzbd.constants import (
 )
 from sabnzbd.lang import list_languages
 from sabnzbd.api import (
+    base_redirect_response,
     report,
     list_scripts,
     list_cats,
@@ -100,9 +97,35 @@ from sabnzbd.api import (
     api_handler,
     halt_and_shutdown,
     build_header,
-    url_for,
+    build_log_response,
     url_netloc,
     Ttemplate,
+)
+from sabnzbd.security import (
+    SESSION_COOKIE_FLASH,
+    SESSION_COOKIE_USER,
+    _MSG_APIKEY_NOT_ON_PAGES,
+    _MSG_MISSING_SESSION,
+    _MSG_SESSION_EXPIRED,
+    _anonymous_session_sender,
+    anonymous_session_tag,
+    check_access,
+    clear_login_failures,
+    clear_session,
+    client_address,
+    client_address_info,
+    constant_time_equals,
+    create_session,
+    csrf_token_for,
+    csrf_token_matches,
+    login_bypassed,
+    login_cooldown_remaining,
+    presented_csrf_token,
+    record_login_failure,
+    use_secure_cookies,
+    validate_any_session,
+    validate_csrf,
+    validate_session,
 )
 from sabnzbd.nzb import NzoInfo
 from sabnzbd.rss import ResolvedEntry, RSSState
@@ -128,7 +151,7 @@ def secured_expose(
     check_configlock: bool = False,
     check_for_login: bool = True,
     check_api_key: bool = False,
-    api_route: bool = False,
+    check_csrf: bool = True,
     access_type: int = 4,
     methods: Collection = ("GET", "POST"),
 ) -> Callable:
@@ -140,7 +163,7 @@ def secured_expose(
             check_configlock=check_configlock,
             check_for_login=check_for_login,
             check_api_key=check_api_key,
-            api_route=api_route,
+            check_csrf=check_csrf,
             access_type=access_type,
             methods=methods,
         )
@@ -158,7 +181,7 @@ def secured_expose(
                         check_configlock=check_configlock,
                         check_for_login=check_for_login,
                         check_api_key=check_api_key,
-                        api_route=api_route,
+                        check_csrf=check_csrf,
                         access_type=access_type,
                     ),
                 ],
@@ -166,49 +189,6 @@ def secured_expose(
         )
 
     return wrap_func
-
-
-def client_address(request: Request) -> Address:
-    """Safe access to request.client, which can be None (e.g. when serving on a
-    unix socket, or with some test clients). Treated as an unknown, non-local
-    client, so access checks fail closed."""
-    return request.client or Address("", 0)
-
-
-def client_address_info(request: Request) -> str:
-    """The client as host:port for logging, with the forwarding chain when there is one"""
-    client = client_address(request)
-    # Bracketed, so the port cannot be read as another group of an IPv6 address
-    host = f"[{client.host}]" if ":" in client.host else client.host
-    if cfg.verify_xff_header() and (xff_ips := request.headers.get("X-Forwarded-For")):
-        return f"{host}:{client.port} (X-Forwarded-For: {xff_ips})"
-    return f"{host}:{client.port}"
-
-
-def check_access(request: Request, access_type: int = 4, warn_user: bool = False) -> bool:
-    """Check if external address is allowed given access_type (Starlette version):
-    1=nzb
-    2=api
-    3=full_api
-    4=webui
-    5=webui with login for external
-    """
-    # Easy, it's allowed
-    if access_type <= cfg.inet_exposure():
-        return True
-
-    # X-Forwarded-For is resolved by uvicorn's ProxyHeadersMiddleware (see the
-    # uvicorn.Config in SABnzbd.py): when verify_xff_header is enabled and the
-    # connecting peer is a trusted local proxy, request.client already holds the
-    # effective client address taken from the XFF chain.
-    remote_ip = client_address(request).host
-
-    # Check if the client IP is a loopback address or considered local
-    is_allowed = is_loopback_addr(remote_ip) or is_local_addr(remote_ip)
-
-    if not is_allowed and warn_user:
-        log_warning_and_ip(request, T("Refused connection from:"))
-    return is_allowed
 
 
 def check_hostname(request: Request) -> bool:
@@ -250,156 +230,85 @@ def check_hostname(request: Request) -> bool:
     return False
 
 
-# Create a more unique ID for each instance
-COOKIE_SECRET = str(randint(1000, 100000) * os.getpid())
-COOKIE_SESSION = "sabnzbd_session"
-
-
-def use_secure_cookies(request: Request) -> bool:
-    """Whether cookies for this request should carry the Secure attribute"""
-    # Taken from the scope, which is what the proxy headers are applied to and what
-    # request.url is built from. The URL itself comes out relative, and its scheme
-    # empty, when there is neither a Host header nor an address to fall back on.
-    return request.scope.get("scheme") == "https" or bool(cfg.enable_https())
-
-
-def set_login_cookie(request: Request, response: Response, remove=False, remember_me=False):
-    """Set login cookie for Starlette (updated version)
-    We try to set a cookie as unique as possible
-    to the current user. Based on it's IP and the
-    current process ID of the SAB instance and a random
-    number, so cookies cannot be re-used
-    """
-    salt = randint(1, 1000)
-
-    # request.client is the effective client: uvicorn resolves the XFF header
-    # from trusted proxies when verify_xff_header is enabled
-    cookie_str = utob(str(salt) + client_address(request).host + COOKIE_SECRET)
-    cookie_value = hashlib.sha1(cookie_str).hexdigest()
-
-    secure = use_secure_cookies(request)
-    if remove:
-        # Remove cookies
-        response.set_cookie(
-            "login_cookie",
-            "",
-            path="/",
-            httponly=True,
-            secure=secure,
-            samesite="strict",
-            expires="Thu, 01 Jan 1970 00:00:00 GMT",
-        )
-        response.set_cookie(
-            "login_salt",
-            "",
-            path="/",
-            httponly=True,
-            secure=secure,
-            samesite="strict",
-            expires="Thu, 01 Jan 1970 00:00:00 GMT",
-        )
-    else:
-        # Set cookies
-        max_age = None
-        if remember_me:
-            max_age = 3600 * 24 * 14  # 14 days
-
-        response.set_cookie(
-            "login_cookie",
-            cookie_value,
-            path="/",
-            httponly=True,
-            secure=secure,
-            samesite="strict",
-            max_age=max_age,
-        )
-        response.set_cookie(
-            "login_salt",
-            str(salt),
-            path="/",
-            httponly=True,
-            secure=secure,
-            samesite="strict",
-            max_age=max_age,
-        )
-
-
 def check_login(request: Request) -> bool:
-    """Check if user is logged in (Starlette version)"""
-    # No authentication required when no username/password is set
-    if not cfg.username() or not cfg.password():
+    """Check if user is logged in"""
+    # No authentication required, or waived for this client
+    if login_bypassed(request):
         return True
 
-    # If we show login for external IP, by using access_type=6 we can check if IP match
-    if cfg.inet_exposure() == 5 and check_access(request, access_type=6):
-        return True
-
-    # Check the cookie
-    return check_login_cookie(request)
+    # Check the session cookie
+    return validate_session(request)
 
 
-def check_login_cookie(request: Request) -> bool:
-    """Check login cookie validity (Starlette version)"""
-    # Do we have everything?
-    login_cookie = request.cookies.get("login_cookie")
-    login_salt = request.cookies.get("login_salt")
-    if not login_cookie or not login_salt:
-        return False
+def check_apikey(request: Request) -> Optional[Response]:
+    """Check session cookie, API-key or NZB-key
+    Return None when OK, otherwise the error response to send
+    """
+    mode = request_params(request).get("mode", "")
 
-    # request.client is the effective client: uvicorn resolves the XFF header
-    # from trusted proxies when verify_xff_header is enabled
-    cookie_str = utob(str(login_salt) + client_address(request).host + COOKIE_SECRET)
-    return login_cookie == hashlib.sha1(cookie_str).hexdigest()
+    # Resolve the call once here and stash it on the request, so the /api route can
+    # dispatch through api_handler without consulting the api table a second time.
+    entry, argument = sabnzbd.api.resolve_api_call(request_params(request))
+    request.state.api_call = (entry, argument)
 
+    # The entry carries the access level required for this specific api-call
+    req_access = entry.access_level
+    if not check_access(request, access_type=req_access, warn_user=True):
+        return forbidden(_MSG_ACCESS_DENIED)
 
-def check_apikey(request: Request, api_route: bool = False) -> Optional[str]:
-    """Check API-key or NZB-key, return None when OK, else an error message"""
-    key = request_params(request).get("apikey")
-
-    if api_route:
-        mode = request_params(request).get("mode", "")
-
-        # Resolve the call once here and stash it on the request, so the /api route can
-        # dispatch through api_handler without consulting the api table a second time.
-        entry, argument = sabnzbd.api.resolve_api_call(request_params(request))
-        request.state.api_call = (entry, argument)
-
-        # The entry carries the access level required for this specific api-call
-        req_access = entry.access_level
-        if not check_access(request, access_type=req_access, warn_user=True):
-            return _MSG_ACCESS_DENIED
-
-        # Skip for auth and version calls
-        if mode in ("version", "auth"):
-            return None
-
-        # NZB-key suffices for nzb-level calls
-        if req_access == 1 and key and key == cfg.nzb_key():
-            return None
-
-    # A valid API-key is required for everything else
-    if not key:
-        log_warning_and_ip(
-            request, T("API Key missing, please enter the api key from Config->General into your 3rd party program:")
-        )
-        return _MSG_APIKEY_REQUIRED
-    elif key == cfg.api_key():
+    # Skip for auth and version calls
+    if mode in ("version", "auth"):
         return None
-    else:
+
+    # A session cookie authorizes the frontend without the apikey, but only with the
+    # session's CSRF token in the header. Header only: this route merges the query string in.
+    cookie_ok = validate_any_session(request)
+    if cookie_ok and csrf_token_matches(request, header_only=True):
+        return None
+
+    # No early return above, so a request carrying both a cookie and a valid apikey stays
+    # authorized
+    key = request_params(request).get("apikey")
+    if key:
+        # Constant-time, like the login credentials
+        if req_access == 1 and constant_time_equals(key, cfg.nzb_key()):
+            return None
+        if constant_time_equals(key, cfg.api_key()):
+            return None
         log_warning_and_ip(
             request, T("API Key incorrect, Use the api key from Config->General in your 3rd party program:")
         )
-        return _MSG_APIKEY_INCORRECT
+        return forbidden(_MSG_APIKEY_INCORRECT)
+
+    if SESSION_COOKIE_USER in request.cookies:
+        # A cookie was presented, so this is a browser
+        stale_token = presented_csrf_token(request, header_only=True)
+        if stale_token:
+            logging.info(
+                "Stale session token from %s, the page will reload for a fresh one", client_address_info(request)
+            )
+        else:
+            log_warning_and_ip(request, T("Refused connection from:"))
+        # The frontend answers a 401 by reloading, so only send one where that fixes it
+        if not cookie_ok or stale_token:
+            return PlainTextResponse(_MSG_SESSION_EXPIRED, status_code=401)
+        return forbidden(_MSG_MISSING_SESSION)
+
+    log_warning_and_ip(
+        request, T("API Key missing, please enter the api key from Config->General into your 3rd party program:")
+    )
+    return forbidden(_MSG_APIKEY_REQUIRED)
 
 
-def template_filtered_response(file: str, search_list: dict[str, Any]):
+def template_filtered_response(file: str, search_list: dict[str, Any], status_code: int = 200):
     """Wrapper for Cheetah response"""
     # We need a copy, because otherwise source-dicts might be modified
     search_list_copy = copy.deepcopy(search_list)
     # 'filters' is excluded because the RSS-filters are listed twice
     recursive_html_escape(search_list_copy, exclude_items=("webdir", "filters"))
     return HTMLResponse(
-        Template(file=file, searchList=[search_list_copy], compilerSettings=CHEETAH_DIRECTIVES).respond()
+        Template(file=file, searchList=[search_list_copy], compilerSettings=CHEETAH_DIRECTIVES).respond(),
+        status_code=status_code,
     )
 
 
@@ -427,25 +336,11 @@ def is_form_post(request: Request) -> bool:
 async def get_request_params(request: Request, merge_query: bool = False) -> MultiDict | QueryParams:
     """Parse the request's parameters.
 
-    A page GET renders a page and never changes state, so only the URL query
-    string is used, returned as the request's immutable QueryParams. A page POST
-    reads the form body only (urlencoded or multipart, with file uploads kept as
-    UploadFile objects) into a mutable MultiDict; the query string is ignored, so
-    parameters cannot be smuggled into form handlers via the URL. A POST without a
-    form body yields an empty MultiDict.
+    A page GET uses the query string, a page POST the form body only (urlencoded or
+    multipart, file uploads kept as UploadFile) and an empty MultiDict without one.
 
-    The merged API routes (merge_query, i.e. /api and the api-key protected
-    *_save routes) keep the CherryPy behavior instead: 3rd-party clients
-    traditionally POST an NZB as a multipart body while passing mode/apikey/output
-    in the query string, so the form body and query string are merged into a
-    mutable MultiDict, the body winning per key. A key supplied only in the query
-    string keeps all of its values. GET, form POST and bodyless POST all take this
-    same path, so a duplicated key resolves identically regardless of method, and
-    the API scalar keys collapse to their first value exactly as CherryPy did.
-
-    ParamsMiddleware stores the result on request.state.params so that
-    request_params(request) returns it in every handler without an extra await.
-    """
+    The merged API route (merge_query, i.e. /api) takes the form body and the query string
+    merged, the body winning per key, and collapses the API scalar keys to their first value."""
     if not merge_query:
         if is_form_post(request):
             return MultiDict(await request.form())
@@ -474,13 +369,13 @@ def request_params(request: Request) -> MultiDict | QueryParams:
     return request.state.params
 
 
+# Disable over-active logging for the form parser
+logging.getLogger("python_multipart.multipart").setLevel(logging.WARNING)
+
+
 class ParamsMiddleware:
-    """Parse a request's parameters onto request.state.params before the handler
-    runs, so request_params(request) returns them without a further await. Attached
-    per route by secured_expose because the merge behavior is route-specific:
-    merge_query follows check_api_key (the /api and *_save routes that accept
-    mode/apikey in the query string alongside a form body). Pure ASGI, and the
-    request body is read once here; handlers only ever read the parsed params."""
+    """Parse a request's parameters onto request.state.params before the handler runs.
+    Attached per route by secured_expose, with merge_query following check_api_key."""
 
     def __init__(self, app, merge_query: bool = False):
         self.app = app
@@ -494,11 +389,9 @@ class ParamsMiddleware:
 
 
 class SecurityMiddleware:
-    """Enforce a route's access rules before its handler runs: config lock, local vs
-    external access, login, and API key. Attached per route by secured_expose with
-    that route's flags, and ordered after ParamsMiddleware so the API-key check can
-    read the parsed request_params. Pure ASGI; a failed check answers with a 403 (or
-    a redirect to /login) without ever invoking the handler."""
+    """Enforce a route's access rules before its handler runs: config lock, local vs external
+    access, login, CSRF token and API key. Attached per route by secured_expose, after
+    ParamsMiddleware. A failed check answers with a 403 or a redirect to /login."""
 
     def __init__(
         self,
@@ -506,38 +399,75 @@ class SecurityMiddleware:
         check_configlock: bool = False,
         check_for_login: bool = True,
         check_api_key: bool = False,
-        api_route: bool = False,
+        check_csrf: bool = True,
         access_type: int = 4,
     ):
         self.app = app
         self.check_configlock = check_configlock
         self.check_for_login = check_for_login
         self.check_api_key = check_api_key
-        self.api_route = api_route
+        self.check_csrf = check_csrf
         self.access_type = access_type
 
     async def __call__(self, scope, receive, send):
-        if scope["type"] == "http" and (response := self.denied_response(Request(scope, receive))):
-            return await response(scope, receive, send)
+        if scope["type"] == "http":
+            request = Request(scope, receive)
+            if response := self.denied_response(request):
+                return await response(scope, receive, send)
+            # Where the login is bypassed, issue an anonymous cookie on the UI pages, unless
+            # the client already holds a session. Injected into the response start.
+            if (
+                self.check_for_login
+                and not self.check_api_key
+                and login_bypassed(request)
+                and not validate_any_session(request)
+            ):
+                send = _anonymous_session_sender(request, send)
+                # The page is rendered before that Set-Cookie reaches the client, so its
+                # token has to belong to the cookie being issued, not the one that arrived
+                request.state.csrf_token = csrf_token_for(anonymous_session_tag())
+            else:
+                request.state.csrf_token = csrf_token_for(request.cookies.get(SESSION_COOKIE_USER, ""))
         await self.app(scope, receive, send)
 
     def denied_response(self, request: Request) -> Optional[Response]:
         """Return the response to send when a check fails, or None when allowed."""
         # Check if config is locked
         if self.check_configlock and cfg.configlock():
-            return PlainTextResponse(_MSG_ACCESS_DENIED_CONFIG_LOCK if cfg.api_warnings() else "", status_code=403)
+            return forbidden(_MSG_ACCESS_DENIED_CONFIG_LOCK)
 
         # Check if external access and if it's allowed
         if not check_access(request, access_type=self.access_type, warn_user=True):
-            return PlainTextResponse(_MSG_ACCESS_DENIED if cfg.api_warnings() else "", status_code=403)
+            return forbidden(_MSG_ACCESS_DENIED)
+
+        # An apikey on a route that does not take one: the refusals below say so rather than
+        # redirecting to the login form. Only consulted once the request is refused anyway.
+        offered_apikey = not self.check_api_key and bool(
+            request_params(request).get("apikey") or request.query_params.get("apikey")
+        )
 
         # Verify login status, only for non-key pages
         if self.check_for_login and not self.check_api_key and not check_login(request):
+            if offered_apikey:
+                log_warning_and_ip(request, T("Refused connection from:"))
+                return forbidden(_MSG_APIKEY_NOT_ON_PAGES)
             return base_redirect_response("/login")
 
-        # Some pages need the correct API key
-        if self.check_api_key and (msg := check_apikey(request, api_route=self.api_route)):
-            return PlainTextResponse(msg if cfg.api_warnings() else "", status_code=403)
+        # CSRF guard: a page POST has to echo its session's token, which only a page from
+        # this instance could have read
+        if self.check_csrf and request.method == "POST" and not validate_csrf(request):
+            # A token that simply does not match is a page left open across a restart
+            if presented_csrf_token(request) and not offered_apikey:
+                logging.info(
+                    "Stale session token from %s, the page will reload for a fresh one", client_address_info(request)
+                )
+            else:
+                log_warning_and_ip(request, T("Refused connection from:"))
+            return forbidden(_MSG_APIKEY_NOT_ON_PAGES if offered_apikey else _MSG_MISSING_SESSION)
+
+        # The /api route: session cookie or apikey, which returns the response to send
+        if self.check_api_key and (error_response := check_apikey(request)):
+            return error_response
 
         return None
 
@@ -545,26 +475,6 @@ class SecurityMiddleware:
 def forbidden(message: str) -> PlainTextResponse:
     """403 response, carrying the reason only when api_warnings is enabled."""
     return PlainTextResponse(message if cfg.api_warnings() else "", status_code=403)
-
-
-# Disable over-active logging for the form parser
-logging.getLogger("python_multipart.multipart").setLevel(logging.WARNING)
-
-
-##############################################################################
-# Helper redirect functions
-##############################################################################
-
-
-def base_redirect_response(root: str = "", **kwargs) -> RedirectResponse:
-    """Create a Starlette RedirectResponse with SABnzbd URL base and query parameters"""
-    url = url_for(root, **kwargs)
-
-    # Log the redirect if API logging is enabled
-    if cfg.api_logging():
-        logging.debug("Redirecting to %s", url)
-
-    return RedirectResponse(url=url, status_code=302)
 
 
 ##############################################################################
@@ -600,21 +510,36 @@ def main_index(request: Request):
         return base_redirect_response("/wizard")
 
 
-@secured_expose(route="/shutdown", check_api_key=True)
+@secured_expose(route="/shutdown")
 async def shutdown(request: Request):
-    # Check for PID
-    pid_in = request_params(request).get("pid")
-    if pid_in and int_conv(pid_in) != os.getpid():
-        return PlainTextResponse("Incorrect PID for this instance, remove PID from URL to initiate shutdown.")
+    """Shut down and show a goodbye page, for UI users; automation should use the
+    mode=shutdown API-call. Only a POST shuts down, authorized like any other page POST, so a
+    stale bookmark or a cross-site link cannot trigger one."""
+    if request.method != "POST":
+        return base_redirect_response("/")
 
     await halt_and_shutdown()
     return PlainTextResponse(T("SABnzbd shutdown finished"))
 
 
-@secured_expose(route="/api", check_api_key=True, api_route=True, access_type=1)
+# check_csrf=False: check_apikey enforces the rule for this route
+@secured_expose(route="/api", check_api_key=True, check_csrf=False, access_type=1)
 async def api(request: Request):
     """Redirect to API-handler, we check the access_type in the API-handler"""
     return await api_handler(request_params(request), request.state.api_call)
+
+
+@secured_expose(route="/log", methods=["POST"])
+def log(request: Request):
+    """Download the log plus a sanitized copy of the ini, for the Help window's log button.
+
+    A page route rather than the mode=showlog API-call because the interface navigates here,
+    and a navigation cannot carry the CSRF header, only the field a page route accepts.
+
+    POST although it changes nothing, so nothing sensitive is served without a token: a GET
+    would be reachable as a cross-site navigation, which could make a victim download their
+    own log. Automation keeps using mode=showlog with an apikey."""
+    return build_log_response()
 
 
 @secured_expose(route="/scriptlog", methods=["GET"])
@@ -671,8 +596,9 @@ def wizard_index(request: Request):
 
 @secured_expose(route="/wizard/one", check_configlock=True, methods=["GET", "POST"])
 def wizard_page_one(request: Request):
-    """Accept language and show server page"""
-    if request_params(request).get("lang"):
+    """Accept language (POSTed by the index page form) and show server page.
+    A GET only renders the page, e.g. when navigating back from page two."""
+    if request.method == "POST" and request_params(request).get("lang"):
         cfg.language.set(request_params(request).get("lang"))
 
     info = build_header(sabnzbd.WIZARD_DIR, request=request)
@@ -715,9 +641,12 @@ def wizard_page_one(request: Request):
 
 @secured_expose(route="/wizard/two", check_configlock=True, methods=["GET", "POST"])
 def wizard_page_two(request: Request):
-    """Accept server and show the final page for restart"""
+    """Accept server (POSTed by the page one form) and show the final page for restart.
+    A GET only renders the page: handle_server mutates its parameters, which is
+    only valid for the mutable form MultiDict of a POST, and saving state on GET
+    would invite replays from the browser history."""
     # Save server details if submitted — no host means the user skipped server setup
-    if request_params(request).get("host"):
+    if request.method == "POST" and request_params(request).get("host"):
         handle_server(request_params(request))
 
     # Show Restart screen
@@ -791,48 +720,73 @@ def get_access_info(request: Optional[Request] = None) -> list[str]:
 ##############################################################################
 
 
-@secured_expose(route="/login", check_for_login=False)
+# check_csrf=False: logging in is the one state-changing request from a client that has
+# never held a session
+@secured_expose(route="/login", check_for_login=False, check_csrf=False)
 async def login_index(request: Request):
     # Already logged in, or no username/password set at all
     if check_login(request):
         return base_redirect_response("/")
 
+    # Check login info
     error = None
+    status_code = 200
+    retry_after = 0
     if request.method == "POST":
-        username = request_params(request).get("username")
-        password = request_params(request).get("password")
-        remember_me = bool(request_params(request).get("remember_me", False))
+        if retry_after := login_cooldown_remaining(request):
+            # Refused without looking at what was submitted
+            error = T("Too many failed login attempts, try again later.")
+            status_code = 429
+            logging.warning(T("Login attempt refused, too many failures from %s"), client_address_info(request))
+        else:
+            username = request_params(request).get("username")
+            password = request_params(request).get("password")
+            remember_me = bool(request_params(request).get("remember_me", False))
 
-        if username == cfg.username() and password == cfg.password():
-            # Create redirect response
-            response = base_redirect_response("/")
-            # Save login cookie
-            set_login_cookie(request, response, remember_me=remember_me)
-            # Log the success
-            logging.info("Successful login from %s", client_address_info(request))
-            return response
-        elif username or password:
-            error = T("Authentication failed, check username/password.")
-            # Warn about the potential security problem
-            logging.warning(T("Unsuccessful login attempt from %s"), client_address_info(request))
+            # Both fields are always compared, so nothing leaks which one matched
+            username_ok = constant_time_equals(username or "", cfg.username())
+            password_ok = constant_time_equals(password or "", cfg.password())
+            if username_ok and password_ok:
+                # Proved it knows the password
+                clear_login_failures(request)
+                # Create redirect response
+                response = base_redirect_response("/")
+                create_session(request, response, remember_me=remember_me)
+                logging.info("Successful login from %s", client_address_info(request))
+                return response
+            elif username or password:
+                error = T("Authentication failed, check username/password.")
+                record_login_failure(request)
+                # Warn about the potential security problem
+                logging.warning(T("Unsuccessful login attempt from %s"), client_address_info(request))
 
     # Show login. Building the header and rendering the Cheetah template are
     # blocking work, so keep them off the event loop.
     def render_login_page():
-        info = build_header(sabnzbd.WEB_DIR_CONFIG, request=request)
+        info = build_header(sabnzbd.WEB_DIR_CONFIG)
         info["error"] = error
-        return template_filtered_response(
+        response = template_filtered_response(
             file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "login", "main.tmpl"),
             search_list=info,
+            status_code=status_code,
         )
+        if retry_after:
+            # How long the cooldown has left
+            response.headers["Retry-After"] = str(retry_after)
+        return response
 
     return await run_in_threadpool(render_login_page)
 
 
-@secured_expose(route="/logout", check_for_login=False, methods=["GET"])
-def logout_index(request: Request):
+@secured_expose(route="/logout", methods=["POST"])
+async def logout(request: Request):
+    """Clear the session and return to the main page. POST-only and the UI submits it
+    as a form, like /shutdown, and authorized like any other page POST — the login
+    check (or the CSRF guard when no credentials are set) requires the SameSite=Strict
+    session cookie, which a cross-site page cannot send, so a stray GET (an <img> or
+    link prefetch) or a forged cross-site form cannot log the user out."""
     response = base_redirect_response("/")
-    set_login_cookie(request, response, remove=True)
+    clear_session(request, response)
     return response
 
 
@@ -896,7 +850,7 @@ def index_config_folders(request: Request):
     )
 
 
-@secured_expose(route="/config/folders/save", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/folders/save", check_configlock=True, methods=["POST"])
 def config_folder_save(request: Request):
     for kw in LIST_DIRPAGE + LIST_BOOL_DIRPAGE:
         if msg := config.get_config("misc", kw).set(request_params(request).get(kw)):
@@ -974,7 +928,7 @@ def index_config_switches(request: Request):
     )
 
 
-@secured_expose(route="/config/switches/save", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/switches/save", check_configlock=True, methods=["POST"])
 def config_switches_save(request: Request):
     for kw in SWITCH_LIST:
         if msg := config.get_config("misc", kw).set(request_params(request).get(kw)):
@@ -1075,7 +1029,7 @@ def index_config_special(request: Request):
     )
 
 
-@secured_expose(route="/config/special/save", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/special/save", check_configlock=True, methods=["POST"])
 def config_special_save(request: Request):
     for kw in SPECIAL_BOOL_LIST + SPECIAL_VALUE_LIST + SPECIAL_LIST_LIST:
         if msg := config.get_config("misc", kw).set(request_params(request).get(kw)):
@@ -1136,13 +1090,16 @@ def index_config_general(request: Request):
 
     conf["nzb_key"] = cfg.nzb_key()
 
+    # The one page that displays the apikey, which is no longer part of build_header
+    conf["apikey"] = cfg.api_key()
+
     return template_filtered_response(
         file=os.path.join(sabnzbd.WEB_DIR_CONFIG, "config_general.tmpl"),
         search_list=conf,
     )
 
 
-@secured_expose(route="/config/general/save", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/general/save", check_configlock=True, methods=["POST"])
 def config_general_save(request: Request):
     # Handle general options
     for kw in GENERAL_LIST:
@@ -1160,7 +1117,7 @@ def config_general_save(request: Request):
     return report(request_params(request), data={"success": True, "restart_req": sabnzbd.RESTART_REQ})
 
 
-@secured_expose(route="/config/general/upload_config", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/general/upload_config", check_configlock=True, methods=["POST"])
 async def config_upload_backup(request: Request):
     """Restore a config backup"""
     config_backup_file = request_params(request).get("config_backup_file")
@@ -1230,24 +1187,24 @@ def index_config_server(request: Request):
     )
 
 
-@secured_expose(route="/config/server/add_server", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/server/add_server", check_configlock=True, methods=["POST"])
 def config_server_add(request: Request):
     return handle_server(request_params(request), new_svr=True)
 
 
-@secured_expose(route="/config/server/save_server", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/server/save_server", check_configlock=True, methods=["POST"])
 def config_server_save(request: Request):
     return handle_server(request_params(request))
 
 
-@secured_expose(route="/config/server/delete_server", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/server/delete_server", check_configlock=True, methods=["POST"])
 def config_server_del(request: Request):
     kw = {"section": "servers", "keyword": request_params(request).get("server")}
     del_from_section(kw)
     return base_redirect_response("/config/server")
 
 
-@secured_expose(route="/config/server/clear_server", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/server/clear_server", check_configlock=True, methods=["POST"])
 def config_server_clr(request: Request):
     server = request_params(request).get("server")
     if server:
@@ -1255,7 +1212,7 @@ def config_server_clr(request: Request):
     return base_redirect_response("/config/server")
 
 
-@secured_expose(route="/config/server/toggle_server", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/server/toggle_server", check_configlock=True, methods=["POST"])
 def config_server_toggle(request: Request):
     server = request_params(request).get("server")
     if server:
@@ -1469,7 +1426,7 @@ def config_rss_index(request: Request):
     )
 
 
-@secured_expose(route="/config/rss/save_rss_rate", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/rss/save_rss_rate", check_configlock=True, methods=["POST"])
 def config_rss_save_rss_rate(request: Request):
     """Save changed RSS automatic readout rate"""
     cfg.rss_rate.set(request_params(request).get("rss_rate"))
@@ -1478,7 +1435,7 @@ def config_rss_save_rss_rate(request: Request):
     return base_redirect_response(_RSS_ROOT)
 
 
-@secured_expose(route="/config/rss/upd_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/rss/upd_rss_feed", check_configlock=True, methods=["POST"])
 def config_rss_upd_rss_feed(request: Request):
     """Update Feed level attributes,
     legacy version: ignores 'enable' parameter
@@ -1500,7 +1457,7 @@ def config_rss_upd_rss_feed(request: Request):
     return _rss_redirect(params.get("feed"))
 
 
-@secured_expose(route="/config/rss/save_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/rss/save_rss_feed", check_configlock=True, methods=["POST"])
 def config_rss_save_rss_feed(request: Request):
     """Update Feed level attributes"""
     params = request_params(request)
@@ -1527,7 +1484,7 @@ def config_rss_save_rss_feed(request: Request):
     return base_redirect_response(_RSS_ROOT, feed=feed_name) if feed_name else base_redirect_response(_RSS_ROOT)
 
 
-@secured_expose(route="/config/rss/toggle_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/rss/toggle_rss_feed", check_configlock=True, methods=["POST"])
 def config_rss_toggle_rss_feed(request: Request):
     """Toggle automatic read-out flag of Feed"""
     params = request_params(request)
@@ -1545,7 +1502,7 @@ def config_rss_toggle_rss_feed(request: Request):
         return base_redirect_response(_RSS_ROOT, feed=feed) if feed else base_redirect_response(_RSS_ROOT)
 
 
-@secured_expose(route="/config/rss/add_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/rss/add_rss_feed", check_configlock=True, methods=["POST"])
 def config_rss_add_rss_feed(request: Request):
     """Add one new RSS feed definition"""
     params = request_params(request)
@@ -1576,14 +1533,14 @@ def config_rss_add_rss_feed(request: Request):
         return base_redirect_response(_RSS_ROOT)
 
 
-@secured_expose(route="/config/rss/upd_rss_filter", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/rss/upd_rss_filter", check_configlock=True, methods=["POST"])
 def config_rss_upd_rss_filter(request: Request):
     """Save updated filter definition"""
     do_upd_rss_filter(dict(request_params(request)))
     return _rss_redirect(request_params(request).get("feed"))
 
 
-@secured_expose(route="/config/rss/del_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/rss/del_rss_feed", check_configlock=True, methods=["POST"])
 def config_rss_del_rss_feed(request: Request):
     """Remove complete RSS feed"""
     feed = request_params(request).get("feed")
@@ -1594,14 +1551,14 @@ def config_rss_del_rss_feed(request: Request):
     return base_redirect_response(_RSS_ROOT)
 
 
-@secured_expose(route="/config/rss/del_rss_filter", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/rss/del_rss_filter", check_configlock=True, methods=["POST"])
 def config_rss_del_rss_filter(request: Request):
     """Remove one RSS filter"""
     do_del_rss_filter(dict(request_params(request)))
     return _rss_redirect(request_params(request).get("feed"))
 
 
-@secured_expose(route="/config/rss/download_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/rss/download_rss_feed", check_configlock=True, methods=["POST"])
 def config_rss_download_rss_feed(request: Request):
     """Force download of all matching jobs in a feed"""
     feed = request_params(request).get("feed")
@@ -1612,7 +1569,7 @@ def config_rss_download_rss_feed(request: Request):
     return _rss_flash_redirect(request, feed, msg)
 
 
-@secured_expose(route="/config/rss/clean_rss_jobs", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/rss/clean_rss_jobs", check_configlock=True, methods=["POST"])
 def config_rss_clean_rss_jobs(request: Request):
     """Remove processed RSS jobs from UI"""
     feed = request_params(request).get("feed")
@@ -1624,7 +1581,7 @@ def config_rss_clean_rss_jobs(request: Request):
     return _rss_redirect(feed)
 
 
-@secured_expose(route="/config/rss/test_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/rss/test_rss_feed", check_configlock=True, methods=["POST"])
 def config_rss_test_rss_feed(request: Request):
     """Read the feed content again and show results"""
     feed = request_params(request).get("feed")
@@ -1641,7 +1598,7 @@ def config_rss_test_rss_feed(request: Request):
     return PlainTextResponse(msg)
 
 
-@secured_expose(route="/config/rss/eval_rss_feed", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/rss/eval_rss_feed", check_configlock=True, methods=["POST"])
 def config_rss_eval_rss_feed(request: Request):
     """Re-apply the filters to the feed"""
     feed = request_params(request).get("feed")
@@ -1651,7 +1608,7 @@ def config_rss_eval_rss_feed(request: Request):
     return _rss_redirect(feed)
 
 
-@secured_expose(route="/config/rss/download", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/rss/download", check_configlock=True, methods=["POST"])
 def config_rss_download(request: Request):
     """Download NZB from provider (Download button)"""
     params = request_params(request)
@@ -1680,7 +1637,7 @@ def config_rss_download(request: Request):
     return _rss_redirect(feed)
 
 
-@secured_expose(route="/config/rss/rss_now", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/rss/rss_now", check_configlock=True, methods=["POST"])
 def config_rss_rss_now(request: Request):
     """Run an automatic RSS run now"""
     sabnzbd.Scheduler.force_rss()
@@ -1824,7 +1781,7 @@ def config_scheduling_index(request: Request):
     )
 
 
-@secured_expose(route="/config/scheduling/add_schedule", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/scheduling/add_schedule", check_configlock=True, methods=["POST"])
 def config_scheduling_add(request: Request):
     params = request_params(request)
     servers = config.get_servers()
@@ -1873,7 +1830,7 @@ def config_scheduling_add(request: Request):
     return base_redirect_response(_SCHED_ROOT)
 
 
-@secured_expose(route="/config/scheduling/del_schedule", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/scheduling/del_schedule", check_configlock=True, methods=["POST"])
 def config_scheduling_del(request: Request):
     schedules = cfg.schedules()
     line = request_params(request).get("line")
@@ -1885,7 +1842,7 @@ def config_scheduling_del(request: Request):
     return base_redirect_response(_SCHED_ROOT)
 
 
-@secured_expose(route="/config/scheduling/toggle_schedule", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/scheduling/toggle_schedule", check_configlock=True, methods=["POST"])
 def config_scheduling_toggle(request: Request):
     schedules = cfg.schedules()
     line = request_params(request).get("line")
@@ -1937,7 +1894,7 @@ def index_config_categories(request: Request):
     )
 
 
-@secured_expose(route="/config/categories/delete", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/categories/delete", check_configlock=True, methods=["POST"])
 def config_categories_delete(request: Request):
     kw = {
         "section": "categories",
@@ -1947,7 +1904,7 @@ def config_categories_delete(request: Request):
     return base_redirect_response("/config/categories")
 
 
-@secured_expose(route="/config/categories/save", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/categories/save", check_configlock=True, methods=["POST"])
 def config_categories_save(request: Request):
     name = request_params(request).get("name", "*")
     newname = request_params(request).get("newname", "")
@@ -2012,14 +1969,14 @@ def config_sorting_index(request: Request):
     )
 
 
-@secured_expose(route="/config/sorting/delete", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/sorting/delete", check_configlock=True, methods=["POST"])
 def config_sorting_delete(request: Request):
     kw = {"section": "sorters", "keyword": request_params(request).get("name")}
     del_from_section(kw)
     return base_redirect_response(_SORTING_ROOT)
 
 
-@secured_expose(route="/config/sorting/save_sorter", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/sorting/save_sorter", check_configlock=True, methods=["POST"])
 def config_sorting_save_sorter(request: Request):
     params = request_params(request)
     kwargs = dict(params)
@@ -2039,7 +1996,7 @@ def config_sorting_save_sorter(request: Request):
     return base_redirect_response(_SORTING_ROOT)
 
 
-@secured_expose(route="/config/sorting/toggle_sorter", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/sorting/toggle_sorter", check_configlock=True, methods=["POST"])
 def config_sorting_toggle_sorter(request: Request):
     """Toggle is_active flag of a sorter"""
     try:
@@ -2315,7 +2272,7 @@ def index_config_notify(request: Request):
     )
 
 
-@secured_expose(route="/config/notify/save", check_api_key=True, check_configlock=True, methods=["POST"])
+@secured_expose(route="/config/notify/save", check_configlock=True, methods=["POST"])
 def config_notify_save(request: Request):
     for section in NOTIFY_OPTIONS:
         for option in NOTIFY_OPTIONS[section]:
@@ -2353,19 +2310,11 @@ class XFrameOptionsMiddleware:
 
 
 class SecureSessionCookieMiddleware:
-    """Add the Secure attribute to the session cookie when the connection warrants it.
-
-    SessionMiddleware builds its cookie flags once at construction, so it cannot know
-    that TLS was terminated at a reverse proxy, which is only visible per request. It
-    is therefore mounted without https_only and wrapped by this middleware, which
-    flags the cookie using the same rule as set_login_cookie. Any other Set-Cookie
-    header is passed through untouched: the login cookies are already flagged where
-    they are set. Pure ASGI (not BaseHTTPMiddleware) to keep streaming responses
-    untouched."""
+    """Add the Secure attribute to the session cookie when the connection warrants it"""
 
     # Matches the cookie emitted by SessionMiddleware, which is mounted with
     # session_cookie=COOKIE_SESSION
-    COOKIE_PREFIX = utob(COOKIE_SESSION + "=")
+    COOKIE_PREFIX = utob(SESSION_COOKIE_FLASH + "=")
 
     def __init__(self, app):
         self.app = app
@@ -2634,7 +2583,7 @@ def create_app() -> Starlette:
         Middleware(
             SessionMiddleware,
             secret_key=secrets.token_hex(),
-            session_cookie=COOKIE_SESSION,
+            session_cookie=SESSION_COOKIE_FLASH,
             same_site="lax",
             https_only=False,
         ),

--- a/sabnzbd/security.py
+++ b/sabnzbd/security.py
@@ -1,0 +1,327 @@
+#!/usr/bin/python3 -OO
+# Copyright 2007-2026 by The SABnzbd-Team (sabnzbd.org)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+sabnzbd.security - authentication, sessions and the per-route access checks
+"""
+
+import hashlib
+import logging
+import hmac
+import secrets
+import time
+from typing import Any
+
+from starlette.datastructures import Address
+from starlette.requests import Request
+from starlette.responses import Response
+
+import sabnzbd
+import sabnzbd.cfg as cfg
+from sabnzbd.encoding import utob
+from sabnzbd.misc import is_local_addr, is_loopback_addr
+
+_MSG_MISSING_SESSION = "Access denied - Missing or invalid session token, reload the page and try again"
+_MSG_APIKEY_NOT_ON_PAGES = (
+    "Access denied - The apikey is only accepted on /api, use the matching api-call instead of this page"
+)
+_MSG_SESSION_EXPIRED = "Session expired, reload the page"
+
+
+# Holds a database-backed login token, or the anonymous tag when the login is bypassed
+SESSION_COOKIE_USER = "sabnzbd_user"
+# The SessionMiddleware cookie, used for RSS flash messages only. Not authentication.
+SESSION_COOKIE_FLASH = "sabnzbd_flash"
+# How long a session survives without being used
+SESSION_DURATION = 3600 * 24 * 14  # 14 days
+# Lifetime from the created stamp, so a session that keeps being used still ends
+SESSION_MAX_AGE = 3600 * 24 * 90  # 90 days
+# Only extend a session's expiry when doing so buys it more than this much extra time
+SESSION_REFRESH_THRESHOLD = 3600 * 24  # 1 day
+
+LOGIN_MAX_ATTEMPTS = 5
+LOGIN_LOCKOUT_TIME = 300  # 5 minutes
+
+# {host: (failures, cooldown_expiry)} cooldown_expiry uses the monotonic clock
+_login_attempts: dict[str, tuple[int, float]] = {}
+
+# Anonymous sessions are issued where the login is bypassed, so the frontend can still authenticate by cookie.
+_ANONYMOUS_SESSION_KEY = secrets.token_bytes(32)
+
+# A token is hmac(_CSRF_KEY, cookie_value), so it is bound to its session and dies with it.
+# The key is regenerated each run, leaving a page open across a restart with a stale token.
+# The token is rendered into the page and echoed back in the header or a field.
+_CSRF_KEY = secrets.token_bytes(32)
+CSRF_HEADER = "X-SABnzbd-CSRF"
+CSRF_FIELD = "csrf_token"
+
+
+def client_address(request: Request) -> Address:
+    """Safe access to request.client, which can be None (e.g. when serving on a
+    unix socket, or with some test clients). Treated as an unknown, non-local
+    client, so access checks fail closed."""
+    return request.client or Address("", 0)
+
+
+def client_address_info(request: Request) -> str:
+    """The client as host:port for logging, with the forwarding chain when there is one"""
+    client = client_address(request)
+    # Bracketed, so the port cannot be read as another group of an IPv6 address
+    host = f"[{client.host}]" if ":" in client.host else client.host
+    if cfg.verify_xff_header() and (xff_ips := request.headers.get("X-Forwarded-For")):
+        return f"{host}:{client.port} (X-Forwarded-For: {xff_ips})"
+    return f"{host}:{client.port}"
+
+
+def use_secure_cookies(request: Request) -> bool:
+    """Whether cookies for this request should carry the Secure attribute"""
+    return request.scope.get("scheme") == "https" or bool(cfg.enable_https())
+
+
+def check_access(request: Request, access_type: int = 4, warn_user: bool = False) -> bool:
+    """Check if external address is allowed given access_type (Starlette version):
+    1=nzb
+    2=api
+    3=full_api
+    4=webui
+    5=webui with login for external
+    """
+    # Easy, it's allowed
+    if access_type <= cfg.inet_exposure():
+        return True
+
+    # X-Forwarded-For is resolved by uvicorn's ProxyHeadersMiddleware (see the
+    # uvicorn.Config in SABnzbd.py): when verify_xff_header is enabled and the
+    # connecting peer is a trusted local proxy, request.client already holds the
+    # effective client address taken from the XFF chain.
+    remote_ip = client_address(request).host
+
+    # Check if the client IP is a loopback address or considered local
+    is_allowed = is_loopback_addr(remote_ip) or is_local_addr(remote_ip)
+
+    if not is_allowed and warn_user and cfg.api_warnings():
+        logging.warning("%s %s", T("Refused connection from:"), client_address_info(request))
+    return is_allowed
+
+
+def _prune_login_attempts(now: float):
+    """Forget clients whose cooldown has run out"""
+    for host in [host for host, (_, cooldown_expiry) in _login_attempts.items() if cooldown_expiry <= now]:
+        del _login_attempts[host]
+
+
+def login_cooldown_remaining(request: Request) -> int:
+    """Whole seconds this client must sit out before another login attempt is considered"""
+    _prune_login_attempts(time.monotonic())
+    failures, cooldown_expiry = _login_attempts.get(client_address(request).host, (0, 0.0))
+    remaining = cooldown_expiry - time.monotonic()
+    if failures < LOGIN_MAX_ATTEMPTS or remaining <= 0:
+        return 0
+    # Rounded up, because a Retry-After of 0 would invite a retry that is still too early
+    return int(remaining) + 1
+
+
+def record_login_failure(request: Request):
+    """Count a failed login against this client"""
+    now = time.monotonic()
+    _prune_login_attempts(now)
+
+    host = client_address(request).host
+    failures = _login_attempts.get(host, (0, 0.0))[0]
+    _login_attempts[host] = (failures + 1, now + LOGIN_LOCKOUT_TIME)
+
+
+def clear_login_failures(request: Request):
+    """Give a client its full allowance back, once it has proved it knows the password"""
+    _login_attempts.pop(client_address(request).host, None)
+
+
+def constant_time_equals(presented: Any, expected: str) -> bool:
+    """Constant-time comparison of a secret. Anything that is not text counts as nothing presented."""
+    if not isinstance(presented, str):
+        presented = ""
+    return hmac.compare_digest(
+        presented.encode("utf-8", "backslashreplace"), expected.encode("utf-8", "backslashreplace")
+    )
+
+
+def credential_fingerprint() -> str:
+    """Fingerprint of the current username/password, stored with each session, so changing either invalidates all sessions"""
+    return hashlib.sha256(utob("%s:%s" % (cfg.username(), cfg.password()))).hexdigest()
+
+
+def hash_session_token(token: str) -> str:
+    """Hash of the raw cookie token; only the hash is stored server-side"""
+    return hashlib.sha256(utob(token)).hexdigest()
+
+
+def create_session(request: Request, response: Response, remember_me: bool = False):
+    """Create a login session and set the session cookie"""
+    token = secrets.token_urlsafe(32)
+    now = int(time.time())
+    sabnzbd.SessionStore.add(
+        token_hash=hash_session_token(token),
+        created=now,
+        expires=now + SESSION_DURATION,
+        cred_fingerprint=credential_fingerprint(),
+    )
+
+    max_age = SESSION_MAX_AGE if remember_me else None
+    response.set_cookie(
+        SESSION_COOKIE_USER,
+        token,
+        path="/",
+        httponly=True,
+        secure=use_secure_cookies(request),
+        samesite="strict",
+        max_age=max_age,
+    )
+
+
+def login_bypassed(request: Request) -> bool:
+    """Return True when check_login lets this request through without a login session"""
+    # No authentication required when no username/password is set
+    if not cfg.username() or not cfg.password():
+        return True
+
+    # If we show login for external IP, by using access_type=6 we can check if IP match
+    return cfg.inet_exposure() == 5 and check_access(request, access_type=6)
+
+
+def anonymous_session_tag() -> str:
+    """The stateless anonymous session cookie value for this run"""
+    return hmac.new(_ANONYMOUS_SESSION_KEY, b"anonymous-session", hashlib.sha256).hexdigest()
+
+
+def validate_anonymous_session(request: Request) -> bool:
+    """Return True when the login is bypassed for this request and it carries a valid
+    anonymous session cookie."""
+    if not login_bypassed(request):
+        return False
+    return constant_time_equals(request.cookies.get(SESSION_COOKIE_USER, ""), anonymous_session_tag())
+
+
+def create_anonymous_session(request: Request, response: Response):
+    """Set the stateless anonymous session cookie on the response"""
+    response.set_cookie(
+        SESSION_COOKIE_USER,
+        anonymous_session_tag(),
+        path="/",
+        httponly=True,
+        secure=use_secure_cookies(request),
+        samesite="strict",
+        max_age=SESSION_DURATION,
+    )
+
+
+def csrf_token_for(cookie_value: str) -> str:
+    """The CSRF token belonging to a session cookie value"""
+    return hmac.new(_CSRF_KEY, utob(cookie_value), hashlib.sha256).hexdigest()
+
+
+def presented_csrf_token(request: Request, header_only: bool = False) -> str:
+    """The CSRF token this request offers, from the header or a form field"""
+    if header_only:
+        return request.headers.get(CSRF_HEADER) or ""
+    presented = request.headers.get(CSRF_HEADER) or request.state.params.get(CSRF_FIELD) or ""
+    # A multipart part named csrf_token arrives as an UploadFile, which is not a token
+    return presented if isinstance(presented, str) else ""
+
+
+def csrf_token_matches(request: Request, header_only: bool = False) -> bool:
+    """Whether the request echoes the CSRF token belonging to the cookie it sent"""
+    return constant_time_equals(
+        presented_csrf_token(request, header_only=header_only),
+        csrf_token_for(request.cookies.get(SESSION_COOKIE_USER, "")),
+    )
+
+
+def validate_csrf(request: Request) -> bool:
+    """Return True when the request carries a valid session and the CSRF token belonging to it"""
+    return validate_any_session(request) and csrf_token_matches(request)
+
+
+def clear_session(request: Request, response: Response):
+    """Delete the request's session (if any) and clear the session cookie"""
+    if token := request.cookies.get(SESSION_COOKIE_USER):
+        sabnzbd.SessionStore.delete(hash_session_token(token))
+    response.set_cookie(
+        SESSION_COOKIE_USER,
+        "",
+        path="/",
+        httponly=True,
+        secure=use_secure_cookies(request),
+        samesite="strict",
+        expires="Thu, 01 Jan 1970 00:00:00 GMT",
+    )
+
+
+def validate_session(request: Request) -> bool:
+    """Return True when the request carries a live session cookie whose credential fingerprint still matches. Others are deleted, a valid one slides its expiry forward."""
+    if (cached := getattr(request.state, "session_valid", None)) is None:
+        cached = _validate_session(request)
+        request.state.session_valid = cached
+    return cached
+
+
+def _validate_session(request: Request) -> bool:
+    """The lookup behind validate_session. Call that instead, so a request pays for this once."""
+    token = request.cookies.get(SESSION_COOKIE_USER)
+    if not token:
+        return False
+
+    token_hash = hash_session_token(token)
+    now = int(time.time())
+    session = sabnzbd.SessionStore.get(token_hash)
+    if not session:
+        return False
+
+    # Idle-expired, past the deadline, or from before a credential change
+    if (
+        session["expires"] < now
+        or session["created"] + SESSION_MAX_AGE < now
+        or session["cred_fingerprint"] != credential_fingerprint()
+    ):
+        sabnzbd.SessionStore.delete(token_hash)
+        return False
+
+    # Slide the idle timeout forward, never past the deadline and never backwards, and only
+    # when it gains real time
+    new_expires = max(session["expires"], min(now + SESSION_DURATION, session["created"] + SESSION_MAX_AGE))
+    if new_expires > session["expires"] + SESSION_REFRESH_THRESHOLD:
+        sabnzbd.SessionStore.touch(token_hash, new_expires)
+
+    return True
+
+
+def validate_any_session(request: Request) -> bool:
+    """Return True when the request carries a session cookie this instance issued"""
+    return validate_anonymous_session(request) or validate_session(request)
+
+
+def _anonymous_session_sender(request: Request, send):
+    """Wrap an ASGI send so the anonymous session cookie is added to the response start"""
+    carrier = Response()
+    create_anonymous_session(request, carrier)
+    cookie_headers = [(key, value) for key, value in carrier.raw_headers if key == b"set-cookie"]
+
+    async def send_with_cookie(message):
+        if message["type"] == "http.response.start":
+            message["headers"] = list(message.get("headers", [])) + cookie_headers
+        await send(message)
+
+    return send_with_cookie

--- a/sabnzbd/sessionstore.py
+++ b/sabnzbd/sessionstore.py
@@ -1,0 +1,86 @@
+#!/usr/bin/python3 -OO
+# Copyright 2007-2026 by The SABnzbd-Team (sabnzbd.org)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+sabnzbd.sessionstore - Storage for web-UI login sessions
+"""
+
+import logging
+import time
+from typing import Optional, TypedDict
+
+from sabnzbd.constants import SESSIONS_FILE_NAME, SESSIONS_VERSION
+from sabnzbd.filesystem import load_admin, save_admin
+
+
+class Session(TypedDict):
+    created: int
+    expires: int
+    cred_fingerprint: str
+
+
+class SessionStore:
+    """Login sessions, held as a dict and written to the admin folder on every change.
+
+    Only ever touched from the web server's event loop, so it needs no locking.
+    """
+
+    def __init__(self):
+        self._sessions: Optional[dict[str, Session]] = None
+
+    @property
+    def sessions(self) -> dict[str, Session]:
+        """The sessions, loaded from disk on first use"""
+        if self._sessions is None:
+            self._load()
+        return self._sessions
+
+    def _load(self):
+        self._sessions = {}
+        try:
+            if data := load_admin(SESSIONS_FILE_NAME, silent=True):
+                version, sessions = data
+                if version == SESSIONS_VERSION:
+                    now = int(time.time())
+                    self._sessions = {token: s for token, s in sessions.items() if s["expires"] > now}
+        except Exception:
+            logging.info("Failed to load sessions", exc_info=True)
+
+    def _save(self):
+        save_admin((SESSIONS_VERSION, self.sessions), SESSIONS_FILE_NAME)
+
+    def get(self, token_hash: str) -> Optional[Session]:
+        """Return the session stored for token_hash, or None"""
+        return self.sessions.get(token_hash)
+
+    def add(self, token_hash: str, created: int, expires: int, cred_fingerprint: str):
+        """Store a new login session, dropping any that expired in the meantime"""
+        now = int(time.time())
+        self._sessions = {token: s for token, s in self.sessions.items() if s["expires"] > now}
+        self._sessions[token_hash] = Session(created=created, expires=expires, cred_fingerprint=cred_fingerprint)
+        self._save()
+
+    def touch(self, token_hash: str, expires: int):
+        """Extend the expiry of a session (sliding window)"""
+        if session := self.get(token_hash):
+            session["expires"] = expires
+            self._save()
+
+    def delete(self, token_hash: str):
+        """Delete a single session"""
+        if self.sessions.pop(token_hash, None):
+            self._save()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,10 @@ import requests
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options as ChromeOptions
 
+import sabnzbd
+import sabnzbd.sessionstore as sessionstore
 from sabnzbd.constants import DB_HISTORY_NAME, DEF_ADMIN_DIR, DEF_INI_FILE
+from sabnzbd.filesystem import load_data, save_data
 from tests.testhelper import (
     FakeHistoryDB,
     SAB_BASE_DIR,
@@ -137,7 +140,7 @@ def run_sabnzbd(clean_cache_dir, compiled_language_files, request):
     def shutdown_sabnzbd():
         # Shutdown SABnzbd
         try:
-            get_url_result("shutdown", SAB_HOST, SAB_PORT)
+            get_api_result("shutdown", SAB_HOST, SAB_PORT)
         except requests.ConnectionError:
             sabnzbd_process.kill()
         except Exception as err:
@@ -290,3 +293,15 @@ def update_history_specs(request):
 
     # Test o'clock
     return
+
+
+@pytest.fixture
+def session_store(tmp_path, monkeypatch):
+    """Wire sabnzbd.SessionStore to a store that saves into tmp_path"""
+    monkeypatch.setattr(sessionstore, "save_admin", lambda data, name: save_data(data, name, str(tmp_path)))
+    monkeypatch.setattr(
+        sessionstore, "load_admin", lambda name, **kwargs: load_data(name, str(tmp_path), remove=False, silent=True)
+    )
+    store = sessionstore.SessionStore()
+    monkeypatch.setattr(sabnzbd, "SessionStore", store, raising=False)
+    return store

--- a/tests/test_api_and_interface.py
+++ b/tests/test_api_and_interface.py
@@ -32,6 +32,7 @@ from starlette.datastructures import Headers, Address, QueryParams, State
 
 import sabnzbd.api as api
 import sabnzbd.interface as interface
+import sabnzbd.security as security
 import sabnzbd
 import sabnzbd.database as db
 from sabnzbd.constants import DB_HISTORY_NAME, DEF_ADMIN_DIR, PP_LOOKUP, AddNzbFileResult, Status
@@ -254,6 +255,14 @@ class TestGetRequestParams:
         params = run_get_request_params("POST", "smuggled=1", body=b"field=value", content_type=FORM, merge_query=False)
         assert params.get("field") == "value"
         assert params.get("smuggled") is None
+
+    def test_csrf_token_cannot_come_from_the_query_string(self):
+        """The CSRF guard reads the token out of these params, so the body-only rule above is
+        what stops a cross-site form from putting one in the URL instead"""
+        params = run_get_request_params(
+            "POST", "csrf_token=smuggled", body=b"field=value", content_type=FORM, merge_query=False
+        )
+        assert params.get("csrf_token") is None
 
 
 class TestOrphanPathTraversal:
@@ -519,18 +528,18 @@ class TestSecuredExpose:
         """Test IPv6 dual stack functionality"""
         request = create_mock_request(remote_ip="::ffff:192.168.0.10")
         # Dual stack IPs should be treated as local
-        assert interface.check_access(request, access_type=4) is True
+        assert security.check_access(request, access_type=4) is True
 
     @pytest.mark.config({"local_ranges": "132.10."})
     def test_dual_stack_local_ranges(self):
         """Test custom local ranges"""
         # IP not in custom local_ranges should be blocked
         request1 = create_mock_request(remote_ip="::ffff:192.168.0.10")
-        assert interface.check_access(request1, access_type=5) is False
+        assert security.check_access(request1, access_type=5) is False
 
         # IP in custom local_ranges should be allowed
         request2 = create_mock_request(remote_ip="::ffff:132.10.0.10")
-        assert interface.check_access(request2, access_type=4) is True
+        assert security.check_access(request2, access_type=4) is True
 
     @pytest.mark.config({"inet_exposure": 2})
     def test_inet_exposure_basic(self):
@@ -539,11 +548,11 @@ class TestSecuredExpose:
         external_request = create_mock_request(remote_ip="11.11.11.11")
 
         # Level 1-2 should be allowed
-        assert interface.check_access(external_request, access_type=1) is True
-        assert interface.check_access(external_request, access_type=2) is True
+        assert security.check_access(external_request, access_type=1) is True
+        assert security.check_access(external_request, access_type=2) is True
         # Level 3+ should be blocked
-        assert interface.check_access(external_request, access_type=3) is False
-        assert interface.check_access(external_request, access_type=4) is False
+        assert security.check_access(external_request, access_type=3) is False
+        assert security.check_access(external_request, access_type=4) is False
 
     @pytest.mark.config({"inet_exposure": 0})
     def test_local_access_always_allowed(self):
@@ -551,8 +560,8 @@ class TestSecuredExpose:
         local_request = create_mock_request(remote_ip="127.0.0.1")
 
         # Even with minimal exposure, local IPs should be allowed
-        assert interface.check_access(local_request, access_type=4) is True
-        assert interface.check_access(local_request, access_type=5) is True
+        assert security.check_access(local_request, access_type=4) is True
+        assert security.check_access(local_request, access_type=5) is True
 
     @pytest.mark.parametrize("inet_exposure", [0, 1, 2, 3, 4, 5])
     @pytest.mark.parametrize("access_type", [1, 2, 3, 4, 5, 6])
@@ -571,20 +580,15 @@ class TestSecuredExpose:
 
         if expected_local:
             # Local and loopback IPs should always be allowed
-            assert interface.check_access(request, access_type) is True
+            assert security.check_access(request, access_type) is True
         else:
             # External IPs should follow inet_exposure rules
             expected_allowed = access_type <= inet_exposure
-            assert interface.check_access(request, access_type) is expected_allowed
+            assert security.check_access(request, access_type) is expected_allowed
 
     @pytest.mark.config({"inet_exposure": 2, "verify_xff_header": True})
     def test_inet_exposure_with_xff_headers(self):
-        """Test inet_exposure behavior with X-Forwarded-For headers.
-
-        The XFF chain is resolved by uvicorn's ProxyHeadersMiddleware before
-        check_access sees the request (see tests/test_interface.py), so
-        request.client already holds the effective client address here.
-        """
+        """request.client already holds the effective client address, resolved by uvicorn"""
         # Local remote IP with external XFF: uvicorn rewrites the client to the
         # external XFF address, which should be denied
         local_request_external_xff = create_mock_request(
@@ -602,15 +606,15 @@ class TestSecuredExpose:
         )
 
         # Local IP with external XFF should be denied
-        assert interface.check_access(local_request_external_xff, access_type=4) is False
+        assert security.check_access(local_request_external_xff, access_type=4) is False
 
         # Local IP with local XFF should be allowed
-        assert interface.check_access(local_request_local_xff, access_type=4) is True
+        assert security.check_access(local_request_local_xff, access_type=4) is True
 
         # External IP should follow inet_exposure rules (XFF ignored for external IPs)
-        assert interface.check_access(external_request, access_type=1) is True
-        assert interface.check_access(external_request, access_type=2) is True
-        assert interface.check_access(external_request, access_type=3) is False
+        assert security.check_access(external_request, access_type=1) is True
+        assert security.check_access(external_request, access_type=2) is True
+        assert security.check_access(external_request, access_type=3) is False
 
     # Note: The comprehensive parametrized test above covers all these scenarios,
     # but this test provides explicit documentation of the API access level meanings
@@ -620,13 +624,13 @@ class TestSecuredExpose:
         external_request = create_mock_request(remote_ip="8.8.8.8")
 
         # access_type = 1: NZB upload access
-        assert interface.check_access(external_request, access_type=1) is True
+        assert security.check_access(external_request, access_type=1) is True
         # access_type = 2: Basic API access
-        assert interface.check_access(external_request, access_type=2) is True
+        assert security.check_access(external_request, access_type=2) is True
         # access_type = 3: Full API access (blocked with inet_exposure=2)
-        assert interface.check_access(external_request, access_type=3) is False
+        assert security.check_access(external_request, access_type=3) is False
         # access_type = 4: WebUI access (blocked with inet_exposure=2)
-        assert interface.check_access(external_request, access_type=4) is False
+        assert security.check_access(external_request, access_type=4) is False
 
     @pytest.mark.config({"inet_exposure": 1})
     def test_inet_exposure_ipv6(self):
@@ -639,14 +643,14 @@ class TestSecuredExpose:
         dual_stack_request = create_mock_request(remote_ip="::ffff:192.168.1.10")
 
         # IPv6 loopback should always be allowed
-        assert interface.check_access(ipv6_local_request, access_type=4) is True
+        assert security.check_access(ipv6_local_request, access_type=4) is True
 
         # IPv6 external should follow inet_exposure rules
-        assert interface.check_access(ipv6_external_request, access_type=1) is True
-        assert interface.check_access(ipv6_external_request, access_type=2) is False
+        assert security.check_access(ipv6_external_request, access_type=1) is True
+        assert security.check_access(ipv6_external_request, access_type=2) is False
 
         # Dual-stack should be treated as local
-        assert interface.check_access(dual_stack_request, access_type=4) is True
+        assert security.check_access(dual_stack_request, access_type=4) is True
 
     @pytest.mark.config({"inet_exposure": 1, "local_ranges": ["4.4.4.0/24"]})
     def test_inet_exposure_custom_local_ranges(self):
@@ -655,7 +659,7 @@ class TestSecuredExpose:
         custom_local_request = create_mock_request(remote_ip="4.4.4.10")
 
         # IP in custom local range should be treated as local
-        assert interface.check_access(custom_local_request, access_type=4) is True
+        assert security.check_access(custom_local_request, access_type=4) is True
 
     # Note: Boundary conditions are covered by the comprehensive parametrized test
     # These tests serve as explicit documentation of the most restrictive/permissive settings
@@ -664,15 +668,15 @@ class TestSecuredExpose:
         """Document the most restrictive inet_exposure setting"""
         external_request = create_mock_request(remote_ip="1.1.1.1")
         # inet_exposure=0: No external access allowed for any access type
-        assert interface.check_access(external_request, access_type=1) is False
+        assert security.check_access(external_request, access_type=1) is False
 
     @pytest.mark.config({"inet_exposure": 5})
     def test_inet_exposure_most_permissive(self):
         """Document the most permissive inet_exposure setting"""
         external_request = create_mock_request(remote_ip="1.1.1.1")
         # inet_exposure=5: External access allowed for access_type 1-5, but not 6
-        assert interface.check_access(external_request, access_type=5) is True
-        assert interface.check_access(external_request, access_type=6) is False
+        assert security.check_access(external_request, access_type=5) is True
+        assert security.check_access(external_request, access_type=6) is False
 
 
 class TestHistory:
@@ -727,3 +731,42 @@ class TestHistory:
 
             # Make sure the job was not added to the list, a completed entry already exists
             assert total_items == len(jobs)
+
+
+@pytest.fixture
+def renderable_header(monkeypatch):
+    """Stand in for the runtime singletons build_header reads, so it can be called outside
+    a running SABnzbd"""
+    for name in ("Scheduler", "Downloader", "GUIHANDLER", "BPSMeter", "ArticleCache", "NzbQueue"):
+        monkeypatch.setattr(sabnzbd, name, Mock(), raising=False)
+    monkeypatch.setattr(sabnzbd.BPSMeter, "quota", 0.0, raising=False)
+    monkeypatch.setattr(sabnzbd.BPSMeter, "left", 0.0, raising=False)
+    monkeypatch.setattr(sabnzbd.Downloader, "bandwidth_perc", 0, raising=False)
+    monkeypatch.setattr(sabnzbd.Downloader, "bandwidth_limit", 0, raising=False)
+    disk = Mock(free=1.0, size=2.0)
+    with patch("sabnzbd.api.diskspace", return_value=(disk, disk)):
+        yield
+
+
+class TestBuildHeaderCsrfToken:
+    """build_header hands the page its CSRF token, but only when it has a request."""
+
+    @pytest.mark.config({"username": "", "password": ""})
+    def test_present_for_a_page_request(self, renderable_header):
+        request = Mock(spec=Request)
+        request.state.csrf_token = "a-token"
+        assert api.build_header(request=request)["csrf_token"] == "a-token"
+
+    @pytest.mark.config({"username": "", "password": ""})
+    def test_absent_without_a_request(self, renderable_header):
+        # The signature build_status() uses, and the one that reaches an API payload
+        assert "csrf_token" not in api.build_header(trans_functions=False)
+        assert "csrf_token" not in api.build_header()
+
+    @pytest.mark.config({"username": "", "password": ""})
+    def test_empty_when_no_middleware_published_one(self, renderable_header):
+        """Routes that render without SecurityMiddleware having set it (/login) get an empty
+        string rather than an AttributeError"""
+        request = Mock(spec=Request)
+        request.state = State({})
+        assert api.build_header(request=request)["csrf_token"] == ""

--- a/tests/test_functional_config.py
+++ b/tests/test_functional_config.py
@@ -159,12 +159,20 @@ class TestConfigCategories(SABnzbdBaseTest):
         self.open_page("http://%s:%s/config/categories" % (SAB_HOST, SAB_PORT))
 
         # Add new category
-        self.driver.find_elements(By.NAME, "newname")[1].send_keys("testCat")
+        self.driver.find_elements(By.NAME, "newname")[1].send_keys(self.category_name)
         self.selenium_wrapper(
             self.driver.find_element, By.XPATH, "//button/text()[normalize-space(.)='Add']/parent::*"
         ).click()
         self.no_page_crash()
+        self.wait_for_ajax()
+
+        # Category names are stored lowercased, so the name as typed must not come back
         assert self.category_name not in self.driver.page_source
+
+        # Reload and confirm it was really saved. Without this the test passes whether the
+        # POST was accepted or refused, because a rejected save leaves the name absent too.
+        self.open_page("http://%s:%s/config/categories" % (SAB_HOST, SAB_PORT))
+        assert self.category_name.lower() in self.driver.page_source
 
 
 class TestConfigRSS(SABnzbdBaseTest):
@@ -308,3 +316,25 @@ class TestConfigServers(SABnzbdBaseTest):
         self.open_config_servers()
         self.add_test_server()
         self.remove_server()
+
+
+class TestGlitterInterface(SABnzbdBaseTest):
+    """Glitter funnels every call through callAPI, so a wrong CSRF header fails all of them at once"""
+
+    def test_interface_loads_and_polls(self):
+        # skip_wizard because the test ini configures no servers, so / would redirect there
+        self.open_page("http://%s:%s/?skip_wizard=1" % (SAB_HOST, SAB_PORT))
+        self.wait_for_ajax()
+
+        # The token reached the page and was installed for every request. Checked because a
+        # missing csrfToken global would throw inside glitter.basic.js and stop the rest of
+        # the interface from initialising -- which leaves the overlay below hidden, so the
+        # overlay alone would not notice.
+        assert self.driver.execute_script(
+            "return csrfToken.length === 64 && ($.ajaxSettings.headers || {})['X-SABnzbd-CSRF'] === csrfToken"
+        ), "Glitter did not install the CSRF header on its API calls"
+
+        # The queue and history refresh drop this overlay over the page when they fail, so
+        # its absence is what says those calls came back authorized
+        overlay = self.selenium_wrapper(self.driver.find_element, By.CLASS_NAME, "main-restarting")
+        assert not overlay.is_displayed(), "Glitter showed the reconnect overlay, so its API calls failed"

--- a/tests/test_functional_misc.py
+++ b/tests/test_functional_misc.py
@@ -39,17 +39,13 @@ from tests.testhelper import (
     SABnzbdBaseTest,
     create_and_read_nzb_fp,
     get_api_result,
-    get_url_result,
+    post_url_result,
     wait_for,
 )
 
 
 class TestShowLogging(SABnzbdBaseTest):
-    def test_showlog(self):
-        """Test the output of the filtered-log button"""
-        # Basic URL-fetching, easier than Selenium file download
-        log_result = get_api_result("showlog")
-
+    def _assert_is_the_log(self, log_result: str):
         # Make sure it has basic log stuff
         assert "The log" in log_result
         assert "Full executable path" in log_result
@@ -57,6 +53,15 @@ class TestShowLogging(SABnzbdBaseTest):
         # Make sure sabnzbd.ini was appended
         assert "__encoding__ = utf-8" in log_result
         assert "[misc]" in log_result
+
+    def test_showlog(self):
+        """Test the output of the filtered-log button"""
+        # Basic URL-fetching, easier than Selenium file download
+        self._assert_is_the_log(get_api_result("showlog"))
+
+    def test_log_page_route(self):
+        """The interface reaches the log through /log as a form POST, not the mode=showlog API-call"""
+        self._assert_is_the_log(post_url_result("log"))
 
 
 class TestQueueRepair(SABnzbdBaseTest):
@@ -230,8 +235,8 @@ class TestDaemonizing(SABnzbdBaseTest):
         assert os.path.getsize(error_log_path) < 1024
 
         try:
-            # Let's shut it down and give it some time to do so
-            get_url_result("shutdown", daemon_host, daemon_port)
+            # Let's shut it down via the API and give it some time to do so
+            get_api_result("shutdown", daemon_host, daemon_port)
             wait_for(
                 lambda: not os.path.exists(pid_file),
                 timeout=3,

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -23,8 +23,9 @@ import asyncio
 import inspect
 import logging
 import logging.config
+from typing import Optional
 import pytest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 from starlette.requests import Request
 from starlette.datastructures import Headers, Address, QueryParams
 import uvicorn
@@ -33,16 +34,12 @@ from uvicorn.lifespan import on as lifespan_on
 from uvicorn.protocols.http import h11_impl, httptools_impl
 from uvicorn.server import ServerState
 
+import sabnzbd
+import sabnzbd.cfg as cfg
+import sabnzbd.security as security
 from sabnzbd import interface
+from tests.test_security import api_request, config_save_middleware, mock_request, page_post, store_session
 from sabnzbd.misc import is_local_addr, is_loopback_addr, xff_trusted_networks
-
-
-def create_mock_request(remote_ip: str = "127.0.0.1", headers: dict | None = None, remote_port: int = 12345):
-    """Create a mock Starlette Request object for testing"""
-    mock_request = Mock(spec=Request)
-    mock_request.client = Address(remote_ip, remote_port)
-    mock_request.headers = Headers(headers or {})
-    return mock_request
 
 
 def resolve_client(remote_ip: str, xff_header: str | None = None, remote_port: int = 12345) -> Address:
@@ -203,41 +200,33 @@ class TestInterfaceFunctions:
                 # Without XFF, only the remote IP and the local ranges setting matter
                 result = is_loopback_addr(remote_ip) or is_local_addr(remote_ip)
 
-            request = create_mock_request(remote_ip=client.host, remote_port=client.port)
+            request = mock_request(remote_ip=client.host, remote_port=client.port)
 
             if access_type <= inet_exposure:
-                assert interface.check_access(request, access_type) is True
+                assert security.check_access(request, access_type) is True
             else:
-                assert interface.check_access(request, access_type) is result
+                assert security.check_access(request, access_type) is result
 
         _func()
 
-    @pytest.mark.config({"api_key": "the_real_api_key", "nzb_key": "the_real_nzb_key"})
+    @pytest.mark.config({"api_key": "the_real_api_key", "nzb_key": "the_real_nzb_key", "api_warnings": True})
     @pytest.mark.parametrize(
-        "api_route, params, expected",
+        "params, expected",
         [
-            # /api route: version/auth public, NZB-key valid for nzb-level calls
-            (True, {"mode": "version"}, None),
-            (True, {"mode": "auth"}, None),
-            (True, {"mode": "addfile", "apikey": "the_real_nzb_key"}, None),
-            (True, {"mode": "queue", "apikey": "the_real_api_key"}, None),
-            (True, {"mode": "queue"}, interface._MSG_APIKEY_REQUIRED),
-            (True, {"mode": "queue", "apikey": "wrong"}, interface._MSG_APIKEY_INCORRECT),
-            # Web-ui routes must ignore 'mode': no version/auth or NZB-key bypass
-            (False, {"mode": "version"}, interface._MSG_APIKEY_REQUIRED),
-            (False, {"mode": "auth"}, interface._MSG_APIKEY_REQUIRED),
-            (False, {"mode": "addfile", "apikey": "the_real_nzb_key"}, interface._MSG_APIKEY_INCORRECT),
-            (False, {"apikey": "the_real_api_key"}, None),
-            (False, {"mode": "version", "apikey": "the_real_api_key"}, None),
-            (False, {"apikey": "wrong"}, interface._MSG_APIKEY_INCORRECT),
-            (False, {}, interface._MSG_APIKEY_REQUIRED),
+            ({"mode": "version"}, None),
+            ({"mode": "auth"}, None),
+            # The NZB-key is valid for nzb-level calls only
+            ({"mode": "addfile", "apikey": "the_real_nzb_key"}, None),
+            ({"mode": "queue", "apikey": "the_real_nzb_key"}, interface._MSG_APIKEY_INCORRECT),
+            ({"mode": "queue", "apikey": "the_real_api_key"}, None),
+            ({"mode": "queue"}, interface._MSG_APIKEY_REQUIRED),
+            ({"mode": "queue", "apikey": "wrong"}, interface._MSG_APIKEY_INCORRECT),
         ],
     )
-    def test_check_apikey_ignores_mode_off_api_route(self, api_route, params, expected):
-        """'mode' is only trusted on the real /api route, not on web-ui handlers."""
-        request = create_mock_request()
-        request.state.params = QueryParams(params)
-        assert interface.check_apikey(request, api_route=api_route) == expected
+    def test_apikey_on_the_api_route(self, params, expected):
+        request = mock_request(params=params)
+        response = interface.check_apikey(request)
+        assert (response.body.decode() if response else None) == expected
 
     @pytest.mark.parametrize(
         "local_ranges, xff_ips, expected_result",
@@ -297,7 +286,7 @@ class TestInterfaceFunctions:
     )
     def test_effective_client_from_xff(self, local_ranges, xff_ips, expected_result):
         def _func():
-            # The effective client IP (used for login-cookie binding and access
+            # The effective client IP (used for access
             # checks) is selected by uvicorn's ProxyHeadersMiddleware: the last
             # XFF entry that is not a trusted (local) proxy, or the first entry
             # when the whole chain is trusted. Connect from loopback, which is
@@ -312,12 +301,11 @@ class TestInterfaceFunctions:
     @pytest.mark.parametrize("inet_exposure", [0, 2, 4])
     @pytest.mark.config(lambda params: {"inet_exposure": params["inet_exposure"], "api_warnings": True})
     def test_check_access_without_client(self, access_type, inet_exposure):
-        # request.client can be None (e.g. unix sockets or some test clients);
-        # this must not raise and must fail closed for restricted access types
-        request = create_mock_request()
+        # request.client can be None on unix sockets and with some test clients
+        request = mock_request()
         request.client = None
 
-        assert interface.check_access(request, access_type, warn_user=True) is (access_type <= inet_exposure)
+        assert security.check_access(request, access_type, warn_user=True) is (access_type <= inet_exposure)
         # The logging helpers must not raise either
         interface.log_warning_and_ip(request, "txt")
 
@@ -473,19 +461,19 @@ class TestClientAddressInfo:
         ],
     )
     def test_brackets_ipv6(self, remote_ip, expected):
-        request = create_mock_request(remote_ip=remote_ip, remote_port=55170)
-        assert interface.client_address_info(request) == expected
+        request = mock_request(remote_ip=remote_ip, remote_port=55170)
+        assert security.client_address_info(request) == expected
 
     @pytest.mark.config({"verify_xff_header": True})
     def test_includes_forwarded_chain(self):
-        request = create_mock_request(remote_ip="::1", remote_port=55170, headers={"X-Forwarded-For": "8.7.6.5, ::1"})
-        assert interface.client_address_info(request) == "[::1]:55170 (X-Forwarded-For: 8.7.6.5, ::1)"
+        request = mock_request(remote_ip="::1", remote_port=55170, headers={"X-Forwarded-For": "8.7.6.5, ::1"})
+        assert security.client_address_info(request) == "[::1]:55170 (X-Forwarded-For: 8.7.6.5, ::1)"
 
     @pytest.mark.config({"verify_xff_header": False})
     def test_omits_forwarded_chain_when_not_verified(self):
         """Without verify_xff_header the header is not trusted, so it is not reported"""
-        request = create_mock_request(remote_ip="::1", remote_port=55170, headers={"X-Forwarded-For": "8.7.6.5"})
-        assert interface.client_address_info(request) == "[::1]:55170"
+        request = mock_request(remote_ip="::1", remote_port=55170, headers={"X-Forwarded-For": "8.7.6.5"})
+        assert security.client_address_info(request) == "[::1]:55170"
 
 
 class TestUseSecureCookies:
@@ -526,12 +514,12 @@ class TestUseSecureCookies:
         ],
     )
     def test_follows_request_scheme(self, scheme, host, server, expected):
-        assert interface.use_secure_cookies(self.make_request(scheme, host, server)) is expected
+        assert security.use_secure_cookies(self.make_request(scheme, host, server)) is expected
 
     @pytest.mark.config({"enable_https": True})
     def test_https_enabled_always_secure(self):
         """Serving https ourselves is enough, whatever the request looks like"""
-        assert interface.use_secure_cookies(self.make_request("http")) is True
+        assert security.use_secure_cookies(self.make_request("http")) is True
 
     @pytest.mark.config({"enable_https": False})
     def test_scheme_from_trusted_proxy(self):
@@ -541,7 +529,7 @@ class TestUseSecureCookies:
         captured = {}
 
         async def asgi_app(scope, receive, send):
-            captured["secure"] = interface.use_secure_cookies(Request(scope))
+            captured["secure"] = security.use_secure_cookies(Request(scope))
 
         def run(remote_ip: str):
             middleware = ProxyHeadersMiddleware(asgi_app, trusted_hosts=xff_trusted_networks())
@@ -562,3 +550,400 @@ class TestUseSecureCookies:
         assert run("127.0.0.1") is True
         # Untrusted peer: the header must be ignored, so no Secure on a plain connection
         assert run("8.7.6.5") is False
+
+
+class TestStaleTokenIsNotAWarning:
+
+    def _levels(self, caplog, run) -> set:
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger=""):
+            run()
+        return {record.levelname for record in caplog.records}
+
+    @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0, "api_warnings": True})
+    def test_api_call_with_a_stale_token_is_only_info(self, session_store, caplog):
+        request = mock_request(security.anonymous_session_tag(), params={"mode": "queue", "name": ""}, csrf="f0" * 32)
+        levels = self._levels(caplog, lambda: interface.check_apikey(request))
+        assert "WARNING" not in levels
+        assert "INFO" in levels
+
+    @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0, "api_warnings": True})
+    def test_api_call_with_no_token_still_warns(self, session_store, caplog):
+        request = api_request(security.anonymous_session_tag(), with_token=False)
+        levels = self._levels(caplog, lambda: interface.check_apikey(request))
+        assert "WARNING" in levels
+
+    @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0, "api_warnings": True})
+    def test_page_post_with_a_stale_token_is_only_info(self, session_store, caplog):
+        request = page_post(security.anonymous_session_tag(), csrf="f0" * 32)
+        levels = self._levels(caplog, lambda: config_save_middleware().denied_response(request))
+        assert "WARNING" not in levels
+        assert "INFO" in levels
+
+    @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0, "api_warnings": True})
+    def test_cross_site_page_post_still_warns(self, session_store, caplog):
+        levels = self._levels(caplog, lambda: config_save_middleware().denied_response(page_post()))
+        assert "WARNING" in levels
+
+
+class TestApiCsrf:
+    """A cookie-authorized API call must echo its session's CSRF token in a header"""
+
+    def _status(self, request) -> Optional[int]:
+        response = interface.check_apikey(request)
+        return response.status_code if response else None
+
+    @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
+    def test_cookie_with_token_authorizes(self, session_store):
+        assert self._status(api_request(security.anonymous_session_tag())) is None
+
+    @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
+    def test_cookie_without_token_is_forbidden(self, session_store):
+        """403, not 401: a reload cannot conjure up a header the client never sends"""
+        assert self._status(api_request(security.anonymous_session_tag(), with_token=False)) == 403
+
+    @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
+    def test_stale_token_asks_for_a_reload(self, session_store):
+        """401, because a reload does fix this one"""
+        request = mock_request(security.anonymous_session_tag(), params={"mode": "queue", "name": ""}, csrf="f0" * 32)
+        assert self._status(request) == 401
+
+    @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
+    def test_apikey_still_works_alongside_a_cookie(self, session_store):
+        """The cookie check must fall through to the key, never reject on its own"""
+        request = mock_request(
+            security.anonymous_session_tag(),
+            params={"mode": "queue", "name": "", "apikey": cfg.api_key()},
+        )
+        assert self._status(request) is None
+        # ...and with no cookie at all, which is how 3rd-party clients call it
+        assert self._status(mock_request(params={"mode": "queue", "name": "", "apikey": cfg.api_key()})) is None
+
+    @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
+    def test_no_mode_is_exempt(self, session_store):
+        """There is no carve-out list, including showlog"""
+        assert self._status(api_request(security.anonymous_session_tag(), mode="showlog", with_token=False)) == 403
+        assert self._status(api_request(security.anonymous_session_tag(), mode="showlog")) is None
+
+    @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
+    def test_token_outside_the_header_is_not_accepted(self, session_store):
+        """This route merges the query string into its params; page routes still take the field"""
+        tag = security.anonymous_session_tag()
+        token = security.csrf_token_for(tag)
+
+        as_parameter = mock_request(tag, params={"mode": "queue", "name": "", security.CSRF_FIELD: token})
+        assert self._status(as_parameter) == 403
+        # The same token in the header is what the frontend sends, and it is accepted
+        assert self._status(api_request(tag)) is None
+
+    @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
+    def test_keyless_and_cookieless_still_reports_missing_key(self, session_store):
+        assert self._status(mock_request(params={"mode": "queue", "name": ""})) == 403
+
+    @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
+    def test_apikey_is_compared_in_constant_time(self, session_store):
+        key = cfg.api_key()
+        assert self._status(mock_request(params={"mode": "queue", "name": "", "apikey": key})) is None
+        # A prefix of the real key is no better than any other wrong key
+        for wrong in (key[:-1], key[:1], "", "x" * len(key)):
+            request = mock_request(params={"mode": "queue", "name": "", "apikey": wrong})
+            assert self._status(request) == 403
+
+    @pytest.mark.parametrize("credentials", [("", ""), ("user", "pass")])
+    @pytest.mark.config(
+        lambda params: {
+            "username": params["credentials"][0],
+            "password": params["credentials"][1],
+            "inet_exposure": 0,
+            "api_warnings": True,
+        }
+    )
+    def test_apikey_does_not_open_the_page_routes(self, session_store, credentials):
+        """Refused the same way whether or not credentials are configured, and never with a redirect to the login form"""
+        request = page_post()
+        request.state.params = {"apikey": cfg.api_key()}
+        request.query_params = QueryParams("")
+
+        response = config_save_middleware().denied_response(request)
+        assert response is not None
+        assert response.status_code == 403
+        assert b"only accepted on /api" in response.body
+
+    @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 0})
+    def test_stray_apikey_does_not_break_a_valid_session(self, session_store):
+        store_session(session_store, "login-token")
+        request = page_post("login-token", csrf=security.csrf_token_for("login-token"))
+        request.state.params = {security.CSRF_FIELD: security.csrf_token_for("login-token")}
+        request.query_params = QueryParams("apikey=" + cfg.api_key())
+        assert config_save_middleware().denied_response(request) is None
+
+    @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
+    def test_version_and_auth_skip_the_check(self, session_store):
+        for mode in ("version", "auth"):
+            assert self._status(mock_request(params={"mode": mode, "name": ""})) is None
+
+
+class TestLogRoute:
+
+    def _route(self):
+        return next(route for route in interface.INTERFACE_ROUTES if getattr(route, "path", None) == "/log")
+
+    def test_registered_as_a_guarded_post_route(self):
+        assert sorted(self._route().methods) == ["POST"]
+
+    @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 0})
+    def test_behind_the_login_check(self, session_store):
+        """Driven through the route as registered, so weakening the decorator fails here"""
+        route = self._route()
+        captured = {}
+
+        async def receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message):
+            if message["type"] == "http.response.start":
+                captured["status"] = message["status"]
+                captured["headers"] = Headers(raw=message["headers"])
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/log",
+            "query_string": b"",
+            "headers": [(b"host", b"127.0.0.1:8080")],
+            "client": ("127.0.0.1", 12345),
+            "server": ("127.0.0.1", 8080),
+            "scheme": "http",
+        }
+        asyncio.run(route.app(scope, receive, send))
+        # Redirected to the login form, and the handler never ran to stream any of the log
+        assert captured["status"] == 302
+        assert captured["headers"]["location"].endswith("/login")
+
+
+# The kinds of session cookie a page POST can arrive with, resolved once the test's
+# credentials are in place
+COOKIE_NONE = "none"
+COOKIE_ANONYMOUS = "anonymous"
+COOKIE_LOGIN = "login"
+COOKIE_FORGED = "forged"
+
+
+def cookie_of_kind(kind: str, store) -> Optional[str]:
+    if kind == COOKIE_NONE:
+        return None
+    if kind == COOKIE_ANONYMOUS:
+        return security.anonymous_session_tag()
+    if kind == COOKIE_FORGED:
+        return "f0" * 32
+    store_session(store, "login-token")
+    return "login-token"
+
+
+# The CSRF token a page POST can arrive with, relative to the cookie it sends
+TOKEN_NONE = "none"
+TOKEN_MATCHING = "matching"
+TOKEN_WRONG = "wrong"
+
+
+def token_of_kind(kind: str, cookie_value: Optional[str]) -> Optional[str]:
+    if kind == TOKEN_NONE:
+        return None
+    if kind == TOKEN_WRONG:
+        return "f0" * 32
+    return security.csrf_token_for(cookie_value or "")
+
+
+class TestPagePostCsrf:
+
+    @pytest.mark.parametrize(
+        "credentials, inet_exposure, cookie, token, allowed",
+        [
+            # No credentials at all: check_login always passes, so this guard is all there is
+            (("", ""), 0, COOKIE_NONE, TOKEN_NONE, False),
+            (("", ""), 0, COOKIE_ANONYMOUS, TOKEN_MATCHING, True),
+            (("", ""), 0, COOKIE_ANONYMOUS, TOKEN_NONE, False),
+            (("", ""), 0, COOKIE_ANONYMOUS, TOKEN_WRONG, False),
+            (("", ""), 0, COOKIE_FORGED, TOKEN_MATCHING, False),
+            (("", ""), 5, COOKIE_NONE, TOKEN_NONE, False),
+            # A token with no cookie must not pass: csrf_token_for("") is computable by anyone
+            (("", ""), 0, COOKIE_NONE, TOKEN_MATCHING, False),
+            # Credentials with the login enforced
+            (("user", "pass"), 0, COOKIE_NONE, TOKEN_NONE, False),
+            (("user", "pass"), 0, COOKIE_LOGIN, TOKEN_MATCHING, True),
+            (("user", "pass"), 0, COOKIE_LOGIN, TOKEN_NONE, False),
+            # inet_exposure 5: the login is waived, so check_login passes with no cookie
+            (("user", "pass"), 5, COOKIE_NONE, TOKEN_NONE, False),
+            (("user", "pass"), 5, COOKIE_FORGED, TOKEN_MATCHING, False),
+            (("user", "pass"), 5, COOKIE_ANONYMOUS, TOKEN_MATCHING, True),
+            (("user", "pass"), 5, COOKIE_ANONYMOUS, TOKEN_NONE, False),
+            # ...without locking out a local client who does hold a real login session
+            (("user", "pass"), 5, COOKIE_LOGIN, TOKEN_MATCHING, True),
+        ],
+    )
+    @pytest.mark.config(
+        lambda params: {
+            "username": params["credentials"][0],
+            "password": params["credentials"][1],
+            "inet_exposure": params["inet_exposure"],
+        }
+    )
+    def test_config_save_post(self, session_store, credentials, inet_exposure, cookie, token, allowed):
+        cookie_value = cookie_of_kind(cookie, session_store)
+        request = page_post(cookie_value, csrf=token_of_kind(token, cookie_value))
+        response = config_save_middleware().denied_response(request)
+        assert (response is None) is allowed
+
+    @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
+    def test_token_accepted_as_form_field(self, session_store):
+        """A form that navigates cannot set a header, so the body is accepted too"""
+        tag = security.anonymous_session_tag()
+        allowed = page_post(tag, csrf_field=security.csrf_token_for(tag))
+        assert config_save_middleware().denied_response(allowed) is None
+        denied = page_post(tag, csrf_field="f0" * 32)
+        assert config_save_middleware().denied_response(denied) is not None
+
+    @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 5})
+    def test_token_is_bound_to_its_own_session(self, session_store):
+        cookie_of_kind(COOKIE_LOGIN, session_store)
+        anonymous_tag = security.anonymous_session_tag()
+
+        login_with_anonymous_token = page_post("login-token", csrf=security.csrf_token_for(anonymous_tag))
+        assert config_save_middleware().denied_response(login_with_anonymous_token) is not None
+
+        anonymous_with_login_token = page_post(anonymous_tag, csrf=security.csrf_token_for("login-token"))
+        assert config_save_middleware().denied_response(anonymous_with_login_token) is not None
+
+    @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 5})
+    def test_external_client_still_needs_login(self, session_store):
+        """The waiver is local-only: an external POST gets no help from the anonymous tag"""
+        tag = security.anonymous_session_tag()
+        request = page_post(tag, remote_ip="9.8.7.6", csrf=security.csrf_token_for(tag))
+        assert config_save_middleware().denied_response(request) is not None
+
+    @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 0})
+    def test_session_is_looked_up_once_per_request(self, session_store):
+        store_session(session_store, "login-token")
+        request = page_post("login-token", csrf=security.csrf_token_for("login-token"))
+
+        with patch.object(sabnzbd.SessionStore, "get", wraps=sabnzbd.SessionStore.get) as get_session:
+            assert config_save_middleware().denied_response(request) is None
+        assert get_session.call_count == 1
+
+    @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
+    def test_get_is_not_guarded(self, session_store):
+        """A first visit has no token yet, so rendering a page must not require one"""
+        assert config_save_middleware().denied_response(mock_request()) is None
+
+
+def run_page_request(cookie: Optional[str] = None, remote_ip: str = "127.0.0.1") -> tuple[list[str], str]:
+    """Drive a page route's SecurityMiddleware over a real ASGI scope, returning the Set-Cookie values it injected and the CSRF token it published"""
+
+    rendered_token = ""
+
+    async def asgi_app(scope, receive, send):
+        # Stand in for a page handler: build_header reads the token off request.state here
+        nonlocal rendered_token
+        rendered_token = scope.get("state", {}).get("csrf_token", "")
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    middleware = interface.SecurityMiddleware(asgi_app, check_for_login=True, check_api_key=False, access_type=4)
+
+    headers = [(b"host", b"127.0.0.1:8080")]
+    if cookie:
+        headers.append((b"cookie", ("%s=%s" % (security.SESSION_COOKIE_USER, cookie)).encode()))
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/config/general",
+        "query_string": b"",
+        "headers": headers,
+        "client": (remote_ip, 12345),
+        "server": ("127.0.0.1", 8080),
+        "scheme": "http",
+        # secured_expose always wraps SecurityMiddleware in ParamsMiddleware
+        "state": {"params": QueryParams("")},
+    }
+    captured: list[str] = []
+
+    async def send(message):
+        if message["type"] == "http.response.start":
+            captured.extend(Headers(raw=message["headers"]).getlist("set-cookie"))
+
+    asyncio.run(middleware(scope, None, send))
+    return captured, rendered_token
+
+
+def issued_session_cookies(cookie: Optional[str] = None, remote_ip: str = "127.0.0.1") -> list[str]:
+    return run_page_request(cookie=cookie, remote_ip=remote_ip)[0]
+
+
+class TestAnonymousSessionIssuing:
+
+    def _issued(self, **kwargs) -> bool:
+        return any(value.startswith(security.SESSION_COOKIE_USER + "=") for value in issued_session_cookies(**kwargs))
+
+    @pytest.mark.config({"username": "", "password": ""})
+    def test_issued_without_credentials(self, session_store):
+        assert self._issued() is True
+
+    @pytest.mark.config({"username": "", "password": ""})
+    def test_not_reissued_when_tag_already_held(self, session_store):
+        assert self._issued(cookie=security.anonymous_session_tag()) is False
+
+    @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 5})
+    def test_issued_when_login_waived_for_local_client(self, session_store):
+        assert self._issued() is True
+
+    @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 5})
+    def test_login_session_not_overwritten(self, session_store):
+        store_session(session_store, "login-token")
+        assert self._issued(cookie="login-token") is False
+
+
+def session_cookie_value(set_cookie_headers: list[str], fallback: Optional[str]) -> str:
+    """The session cookie the client is left holding after a response"""
+    for value in set_cookie_headers:
+        if value.startswith(security.SESSION_COOKIE_USER + "="):
+            return value.split("=", 1)[1].split(";", 1)[0]
+    return fallback or ""
+
+
+class TestRenderedTokenMatchesCookie:
+
+    def _assert_token_matches(self, cookie: Optional[str]):
+        set_cookies, rendered_token = run_page_request(cookie=cookie)
+        held = session_cookie_value(set_cookies, cookie)
+        assert rendered_token == security.csrf_token_for(held)
+        assert rendered_token, "a page rendered no usable token at all"
+
+    @pytest.mark.config({"username": "", "password": ""})
+    def test_first_load_with_no_cookie(self, session_store):
+        self._assert_token_matches(None)
+
+    @pytest.mark.config({"username": "", "password": ""})
+    def test_load_with_stale_cookie(self, session_store):
+        # A tag from before a restart rotated the key: a fresh cookie is issued
+        self._assert_token_matches("f0" * 32)
+
+    @pytest.mark.config({"username": "", "password": ""})
+    def test_steady_state_anonymous(self, session_store):
+        self._assert_token_matches(security.anonymous_session_tag())
+
+    @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 0})
+    def test_login_session(self, session_store):
+        store_session(session_store, "login-token")
+        self._assert_token_matches("login-token")
+
+    @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 5})
+    def test_login_session_while_login_waived(self, session_store):
+        store_session(session_store, "login-token")
+        self._assert_token_matches("login-token")
+
+    @pytest.mark.config({"username": "", "password": ""})
+    def test_rendered_token_authorizes_the_next_post(self, session_store):
+        set_cookies, rendered_token = run_page_request()
+        held = session_cookie_value(set_cookies, None)
+        request = page_post(held, csrf=rendered_token)
+        assert config_save_middleware().denied_response(request) is None

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,494 @@
+#!/usr/bin/python3 -OO
+# Copyright 2007-2026 by The SABnzbd-Team (sabnzbd.org)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+tests.test_security - Testing authentication, sessions and the CSRF token
+"""
+
+import asyncio
+import io
+import time
+from typing import Optional
+import pytest
+from unittest.mock import Mock, patch
+from starlette.requests import Request
+from starlette.responses import HTMLResponse
+from starlette.datastructures import Headers, Address, QueryParams, State, UploadFile
+
+import sabnzbd
+import sabnzbd.cfg as cfg
+import sabnzbd.security as security
+from sabnzbd import interface
+
+
+def mock_request(
+    token: Optional[str] = None,
+    *,
+    params: Optional[dict] = None,
+    headers: Optional[dict] = None,
+    csrf: Optional[str] = None,
+    method: str = "GET",
+    remote_ip: str = "127.0.0.1",
+    remote_port: int = 12345,
+    scheme: str = "http",
+):
+    """Mock Starlette Request"""
+    if csrf is not None:
+        headers = {**(headers or {}), security.CSRF_HEADER: csrf}
+
+    request = Mock(spec=Request)
+    request.method = method
+    request.client = Address(remote_ip, remote_port)
+    request.headers = Headers(headers or {})
+    request.cookies = {security.SESSION_COOKIE_USER: token} if token else {}
+    request.query_params = QueryParams("")
+    request.state = State({})
+    request.state.params = params or {}
+    request.scope = {
+        "type": "http",
+        "method": method,
+        "scheme": scheme,
+        "headers": request.headers.raw,
+        "client": (remote_ip, remote_port),
+    }
+    return request
+
+
+def api_request(token: Optional[str] = None, *, mode: str = "queue", with_token: bool = True, **kwargs):
+    """Mock /api request authorized by a session cookie, echoing its CSRF token unless with_token is False"""
+    return mock_request(
+        token,
+        params={"mode": mode, "name": "", **kwargs},
+        csrf=security.csrf_token_for(token or "") if with_token else None,
+    )
+
+
+def store_session(
+    store,
+    token: str,
+    expires_offset: int = security.SESSION_DURATION,
+    created_offset: int = 0,
+):
+    """Add a login session for token, valid for the credentials configured now"""
+    now = int(time.time())
+    store.add(
+        security.hash_session_token(token),
+        now + created_offset,
+        now + expires_offset,
+        security.credential_fingerprint(),
+    )
+
+
+def login_post(username: str = "", password: str = "", remote_ip: str = "127.0.0.1"):
+    """A POST of the login form"""
+    return mock_request(params={"username": username, "password": password}, method="POST", remote_ip=remote_ip)
+
+
+def locked_out(request) -> bool:
+    """Whether the cooldown is running for this client"""
+    return security.login_cooldown_remaining(request) > 0
+
+
+def page_post(
+    cookie: Optional[str] = None,
+    remote_ip: str = "127.0.0.1",
+    csrf: Optional[str] = None,
+    csrf_field: Optional[str] = None,
+):
+    """A page POST carrying an optional session cookie and CSRF token"""
+    params = {security.CSRF_FIELD: csrf_field} if csrf_field is not None else None
+    return mock_request(cookie, params=params, csrf=csrf, method="POST", remote_ip=remote_ip)
+
+
+def config_save_middleware() -> interface.SecurityMiddleware:
+    """SecurityMiddleware as secured_expose attaches it to a config *_save route"""
+    return interface.SecurityMiddleware(
+        Mock(), check_configlock=True, check_for_login=True, check_api_key=False, access_type=4
+    )
+
+
+class TestHostileTokenValues:
+    """Secrets arrive as text off the wire, and hmac.compare_digest refuses non-ASCII str"""
+
+    # Headers and cookies are latin-1, so they carry any byte up to U+00FF. A form body is
+    # UTF-8 and carries anything, including U+FFFD and a lone surrogate.
+    WIRE_HOSTILE = ["\xff\xfe", "\xe9" * 64, "caf\xe9"]
+    BODY_HOSTILE = [*WIRE_HOSTILE, "�", "\U0001f600", "\ud800"]
+
+    def test_compare_helper_rejects_instead_of_raising(self):
+        for value in self.BODY_HOSTILE:
+            assert security.constant_time_equals(value, "a" * 64) is False
+            assert security.constant_time_equals("a" * 64, value) is False
+        # ...and still matches what it should
+        assert security.constant_time_equals("a" * 64, "a" * 64) is True
+
+    @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
+    def test_hostile_session_cookie_is_rejected(self, session_store):
+        """Runs on a page GET with no credentials configured, so it needs no authentication at all"""
+        for value in self.WIRE_HOSTILE:
+            assert security.validate_anonymous_session(mock_request(value)) is False
+            assert security.validate_any_session(mock_request(value)) is False
+
+    @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
+    def test_hostile_csrf_token_in_header_is_rejected(self, session_store):
+        tag = security.anonymous_session_tag()
+        for value in self.WIRE_HOSTILE:
+            assert security.csrf_token_matches(mock_request(tag, csrf=value)) is False
+            assert config_save_middleware().denied_response(page_post(tag, csrf=value)) is not None
+
+    @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
+    def test_hostile_csrf_token_in_form_field_is_rejected(self, session_store):
+        tag = security.anonymous_session_tag()
+        for value in self.BODY_HOSTILE:
+            request = mock_request(tag, params={security.CSRF_FIELD: value})
+            assert security.csrf_token_matches(request) is False
+            assert config_save_middleware().denied_response(page_post(tag, csrf_field=value)) is not None
+
+    @staticmethod
+    def _upload_part():
+        """What a multipart part named apikey/csrf_token/password parses into"""
+        return UploadFile(file=io.BytesIO(b"not-a-token"), filename="part.txt")
+
+    def test_a_file_part_is_not_a_secret(self):
+        """A field name sent as a multipart file gives an UploadFile, which has no .encode()"""
+        assert security.constant_time_equals(self._upload_part(), "a" * 64) is False
+        # Compared against nothing rather than str()-ed, so no repr can stand in for a secret
+        assert security.constant_time_equals(self._upload_part(), str(self._upload_part())) is False
+
+    @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
+    def test_csrf_token_sent_as_a_file_part_is_refused(self, session_store):
+        tag = security.anonymous_session_tag()
+        request = mock_request(tag, params={security.CSRF_FIELD: self._upload_part()})
+        assert security.presented_csrf_token(request) == ""
+        assert security.csrf_token_matches(request) is False
+        denied = page_post(tag, csrf_field=self._upload_part())
+        assert config_save_middleware().denied_response(denied) is not None
+
+    @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
+    def test_apikey_sent_as_a_file_part_is_refused(self, session_store):
+        request = mock_request(params={"mode": "queue", "name": "", "apikey": self._upload_part()})
+        response = interface.check_apikey(request)
+        assert response is not None and response.status_code == 403
+
+    @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 0})
+    def test_hostile_credentials_are_rejected(self, session_store):
+        for value in self.BODY_HOSTILE:
+            assert security.constant_time_equals(value, "user") is False
+
+
+class TestSessionAuth:
+
+    @pytest.mark.config({"username": "user", "password": "pass"})
+    def test_valid_session_authorizes(self, session_store):
+        store_session(session_store, "good-token")
+        assert security.validate_session(mock_request("good-token")) is True
+
+    @pytest.mark.config({"username": "user", "password": "pass"})
+    def test_no_cookie_rejected(self, session_store):
+        assert security.validate_session(mock_request(None)) is False
+
+    @pytest.mark.config({"username": "user", "password": "pass"})
+    def test_expired_session_rejected_and_deleted(self, session_store):
+        store_session(session_store, "old-token", expires_offset=-10)
+        assert security.validate_session(mock_request("old-token")) is False
+        # The stale row is cleaned up on rejection
+        assert session_store.get(security.hash_session_token("old-token")) is None
+
+    @pytest.mark.config({"username": "user", "password": "pass"})
+    def test_credential_change_invalidates_session(self, session_store):
+        store_session(session_store, "tok")
+        assert security.validate_session(mock_request("tok")) is True
+        # Changing the password changes the fingerprint, invalidating existing sessions
+        cfg.password.set("newpass")
+        assert security.validate_session(mock_request("tok")) is False
+
+    @pytest.mark.config({"username": "user", "password": "pass"})
+    def test_sliding_expiry_extends(self, session_store):
+        # Store a session already past its refresh threshold so validation touches it
+        store_session(session_store, "tok", expires_offset=security.SESSION_REFRESH_THRESHOLD)
+        token_hash = security.hash_session_token("tok")
+        before = session_store.get(token_hash)["expires"]
+        assert security.validate_session(mock_request("tok")) is True
+        after = session_store.get(token_hash)["expires"]
+        assert after > before
+
+    @pytest.mark.config({"username": "user", "password": "pass"})
+    def test_recently_used_session_is_not_rewritten(self, session_store):
+        store_session(session_store, "tok")
+        token_hash = security.hash_session_token("tok")
+        before = session_store.get(token_hash)["expires"]
+        assert security.validate_session(mock_request("tok")) is True
+        assert session_store.get(token_hash)["expires"] == before
+
+
+class TestLoginRateLimiting:
+
+    @pytest.fixture(autouse=True)
+    def no_recorded_failures(self, monkeypatch):
+        """Empty tracker per test, and a web dir for login_index to build a template path from"""
+        monkeypatch.setattr(sabnzbd, "WEB_DIR_CONFIG", "/nonexistent", raising=False)
+        security._login_attempts.clear()
+        yield
+        security._login_attempts.clear()
+
+    def test_allowance_before_lockout(self):
+        request = login_post()
+        for _ in range(security.LOGIN_MAX_ATTEMPTS - 1):
+            security.record_login_failure(request)
+            assert locked_out(request) is False
+        # The one that uses up the allowance
+        security.record_login_failure(request)
+        assert locked_out(request) is True
+
+    def test_cooldown_expires(self):
+        request = login_post()
+        for _ in range(security.LOGIN_MAX_ATTEMPTS):
+            security.record_login_failure(request)
+        assert locked_out(request) is True
+
+        # Rewind the cooldown rather than sleeping through it
+        failures, cooldown_expiry = security._login_attempts["127.0.0.1"]
+        security._login_attempts["127.0.0.1"] = (failures, cooldown_expiry - security.LOGIN_LOCKOUT_TIME - 1)
+        assert locked_out(request) is False
+
+    def test_success_restores_the_allowance(self):
+        request = login_post()
+        for _ in range(security.LOGIN_MAX_ATTEMPTS):
+            security.record_login_failure(request)
+        assert locked_out(request) is True
+        security.clear_login_failures(request)
+        assert locked_out(request) is False
+        assert "127.0.0.1" not in security._login_attempts
+
+    def test_lockout_is_per_client(self):
+        attacker = login_post(remote_ip="10.11.12.13")
+        for _ in range(security.LOGIN_MAX_ATTEMPTS):
+            security.record_login_failure(attacker)
+        assert locked_out(attacker) is True
+        assert locked_out(login_post(remote_ip="127.0.0.1")) is False
+
+    def test_stale_entries_are_dropped(self):
+        old = login_post(remote_ip="10.11.12.13")
+        for _ in range(security.LOGIN_MAX_ATTEMPTS):
+            security.record_login_failure(old)
+        failures, cooldown_expiry = security._login_attempts["10.11.12.13"]
+        security._login_attempts["10.11.12.13"] = (failures, cooldown_expiry - security.LOGIN_LOCKOUT_TIME - 1)
+
+        security.record_login_failure(login_post(remote_ip="127.0.0.1"))
+        assert "10.11.12.13" not in security._login_attempts
+
+        # And that address is back to a clean slate, not still one away from a lockout
+        security.record_login_failure(old)
+        assert security._login_attempts["10.11.12.13"][0] == 1
+
+    @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 0})
+    def test_correct_credentials_are_refused_while_locked_out(self, session_store):
+        """Answers 429, and must not look at the credentials while the cooldown runs"""
+        request = login_post(username="user", password="pass")
+        for _ in range(security.LOGIN_MAX_ATTEMPTS):
+            security.record_login_failure(request)
+
+        with (
+            patch("sabnzbd.interface.build_header", return_value={}),
+            patch("sabnzbd.interface.template_filtered_response") as render,
+            patch("sabnzbd.security.create_session") as create_session,
+        ):
+            asyncio.run(interface.login_index(request))
+
+        # No session handed out, despite the credentials being exactly right
+        create_session.assert_not_called()
+        assert render.call_args.kwargs["status_code"] == 429
+        assert "Too many" in render.call_args.kwargs["search_list"]["error"]
+
+    @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 0})
+    def test_failed_login_is_counted_and_success_clears_it(self, session_store):
+        """Through the handler rather than the helpers, so the wiring is covered too"""
+        wrong = login_post(username="user", password="nope")
+        with (
+            patch("sabnzbd.interface.build_header", return_value={}),
+            patch("sabnzbd.interface.template_filtered_response") as render,
+        ):
+            asyncio.run(interface.login_index(wrong))
+        assert render.call_args.kwargs["status_code"] == 200
+        assert security._login_attempts["127.0.0.1"][0] == 1
+
+        right = login_post(username="user", password="pass")
+        asyncio.run(interface.login_index(right))
+        assert "127.0.0.1" not in security._login_attempts
+
+    def test_cooldown_remaining_counts_down_and_rounds_up(self):
+        request = login_post()
+        assert security.login_cooldown_remaining(request) == 0
+        for _ in range(security.LOGIN_MAX_ATTEMPTS):
+            security.record_login_failure(request)
+
+        remaining = security.login_cooldown_remaining(request)
+        # Rounded up, so it is never 0 while the client is still locked out
+        assert 0 < remaining <= security.LOGIN_LOCKOUT_TIME + 1
+
+        # Most of the cooldown served: still non-zero, and smaller than it was
+        failures, cooldown_expiry = security._login_attempts["127.0.0.1"]
+        security._login_attempts["127.0.0.1"] = (failures, cooldown_expiry - security.LOGIN_LOCKOUT_TIME + 2)
+        assert 0 < security.login_cooldown_remaining(request) < remaining
+
+    def test_cooldown_survives_a_wall_clock_jump(self, monkeypatch):
+        request = login_post()
+        for _ in range(security.LOGIN_MAX_ATTEMPTS):
+            security.record_login_failure(request)
+        assert locked_out(request) is True
+
+        # Jump the wall clock a year forward from where it really is; the cooldown is unmoved
+        real_time = time.time
+        monkeypatch.setattr(time, "time", lambda: real_time() + 3600 * 24 * 365)
+        assert locked_out(request) is True
+
+    def test_stale_entries_are_dropped_on_a_read(self):
+        old = login_post(remote_ip="10.11.12.13")
+        for _ in range(security.LOGIN_MAX_ATTEMPTS):
+            security.record_login_failure(old)
+        failures, cooldown_expiry = security._login_attempts["10.11.12.13"]
+        security._login_attempts["10.11.12.13"] = (failures, cooldown_expiry - security.LOGIN_LOCKOUT_TIME - 1)
+
+        # A read on behalf of some other client is enough
+        assert locked_out(login_post(remote_ip="127.0.0.1")) is False
+        assert "10.11.12.13" not in security._login_attempts
+
+    @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 0})
+    def test_lockout_response_says_how_long_to_wait(self, session_store):
+        request = login_post(username="user", password="pass")
+        for _ in range(security.LOGIN_MAX_ATTEMPTS):
+            security.record_login_failure(request)
+
+        # A real response, so the assertions below read the header the client would actually get
+        with (
+            patch("sabnzbd.interface.build_header", return_value={}),
+            patch(
+                "sabnzbd.interface.template_filtered_response",
+                side_effect=lambda **kwargs: HTMLResponse("", status_code=kwargs["status_code"]),
+            ),
+        ):
+            response = asyncio.run(interface.login_index(request))
+
+        assert response.status_code == 429
+        assert 0 < int(response.headers["Retry-After"]) <= security.LOGIN_LOCKOUT_TIME + 1
+
+
+class TestSessionAbsoluteDeadline:
+    """SESSION_MAX_AGE, counted from the created stamp, caps a session however active it is"""
+
+    @pytest.mark.config({"username": "user", "password": "pass"})
+    def test_session_past_its_deadline_is_rejected_and_deleted(self, session_store):
+        # Idle timeout still in the future, so only the absolute deadline can refuse this
+        store_session(
+            session_store,
+            "old-tok",
+            created_offset=-(security.SESSION_MAX_AGE + 60),
+            expires_offset=security.SESSION_DURATION,
+        )
+        assert security.validate_session(mock_request("old-tok")) is False
+        assert session_store.get(security.hash_session_token("old-tok")) is None
+
+    @pytest.mark.config({"username": "user", "password": "pass"})
+    def test_session_just_inside_its_deadline_still_works(self, session_store):
+        store_session(
+            session_store,
+            "tok",
+            created_offset=-(security.SESSION_MAX_AGE - 3600),
+            expires_offset=security.SESSION_REFRESH_THRESHOLD,
+        )
+        assert security.validate_session(mock_request("tok")) is True
+
+    @pytest.mark.config({"username": "user", "password": "pass"})
+    def test_slide_is_clamped_to_the_deadline(self, session_store):
+        # Deadline half a window away, and idle-expiry close enough that the slide fires
+        created_offset = -(security.SESSION_MAX_AGE - security.SESSION_DURATION // 2)
+        store_session(session_store, "tok", created_offset=created_offset, expires_offset=3600)
+        token_hash = security.hash_session_token("tok")
+        deadline = session_store.get(token_hash)["created"] + security.SESSION_MAX_AGE
+
+        assert security.validate_session(mock_request("tok")) is True
+        expires = session_store.get(token_hash)["expires"]
+        assert expires == deadline
+        # ...and it really was clamped, not just left alone
+        assert expires < int(time.time()) + security.SESSION_DURATION
+
+    @pytest.mark.config({"username": "user", "password": "pass"})
+    def test_pinned_session_stops_being_rewritten(self, session_store):
+        # created so that the deadline is an hour away, with expires already pinned to it
+        store_session(
+            session_store,
+            "tok",
+            created_offset=-(security.SESSION_MAX_AGE - 3600),
+            expires_offset=3600,
+        )
+        token_hash = security.hash_session_token("tok")
+        session = session_store.get(token_hash)
+        assert session["expires"] == session["created"] + security.SESSION_MAX_AGE
+
+        with patch.object(sabnzbd.SessionStore, "touch") as touch:
+            assert security.validate_session(mock_request("tok")) is True
+        touch.assert_not_called()
+        assert session_store.get(token_hash)["expires"] == session["expires"]
+
+    @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 0})
+    def test_check_apikey_accepts_session_without_key(self, session_store):
+        store_session(session_store, "browser-token")
+        # A local browser call with a valid session and its CSRF token, but no apikey
+        assert interface.check_apikey(api_request("browser-token")) is None
+
+
+class TestAnonymousSession:
+    """Anonymous sessions are stateless (HMAC cookie), never database rows"""
+
+    @pytest.mark.config({"username": "", "password": ""})
+    def test_valid_tag_accepted(self):
+        assert security.validate_anonymous_session(mock_request(security.anonymous_session_tag())) is True
+
+    @pytest.mark.config({"username": "", "password": ""})
+    def test_missing_or_wrong_tag_rejected(self):
+        assert security.validate_anonymous_session(mock_request(None)) is False
+        assert security.validate_anonymous_session(mock_request("forged-tag")) is False
+
+    @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 0})
+    def test_rejected_when_credentials_configured(self):
+        # A tag minted while auth was off grants nothing once credentials are set
+        assert security.validate_anonymous_session(mock_request(security.anonymous_session_tag())) is False
+
+    @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 5})
+    def test_accepted_when_login_waived_for_local_client(self):
+        # inet_exposure 5 waives the login for local clients, so their page loads get an
+        # anonymous cookie
+        assert security.validate_anonymous_session(mock_request(security.anonymous_session_tag())) is True
+        # An external client still needs to log in, so no tag is good enough
+        external = mock_request(security.anonymous_session_tag(), remote_ip="9.8.7.6")
+        assert security.validate_anonymous_session(external) is False
+
+    @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
+    def test_check_apikey_accepts_anonymous_without_key(self):
+        assert interface.check_apikey(api_request(security.anonymous_session_tag())) is None
+
+    @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 5})
+    def test_check_apikey_accepts_anonymous_when_login_waived(self, session_store):
+        assert interface.check_apikey(api_request(security.anonymous_session_tag())) is None
+
+    @pytest.mark.config({"username": "", "password": ""})
+    def test_create_sets_matching_cookie(self):
+        request = Mock()
+        response = Mock()
+        security.create_anonymous_session(request, response)
+        assert response.set_cookie.call_args.args[1] == security.anonymous_session_tag()
+        assert response.set_cookie.call_args.args[0] == security.SESSION_COOKIE_USER

--- a/tests/test_sessionstore.py
+++ b/tests/test_sessionstore.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python3 -OO
+# Copyright 2007-2026 by The SABnzbd-Team (sabnzbd.org)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+tests.test_sessionstore - Testing the web-UI session store
+"""
+
+import time
+
+import sabnzbd.sessionstore as sessionstore
+
+
+class TestSessionStore:
+    def test_roundtrip_and_delete(self, session_store):
+        now = int(time.time())
+        session_store.add("hash1", now, now + 2000, "fp")
+        assert session_store.get("hash1") == {"created": now, "expires": now + 2000, "cred_fingerprint": "fp"}
+
+        session_store.touch("hash1", now + 5000)
+        assert session_store.get("hash1")["expires"] == now + 5000
+
+        session_store.delete("hash1")
+        assert session_store.get("hash1") is None
+
+    def test_sessions_survive_a_restart(self, session_store):
+        now = int(time.time())
+        session_store.add("hash1", now, now + 2000, "fp")
+        assert sessionstore.SessionStore().get("hash1") is not None
+
+    def test_expired_sessions_are_dropped_on_load(self, session_store):
+        now = int(time.time())
+        session_store.add("fresh", now, now + 10000, "fp")
+        # Adding purges before it inserts, so this one is still there to be dropped on load
+        session_store.add("old", 0, now - 100, "fp")
+
+        reopened = sessionstore.SessionStore()
+        assert reopened.get("fresh") is not None
+        assert reopened.get("old") is None
+
+    def test_generation_bump_drops_the_contents(self, session_store, monkeypatch):
+        now = int(time.time())
+        session_store.add("hash1", now, now + 10000, "fp")
+        monkeypatch.setattr(sessionstore, "SESSIONS_VERSION", sessionstore.SESSIONS_VERSION + 1)
+        assert sessionstore.SessionStore().get("hash1") is None
+
+    def test_unreadable_file_starts_empty(self, session_store, tmp_path):
+        (tmp_path / sessionstore.SESSIONS_FILE_NAME).write_bytes(b"not a pickle" * 42)
+        assert sessionstore.SessionStore().get("hash1") is None

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -23,6 +23,7 @@ import copy
 import io
 import os
 import shutil
+import re
 import socket
 import tempfile
 import time
@@ -261,6 +262,28 @@ def get_url_result(url="", host=SAB_HOST, port=SAB_PORT):
     """Do basic request to web page"""
     arguments = {"apikey": SAB_APIKEY}
     return requests.get("http://%s:%s/%s/" % (host, port, url), params=arguments).text
+
+
+def get_page_session(host=SAB_HOST, port=SAB_PORT) -> tuple[requests.Session, str]:
+    """Load a page as a browser would, returning the session holding its cookie and the CSRF token it rendered"""
+    session = requests.Session()
+    page = session.get("http://%s:%s/config/general" % (host, port))
+    page.raise_for_status()
+
+    # Every skin renders it into a var for its ajax calls; the quoting differs between them
+    token = re.search(r"""var csrfToken = ['"]([a-f0-9]+)['"]""", page.text)
+    assert token, "no CSRF token in the page, so a page POST cannot be built"
+    return session, token.group(1)
+
+
+def post_url_result(url="", data=None, host=SAB_HOST, port=SAB_PORT) -> str:
+    """POST to a page route the way the interface does, with a session cookie and its token"""
+    session, csrf_token = get_page_session(host, port)
+    payload = {"csrf_token": csrf_token}
+    payload.update(data or {})
+    response = session.post("http://%s:%s/%s" % (host, port, url), data=payload)
+    response.raise_for_status()
+    return response.text
 
 
 def get_api_result(mode, host=SAB_HOST, port=SAB_PORT, extra_arguments={}):
@@ -502,31 +525,16 @@ class SABnzbdBaseTest:
             pass
 
     def wait_for_alert(self, timeout=15):
-        """Wait for a JS confirm()/alert dialog and return it.
-
-        Selenium's click() can return before a dialog opened synchronously in the
-        click handler is registered, and a confirm() raised from an AJAX success
-        callback only appears once the request settles. Waiting explicitly avoids
-        both races. Use this only where a dialog is guaranteed."""
+        """Wait for a JS confirm()/alert dialog and return it. Use only where a dialog is guaranteed."""
         WebDriverWait(self.driver, timeout).until(EC.alert_is_present())
         return self.driver.switch_to.alert
 
     def dismiss_restart_prompt(self, timeout=15):
-        """Dismiss the "restart required" confirmation raised after saving.
-
-        Changing username/password (and other guarded options) sets RESTART_REQ,
-        so the save callback always pops a confirm() dialog. Cancel it (= no
-        restart). The alert is guaranteed here, so wait for it deterministically."""
+        """Dismiss the "restart required" confirmation raised after saving"""
         self.wait_for_alert(timeout).dismiss()
 
     def dismiss_alert_if_present(self, timeout=15):
-        """Wait until a submitted save settles, dismissing a restart-request
-        confirm() only if one is raised.
-
-        Use where the dialog is conditional (a save that may or may not change a
-        guarded option), so its absence must not fail the test. The alert, if any,
-        is popped in the same JS turn that completes the request, so poll for either
-        terminal state and return as soon as one is reached."""
+        """Wait until a submitted save settles, dismissing a restart-request confirm() only if one is raised"""
         deadline = time.time() + timeout
         while time.time() < deadline:
             if EC.alert_is_present()(self.driver):


### PR DESCRIPTION
Replaces the web interface's authentication with persistent sessions, takes the apikey out of the UI, and adds CSRF protection.

| Before | After |
|---|---|
| Sessions died on restart, bound to an address | Survive restarts, capped at 90 days, revoked on credential change |
| apikey in every page's HTML | Never in a page; refused on page routes |
| CSRF rested on `SameSite` alone; `/api` unprotected | Per-session token on every state change |
| Unlimited password guessing | 5 attempts per address, then a 5-minute cooldown |

## Sessions

- A dict saved to `admin/sessions.sab` with `save_admin`/`load_admin`, like the queue — no database, no new dependency. Persisted so a restart does not log everyone out
- Cookie holds a 256-bit random token, of which only the SHA-256 hash is stored. 14-day idle timeout, sliding on use, with a 90-day cap from creation
- Each session stores a fingerprint of the credentials, so changing the username or password revokes every existing session
- `HttpOnly`, `SameSite=Strict` and `Secure` decided per request, so it works behind a TLS-terminating proxy

## CSRF protection

- Per-session token, `hmac(key, cookie)` — nothing stored, no lookup, and it dies with the session
- Required on every state-changing page POST, and as a header on cookie-authorised `/api` calls so it cannot ride in a URL
- Not gated on whether a login is configured: `SameSite` is not origin-scoped, so another port on the same host is same-site and its forms do carry the cookie
- `/shutdown`, `/logout`, the wizard steps and the log download became POSTs

## The apikey

- No page embeds it; `check_api_key` is gone from ~35 config routes, and an apikey on a page route is refused with a message pointing at `/api`
- New `/log` route serves the log as a guarded POST, so `mode=showlog` needs no CSRF exemption and stays available for automation

## Breaking changes

- **An apikey no longer opens the config `*_save` routes.** Use the matching `mode=set_config` call; the 403 names the replacement.
- A new `sessions.sab` in `admin_dir`, excluded from config backups.

## Future work

- Stop showing the apikey at all — the end state is a stored hash, shown once when generated
- Hash the ini password: `credential_fingerprint` becomes `sha256(username + ":" + hash)`, provided the stored hash is stable
- Persist the CSRF and anonymous keys, so a page left open across a restart still holds a valid token

---

Fixes #3063
