### PR TITLE
Don't let uvicorn logging pollute the log and notifications

### DIFF
--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1086,6 +1086,9 @@ def main():
             rollover_log = logging.handlers.RotatingFileHandler(
                 sabnzbd.LOGFILE, "a+", sabnzbd.cfg.log_size(), sabnzbd.cfg.log_backups()
             )
+            # Set the level here as well as on the logger, so records that were
+            # created at a higher level and lowered afterwards are also dropped
+            rollover_log.setLevel(LOGLEVELS[logging_level + 1])
             rollover_log.setFormatter(logging.Formatter(logformat))
             logger.addHandler(rollover_log)
 
@@ -1221,38 +1224,12 @@ def main():
             if full_path := getattr(sabnzbd.cfg, setting).get_path():
                 sabnzbd.CONFIG_BACKUP_HTTPS_OK.append(full_path)
 
-    # Catch logging using SABnzbd handlers
-    # Format: https://github.com/encode/uvicorn/blob/d43afed1cfa018a85c83094da8a2dd29f656d676/uvicorn/config.py#L82-L114
-    uvicorn_logging_config = {
-        "version": 1,
-        "disable_existing_loggers": False,
-        "formatters": {
-            "access": {
-                "()": "uvicorn.logging.AccessFormatter",
-                "fmt": '%(asctime)s::%(levelname)s::%(client_addr)s - "%(request_line)s" %(status_code)s',
-                "use_colors": False,
-            },
-        },
-        "handlers": {},
-        "loggers": {
-            "uvicorn": {"propagate": True},
-            "uvicorn.error": {"propagate": True},
-            "uvicorn.access": {"propagate": False, "level": "INFO"},
-        },
-    }
-
     # Do we want web-server access logging? Cannot be done via the config
     if weblogging:
         sabnzbd.WEBLOGFILE = os.path.join(logdir, DEF_LOG_ACCESSFILE)
-        uvicorn_logging_config["handlers"]["access_file"] = {
-            "class": "logging.handlers.RotatingFileHandler",
-            "formatter": "access",
-            "filename": sabnzbd.WEBLOGFILE,
-            "maxBytes": sabnzbd.cfg.log_size(),
-            "backupCount": sabnzbd.cfg.log_backups(),
-            "encoding": "utf-8",
-        }
-        uvicorn_logging_config["loggers"]["uvicorn.access"]["handlers"] = ["access_file"]
+
+    # Catch logging using SABnzbd handlers
+    uvicorn_logging_config = sabnzbd.interface.uvicorn_logging_config(sabnzbd.WEBLOGFILE)
 
     # Claim the port here rather than letting uvicorn do it, because this is the
     # first point where the host and port are final. Everything before this was
@@ -1342,6 +1319,8 @@ def main():
             logger.setLevel(level)
             if console_logging:
                 console.setLevel(level)
+            if not no_file_log:
+                rollover_log.setLevel(level)
 
         # 300 sec polling tasks
         if not timer % 100:

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -2430,6 +2430,86 @@ class RequestLoggingMiddleware:
                 )
 
 
+class UvicornNoiseFilter(logging.Filter):
+    """Log uvicorn messages that are not news to SABnzbd as debug messages.
+
+    Three kinds of records get in the way. Its start-up and shutdown are logged
+    at info level, repeating what we already log ourselves. It warns about
+    clients sending a malformed request or asking for an upgrade we do not
+    support, which says nothing about the state of SABnzbd, yet shows up in the
+    web-interface and is sent out as a notification. And it reports a failed
+    start-up twice, once with the reason and once as a bare summary, while we
+    report it ourselves as well before giving up.
+
+    They are demoted rather than dropped, so they are still there when debug
+    logging is on: the missing half of a start-up sequence, or the reason a
+    client fails to connect. The handlers take it from there, they all have a
+    level, so the message only reaches the ones that want it. Warnings and
+    errors about our own web-interface are left alone.
+    """
+
+    # Logged by uvicorn/protocols/http/{h11,httptools}_impl.py
+    CLIENT_ERRORS = (
+        "Invalid HTTP request received.",
+        "Unsupported upgrade request.",
+        "No supported WebSocket library detected.",
+    )
+
+    # Logged by uvicorn/lifespan/on.py, after the reason was logged separately
+    REPORTED_FAILURES = ("Application startup failed. Exiting.",)
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        if (
+            record.levelno == logging.INFO
+            or (record.levelno == logging.WARNING and message.startswith(self.CLIENT_ERRORS))
+            or (record.levelno == logging.ERROR and message.startswith(self.REPORTED_FAILURES))
+        ):
+            record.levelno = logging.DEBUG
+            record.levelname = logging.getLevelName(logging.DEBUG)
+        return True
+
+
+def uvicorn_logging_config(access_log_file: Optional[str] = None) -> dict[str, Any]:
+    """Make uvicorn log through the SABnzbd handlers, so its output ends up in
+    the regular logfile. Access logging goes to its own file, if requested.
+    Format: https://github.com/encode/uvicorn/blob/d43afed1cfa018a85c83094da8a2dd29f656d676/uvicorn/config.py#L82-L114
+    """
+    logging_config = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "access": {
+                "()": "uvicorn.logging.AccessFormatter",
+                "fmt": '%(asctime)s::%(levelname)s::%(client_addr)s - "%(request_line)s" %(status_code)s',
+                "use_colors": False,
+            },
+        },
+        "filters": {
+            "uvicorn_noise": {"()": "sabnzbd.interface.UvicornNoiseFilter"},
+        },
+        "handlers": {},
+        "loggers": {
+            "uvicorn": {"propagate": True},
+            "uvicorn.error": {"propagate": True, "filters": ["uvicorn_noise"]},
+            "uvicorn.access": {"propagate": False, "level": "INFO"},
+        },
+    }
+
+    if access_log_file:
+        logging_config["handlers"]["access_file"] = {
+            "class": "logging.handlers.RotatingFileHandler",
+            "formatter": "access",
+            "filename": access_log_file,
+            "maxBytes": cfg.log_size(),
+            "backupCount": cfg.log_backups(),
+            "encoding": "utf-8",
+        }
+        logging_config["loggers"]["uvicorn.access"]["handlers"] = ["access_file"]
+
+    return logging_config
+
+
 class ThreadedServer(uvicorn.Server):
     """uvicorn server running in a background thread, so the main thread stays
     free for the SABnzbd main loop."""

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -20,11 +20,18 @@ tests.test_interface - Testing functions in interface.py
 """
 
 import asyncio
+import inspect
+import logging
+import logging.config
 import pytest
 from unittest.mock import Mock
 from starlette.requests import Request
 from starlette.datastructures import Headers, Address
+import uvicorn
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
+from uvicorn.lifespan import on as lifespan_on
+from uvicorn.protocols.http import h11_impl, httptools_impl
+from uvicorn.server import ServerState
 
 from sabnzbd import interface
 from sabnzbd.misc import is_local_addr, is_loopback_addr, xff_trusted_networks
@@ -310,3 +317,111 @@ class TestInterfaceFunctions:
                 assert network not in networks
 
         _func()
+
+
+async def empty_app(scope, receive, send):
+    """Minimal ASGI app, replying to anything that does reach it"""
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({"type": "http.response.body", "body": b""})
+
+
+def is_client_error(record: logging.LogRecord) -> bool:
+    """Was this record logged by uvicorn because of client behavior?"""
+    return record.getMessage().startswith(interface.UvicornNoiseFilter.CLIENT_ERRORS)
+
+
+def feed_raw_request(protocol_class, data: bytes):
+    """Hand raw bytes to a real uvicorn HTTP protocol, so it logs whatever it
+    makes of them, just like it would for an actual connection."""
+
+    async def _run():
+        # log_config=None: the logging setup under test is applied by the fixture
+        config = uvicorn.Config(app=empty_app, log_config=None)
+        config.load()
+        protocol = protocol_class(config=config, server_state=ServerState(), app_state={})
+        transport = Mock()
+        transport.get_extra_info = lambda name, default=None: ("127.0.0.1", 12345) if name == "peername" else default
+        protocol.connection_made(transport)
+        protocol.data_received(data)
+
+    asyncio.run(_run())
+
+
+class TestUvicornLogging:
+    @pytest.fixture(autouse=True)
+    def uvicorn_logging(self):
+        """Apply the logging configuration that SABnzbd hands to uvicorn and
+        restore the previous state afterwards, so other tests are unaffected."""
+        loggers = [logging.getLogger(name) for name in ("uvicorn", "uvicorn.error", "uvicorn.access")]
+        saved = [(logger.level, logger.propagate, logger.handlers[:], logger.filters[:]) for logger in loggers]
+        logging.config.dictConfig(interface.uvicorn_logging_config())
+        yield
+        for logger, (level, propagate, handlers, filters) in zip(loggers, saved):
+            logger.setLevel(level)
+            logger.propagate = propagate
+            logger.handlers = handlers
+            logger.filters = filters
+
+    @pytest.mark.parametrize("protocol_class", [h11_impl.H11Protocol, httptools_impl.HttpToolsProtocol])
+    @pytest.mark.parametrize(
+        "raw_request",
+        [
+            # Not HTTP at all, as sent by port scanners and misdirected clients
+            b"\x16\x03\x01\x00\xf4\x01\x00\x00\xf0\x03\x03",
+            # Valid HTTP, but asking for an upgrade we do not support
+            b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: upgrade\r\nUpgrade: h2c\r\n\r\n",
+        ],
+    )
+    def test_client_errors_are_not_warnings(self, protocol_class, raw_request, caplog):
+        # A handler that only wants INFO and up, just like the console and logfile
+        # handlers when debug logging is off, must not see the message at all
+        caplog.set_level(logging.INFO)
+        feed_raw_request(protocol_class, raw_request)
+        assert not [record for record in caplog.records if record.levelno >= logging.WARNING]
+        assert not [record for record in caplog.records if is_client_error(record)]
+
+    @pytest.mark.parametrize("protocol_class", [h11_impl.H11Protocol, httptools_impl.HttpToolsProtocol])
+    def test_client_errors_are_kept_for_debug_logging(self, protocol_class, caplog):
+        caplog.set_level(logging.DEBUG)
+        feed_raw_request(protocol_class, b"\x16\x03\x01\x00\xf4\x01\x00\x00\xf0\x03\x03")
+        assert [
+            record
+            for record in caplog.records
+            if record.levelname == "DEBUG" and record.getMessage() == "Invalid HTTP request received."
+        ]
+
+    def test_lifecycle_messages_are_not_logged(self, caplog):
+        # Starting and stopping is already logged by SABnzbd itself
+        caplog.set_level(logging.INFO)
+        logging.getLogger("uvicorn.error").info("Application startup complete.")
+        assert not caplog.records
+
+    def test_lifecycle_messages_are_kept_for_debug_logging(self, caplog):
+        caplog.set_level(logging.DEBUG)
+        logging.getLogger("uvicorn.error").info("Application startup complete.")
+        assert [record for record in caplog.records if record.levelname == "DEBUG"]
+
+    def test_failures_reported_by_sabnzbd_are_not_logged_twice(self, caplog):
+        # SABnzbd logs its own error, including the reason, when the
+        # web-interface fails to start, so this summary adds nothing
+        caplog.set_level(logging.INFO)
+        logging.getLogger("uvicorn.error").error("Application startup failed. Exiting.")
+        assert not caplog.records
+
+    def test_reason_for_a_failed_start_still_propagates(self, caplog):
+        caplog.set_level(logging.INFO)
+        logging.getLogger("uvicorn.error").error("Exception in 'lifespan' protocol")
+        assert [record for record in caplog.records if record.levelno == logging.ERROR]
+
+    def test_real_warnings_still_propagate(self, caplog):
+        caplog.set_level(logging.INFO)
+        logging.getLogger("uvicorn.error").warning("Exceeded concurrency limit.")
+        logging.getLogger("uvicorn.error").error("Exception in ASGI application")
+        assert [record for record in caplog.records if record.levelno == logging.WARNING]
+        assert [record for record in caplog.records if record.levelno == logging.ERROR]
+
+    def test_filtered_messages_still_used_by_uvicorn(self):
+        """Guard against uvicorn rewording the messages we filter on"""
+        uvicorn_source = "".join(inspect.getsource(module) for module in (h11_impl, httptools_impl, lifespan_on))
+        for message in interface.UvicornNoiseFilter.CLIENT_ERRORS + interface.UvicornNoiseFilter.REPORTED_FAILURES:
+            assert message in uvicorn_source


### PR DESCRIPTION
Fixes #3565

`uvicorn.errors` is rather misleading, it's more just uvicorn application log logging startup/shutdown messages.

I've downgraded the warnings for invalid requests to DEBUG and downgraded an ERROR to DEBUG for a failed start that we log ourselves anyway.