### PR TITLE
Fix race in TestAddingNZBsClean and share the NZB-adding helpers

### DIFF
--- a/tests/test_functional_adding_nzbs.py
+++ b/tests/test_functional_adding_nzbs.py
@@ -20,16 +20,19 @@ tests.test_functional_adding_nzbs - Tests for settings interaction when adding N
 """
 
 import os
-import shutil
 import stat
 import sys
-import time
 from functools import cached_property
 from random import choice, randint, sample
 
 import pytest
 
-from tests.testhelper import SAB_CACHE_DIR, create_nzb, get_api_result, random_name
+from tests.testhelper import (
+    MIN_FILESIZE,
+    SAB_CACHE_DIR,
+    AddingNZBsTestBase,
+    get_api_result,
+)
 
 from sabnzbd.constants import (
     PAUSED_PRIORITY,
@@ -111,10 +114,6 @@ ALL_PRIOS = {
     REPAIR_PRIORITY: "Repair",
 }
 
-# Min/max size for random files used in generated NZBs (bytes)
-MIN_FILESIZE = 128
-MAX_FILESIZE = 1024
-
 # Tags to randomise category/script/nzb name
 CAT_RANDOM = os.urandom(4).hex()
 SCRIPT_RANDOM = os.urandom(4).hex()
@@ -146,22 +145,10 @@ def pause_and_clear():
 
 
 @pytest.mark.usefixtures("run_sabnzbd", "pause_and_clear")
-class TestAddingNZBs:
+class TestAddingNZBs(AddingNZBsTestBase):
     @cached_property
     def config(self):
         return ModuleVars()
-
-    def _api_set_config(self, keyword, value):
-        """Shorthand for the API-call to change the config settings"""
-        json = get_api_result(
-            mode="set_config",
-            extra_arguments={
-                "section": "misc",
-                "keyword": keyword,
-                "value": value,
-            },
-        )
-        assert value == json["config"]["misc"][keyword]
 
     def _setup_script_dir(self):
         self.config.SCRIPT_DIR = os.path.join(SAB_CACHE_DIR, "scripts" + SCRIPT_RANDOM)
@@ -227,19 +214,6 @@ class TestAddingNZBs:
             },
         )
         assert ("*", priority) == (json["config"]["categories"][0]["name"], json["config"]["categories"][0]["priority"])
-
-    def _create_random_nzb(self, metadata=None):
-        # Create some simple, unique nzb
-        job_dir = os.path.join(SAB_CACHE_DIR, "NZB" + os.urandom(8).hex())
-        try:
-            os.mkdir(job_dir)
-            job_file = "%s.bin" % random_name()
-            with open(os.path.join(job_dir, job_file), "wb") as f:
-                f.write(os.urandom(randint(MIN_FILESIZE, MAX_FILESIZE)))
-        except Exception:
-            pytest.fail("Failed to create random nzb")
-
-        return create_nzb(job_dir, metadata=metadata)
 
     def _create_meta_nzb(self, cat_meta):
         return self._create_random_nzb(metadata={"category": cat_meta})
@@ -572,26 +546,6 @@ class TestAddingNZBs:
 
         # Unset size limit
         self._api_set_config("size_limit", "")
-
-    def _add_backup_directory(self):
-        # Set an nzb backup directory
-        backup_dir = os.path.join(SAB_CACHE_DIR, "nzb_backup_dir" + os.urandom(4).hex())
-        self._api_set_config("nzb_backup_dir", backup_dir)
-        return backup_dir
-
-    def _clear_and_reset_backup_directory(self, backup_dir):
-        # Reset duplicate handling (0), nzb_backup_dir ("")
-        get_api_result(mode="set_config_default", extra_arguments={"keyword": ["no_dupes", "nzb_backup_dir"]})
-
-        # Remove backup_dir
-        for timer in range(0, 5):
-            try:
-                shutil.rmtree(backup_dir)
-                break
-            except OSError:
-                time.sleep(1)
-        else:
-            pytest.fail("Failed to erase nzb_backup_dir %s" % backup_dir)
 
     @pytest.mark.parametrize("prio_def_cat", sample(VALID_DEFAULT_PRIORITIES, 2))
     @pytest.mark.parametrize("prio_add", PRIO_OPTS_ADD)

--- a/tests/test_functional_adding_nzbs_clean.py
+++ b/tests/test_functional_adding_nzbs_clean.py
@@ -20,24 +20,23 @@ tests.test_functional_adding_nzbs_clean - Tests for settings interaction when ad
 """
 
 import os
-import time
 from zipfile import ZipFile
 
 import pytest
 
-import tests.test_functional_adding_nzbs as test_functional_adding_nzbs
 from sabnzbd.constants import STOP_PRIORITY
-from tests.testhelper import get_api_result
+from tests.testhelper import AddingNZBsTestBase, get_api_result, wait_for
+
+
+def get_slot(mode: str, nzo_id: str):
+    """Return the queue or history slot of the job, if it has one"""
+    if slots := get_api_result(mode=mode, extra_arguments={"nzo_ids": nzo_id})[mode]["slots"]:
+        return slots[0]
+    return None
 
 
 @pytest.mark.usefixtures("run_sabnzbd")
-class TestAddingNZBsClean:
-    # Copy from the base class
-    _api_set_config = test_functional_adding_nzbs.TestAddingNZBs._api_set_config
-    _create_random_nzb = test_functional_adding_nzbs.TestAddingNZBs._create_random_nzb
-    _add_backup_directory = test_functional_adding_nzbs.TestAddingNZBs._add_backup_directory
-    _clear_and_reset_backup_directory = test_functional_adding_nzbs.TestAddingNZBs._clear_and_reset_backup_directory
-
+class TestAddingNZBsClean(AddingNZBsTestBase):
     def test_adding_nzbs_nzoids(self):
         """Test if we return the right output"""
         # Create NZB and zipped version
@@ -75,21 +74,20 @@ class TestAddingNZBsClean:
             )
 
             # Wait for the job to be removed and appear in the history
-            for _ in range(100):
-                try:
-                    history = get_api_result(mode="history", extra_arguments={"nzo_ids": job1["nzo_ids"][0]})["history"]
-                    assert history["slots"][0]["nzo_id"] == job1["nzo_ids"][0]
-                    assert history["slots"][0]["status"] == "Failed"
-                    break
-                except (IndexError, AssertionError):
-                    time.sleep(0.1)
-            else:
-                pytest.fail("Job did not appear in history")
+            wait_for(
+                lambda: (slot := get_slot("history", job1["nzo_ids"][0])) and slot["status"] == "Failed",
+                timeout=10,
+                err_msg="Job did not appear in history",
+            )
+
+            def alternative_released():
+                """Jobs show up in the history as soon as they enter post-processing, but their
+                alternatives are only released at the end of it, so we have to wait for that"""
+                if (slot := get_slot("queue", job2["nzo_ids"][0])) and "ALTERNATIVE" not in slot["labels"]:
+                    return slot
 
             # Now the second job should no longer be paused and labelled
-            queue = get_api_result(mode="queue", extra_arguments={"nzo_ids": job2["nzo_ids"][0]})
-            job_in_queue = queue["queue"]["slots"][0]
-            assert "ALTERNATIVE" not in job_in_queue["labels"]
+            job_in_queue = wait_for(alternative_released, timeout=10, err_msg="Duplicate alternative was not released")
             assert job_in_queue["status"] == "Queued"
 
             # Reset duplicate detection
@@ -103,18 +101,13 @@ class TestAddingNZBsClean:
             assert job["nzo_ids"]
 
             # Wait for the job to be removed and appear in the history
-            for _ in range(100):
-                try:
-                    queue = get_api_result(mode="queue", extra_arguments={"nzo_ids": job["nzo_ids"][0]})["queue"]
-                    assert not queue["slots"]
-                    history = get_api_result(mode="history", extra_arguments={"nzo_ids": job["nzo_ids"][0]})["history"]
-                    assert history["slots"][0]["nzo_id"] == job["nzo_ids"][0]
-                    assert history["slots"][0]["status"] == "Failed"
-                    break
-                except (IndexError, AssertionError):
-                    time.sleep(0.1)
-            else:
-                pytest.fail("Job did not appear in history")
+            wait_for(
+                lambda: not get_slot("queue", job["nzo_ids"][0])
+                and (slot := get_slot("history", job["nzo_ids"][0]))
+                and slot["status"] == "Failed",
+                timeout=10,
+                err_msg="Job did not appear in history",
+            )
 
             # Reset and clean up
             get_api_result(

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -22,6 +22,7 @@ tests.testhelper - Basic helper functions
 import copy
 import io
 import os
+import shutil
 import socket
 import time
 import uuid
@@ -419,6 +420,60 @@ class FakeHistoryDB(db.HistoryDB):
                 category=choice(self.category_options),
                 password=choice(["secret", ""]),
             )
+
+
+# Min/max size for random files used in generated NZBs (bytes)
+MIN_FILESIZE = 128
+MAX_FILESIZE = 1024
+
+
+class AddingNZBsTestBase:
+    """Helpers shared by the functional tests that add NZBs to a running SABnzbd"""
+
+    def _api_set_config(self, keyword, value):
+        """Shorthand for the API-call to change the config settings"""
+        json = get_api_result(
+            mode="set_config",
+            extra_arguments={
+                "section": "misc",
+                "keyword": keyword,
+                "value": value,
+            },
+        )
+        assert value == json["config"]["misc"][keyword]
+
+    def _create_random_nzb(self, metadata=None):
+        # Create some simple, unique nzb
+        job_dir = os.path.join(SAB_CACHE_DIR, "NZB" + os.urandom(8).hex())
+        try:
+            os.mkdir(job_dir)
+            job_file = "%s.bin" % random_name()
+            with open(os.path.join(job_dir, job_file), "wb") as f:
+                f.write(os.urandom(randint(MIN_FILESIZE, MAX_FILESIZE)))
+        except Exception:
+            pytest.fail("Failed to create random nzb")
+
+        return create_nzb(job_dir, metadata=metadata)
+
+    def _add_backup_directory(self):
+        # Set an nzb backup directory
+        backup_dir = os.path.join(SAB_CACHE_DIR, "nzb_backup_dir" + os.urandom(4).hex())
+        self._api_set_config("nzb_backup_dir", backup_dir)
+        return backup_dir
+
+    def _clear_and_reset_backup_directory(self, backup_dir):
+        # Reset duplicate handling (0), nzb_backup_dir ("")
+        get_api_result(mode="set_config_default", extra_arguments={"keyword": ["no_dupes", "nzb_backup_dir"]})
+
+        # Remove backup_dir
+        for timer in range(0, 5):
+            try:
+                shutil.rmtree(backup_dir)
+                break
+            except OSError:
+                time.sleep(1)
+        else:
+            pytest.fail("Failed to erase nzb_backup_dir %s" % backup_dir)
 
 
 @pytest.mark.usefixtures("run_sabnzbd", "run_sabnews_and_selenium")


### PR DESCRIPTION
Jobs are listed in the history output as soon as they enter the post-processing queue, and a stopped job has its status set to Failed at the very start of process_job. The duplicate alternative is only released near the end of it, so waiting for the job to show up in the history as failed does not guarantee the alternative was already released. The gap is tiny when running serially, but wide enough to fail the test under the load of pytest-xdist. Wait for the label to be dropped instead.

Also move the helpers shared by both adding-NZB test classes into a base class in testhelper, so the clean tests no longer have to import the other test module to copy its methods.