### PR TITLE
Announce notification test results to screen readers

### DIFF
--- a/interfaces/Config/templates/config_notify.tmpl
+++ b/interfaces/Config/templates/config_notify.tmpl
@@ -93,8 +93,8 @@
                 </div>
                 <div class="field-pair no-field-pair-bg">
                     <button class="btn btn-default saveButton"><span class="glyphicon glyphicon-ok"></span> $T('button-saveChanges')</button>
-                    <button class="btn btn-default" type="button" id="test_email" rel="$T('askTestEmail')"><span class="glyphicon glyphicon-envelope"></span> $T('link-testEmail')</button>
-                    <div class="result-box">
+                    <button class="btn btn-default" type="button" id="test_email" rel="$T('askTestEmail')" aria-busy="false"><span class="glyphicon glyphicon-envelope" aria-hidden="true"></span> $T('link-testEmail')</button>
+                    <div class="result-box" role="status" aria-live="polite" aria-atomic="true">
                         <div class="alert"></div>
                     </div>
                 </div>
@@ -117,8 +117,8 @@
                 $show_notify_checkboxes('ncenter')
                 <div class="field-pair no-field-pair-bg">
                     <button class="btn btn-default saveButton"><span class="glyphicon glyphicon-ok"></span> $T('button-saveChanges')</button>
-                    <button class="btn btn-default" type="button" id="test_notif"><span class="glyphicon glyphicon-comment"></span> $T('testNotify')</button>
-                    <div class="result-box">
+                    <button class="btn btn-default" type="button" id="test_notif" aria-busy="false"><span class="glyphicon glyphicon-comment" aria-hidden="true"></span> $T('testNotify')</button>
+                    <div class="result-box" role="status" aria-live="polite" aria-atomic="true">
                         <div class="alert"></div>
                     </div>
                 </div>
@@ -143,8 +143,8 @@
                 $show_notify_checkboxes('acenter')
                 <div class="field-pair no-field-pair-bg">
                     <button class="btn btn-default saveButton"><span class="glyphicon glyphicon-ok"></span> $T('button-saveChanges')</button>
-                    <button class="btn btn-default" type="button" id="test_windows"><span class="glyphicon glyphicon-comment"></span> $T('testNotify')</button>
-                    <div class="result-box">
+                    <button class="btn btn-default" type="button" id="test_windows" aria-busy="false"><span class="glyphicon glyphicon-comment" aria-hidden="true"></span> $T('testNotify')</button>
+                    <div class="result-box" role="status" aria-live="polite" aria-atomic="true">
                         <div class="alert"></div>
                     </div>
                 </div>
@@ -169,8 +169,8 @@
                 $show_notify_checkboxes('ntfosd')
                 <div class="field-pair no-field-pair-bg">
                     <button class="btn btn-default saveButton"><span class="glyphicon glyphicon-ok"></span> $T('button-saveChanges')</button>
-                    <button class="btn btn-default" type="button" id="test_osd"><span class="glyphicon glyphicon-comment"></span> $T('testNotify')</button>
-                    <div class="result-box">
+                    <button class="btn btn-default" type="button" id="test_osd" aria-busy="false"><span class="glyphicon glyphicon-comment" aria-hidden="true"></span> $T('testNotify')</button>
+                    <div class="result-box" role="status" aria-live="polite" aria-atomic="true">
                         <div class="alert"></div>
                     </div>
                 </div>
@@ -216,8 +216,8 @@
 
                 <div class="field-pair no-field-pair-bg">
                     <button class="btn btn-default saveButton"><span class="glyphicon glyphicon-ok"></span> $T('button-saveChanges')</button>
-                    <button class="btn btn-default" type="button" id="test_apprise"><span class="glyphicon glyphicon-comment"></span> $T('testNotify')</button>
-                    <div class="result-box">
+                    <button class="btn btn-default" type="button" id="test_apprise" aria-busy="false"><span class="glyphicon glyphicon-comment" aria-hidden="true"></span> $T('testNotify')</button>
+                    <div class="result-box" role="status" aria-live="polite" aria-atomic="true">
                         <div class="alert"></div>
                     </div>
                 </div>
@@ -255,8 +255,8 @@
                 $show_notify_checkboxes('nscript')
                 <div class="field-pair no-field-pair-bg">
                     <button class="btn btn-default saveButton"><span class="glyphicon glyphicon-ok"></span> $T('button-saveChanges')</button>
-                    <button class="btn btn-default" type="button" id="test_nscript"><span class="glyphicon glyphicon-comment"></span> $T('testNotify')</button>
-                    <div class="result-box">
+                    <button class="btn btn-default" type="button" id="test_nscript" aria-busy="false"><span class="glyphicon glyphicon-comment" aria-hidden="true"></span> $T('testNotify')</button>
+                    <div class="result-box" role="status" aria-live="polite" aria-atomic="true">
                         <div class="alert"></div>
                     </div>
                 </div>
@@ -300,8 +300,8 @@
                 <!--#end for#-->
                 <div class="field-pair no-field-pair-bg">
                     <button class="btn btn-default saveButton"><span class="glyphicon glyphicon-ok"></span> $T('button-saveChanges')</button>
-                    <button class="btn btn-default" type="button" id="test_prowl"><span class="glyphicon glyphicon-comment"></span> $T('testNotify')</button>
-                    <div class="result-box">
+                    <button class="btn btn-default" type="button" id="test_prowl" aria-busy="false"><span class="glyphicon glyphicon-comment" aria-hidden="true"></span> $T('testNotify')</button>
+                    <div class="result-box" role="status" aria-live="polite" aria-atomic="true">
                         <div class="alert"></div>
                     </div>
                 </div>
@@ -366,8 +366,8 @@
                 <!--#end for#-->
                 <div class="field-pair no-field-pair-bg">
                     <button class="btn btn-default saveButton"><span class="glyphicon glyphicon-ok"></span> $T('button-saveChanges')</button>
-                    <button class="btn btn-default" type="button" id="test_pushover"><span class="glyphicon glyphicon-comment"></span> $T('testNotify')</button>
-                    <div class="result-box">
+                    <button class="btn btn-default" type="button" id="test_pushover" aria-busy="false"><span class="glyphicon glyphicon-comment" aria-hidden="true"></span> $T('testNotify')</button>
+                    <div class="result-box" role="status" aria-live="polite" aria-atomic="true">
                         <div class="alert"></div>
                     </div>
                 </div>
@@ -403,8 +403,8 @@
                 $show_notify_checkboxes('pushbullet')
                 <div class="field-pair no-field-pair-bg">
                     <button class="btn btn-default saveButton"><span class="glyphicon glyphicon-ok"></span> $T('button-saveChanges')</button>
-                    <button class="btn btn-default" type="button" id="test_pushbullet"><span class="glyphicon glyphicon-comment"></span> $T('testNotify')</button>
-                    <div class="result-box">
+                    <button class="btn btn-default" type="button" id="test_pushbullet" aria-busy="false"><span class="glyphicon glyphicon-comment" aria-hidden="true"></span> $T('testNotify')</button>
+                    <div class="result-box" role="status" aria-live="polite" aria-atomic="true">
                         <div class="alert"></div>
                     </div>
                 </div>
@@ -445,6 +445,7 @@ jQuery(document).ready(function(){
         }
         // Disable button and get the data
         jQuery(buttonObj).attr("disabled", "disabled")
+        jQuery(buttonObj).attr("aria-busy", "true")
         jQuery(buttonObj).find('span').toggleClass('glyphicon-comment glyphicon-refresh spin-glyphicon')
         var data = { mode: buttonObj.id, apikey: '$apikey', output: 'json' };
         jQuery(buttonObj).parents('.section').extractFormDataTo(data);
@@ -460,16 +461,17 @@ jQuery(document).ready(function(){
         }).then(function(data) {
             // Remove disabled and make the box
             jQuery(buttonObj).removeAttr("disabled")
+            jQuery(buttonObj).attr("aria-busy", "false")
             jQuery(buttonObj).find('span').toggleClass('glyphicon-comment glyphicon-refresh spin-glyphicon')
             resultBox.removeClass('alert-success alert-danger').show()
             if(data.status) {
                 resultBox.addClass('alert-success')
                 resultBox.text('$T('notifications-notesent')')
-                resultBox.prepend('<span class="glyphicon glyphicon-ok-sign"></span> ')
+                resultBox.prepend('<span class="glyphicon glyphicon-ok-sign" aria-hidden="true"></span> ')
             } else {
                 resultBox.addClass('alert-danger')
                 resultBox.text(data.error)
-                resultBox.prepend('<span class="glyphicon glyphicon-exclamation-sign"></span> ')
+                resultBox.prepend('<span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span> ')
             }
         })
     }


### PR DESCRIPTION
Notification test results are currently shown in an alert box, but screen readers are not notified when the result changes.

This makes the result boxes live status regions for all of the notification types. It also marks the selected test button as busy while the test runs and hides the decorative test, spinner, success, and error icons from screen readers.

All of the notification types continue to use the existing shared test function. This does not change the API, translations, or visual layout.

Testing:
- Confirmed all nine notification tests use the updated status regions and busy state.
- Ran Black and Ruff.
- Ran the Config page rendering and submission test.
