### PR TITLE
Use root relative URLs

### DIFF
--- a/sabnzbd/api.py
+++ b/sabnzbd/api.py
@@ -1920,7 +1920,7 @@ def clear_trans_cache():
     sabnzbd.WEBUI_READY = True
 
 
-def url_for(path: str = "", request: Optional[Request] = None, absolute: bool = True, **kwargs) -> str:
+def url_for(path: str = "", **kwargs) -> str:
     """Build an absolute URL below the configured URL base.
 
     Templates reach this as $url(...), so a link never depends on the depth of the
@@ -1938,8 +1938,6 @@ def url_for(path: str = "", request: Optional[Request] = None, absolute: bool = 
     # so normalising the path to a single leading slash is enough to join them
     url = cfg.url_base() + "/" + path.lstrip("/")
 
-    if absolute:
-        url = url_origin(request) + url
     if kwargs:
         url = "%s?%s" % (url, urllib.parse.urlencode(kwargs))
     if fragment:
@@ -1964,22 +1962,6 @@ def url_netloc(host: Optional[str], scheme: str, port: Optional[int]) -> str:
     return "%s:%s" % (host, port)
 
 
-def url_origin(request: Optional[Request] = None) -> str:
-    """The scheme://host[:port] SABnzbd was reached by, for use in absolute URLs.
-
-    Taken from the request when there is one: uvicorn's ProxyHeadersMiddleware has
-    already applied X-Forwarded-Proto by then (when verify_xff_header is enabled), so
-    this stays correct behind a reverse proxy terminating TLS on another port. Without
-    a request there is nothing to observe, so fall back to the configured scheme and
-    port on localhost."""
-    if request:
-        return "%s://%s" % (request.url.scheme, url_netloc(request.url.hostname, request.url.scheme, request.url.port))
-
-    scheme = "https" if cfg.enable_https() else "http"
-    port = cfg.https_port() if cfg.enable_https() else cfg.web_port()
-    return "%s://%s" % (scheme, url_netloc("localhost", scheme, port))
-
-
 def build_header(
     webdir: str = "",
     for_template: bool = True,
@@ -1995,16 +1977,7 @@ def build_header(
         if trans_functions:
             header["T"] = Ttemplate
             header["Tspec"] = Tspec
-
-            # Bound to this request so $url() can see the scheme and host it was reached by.
-            # Deliberately a closure rather than functools.partial: template_filtered_response
-            # deep-copies the search list, and deepcopy treats a function as atomic but walks a
-            # partial's keywords -- which would drag in the request's scope, the app and its
-            # whole route graph, and blow the recursion limit.
-            def bound_url_for(path: str = "", **kwargs) -> str:
-                return url_for(path, request=request, **kwargs)
-
-            header["url"] = bound_url_for
+            header["url"] = url_for
 
         header["uptime"] = calc_age(sabnzbd.START)
         header["color_scheme"] = sabnzbd.WEB_COLOR or ""

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -101,7 +101,6 @@ from sabnzbd.api import (
     halt_and_shutdown,
     build_header,
     url_for,
-    url_origin,
     url_netloc,
     Ttemplate,
 )
@@ -537,10 +536,7 @@ logging.getLogger("python_multipart.multipart").setLevel(logging.WARNING)
 
 def base_redirect_response(root: str = "", **kwargs) -> RedirectResponse:
     """Create a Starlette RedirectResponse with SABnzbd URL base and query parameters"""
-    # Shares url_for with the templates so redirect targets and links stay in step.
-    # Root-relative on purpose: a Location header should send the client back to the
-    # host it just used, not to whatever origin this process thinks it is on.
-    url = url_for(root, absolute=False, **kwargs)
+    url = url_for(root, **kwargs)
 
     # Log the redirect if API logging is enabled
     if cfg.api_logging():
@@ -712,7 +708,7 @@ def wizard_page_two(request: Request):
     return template_filtered_response(file=os.path.join(sabnzbd.WIZARD_DIR, "two.html"), search_list=info)
 
 
-def get_access_info(request: Optional[Request] = None) -> set[str]:
+def get_access_info(request: Optional[Request] = None) -> list[str]:
     """Build up a list of url's that sabnzbd can be accessed from"""
     web_host = cfg.web_host()
     host = socket.gethostname().lower()
@@ -747,7 +743,11 @@ def get_access_info(request: Optional[Request] = None) -> set[str]:
     # Lead with the URL this page was actually reached by, which is the one we know works.
     # Built from the origin rather than url_for() so it matches the bare "scheme://host+base"
     # shape of the entries below and dedupes against them.
-    urls = [url_origin(request) + cfg.url_base()]
+    urls = set()
+    if request:
+        base_url = str(request.base_url).rstrip("/")
+        url_base = cfg.url_base().lstrip("/")
+        urls.add(f"{base_url}/{url_base}" if url_base else base_url)
 
     if cfg.enable_https():
         scheme = "https"
@@ -758,10 +758,10 @@ def get_access_info(request: Optional[Request] = None) -> set[str]:
 
     for sock in socks:
         if sock:
-            urls.append("%s://%s%s" % (scheme, url_netloc(sock, scheme, port), cfg.url_base()))
+            urls.add("%s://%s%s" % (scheme, url_netloc(sock, scheme, port), cfg.url_base()))
 
-    # Return a unique list
-    return set(urls)
+    # Return a unique list, with HTTPS URLs first
+    return sorted(urls, key=lambda url: (not url.startswith("https://"), url))
 
 
 ##############################################################################


### PR DESCRIPTION
It could break behind proxies otherwise.

Assets are included as `href="/static/bootstrap/css/bootstrap.min.css"` rather than `href="https://domain/static/..."`

Needed to also change the access URL shown at the end of the wizard, so made it sort so https are first then alphabetically 
