### PR TITLE
Announce server test results to screen readers

### DIFF
--- a/interfaces/Config/templates/config_server.tmpl
+++ b/interfaces/Config/templates/config_server.tmpl
@@ -138,8 +138,8 @@
                     </div>
                     <div class="field-pair no-field-pair-bg">
                         <button class="btn btn-default addNewServer" disabled data-toggle="tooltip" data-placement="top" title="$T('wizard-test-server-required')"><span class="glyphicon glyphicon-plus"></span> $T('button-addServer')</button>
-                        <button class="btn btn-default testServer" type="button"><span class="glyphicon glyphicon-sort"></span> $T('button-testServer')</button>
-                        <div class="result-box">
+                        <button class="btn btn-default testServer" type="button" aria-busy="false"><span class="glyphicon glyphicon-sort" aria-hidden="true"></span> $T('button-testServer')</button>
+                        <div class="result-box" role="status" aria-live="polite" aria-atomic="true">
                             <div class="alert"></div>
                         </div>
                     </div>
@@ -275,10 +275,10 @@
                         </div>
                         <div class="field-pair no-field-pair-bg">
                             <button class="btn btn-default saveButton"><span class="glyphicon glyphicon-ok"></span> $T('button-saveChanges')</button>
-                            <button class="btn btn-default testServer" type="button"><span class="glyphicon glyphicon-sort"></span> $T('button-testServer')</button>
+                            <button class="btn btn-default testServer" type="button" aria-busy="false"><span class="glyphicon glyphicon-sort" aria-hidden="true"></span> $T('button-testServer')</button>
                             <button class="btn btn-default delServer"><span class="glyphicon glyphicon-trash"></span> $T('button-delServer')</button>
 
-                            <div class="result-box">
+                            <div class="result-box" role="status" aria-live="polite" aria-atomic="true">
                                 <div class="alert"></div>
                             </div>
                         </div>
@@ -547,7 +547,9 @@
             var theButton = jQuery(this)
             var resultBox = theButton.parents('.col1').find('.result-box .alert');
             theButton.attr("disabled", "disabled")
+            theButton.attr("aria-busy", "true")
             theButton.find('span').toggleClass('glyphicon-sort glyphicon-refresh spin-glyphicon')
+            resultBox.removeClass('alert-success alert-danger').html("$T('srv-testing')").show()
             jQuery.ajax({
                 type: "POST",
                 url: "$url('api')",
@@ -560,12 +562,13 @@
                 resultBox.removeClass('alert-success alert-danger').show()
                 resultBox.html(msg)
                 theButton.removeAttr("disabled")
+                theButton.attr("aria-busy", "false")
                 theButton.find('span').toggleClass('glyphicon-sort glyphicon-refresh spin-glyphicon')
 
                 // Success or not?
                 if(data.value.result) {
                     resultBox.addClass('alert-success')
-                    resultBox.prepend('<span class="glyphicon glyphicon-ok-sign"></span> ')
+                    resultBox.prepend('<span class="glyphicon glyphicon-ok-sign" aria-hidden="true"></span> ')
 
                     // Allow adding the new server if we are in the new-server section
                     if(theButton.parents("form[data-form='add-server']").length) {
@@ -576,7 +579,7 @@
                     }
                 } else {
                     resultBox.addClass('alert-danger')
-                    resultBox.prepend('<span class="glyphicon glyphicon-exclamation-sign"></span> ')
+                    resultBox.prepend('<span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span> ')
 
                     // Disable the adding of new server, just to be sure
                     if(theButton.parents("form[data-form='add-server']").length) {

--- a/interfaces/wizard/one.html
+++ b/interfaces/wizard/one.html
@@ -89,10 +89,10 @@
                         </div>
                         <div class="row">
                             <div class="col-sm-4">
-                                <button id="serverTest" class="btn btn-default" data-toggle="tooltip" data-placement="left"><span class="glyphicon glyphicon-sort"></span> $T('wizard-button-testServer')</button>
+                                <button id="serverTest" class="btn btn-default" data-toggle="tooltip" data-placement="left" aria-busy="false"><span class="glyphicon glyphicon-sort" aria-hidden="true"></span> $T('wizard-button-testServer')</button>
                             </div>
                             <div class="col-sm-8">
-                                <div id="serverResponse" class="well well-sm">$T('wizard-server-text')</div>
+                                <div id="serverResponse" class="well well-sm" role="status" aria-live="polite" aria-atomic="true">$T('wizard-server-text')</div>
                             </div>
                         </div>
 

--- a/interfaces/wizard/static/javascript/checkserver.js
+++ b/interfaces/wizard/static/javascript/checkserver.js
@@ -41,20 +41,22 @@ $(document).ready(function() {
             return false;
         }
         
+        $('#serverTest').attr('aria-busy', 'true');
         $('#serverResponse').html(txtChecking);
         $.getJSON(
             "../api?mode=config&name=test_server&output=json",
             $("form").serialize(),
             function(result) {
                 if (result.value.result) {
-                    r = '<span class="success"><span class="glyphicon glyphicon-ok"></span> ' + result.value.message + '</span>';
+                    r = '<span class="success"><span class="glyphicon glyphicon-ok" aria-hidden="true"></span> ' + result.value.message + '</span>';
                     setTestResult(true);
                 } else {
-                    r = '<span class="failed"><span class="glyphicon glyphicon-minus-sign"></span> ' + result.value.message + '</span>';
+                    r = '<span class="failed"><span class="glyphicon glyphicon-minus-sign" aria-hidden="true"></span> ' + result.value.message + '</span>';
                     setTestResult(false);
                 }
                 r = r.replace('https://sabnzbd.org/certificate-errors', '<a href="https://sabnzbd.org/certificate-errors" class="failed" target="_blank">https://sabnzbd.org/certificate-errors</a>')
                 $('#serverResponse').html(r);
+                $('#serverTest').attr('aria-busy', 'false');
             }
         );
         return false;


### PR DESCRIPTION
Server test updates are currently only shown visually, so screen reader users do not hear when a test starts or whether it worked.

This adds live status updates to the server tests in Config and the setup wizard. It also marks the Test Server button as busy while testing and hides the decorative icons from screen readers.

This uses the existing translated text and does not change the layout or server test behavior.

Testing:
- Checked the JavaScript syntax.
- Ran Black and Ruff.
- Ran the server add, test, and remove workflow.
