### PR TITLE
Stop tests that create NZBs from racing

### DIFF
--- a/tests/sabnews.py
+++ b/tests/sabnews.py
@@ -30,6 +30,7 @@ import re
 import time
 
 from random import randint
+from typing import Optional
 
 import sabctools
 
@@ -154,10 +155,19 @@ async def serve_sabnews(hostname, port):
         await server.serve_forever()
 
 
-def create_nzb(nzb_file=None, nzb_dir=None, metadata=None):
+def create_nzb(
+    nzb_file: Optional[str] = None,
+    nzb_dir: Optional[str] = None,
+    metadata: Optional[dict[str, str]] = None,
+    output_file: Optional[str] = None,
+):
+    """Create an NZB from a directory or a single file.
+    Pass output_file to write it somewhere other than next to the input, so callers that
+    share an input directory do not have to share the output file as well.
+    """
     article_size = 500000
     files_for_nzb = []
-    output_file = ""
+    default_output_file = ""
 
     # Either use directory or single file
     if nzb_dir:
@@ -165,16 +175,19 @@ def create_nzb(nzb_file=None, nzb_dir=None, metadata=None):
         if not os.path.exists(nzb_dir) or not os.path.isdir(nzb_dir):
             raise NotADirectoryError("%s is not a valid directory" % nzb_dir)
 
-        # List all files
+        # List all files, but never an NZB: that is what we are creating here, so it is
+        # either one we made earlier or one another test is busy with right now
         files_for_nzb = [os.path.join(nzb_dir, fl) for fl in os.listdir(nzb_dir)]
-        files_for_nzb = [fl for fl in files_for_nzb if os.path.isfile(fl)]
-        output_file = os.path.join(nzb_dir, os.path.basename(os.path.normpath(nzb_dir)) + ".nzb")
+        files_for_nzb = [fl for fl in files_for_nzb if os.path.isfile(fl) and not fl.endswith(".nzb")]
+        default_output_file = os.path.join(nzb_dir, os.path.basename(os.path.normpath(nzb_dir)) + ".nzb")
 
     if nzb_file:
         if not os.path.exists(nzb_file) or not os.path.isfile(nzb_file):
             raise FileNotFoundError("Cannot find %s or it is not a file" % nzb_file)
         files_for_nzb = [nzb_file]
-        output_file = os.path.splitext(nzb_file)[0] + ".nzb"
+        default_output_file = os.path.splitext(nzb_file)[0] + ".nzb"
+
+    output_file = output_file or default_output_file
 
     if not files_for_nzb:
         raise RuntimeError("No files found to include in NZB")

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -24,6 +24,7 @@ import io
 import os
 import shutil
 import socket
+import tempfile
 import time
 import uuid
 from http.client import RemoteDisconnected
@@ -275,21 +276,22 @@ def get_api_result(mode, host=SAB_HOST, port=SAB_PORT, extra_arguments={}):
     return r.text
 
 
-def create_nzb(nzb_dir: str, metadata: Optional[dict[str, str]] = None) -> str:
+def create_nzb(nzb_dir: str, metadata: Optional[dict[str, str]] = None, output_file: Optional[str] = None) -> str:
     """Create NZB from directory using SABNews"""
     nzb_dir_full = os.path.join(SAB_DATA_DIR, nzb_dir)
-    return tests.sabnews.create_nzb(nzb_dir=nzb_dir_full, metadata=metadata)
+    return tests.sabnews.create_nzb(nzb_dir=nzb_dir_full, metadata=metadata, output_file=output_file)
 
 
 def create_and_read_nzb_fp(nzbdir: str, metadata: Optional[dict[str, str]] = None) -> BinaryIO:
-    """Create NZB, return data and delete file"""
-    # Create NZB-file to import
-    nzb_path = create_nzb(nzbdir, metadata)
-    with open(nzb_path, "rb") as nzb_data_fp:
-        nzb_data = nzb_data_fp.read()
-    # Remove the created NZB-file
-    os.remove(nzb_path)
-    return io.BytesIO(nzb_data)
+    """Create NZB and return its data, leaving no file behind"""
+    # Write the NZB to its own temporary directory. The input directories are shared
+    # between tests, so writing it there has tests running in parallel reading and
+    # removing each other's file. Leaving it out of there also keeps it from ending up
+    # in the next NZB created from the same input.
+    with tempfile.TemporaryDirectory() as nzb_output_dir:
+        nzb_path = create_nzb(nzbdir, metadata, output_file=os.path.join(nzb_output_dir, "test.nzb"))
+        with open(nzb_path, "rb") as nzb_data_fp:
+            return io.BytesIO(nzb_data_fp.read())
 
 
 def httpserver_handler_data_dir(request: Request):


### PR DESCRIPTION
Fixes `FAILED tests/test_functional_downloads.py::TestDownloadFlow::test_download_basic_rar5 - FileNotFoundError: [Errno 2] No such file or directory: '/home/runner/work/sabnzbd/sabnzbd/tests/data/basic_rar5/basic_rar5.nzb'`

The nzb was created in the input directory, multiple runners raced creating and deleting it and sometimes including an nzb another runner created