### PR TITLE
Fix rss clearing at startup and downloaded items still in the feed

### DIFF
--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -536,8 +536,8 @@ def delayed_startup_actions():
     # aren't on 24/7 and typically don't benefit from the daily scheduled call at midnight
     sabnzbd.database.scheduled_history_purge()
 
-    # Purge links older than 3 days
-    sabnzbd.rss.expired_purge()
+    # Drop leftover records of feeds that are no longer configured
+    sabnzbd.rss.purge_removed_feeds()
 
     # Start SSDP and Bonjour if SABnzbd isn't listening on localhost only
     if sabnzbd.cfg.enable_broadcast() and not misc.is_localhost(cfg.web_host()):

--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -847,10 +847,13 @@ class RSSRepository:
         )
         return bool(self.db.cursor.fetchone()["found"])
 
-    def expired_purge(self):
-        """Removed expired links from all feeds"""
+    def purge_removed_feeds(self):
+        """Remove all records of feeds that are no longer configured"""
+        configured = set(config.get_rss())
         for feed in self.get_feeds():
-            self.remove_obsolete(feed)
+            if feed not in configured:
+                logging.debug("Purging records of removed feed %s", feed)
+                self.clear_feed(feed)
 
     def import_rss_records(self):
         """Migrate old RSS database"""
@@ -1266,10 +1269,10 @@ def special_rss_site(url: str) -> bool:
     return bool(cfg.rss_filenames() or match_str(url, cfg.rss_odd_titles()))
 
 
-def expired_purge():
-    """Purge links older than 3 days"""
+def purge_removed_feeds():
+    """Purge records of feeds that are no longer configured"""
     with rss_repository() as repo:
-        repo.expired_purge()
+        repo.purge_removed_feeds()
 
 
 @contextmanager

--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -1001,7 +1001,8 @@ class RSSReader:
             if new_downloads and cfg.email_rss() and not force:
                 emailer.rss_mail(feed, new_downloads)
 
-            repo.remove_obsolete(feed, new_links, purge_downloaded=True)
+            if readout:
+                repo.remove_obsolete(feed, new_links, purge_downloaded=True)
 
         return ""
 

--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -621,10 +621,10 @@ class RSSRepository:
         """
         Expire G/B links that are not in new_jobs (mark them 'X')
 
-        Expired links older than 3 days are removed
+        Expired links older than 7 days are removed
         """
         now = datetime.datetime.now(datetime.timezone.utc)
-        limit = int((now - datetime.timedelta(days=3)).timestamp())
+        limit = int((now - datetime.timedelta(days=7)).timestamp())
 
         if new_urls:
             # Create temporary table for all new URLs

--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -635,6 +635,22 @@ class RSSRepository:
                 placeholders = ",".join(["(?)"] * len(batch))
                 self.db.execute(f"INSERT INTO temp_urls(url) VALUES {placeholders}", batch)
 
+            # Refresh seen_at for everything still listed in the feed. Entries in a terminal
+            # state are skipped during evaluation, so this is the only place they are touched
+            # and without it they would be purged while still present in the feed.
+            self.db.execute(
+                """
+                UPDATE rss
+                SET seen_at = ?
+                WHERE feed = ?
+                  AND url IN (SELECT url FROM temp_urls)
+            """,
+                (
+                    int(datetime.datetime.now(datetime.timezone.utc).timestamp()),
+                    feed,
+                ),
+            )
+
             # Update rss to mark G/B not in temp_urls as X
             self.db.execute(
                 """

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -1072,3 +1072,49 @@ class TestRSS:
         repo.purge_removed_feeds()
 
         assert set(repo.get_feeds()) == {configured_feed}
+
+    def test_process_feed_without_readout_keeps_stored_jobs(self, httpserver: HTTPServer, tmp_rss):
+        """Replaying stored jobs (readout=False) must not expire or purge anything."""
+        repo, reader = tmp_rss
+        feed_name = "NoReadoutFeed"
+        feed_xml = """<?xml version="1.0" encoding="utf-8"?>
+        <rss version="2.0">
+          <channel>
+            <title>NoReadout</title>
+            <item>
+                <title>New.Show.S01E01.720p</title>
+                <link>http://example.test/no-readout/current</link>
+                <guid>http://example.test/info/no-readout-current</guid>
+                <category>tv</category>
+                <pubDate>Wed, 01 Jan 2025 00:00:00 GMT</pubDate>
+            </item>
+          </channel>
+        </rss>
+        """
+        httpserver.expect_request("/rss_no_readout.xml").respond_with_data(feed_xml, content_type="application/rss+xml")
+        self.setup_rss(feed_name, httpserver.url_for("/rss_no_readout.xml"))
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        old_url = "http://example.test/no-readout/expired"
+        repo.upsert(
+            ResolvedEntry(
+                feed=feed_name,
+                link=old_url,
+                title="Old.Show.S01E01.720p",
+                infourl=None,
+                size=10,
+                age=now - datetime.timedelta(weeks=52),
+                seen_at=now - datetime.timedelta(days=4),
+                season=1,
+                episode=1,
+                category=None,
+                state=RSSState.EXPIRED,
+            )
+        )
+
+        assert reader.process_feed(feed_name, readout=False) == ""
+        assert repo.find_job_by_url(feed_name, old_url) is not None
+
+        # A real readout does not find the link anymore, so it gets purged
+        assert reader.process_feed(feed_name, readout=True) == ""
+        assert repo.find_job_by_url(feed_name, old_url) is None

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -1041,3 +1041,34 @@ class TestRSS:
 
         # Shared link must only appear once
         assert links == {shared_link, a_only_link, b_only_link}
+
+    def test_purge_removed_feeds_only_drops_unconfigured_feeds(self, tmp_rss):
+        """Records should only be dropped for feeds that are no longer configured."""
+        repo, _reader = tmp_rss
+        configured_feed = "ConfiguredFeed"
+        removed_feed = "RemovedFeed"
+
+        self.setup_rss(configured_feed, "http://example.test/rss.xml")
+
+        age = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(weeks=52)
+        old_seen_at = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=30)
+        for feed in (configured_feed, removed_feed):
+            repo.upsert(
+                ResolvedEntry(
+                    feed=feed,
+                    link=f"http://example.test/{feed}/job",
+                    title=f"{feed} job",
+                    infourl=None,
+                    size=10,
+                    age=age,
+                    seen_at=old_seen_at,
+                    season=1,
+                    episode=1,
+                    category=None,
+                    state=RSSState.GOOD,
+                )
+            )
+
+        repo.purge_removed_feeds()
+
+        assert set(repo.get_feeds()) == {configured_feed}

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -777,7 +777,7 @@ class TestRSS:
 
         now = datetime.datetime.now(datetime.timezone.utc)
         age = now - datetime.timedelta(weeks=52)
-        old_seen_at = now - datetime.timedelta(days=4)
+        old_seen_at = now - datetime.timedelta(days=8)
         new_seen_at = now - datetime.timedelta(days=1)
 
         # Old good item that should be kept because it is part of the new_urls set
@@ -1104,7 +1104,7 @@ class TestRSS:
                 infourl=None,
                 size=10,
                 age=now - datetime.timedelta(weeks=52),
-                seen_at=now - datetime.timedelta(days=4),
+                seen_at=now - datetime.timedelta(days=8),
                 season=1,
                 episode=1,
                 category=None,

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -1118,3 +1118,46 @@ class TestRSS:
         # A real readout does not find the link anymore, so it gets purged
         assert reader.process_feed(feed_name, readout=True) == ""
         assert repo.find_job_by_url(feed_name, old_url) is None
+
+    def test_downloaded_item_still_in_feed_is_not_redownloaded(self, httpserver: HTTPServer, tmp_rss, mocker):
+        """An item that stays in the feed must survive the retention period and not be grabbed twice."""
+        repo, reader = tmp_rss
+        feed_name = "LongLivedFeed"
+        link = "http://example.test/long-lived"
+        feed_xml = f"""<?xml version="1.0" encoding="utf-8"?>
+        <rss version="2.0">
+          <channel>
+            <title>LongLived</title>
+            <item>
+                <title>Show.S01E01.720p</title>
+                <link>{link}</link>
+                <guid>http://example.test/info/long-lived</guid>
+                <category>tv</category>
+                <pubDate>Wed, 01 Jan 2025 00:00:00 GMT</pubDate>
+            </item>
+          </channel>
+        </rss>
+        """
+        httpserver.expect_request("/rss_long_lived.xml").respond_with_data(feed_xml, content_type="application/rss+xml")
+        self.setup_rss(feed_name, httpserver.url_for("/rss_long_lived.xml"))
+
+        add_url = mocker.patch("sabnzbd.urlgrabber.add_url")
+        assert reader.process_feed(feed_name, download=True, force=True) == ""
+        assert add_url.call_count == 1
+        assert repo.find_job_by_url(feed_name, link).state is RSSState.DOWNLOADED
+
+        # Pretend the item was downloaded longer ago than the retention period, while
+        # it is still being served by the feed
+        stale = int((datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=30)).timestamp())
+        repo.db.execute("UPDATE rss SET seen_at = ? WHERE feed = ?", (stale, feed_name))
+
+        # Still being listed should refresh seen_at instead of purging the job
+        assert reader.process_feed(feed_name, download=True) == ""
+        job = repo.find_job_by_url(feed_name, link)
+        assert job is not None
+        assert job.state is RSSState.DOWNLOADED
+        assert job.seen_at.timestamp() > stale
+
+        # And it must not be picked up as a new job on the next scans
+        assert reader.process_feed(feed_name, download=True) == ""
+        assert add_url.call_count == 1


### PR DESCRIPTION
Fixes #3574

~~As requested I also wanted to add a `rss_retention` config option, I've put it on /config/rss instead of specials because  history retention is part of the normal switches config screens and it's on it's own page anyway so doesn't look cluttered.~~

- Increased default retention to 7 days
- ~~Configurable retention on /config/rss~~ - separate PR
- Only purges unconfigured rss feeds at startup, and only expired items so removing and readding with the same name doesn’t purge immediately
- Only purges if the feed was `readout=True`
- Main reported issue is because `seen_at` was not updated for downloaded items
