### PR TITLE
Fix display of downloaded rss history

### DIFF
--- a/interfaces/Config/templates/config_rss.tmpl
+++ b/interfaces/Config/templates/config_rss.tmpl
@@ -479,26 +479,18 @@
                     <table class="catTable">
                         <thead>
                             <tr>
-                                <th class="no-sort">$T('link-download')</th>
+                                <th class="default-sort">$T('rss-added')</th>
                                 <th>$T('rss-filter')</th>
                                 <th>$T('size')</th>
                                 <th width="60%">$T('sort-title')</th>
                                 <th>$T('category')</th>
-                                <th class="default-sort">$T('nzo-age')</th>
+                                <th>$T('nzo-age')</th>
                                 <th>$T('source')</th>
                             </tr>
                         </thead>
-                        <!--#for $job in $matched#-->
+                        <!--#for $job in $downloaded#-->
                             <tr class="infoTableSeperator">
-                                <td>
-                                    <form action="$url('config/rss/download')" method="post">
-                                        <input type="hidden" value="$active_feed" name="feed" />
-                                        <input type="hidden" name="apikey" value="$apikey" />
-                                        <input type="hidden" name="url" value="$job['url']" />
-                                        <input type="hidden" name="nzbname" value="$job['nzbname']" />
-                                        <button type="submit" class="btn btn-default"><span class="glyphicon glyphicon-plus-sign"></span> $T('link-download')</button>
-                                    </form>
-                                </td>
+                                <td data-sort-value="$job['time_downloaded_ms']">$job['time_downloaded']</td>
                                 <td>$job['rule'] $job['skip']</td>
                                 <td data-sort-value="$job['size']">$job['size_units']</td>
                                 <td>$job['title']</td>


### PR DESCRIPTION
Bad merge from uvicorn changes, I expect I copied the "good" table when downloaded is supposed to be slightly different anyway.

Restored table as was in 5.0.4