### PR TITLE
Keep the client address of incoming connections when a proxy is set

### DIFF
--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -69,6 +69,9 @@ from sabnzbd.decorators import conditional_cache, synchronized
 from sabnzbd.encoding import ubtou, platform_btou
 from sabnzbd.filesystem import userxbit, make_script_path, remove_file, strip_extensions, safe_fnmatch
 
+# Keep the real socket around, setting a proxy replaces socket.socket
+_ORIGINAL_SOCKET = socket.socket
+
 if sabnzbd.WINDOWS:
     try:
         import winreg
@@ -1597,6 +1600,19 @@ def run_script(script: str):
             logging.info("Failed script %s, Traceback: ", script, exc_info=True)
 
 
+class ProxiedSocket(socks.socksocket):
+    """Socket that connects through the proxy, but still reports the peer of incoming connections.
+
+    PySocks proxies a process by replacing socket.socket, and socket.accept() builds
+    accepted sockets from that same global. So sockets accepted by our web server are
+    PySocks sockets as well, and its getpeername() returns proxy_peername, which is only
+    ever set by an outgoing connect() through the proxy. Without this, every request
+    would arrive without a client address and be refused by check_access()."""
+
+    def getpeername(self):
+        return self.proxy_peername or _ORIGINAL_SOCKET.getpeername(self)
+
+
 def set_socks5_proxy():
     if cfg.socks5_proxy_url():
         proxy = urllib.parse.urlparse(cfg.socks5_proxy_url())
@@ -1609,7 +1625,7 @@ def set_socks5_proxy():
             proxy.username,
             proxy.password,
         )
-        socket.socket = socks.socksocket
+        socket.socket = ProxiedSocket
 
 
 def set_https_verification(value: bool) -> bool:

--- a/sabnzbd/misc.py
+++ b/sabnzbd/misc.py
@@ -1603,14 +1603,16 @@ def run_script(script: str):
 class ProxiedSocket(socks.socksocket):
     """Socket that connects through the proxy, but still reports the peer of incoming connections.
 
-    PySocks proxies a process by replacing socket.socket, and socket.accept() builds
-    accepted sockets from that same global. So sockets accepted by our web server are
-    PySocks sockets as well, and its getpeername() returns proxy_peername, which is only
-    ever set by an outgoing connect() through the proxy. Without this, every request
-    would arrive without a client address and be refused by check_access()."""
+    getpeername() must stay a plain attribute read: PySocks calls it internally from
+    settimeout(), and raising OSError there for an unconnected socket leaves our
+    listening socket stuck in blocking mode."""
 
-    def getpeername(self):
-        return self.proxy_peername or _ORIGINAL_SOCKET.getpeername(self)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        try:
+            self.proxy_peername = _ORIGINAL_SOCKET.getpeername(self)
+        except OSError:
+            pass
 
 
 def set_socks5_proxy():

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1577,3 +1577,17 @@ class TestSetSocks5Proxy:
                 with accepted:
                     assert isinstance(accepted, misc.ProxiedSocket)
                     assert accepted.getpeername() == client.getsockname() == address
+
+    @pytest.mark.config({"socks5_proxy_url": "socks5://proxy.example:1080"})
+    def test_timeout_is_applied_to_a_socket_without_a_peer(self):
+        """PySocks only applies a timeout to the real socket when getpeername() does not
+        raise, so a listening socket must not be left blocking by setblocking(False)"""
+        misc.set_socks5_proxy()
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+            assert isinstance(listener, misc.ProxiedSocket)
+            listener.bind(("127.0.0.1", 0))
+            listener.listen(1)
+            listener.setblocking(False)
+            assert misc._ORIGINAL_SOCKET.gettimeout(listener) == 0.0
+            with pytest.raises(BlockingIOError):
+                listener.accept()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -35,6 +35,7 @@ from unittest import mock
 
 import pytest
 import rarfile
+import socks
 
 from sabnzbd import lang, misc, newsunpack, cfg
 from sabnzbd.config import ConfigCat, get_sorters, save_config
@@ -1536,3 +1537,43 @@ class TestCgroupMemoryLimit:
         with self.patched_open({}):
             with mock.patch("sabnzbd.misc._physical_memory", return_value=None):
                 assert misc.get_memory() == 0
+
+
+class TestSetSocks5Proxy:
+    """The proxy is applied by replacing socket.socket, which also affects the sockets
+    our own web server accepts. It must keep reporting who is connecting to us."""
+
+    @pytest.fixture(autouse=True)
+    def restore_socket(self):
+        yield
+        socks.socksocket.default_proxy = None
+        socket.socket = misc._ORIGINAL_SOCKET
+
+    @pytest.mark.config({"socks5_proxy_url": "socks5://proxy.example:1080"})
+    def test_proxy_is_set(self):
+        misc.set_socks5_proxy()
+        assert socket.socket is misc.ProxiedSocket
+        assert socks.socksocket.default_proxy[:3] == (socks.SOCKS5, "proxy.example", 1080)
+
+    def test_no_proxy_leaves_the_socket_alone(self):
+        misc.set_socks5_proxy()
+        assert socket.socket is misc._ORIGINAL_SOCKET
+        assert not socks.socksocket.default_proxy
+
+    @pytest.mark.config({"socks5_proxy_url": "socks5://proxy.example:1080"})
+    def test_accepted_connection_still_has_a_peer(self):
+        """Without this, every request reaches the web server without a client
+        address and is refused by check_access()"""
+        with misc._ORIGINAL_SOCKET(socket.AF_INET, socket.SOCK_STREAM) as listener:
+            listener.bind(("127.0.0.1", 0))
+            listener.listen(1)
+            misc.set_socks5_proxy()
+
+            # Connect without the proxy, only the accepted side is of interest here
+            with misc._ORIGINAL_SOCKET(socket.AF_INET, socket.SOCK_STREAM) as client:
+                client.settimeout(10)
+                client.connect(listener.getsockname())
+                accepted, address = listener.accept()
+                with accepted:
+                    assert isinstance(accepted, misc.ProxiedSocket)
+                    assert accepted.getpeername() == client.getsockname() == address


### PR DESCRIPTION
Fixes #3594

Setting `socks5_proxy_url` made SABnzbd refuse every request with "External internet access denied", including from `127.0.0.1` and including the web UI itself, leaving no way back in other than editing the ini by hand.

PySocks proxies the process by replacing `socket.socket`, and `socket.accept()` builds accepted sockets from that very global, so the connections our own web server accepts are PySocks sockets too. Its `getpeername()` returns `proxy_peername`, which is only ever set by an outgoing `connect()` through the proxy, and it returns `None` rather than raising. Uvicorn asks the socket before falling back to the address asyncio kept from `accept()`, so it never got that far and the request arrived without a client address, which `check_access()` correctly refuses.

Cheroot used the address returned by `accept()` and never called `getpeername()`, so this only started with #3550.

## Test plan

- [x] `pytest tests/test_misc.py -k Socks5` covers the accepted-socket case, confirmed it fails without the fix
- [x] Full suite passes locally
- [x] Verified manually: with `socks5_proxy_url` set and `inet_exposure` at its default of 0, `/`, `/config/general/`, and `/api` all returned 403 before this change and 200 after, with the log line changing from `Request GET /api from :0` to the real client address