### PR TITLE
Fix rss "Clear Downloaded" did not appear to do anything

### DIFF
--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -686,12 +686,18 @@ class RSSRepository:
     def get_feed_jobs(
         self,
         feed: Optional[str] = None,
+        archive: Optional[bool] = None,
         search: Optional[str] = None,
         states: Optional[list[RSSState]] = None,
     ) -> Generator[ResolvedEntry, Any, None]:
         """Return records for specified jobs"""
         command_args = []
         where_clauses = []
+
+        if archive:
+            where_clauses.append("archived_at IS NOT NULL")
+        else:
+            where_clauses.append("archived_at IS NULL")
 
         if search is not None:
             where_clauses.append("title LIKE ?")

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -736,9 +736,15 @@ class TestRSS:
         assert job_after_clear.archived_at is not None
         assert job_after_clear.is_downloaded
 
-        # get_jobs should return all jobs for a feed
+        # get_jobs should return all non-archived jobs for a feed
         jobs_from_get_jobs = list(repo.get_feed_jobs(feed=feed))
-        assert {j.link for j in jobs_from_get_jobs} == set(links_by_feed[feed])
+        assert {j.link for j in jobs_from_get_jobs} == {
+            job_link for job_link in links_by_feed[feed] if job_link is not link
+        }
+
+        # get_jobs archive should return only archived jobs for a feed
+        jobs_from_get_jobs = list(repo.get_feed_jobs(feed=feed, archive=True))
+        assert {j.link for j in jobs_from_get_jobs} == {link}
 
         # is_duplicate should detect similar jobs in other feeds
         duplicate_candidate = ResolvedEntry(


### PR DESCRIPTION
The button worked, but archived items were still shown.
Logic copied from what `fetch_history` does.