### PR TITLE
Tighten IPv6 and Host header handling

### DIFF
--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -254,7 +254,10 @@ COOKIE_SESSION = "sabnzbd_session"
 
 def use_secure_cookies(request: Request) -> bool:
     """Whether cookies for this request should carry the Secure attribute"""
-    return request.url.scheme == "https" or bool(cfg.enable_https())
+    # Taken from the scope, which is what the proxy headers are applied to and what
+    # request.url is built from. The URL itself comes out relative, and its scheme
+    # empty, when there is neither a Host header nor an address to fall back on.
+    return request.scope.get("scheme") == "https" or bool(cfg.enable_https())
 
 
 def set_login_cookie(request: Request, response: Response, remove=False, remember_me=False):

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -172,6 +172,16 @@ def client_address(request: Request) -> Address:
     return request.client or Address("", 0)
 
 
+def client_address_info(request: Request) -> str:
+    """The client as host:port for logging, with the forwarding chain when there is one"""
+    client = client_address(request)
+    # Bracketed, so the port cannot be read as another group of an IPv6 address
+    host = f"[{client.host}]" if ":" in client.host else client.host
+    if cfg.verify_xff_header() and (xff_ips := request.headers.get("X-Forwarded-For")):
+        return f"{host}:{client.port} (X-Forwarded-For: {xff_ips})"
+    return f"{host}:{client.port}"
+
+
 def check_access(request: Request, access_type: int = 4, warn_user: bool = False) -> bool:
     """Check if external address is allowed given access_type (Starlette version):
     1=nzb
@@ -388,10 +398,7 @@ def template_filtered_response(file: str, search_list: dict[str, Any]):
 def log_warning_and_ip(request: Request, txt: str):
     """Include the IP and the Proxy-IP for warnings (Starlette version)"""
     if cfg.api_warnings():
-        remote_info = "%s:%s" % client_address(request)
-        if cfg.verify_xff_header() and (xff_ips := request.headers.get("X-Forwarded-For")):
-            remote_info += f" (X-Forwarded-For: {xff_ips})"
-        logging.warning("%s %s", txt, remote_info)
+        logging.warning("%s %s", txt, client_address_info(request))
 
 
 # CherryPy collapsed these API routing/scalar keys to their first value when a key
@@ -792,18 +799,12 @@ async def login_index(request: Request):
             # Save login cookie
             set_login_cookie(request, response, remember_me=remember_me)
             # Log the success
-            remote_info = "%s:%s" % client_address(request)
-            if cfg.verify_xff_header() and (xff_ips := request.headers.get("X-Forwarded-For")):
-                remote_info += f" (X-Forwarded-For: {xff_ips})"
-            logging.info("Successful login from %s", remote_info)
+            logging.info("Successful login from %s", client_address_info(request))
             return response
         elif username or password:
             error = T("Authentication failed, check username/password.")
             # Warn about the potential security problem
-            remote_info = "%s:%s" % client_address(request)
-            if cfg.verify_xff_header() and (xff_ips := request.headers.get("X-Forwarded-For")):
-                remote_info += f" (X-Forwarded-For: {xff_ips})"
-            logging.warning(T("Unsuccessful login attempt from %s"), remote_info)
+            logging.warning(T("Unsuccessful login attempt from %s"), client_address_info(request))
 
     # Show login. Building the header and rendering the Cheetah template are
     # blocking work, so keep them off the event loop.
@@ -2418,19 +2419,12 @@ class RequestLoggingMiddleware:
             # request did not pass through secured_expose, so there is nothing to log.
             if cfg.api_logging() and (params := scope.get("state", {}).get("params")) is not None:
                 request = Request(scope)
-                if xff_ips := request.headers.get("X-Forwarded-For"):
-                    remote_label = "%s (X-Forwarded-For: %s) [%s]" % (
-                        client_address(request).host,
-                        xff_ips,
-                        request.headers.get("User-Agent"),
-                    )
-                else:
-                    remote_label = "%s [%s]" % (client_address(request).host, request.headers.get("User-Agent"))
                 logging.debug(
-                    "Request %s %s from %s %s",
+                    "Request %s %s from %s [%s] %s",
                     request.method,
                     request.url.path,
-                    remote_label,
+                    client_address_info(request),
+                    request.headers.get("User-Agent"),
                     dict(params),
                 )
 

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -117,6 +117,8 @@ _MSG_MISSING_AUTH = "Missing authentication"
 _MSG_APIKEY_REQUIRED = "API Key Required"
 _MSG_APIKEY_INCORRECT = "API Key Incorrect"
 
+RE_HOST_PORT = re.compile(":[0-9]+$")
+
 INTERFACE_ROUTES: list[Route | Mount] = []
 
 
@@ -212,10 +214,13 @@ def check_hostname(request: Request) -> bool:
 
     # Remove the port-part (like ':8080'), if it is there, always on the right hand side.
     # Not to be confused with IPv6 colons (within square brackets)
-    host = re.sub(":[0123456789]+$", "", host).lower()
+    host = RE_HOST_PORT.sub("", host).lower()
 
-    # Fine if localhost or IP
-    if host == "localhost" or is_ipv4_addr(host) or is_ipv6_addr(host):
+    # Fine if localhost or IP. RFC 7230 requires an IPv6 literal in a Host header to be
+    # bracketed, so brackets are required here too: without them there is no telling
+    # where the address ends and the port begins, and a bare "1234:5678::1:8080" would
+    # otherwise pass as an address after the port-stripping above took a guess at it.
+    if host == "localhost" or is_ipv4_addr(host) or (host.startswith("[") and is_ipv6_addr(host)):
         return True
 
     # Check on the whitelist

--- a/tests/test_api_and_interface.py
+++ b/tests/test_api_and_interface.py
@@ -485,6 +485,22 @@ class TestSecuredExpose:
         bad_request = create_mock_request(hostname="not_me")
         assert interface.check_hostname(bad_request) is True
 
+    def test_check_hostname_bare_ipv6_is_refused(self):
+        """An IPv6 literal must be bracketed in a Host header (RFC 7230). A bare one is
+        ambiguous, as there is no telling where the address ends and the port begins,
+        so it must not be accepted as if the trailing group were a port number."""
+        for bad_hostname in (
+            "1234:5678::1:8080",
+            "bla:bla:1234",
+            "::ffff:127.0.0.1:8080",
+            "2001:db8:3333:4444:5555:6666:7777:8888",
+        ):
+            assert interface.check_hostname(create_mock_request(hostname=bad_hostname)) is False
+
+        # The bracketed forms of the same addresses stay allowed
+        for good_hostname in ("[1234:5678::1]:8080", "[::ffff:127.0.0.1]:8080", "[1234:5678::1]"):
+            assert interface.check_hostname(create_mock_request(hostname=good_hostname)) is True
+
     @pytest.mark.config({"host_whitelist": "test.com, not_evil"})
     def test_check_hostname_whitelist(self):
         """Test hostname whitelist functionality"""

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -425,3 +425,37 @@ class TestUvicornLogging:
         uvicorn_source = "".join(inspect.getsource(module) for module in (h11_impl, httptools_impl, lifespan_on))
         for message in interface.UvicornNoiseFilter.CLIENT_ERRORS + interface.UvicornNoiseFilter.REPORTED_FAILURES:
             assert message in uvicorn_source
+
+
+class TestClientAddressInfo:
+    """The client address goes into log lines as host:port, so an IPv6 address has to
+    be bracketed: ::ffff:127.0.0.1:55170 gives no clue where the address stops."""
+
+    @pytest.mark.config({"verify_xff_header": False})
+    @pytest.mark.parametrize(
+        "remote_ip, expected",
+        [
+            ("127.0.0.1", "127.0.0.1:55170"),
+            ("10.11.12.13", "10.11.12.13:55170"),
+            ("::1", "[::1]:55170"),
+            # Dual-stack listener reporting an IPv4 client
+            ("::ffff:127.0.0.1", "[::ffff:127.0.0.1]:55170"),
+            ("2001:470:1:332::152", "[2001:470:1:332::152]:55170"),
+            # Unknown client, request.client was None
+            ("", ":55170"),
+        ],
+    )
+    def test_brackets_ipv6(self, remote_ip, expected):
+        request = create_mock_request(remote_ip=remote_ip, remote_port=55170)
+        assert interface.client_address_info(request) == expected
+
+    @pytest.mark.config({"verify_xff_header": True})
+    def test_includes_forwarded_chain(self):
+        request = create_mock_request(remote_ip="::1", remote_port=55170, headers={"X-Forwarded-For": "8.7.6.5, ::1"})
+        assert interface.client_address_info(request) == "[::1]:55170 (X-Forwarded-For: 8.7.6.5, ::1)"
+
+    @pytest.mark.config({"verify_xff_header": False})
+    def test_omits_forwarded_chain_when_not_verified(self):
+        """Without verify_xff_header the header is not trusted, so it is not reported"""
+        request = create_mock_request(remote_ip="::1", remote_port=55170, headers={"X-Forwarded-For": "8.7.6.5"})
+        assert interface.client_address_info(request) == "[::1]:55170"

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -459,3 +459,79 @@ class TestClientAddressInfo:
         """Without verify_xff_header the header is not trusted, so it is not reported"""
         request = create_mock_request(remote_ip="::1", remote_port=55170, headers={"X-Forwarded-For": "8.7.6.5"})
         assert interface.client_address_info(request) == "[::1]:55170"
+
+
+class TestUseSecureCookies:
+    """The Secure attribute must follow the connection the request actually arrived on,
+    including TLS terminated by a trusted reverse proxy in front of SABnzbd."""
+
+    @staticmethod
+    def make_request(scheme: str, host: str | None = "sab.example.com", server=("127.0.0.1", 8080)) -> Request:
+        headers = [(b"host", host.encode())] if host is not None else []
+        return Request(
+            {
+                "type": "http",
+                "method": "GET",
+                "path": "/",
+                "query_string": b"",
+                "scheme": scheme,
+                "headers": headers,
+                "client": ("127.0.0.1", 12345),
+                "server": server,
+            }
+        )
+
+    @pytest.mark.config({"enable_https": False})
+    @pytest.mark.parametrize(
+        "scheme, host, server, expected",
+        [
+            ("http", "sab.example.com", ("127.0.0.1", 8080), False),
+            ("https", "sab.example.com", ("127.0.0.1", 8080), True),
+            # No Host header: the scheme must still decide the flag
+            ("https", None, ("127.0.0.1", 8080), True),
+            # An IPv6 listen address leaves the URL unparseable, the scheme is unaffected
+            ("https", None, ("::ffff:127.0.0.1", 8080), True),
+            ("https", "1234:5678::1:8080", ("::1", 8080), True),
+            # Neither a Host header nor an address: the URL is relative and has no
+            # scheme at all, which must not silently drop the Secure attribute
+            ("https", None, None, True),
+            ("http", None, None, False),
+        ],
+    )
+    def test_follows_request_scheme(self, scheme, host, server, expected):
+        assert interface.use_secure_cookies(self.make_request(scheme, host, server)) is expected
+
+    @pytest.mark.config({"enable_https": True})
+    def test_https_enabled_always_secure(self):
+        """Serving https ourselves is enough, whatever the request looks like"""
+        assert interface.use_secure_cookies(self.make_request("http")) is True
+
+    @pytest.mark.config({"enable_https": False})
+    def test_scheme_from_trusted_proxy(self):
+        """X-Forwarded-Proto from a trusted proxy is resolved into the scope by
+        uvicorn, so a proxy terminating TLS still gets the Secure attribute."""
+
+        captured = {}
+
+        async def asgi_app(scope, receive, send):
+            captured["secure"] = interface.use_secure_cookies(Request(scope))
+
+        def run(remote_ip: str):
+            middleware = ProxyHeadersMiddleware(asgi_app, trusted_hosts=xff_trusted_networks())
+            scope = {
+                "type": "http",
+                "method": "GET",
+                "path": "/",
+                "query_string": b"",
+                "scheme": "http",
+                "client": (remote_ip, 12345),
+                "server": ("127.0.0.1", 8080),
+                "headers": [(b"host", b"sab.example.com"), (b"x-forwarded-proto", b"https")],
+            }
+            asyncio.run(middleware(scope, None, None))
+            return captured["secure"]
+
+        # Trusted proxy: the forwarded scheme is honoured
+        assert run("127.0.0.1") is True
+        # Untrusted peer: the header must be ignored, so no Secure on a plain connection
+        assert run("8.7.6.5") is False


### PR DESCRIPTION
Follow-up to #3561. The 500 is already gone on develop (https://github.com/sabnzbd/sabnzbd/pull/3572 removed `url_origin`), verified on `::1` with the reported headers. These are the IPv6 and Host header problems found alongside it.

- **Refuse unbracketed IPv6 addresses in the Host header** - RFC 7230 wants brackets; without them `check_hostname` had to guess where the address ended, cutting the trailing group off `1234:5678::1:8080`.
- **Bracket the IPv6 client address logged with warnings** - was `::ffff:127.0.0.1:55170`; the repeated formatting moved into one helper.
- **Decide the Secure cookie attribute from the request scope** - with no `Host` header and no address to fall back on, `request.url` is relative and its scheme empty, so `Secure` was left off the cookies on an encrypted connection:

  ```python
  str(request.url)         # '/'
  request.url.scheme       # ''       reads as "not https"
  request.scope["scheme"]  # 'https'  the connection really is TLS
  ```
