### PR TITLE
Replace anonymous session cookie with stable CSRF identity

### DIFF
--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -107,8 +107,6 @@ from sabnzbd.security import (
     _MSG_APIKEY_NOT_ON_PAGES,
     _MSG_MISSING_SESSION,
     _MSG_SESSION_EXPIRED,
-    _anonymous_session_sender,
-    anonymous_session_tag,
     check_access,
     clear_login_failures,
     clear_session,
@@ -116,6 +114,7 @@ from sabnzbd.security import (
     client_address_info,
     constant_time_equals,
     create_session,
+    csrf_identity,
     csrf_token_for,
     csrf_token_matches,
     login_bypassed,
@@ -280,9 +279,10 @@ def check_apikey(request: Request) -> Optional[Response]:
         )
         return forbidden(_MSG_APIKEY_INCORRECT)
 
-    if SESSION_COOKIE_USER in request.cookies:
-        # A cookie was presented, so this is a browser
-        stale_token = presented_csrf_token(request, header_only=True)
+    # A session cookie or a presented CSRF token marks this as a browser rather than a
+    # 3rd-party client. With the login bypassed there is no cookie, so the token stands in.
+    stale_token = presented_csrf_token(request, header_only=True)
+    if SESSION_COOKIE_USER in request.cookies or stale_token:
         if stale_token:
             logging.info(
                 "Stale session token from %s, the page will reload for a fresh one", client_address_info(request)
@@ -414,20 +414,9 @@ class SecurityMiddleware:
             request = Request(scope, receive)
             if response := self.denied_response(request):
                 return await response(scope, receive, send)
-            # Where the login is bypassed, issue an anonymous cookie on the UI pages, unless
-            # the client already holds a session. Injected into the response start.
-            if (
-                self.check_for_login
-                and not self.check_api_key
-                and login_bypassed(request)
-                and not validate_any_session(request)
-            ):
-                send = _anonymous_session_sender(request, send)
-                # The page is rendered before that Set-Cookie reaches the client, so its
-                # token has to belong to the cookie being issued, not the one that arrived
-                request.state.csrf_token = csrf_token_for(anonymous_session_tag())
-            else:
-                request.state.csrf_token = csrf_token_for(request.cookies.get(SESSION_COOKIE_USER, ""))
+            # The page renders this token; a login-bypassed request with no cookie binds it
+            # to a stable identity, so it stays valid across requests without any cookie.
+            request.state.csrf_token = csrf_token_for(csrf_identity(request))
         await self.app(scope, receive, send)
 
     def denied_response(self, request: Request) -> Optional[Response]:

--- a/sabnzbd/security.py
+++ b/sabnzbd/security.py
@@ -42,7 +42,7 @@ _MSG_APIKEY_NOT_ON_PAGES = (
 _MSG_SESSION_EXPIRED = "Session expired, reload the page"
 
 
-# Holds a database-backed login token, or the anonymous tag when the login is bypassed
+# Holds the login token for an authenticated session; absent where the login is bypassed
 SESSION_COOKIE_USER = "sabnzbd_user"
 # The SessionMiddleware cookie, used for RSS flash messages only. Not authentication.
 SESSION_COOKIE_FLASH = "sabnzbd_flash"
@@ -59,15 +59,15 @@ LOGIN_LOCKOUT_TIME = 300  # 5 minutes
 # {host: (failures, cooldown_expiry)} cooldown_expiry uses the monotonic clock
 _login_attempts: dict[str, tuple[int, float]] = {}
 
-# Anonymous sessions are issued where the login is bypassed, so the frontend can still authenticate by cookie.
-_ANONYMOUS_SESSION_KEY = secrets.token_bytes(32)
-
-# A token is hmac(_CSRF_KEY, cookie_value), so it is bound to its session and dies with it.
+# A token is hmac(_CSRF_KEY, identity), so it is bound to its session and dies with it.
 # The key is regenerated each run, leaving a page open across a restart with a stale token.
 # The token is rendered into the page and echoed back in the header or a field.
 _CSRF_KEY = secrets.token_bytes(32)
 CSRF_HEADER = "X-SABnzbd-CSRF"
 CSRF_FIELD = "csrf_token"
+# A login-bypassed request carries no session cookie; its CSRF token binds to this stable
+# identity instead. _CSRF_KEY, not this value, is the secret that makes the token unguessable.
+_ANONYMOUS_CSRF_IDENTITY = "anonymous"
 
 
 def client_address(request: Request) -> Address:
@@ -202,35 +202,17 @@ def login_bypassed(request: Request) -> bool:
     return cfg.inet_exposure() == 5 and check_access(request, access_type=6)
 
 
-def anonymous_session_tag() -> str:
-    """The stateless anonymous session cookie value for this run"""
-    return hmac.new(_ANONYMOUS_SESSION_KEY, b"anonymous-session", hashlib.sha256).hexdigest()
+def csrf_identity(request: Request) -> str:
+    """The value a request's CSRF token binds to: its session cookie, or a stable constant
+    when the login is bypassed and no session cookie is present."""
+    if cookie := request.cookies.get(SESSION_COOKIE_USER, ""):
+        return cookie
+    return _ANONYMOUS_CSRF_IDENTITY if login_bypassed(request) else ""
 
 
-def validate_anonymous_session(request: Request) -> bool:
-    """Return True when the login is bypassed for this request and it carries a valid
-    anonymous session cookie."""
-    if not login_bypassed(request):
-        return False
-    return constant_time_equals(request.cookies.get(SESSION_COOKIE_USER, ""), anonymous_session_tag())
-
-
-def create_anonymous_session(request: Request, response: Response):
-    """Set the stateless anonymous session cookie on the response"""
-    response.set_cookie(
-        SESSION_COOKIE_USER,
-        anonymous_session_tag(),
-        path="/",
-        httponly=True,
-        secure=use_secure_cookies(request),
-        samesite="strict",
-        max_age=SESSION_DURATION,
-    )
-
-
-def csrf_token_for(cookie_value: str) -> str:
-    """The CSRF token belonging to a session cookie value"""
-    return hmac.new(_CSRF_KEY, utob(cookie_value), hashlib.sha256).hexdigest()
+def csrf_token_for(identity: str) -> str:
+    """The CSRF token belonging to a session identity"""
+    return hmac.new(_CSRF_KEY, utob(identity), hashlib.sha256).hexdigest()
 
 
 def presented_csrf_token(request: Request, header_only: bool = False) -> str:
@@ -243,10 +225,12 @@ def presented_csrf_token(request: Request, header_only: bool = False) -> str:
 
 
 def csrf_token_matches(request: Request, header_only: bool = False) -> bool:
-    """Whether the request echoes the CSRF token belonging to the cookie it sent"""
-    return constant_time_equals(
+    """Whether the request echoes the CSRF token belonging to its identity. A request
+    with no identity never matches, so a direct caller cannot bypass that guard."""
+    identity = csrf_identity(request)
+    return bool(identity) and constant_time_equals(
         presented_csrf_token(request, header_only=header_only),
-        csrf_token_for(request.cookies.get(SESSION_COOKIE_USER, "")),
+        csrf_token_for(identity),
     )
 
 
@@ -309,19 +293,6 @@ def _validate_session(request: Request) -> bool:
 
 
 def validate_any_session(request: Request) -> bool:
-    """Return True when the request carries a session cookie this instance issued"""
-    return validate_anonymous_session(request) or validate_session(request)
-
-
-def _anonymous_session_sender(request: Request, send):
-    """Wrap an ASGI send so the anonymous session cookie is added to the response start"""
-    carrier = Response()
-    create_anonymous_session(request, carrier)
-    cookie_headers = [(key, value) for key, value in carrier.raw_headers if key == b"set-cookie"]
-
-    async def send_with_cookie(message):
-        if message["type"] == "http.response.start":
-            message["headers"] = list(message.get("headers", [])) + cookie_headers
-        await send(message)
-
-    return send_with_cookie
+    """Return True when the request may act as a session: the login is bypassed, or it
+    carries a valid session cookie this instance issued."""
+    return login_bypassed(request) or validate_session(request)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -38,7 +38,15 @@ import sabnzbd
 import sabnzbd.cfg as cfg
 import sabnzbd.security as security
 from sabnzbd import interface
-from tests.test_security import api_request, config_save_middleware, mock_request, page_post, store_session
+from tests.test_security import (
+    anonymous_csrf,
+    api_request,
+    config_save_middleware,
+    mock_request,
+    page_post,
+    set_csrf_header,
+    store_session,
+)
 from sabnzbd.misc import is_local_addr, is_loopback_addr, xff_trusted_networks
 
 
@@ -562,20 +570,20 @@ class TestStaleTokenIsNotAWarning:
 
     @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0, "api_warnings": True})
     def test_api_call_with_a_stale_token_is_only_info(self, session_store, caplog):
-        request = mock_request(security.anonymous_session_tag(), params={"mode": "queue", "name": ""}, csrf="f0" * 32)
+        request = mock_request(params={"mode": "queue", "name": ""}, csrf="f0" * 32)
         levels = self._levels(caplog, lambda: interface.check_apikey(request))
         assert "WARNING" not in levels
         assert "INFO" in levels
 
     @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0, "api_warnings": True})
     def test_api_call_with_no_token_still_warns(self, session_store, caplog):
-        request = api_request(security.anonymous_session_tag(), with_token=False)
+        request = api_request(None, with_token=False)
         levels = self._levels(caplog, lambda: interface.check_apikey(request))
         assert "WARNING" in levels
 
     @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0, "api_warnings": True})
     def test_page_post_with_a_stale_token_is_only_info(self, session_store, caplog):
-        request = page_post(security.anonymous_session_tag(), csrf="f0" * 32)
+        request = page_post(csrf="f0" * 32)
         levels = self._levels(caplog, lambda: config_save_middleware().denied_response(request))
         assert "WARNING" not in levels
         assert "INFO" in levels
@@ -587,34 +595,32 @@ class TestStaleTokenIsNotAWarning:
 
 
 class TestApiCsrf:
-    """A cookie-authorized API call must echo its session's CSRF token in a header"""
+    """A cookie-authorized API call must echo its session's CSRF token in a header; with the
+    login bypassed the token stands alone, bound to a stable identity and carrying no cookie"""
 
     def _status(self, request) -> Optional[int]:
         response = interface.check_apikey(request)
         return response.status_code if response else None
 
     @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
-    def test_cookie_with_token_authorizes(self, session_store):
-        assert self._status(api_request(security.anonymous_session_tag())) is None
+    def test_token_without_cookie_authorizes(self, session_store):
+        assert self._status(api_request(None)) is None
 
     @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
-    def test_cookie_without_token_is_forbidden(self, session_store):
+    def test_missing_token_is_forbidden(self, session_store):
         """403, not 401: a reload cannot conjure up a header the client never sends"""
-        assert self._status(api_request(security.anonymous_session_tag(), with_token=False)) == 403
+        assert self._status(api_request(None, with_token=False)) == 403
 
     @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
     def test_stale_token_asks_for_a_reload(self, session_store):
-        """401, because a reload does fix this one"""
-        request = mock_request(security.anonymous_session_tag(), params={"mode": "queue", "name": ""}, csrf="f0" * 32)
+        """401, because a reload does fix this one: a page from before a key rotation"""
+        request = mock_request(params={"mode": "queue", "name": ""}, csrf="f0" * 32)
         assert self._status(request) == 401
 
     @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
     def test_apikey_still_works_alongside_a_cookie(self, session_store):
         """The cookie check must fall through to the key, never reject on its own"""
-        request = mock_request(
-            security.anonymous_session_tag(),
-            params={"mode": "queue", "name": "", "apikey": cfg.api_key()},
-        )
+        request = mock_request("f0" * 32, params={"mode": "queue", "name": "", "apikey": cfg.api_key()})
         assert self._status(request) is None
         # ...and with no cookie at all, which is how 3rd-party clients call it
         assert self._status(mock_request(params={"mode": "queue", "name": "", "apikey": cfg.api_key()})) is None
@@ -622,19 +628,16 @@ class TestApiCsrf:
     @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
     def test_no_mode_is_exempt(self, session_store):
         """There is no carve-out list, including showlog"""
-        assert self._status(api_request(security.anonymous_session_tag(), mode="showlog", with_token=False)) == 403
-        assert self._status(api_request(security.anonymous_session_tag(), mode="showlog")) is None
+        assert self._status(api_request(None, mode="showlog", with_token=False)) == 403
+        assert self._status(api_request(None, mode="showlog")) is None
 
     @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
     def test_token_outside_the_header_is_not_accepted(self, session_store):
         """This route merges the query string into its params; page routes still take the field"""
-        tag = security.anonymous_session_tag()
-        token = security.csrf_token_for(tag)
-
-        as_parameter = mock_request(tag, params={"mode": "queue", "name": "", security.CSRF_FIELD: token})
+        as_parameter = mock_request(params={"mode": "queue", "name": "", security.CSRF_FIELD: anonymous_csrf()})
         assert self._status(as_parameter) == 403
         # The same token in the header is what the frontend sends, and it is accepted
-        assert self._status(api_request(tag)) is None
+        assert self._status(api_request(None)) is None
 
     @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
     def test_keyless_and_cookieless_still_reports_missing_key(self, session_store):
@@ -724,7 +727,6 @@ class TestLogRoute:
 # The kinds of session cookie a page POST can arrive with, resolved once the test's
 # credentials are in place
 COOKIE_NONE = "none"
-COOKIE_ANONYMOUS = "anonymous"
 COOKIE_LOGIN = "login"
 COOKIE_FORGED = "forged"
 
@@ -732,26 +734,24 @@ COOKIE_FORGED = "forged"
 def cookie_of_kind(kind: str, store) -> Optional[str]:
     if kind == COOKIE_NONE:
         return None
-    if kind == COOKIE_ANONYMOUS:
-        return security.anonymous_session_tag()
     if kind == COOKIE_FORGED:
         return "f0" * 32
     store_session(store, "login-token")
     return "login-token"
 
 
-# The CSRF token a page POST can arrive with, relative to the cookie it sends
+# The CSRF token a page POST can arrive with, relative to the identity it presents
 TOKEN_NONE = "none"
 TOKEN_MATCHING = "matching"
 TOKEN_WRONG = "wrong"
 
 
-def token_of_kind(kind: str, cookie_value: Optional[str]) -> Optional[str]:
-    if kind == TOKEN_NONE:
-        return None
-    if kind == TOKEN_WRONG:
-        return "f0" * 32
-    return security.csrf_token_for(cookie_value or "")
+def apply_token_of_kind(kind: str, request):
+    """Set the request's CSRF header to the given kind, relative to its own identity"""
+    if kind == TOKEN_MATCHING:
+        set_csrf_header(request, security.csrf_token_for(security.csrf_identity(request)))
+    elif kind == TOKEN_WRONG:
+        set_csrf_header(request, "f0" * 32)
 
 
 class TestPagePostCsrf:
@@ -759,24 +759,22 @@ class TestPagePostCsrf:
     @pytest.mark.parametrize(
         "credentials, inet_exposure, cookie, token, allowed",
         [
-            # No credentials at all: check_login always passes, so this guard is all there is
+            # Login bypassed: there is no cookie, so the CSRF token alone gates the POST
             (("", ""), 0, COOKIE_NONE, TOKEN_NONE, False),
-            (("", ""), 0, COOKIE_ANONYMOUS, TOKEN_MATCHING, True),
-            (("", ""), 0, COOKIE_ANONYMOUS, TOKEN_NONE, False),
-            (("", ""), 0, COOKIE_ANONYMOUS, TOKEN_WRONG, False),
-            (("", ""), 0, COOKIE_FORGED, TOKEN_MATCHING, False),
+            (("", ""), 0, COOKIE_NONE, TOKEN_MATCHING, True),
+            (("", ""), 0, COOKIE_NONE, TOKEN_WRONG, False),
             (("", ""), 5, COOKIE_NONE, TOKEN_NONE, False),
-            # A token with no cookie must not pass: csrf_token_for("") is computable by anyone
-            (("", ""), 0, COOKIE_NONE, TOKEN_MATCHING, False),
-            # Credentials with the login enforced
+            # Credentials with the login enforced: a valid session cookie is required
             (("user", "pass"), 0, COOKIE_NONE, TOKEN_NONE, False),
+            # A matching token with no session cookie still fails the login check
+            (("user", "pass"), 0, COOKIE_NONE, TOKEN_MATCHING, False),
             (("user", "pass"), 0, COOKIE_LOGIN, TOKEN_MATCHING, True),
             (("user", "pass"), 0, COOKIE_LOGIN, TOKEN_NONE, False),
-            # inet_exposure 5: the login is waived, so check_login passes with no cookie
+            # A forged cookie is no session, even with the token that matches its identity
+            (("user", "pass"), 0, COOKIE_FORGED, TOKEN_MATCHING, False),
+            # inet_exposure 5: the login is waived for local clients, so no cookie is needed
             (("user", "pass"), 5, COOKIE_NONE, TOKEN_NONE, False),
-            (("user", "pass"), 5, COOKIE_FORGED, TOKEN_MATCHING, False),
-            (("user", "pass"), 5, COOKIE_ANONYMOUS, TOKEN_MATCHING, True),
-            (("user", "pass"), 5, COOKIE_ANONYMOUS, TOKEN_NONE, False),
+            (("user", "pass"), 5, COOKIE_NONE, TOKEN_MATCHING, True),
             # ...without locking out a local client who does hold a real login session
             (("user", "pass"), 5, COOKIE_LOGIN, TOKEN_MATCHING, True),
         ],
@@ -789,36 +787,35 @@ class TestPagePostCsrf:
         }
     )
     def test_config_save_post(self, session_store, credentials, inet_exposure, cookie, token, allowed):
-        cookie_value = cookie_of_kind(cookie, session_store)
-        request = page_post(cookie_value, csrf=token_of_kind(token, cookie_value))
+        request = page_post(cookie_of_kind(cookie, session_store))
+        apply_token_of_kind(token, request)
         response = config_save_middleware().denied_response(request)
         assert (response is None) is allowed
 
     @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
     def test_token_accepted_as_form_field(self, session_store):
         """A form that navigates cannot set a header, so the body is accepted too"""
-        tag = security.anonymous_session_tag()
-        allowed = page_post(tag, csrf_field=security.csrf_token_for(tag))
+        allowed = page_post(None, csrf_field=anonymous_csrf())
         assert config_save_middleware().denied_response(allowed) is None
-        denied = page_post(tag, csrf_field="f0" * 32)
+        denied = page_post(None, csrf_field="f0" * 32)
         assert config_save_middleware().denied_response(denied) is not None
 
     @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 5})
     def test_token_is_bound_to_its_own_session(self, session_store):
-        cookie_of_kind(COOKIE_LOGIN, session_store)
-        anonymous_tag = security.anonymous_session_tag()
+        store_session(session_store, "login-token")
 
-        login_with_anonymous_token = page_post("login-token", csrf=security.csrf_token_for(anonymous_tag))
+        # A login session's cookie carrying the anonymous token (the wrong identity) is refused
+        login_with_anonymous_token = page_post("login-token", csrf=anonymous_csrf())
         assert config_save_middleware().denied_response(login_with_anonymous_token) is not None
 
-        anonymous_with_login_token = page_post(anonymous_tag, csrf=security.csrf_token_for("login-token"))
-        assert config_save_middleware().denied_response(anonymous_with_login_token) is not None
+        # And the login token presented with no cookie (the anonymous identity) is refused
+        no_cookie_with_login_token = page_post(None, csrf=security.csrf_token_for("login-token"))
+        assert config_save_middleware().denied_response(no_cookie_with_login_token) is not None
 
     @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 5})
     def test_external_client_still_needs_login(self, session_store):
-        """The waiver is local-only: an external POST gets no help from the anonymous tag"""
-        tag = security.anonymous_session_tag()
-        request = page_post(tag, remote_ip="9.8.7.6", csrf=security.csrf_token_for(tag))
+        """The waiver is local-only: an external POST gets no help from the CSRF token"""
+        request = page_post(None, remote_ip="9.8.7.6", csrf=anonymous_csrf())
         assert config_save_middleware().denied_response(request) is not None
 
     @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 0})
@@ -875,75 +872,52 @@ def run_page_request(cookie: Optional[str] = None, remote_ip: str = "127.0.0.1")
     return captured, rendered_token
 
 
-def issued_session_cookies(cookie: Optional[str] = None, remote_ip: str = "127.0.0.1") -> list[str]:
-    return run_page_request(cookie=cookie, remote_ip=remote_ip)[0]
+class TestPageLoadIssuesNoSessionCookie:
+    """Page loads never set a session cookie; login sessions come only from the login form"""
 
-
-class TestAnonymousSessionIssuing:
-
-    def _issued(self, **kwargs) -> bool:
-        return any(value.startswith(security.SESSION_COOKIE_USER + "=") for value in issued_session_cookies(**kwargs))
+    def _session_cookies(self, **kwargs) -> list[str]:
+        set_cookies, _ = run_page_request(**kwargs)
+        return [value for value in set_cookies if value.startswith(security.SESSION_COOKIE_USER + "=")]
 
     @pytest.mark.config({"username": "", "password": ""})
-    def test_issued_without_credentials(self, session_store):
-        assert self._issued() is True
-
-    @pytest.mark.config({"username": "", "password": ""})
-    def test_not_reissued_when_tag_already_held(self, session_store):
-        assert self._issued(cookie=security.anonymous_session_tag()) is False
+    def test_none_issued_when_login_bypassed(self, session_store):
+        assert self._session_cookies() == []
 
     @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 5})
-    def test_issued_when_login_waived_for_local_client(self, session_store):
-        assert self._issued() is True
+    def test_none_issued_for_waived_local_client(self, session_store):
+        assert self._session_cookies() == []
 
     @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 5})
-    def test_login_session_not_overwritten(self, session_store):
+    def test_login_session_left_untouched(self, session_store):
         store_session(session_store, "login-token")
-        assert self._issued(cookie="login-token") is False
+        assert self._session_cookies(cookie="login-token") == []
 
 
-def session_cookie_value(set_cookie_headers: list[str], fallback: Optional[str]) -> str:
-    """The session cookie the client is left holding after a response"""
-    for value in set_cookie_headers:
-        if value.startswith(security.SESSION_COOKIE_USER + "="):
-            return value.split("=", 1)[1].split(";", 1)[0]
-    return fallback or ""
+class TestRenderedToken:
+    """The token a page renders is the one that authorizes its next POST"""
 
-
-class TestRenderedTokenMatchesCookie:
-
-    def _assert_token_matches(self, cookie: Optional[str]):
-        set_cookies, rendered_token = run_page_request(cookie=cookie)
-        held = session_cookie_value(set_cookies, cookie)
-        assert rendered_token == security.csrf_token_for(held)
+    def _rendered(self, cookie: Optional[str] = None, remote_ip: str = "127.0.0.1") -> str:
+        _set_cookies, rendered_token = run_page_request(cookie=cookie, remote_ip=remote_ip)
         assert rendered_token, "a page rendered no usable token at all"
+        return rendered_token
 
     @pytest.mark.config({"username": "", "password": ""})
-    def test_first_load_with_no_cookie(self, session_store):
-        self._assert_token_matches(None)
-
-    @pytest.mark.config({"username": "", "password": ""})
-    def test_load_with_stale_cookie(self, session_store):
-        # A tag from before a restart rotated the key: a fresh cookie is issued
-        self._assert_token_matches("f0" * 32)
-
-    @pytest.mark.config({"username": "", "password": ""})
-    def test_steady_state_anonymous(self, session_store):
-        self._assert_token_matches(security.anonymous_session_tag())
+    def test_bypassed_binds_to_the_stable_identity(self, session_store):
+        # No cookie is needed: the token binds to the stable anonymous identity
+        assert self._rendered(None) == anonymous_csrf()
 
     @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 0})
-    def test_login_session(self, session_store):
+    def test_login_session_binds_to_its_cookie(self, session_store):
         store_session(session_store, "login-token")
-        self._assert_token_matches("login-token")
+        assert self._rendered("login-token") == security.csrf_token_for("login-token")
 
     @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 5})
     def test_login_session_while_login_waived(self, session_store):
         store_session(session_store, "login-token")
-        self._assert_token_matches("login-token")
+        assert self._rendered("login-token") == security.csrf_token_for("login-token")
 
     @pytest.mark.config({"username": "", "password": ""})
     def test_rendered_token_authorizes_the_next_post(self, session_store):
-        set_cookies, rendered_token = run_page_request()
-        held = session_cookie_value(set_cookies, None)
-        request = page_post(held, csrf=rendered_token)
+        rendered = self._rendered(None)
+        request = page_post(None, csrf=rendered)
         assert config_save_middleware().denied_response(request) is None

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -68,13 +68,22 @@ def mock_request(
     return request
 
 
+def set_csrf_header(request, token: str):
+    """Add the CSRF header to an already-built mock request"""
+    request.headers = Headers({**dict(request.headers.items()), security.CSRF_HEADER: token})
+
+
+def anonymous_csrf() -> str:
+    """The CSRF token a login-bypassed request (no cookie) must echo"""
+    return security.csrf_token_for(security._ANONYMOUS_CSRF_IDENTITY)
+
+
 def api_request(token: Optional[str] = None, *, mode: str = "queue", with_token: bool = True, **kwargs):
-    """Mock /api request authorized by a session cookie, echoing its CSRF token unless with_token is False"""
-    return mock_request(
-        token,
-        params={"mode": mode, "name": "", **kwargs},
-        csrf=security.csrf_token_for(token or "") if with_token else None,
-    )
+    """Mock /api request; echoes the CSRF token its identity expects unless with_token is False"""
+    request = mock_request(token, params={"mode": mode, "name": "", **kwargs})
+    if with_token:
+        set_csrf_header(request, security.csrf_token_for(security.csrf_identity(request)))
+    return request
 
 
 def store_session(
@@ -136,27 +145,24 @@ class TestHostileTokenValues:
         # ...and still matches what it should
         assert security.constant_time_equals("a" * 64, "a" * 64) is True
 
-    @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
+    @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 0})
     def test_hostile_session_cookie_is_rejected(self, session_store):
-        """Runs on a page GET with no credentials configured, so it needs no authentication at all"""
+        """With the login enforced, a session cookie of hostile bytes matches no stored session"""
         for value in self.WIRE_HOSTILE:
-            assert security.validate_anonymous_session(mock_request(value)) is False
             assert security.validate_any_session(mock_request(value)) is False
 
     @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
     def test_hostile_csrf_token_in_header_is_rejected(self, session_store):
-        tag = security.anonymous_session_tag()
         for value in self.WIRE_HOSTILE:
-            assert security.csrf_token_matches(mock_request(tag, csrf=value)) is False
-            assert config_save_middleware().denied_response(page_post(tag, csrf=value)) is not None
+            assert security.csrf_token_matches(mock_request(csrf=value)) is False
+            assert config_save_middleware().denied_response(page_post(csrf=value)) is not None
 
     @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
     def test_hostile_csrf_token_in_form_field_is_rejected(self, session_store):
-        tag = security.anonymous_session_tag()
         for value in self.BODY_HOSTILE:
-            request = mock_request(tag, params={security.CSRF_FIELD: value})
+            request = mock_request(params={security.CSRF_FIELD: value})
             assert security.csrf_token_matches(request) is False
-            assert config_save_middleware().denied_response(page_post(tag, csrf_field=value)) is not None
+            assert config_save_middleware().denied_response(page_post(csrf_field=value)) is not None
 
     @staticmethod
     def _upload_part():
@@ -171,11 +177,10 @@ class TestHostileTokenValues:
 
     @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
     def test_csrf_token_sent_as_a_file_part_is_refused(self, session_store):
-        tag = security.anonymous_session_tag()
-        request = mock_request(tag, params={security.CSRF_FIELD: self._upload_part()})
+        request = mock_request(params={security.CSRF_FIELD: self._upload_part()})
         assert security.presented_csrf_token(request) == ""
         assert security.csrf_token_matches(request) is False
-        denied = page_post(tag, csrf_field=self._upload_part())
+        denied = page_post(csrf_field=self._upload_part())
         assert config_save_middleware().denied_response(denied) is not None
 
     @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
@@ -451,44 +456,58 @@ class TestSessionAbsoluteDeadline:
         assert interface.check_apikey(api_request("browser-token")) is None
 
 
-class TestAnonymousSession:
-    """Anonymous sessions are stateless (HMAC cookie), never database rows"""
+class TestBypassedLoginSession:
+    """With the login bypassed there is no session cookie: the request is trusted for being
+    local, and its CSRF token binds to a stable identity rather than to a cookie."""
 
     @pytest.mark.config({"username": "", "password": ""})
-    def test_valid_tag_accepted(self):
-        assert security.validate_anonymous_session(mock_request(security.anonymous_session_tag())) is True
-
-    @pytest.mark.config({"username": "", "password": ""})
-    def test_missing_or_wrong_tag_rejected(self):
-        assert security.validate_anonymous_session(mock_request(None)) is False
-        assert security.validate_anonymous_session(mock_request("forged-tag")) is False
+    def test_any_session_holds_without_cookie(self):
+        assert security.validate_any_session(mock_request(None)) is True
 
     @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 0})
-    def test_rejected_when_credentials_configured(self):
-        # A tag minted while auth was off grants nothing once credentials are set
-        assert security.validate_anonymous_session(mock_request(security.anonymous_session_tag())) is False
+    def test_denied_without_cookie_when_login_enforced(self, session_store):
+        assert security.validate_any_session(mock_request(None)) is False
 
     @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 5})
-    def test_accepted_when_login_waived_for_local_client(self):
-        # inet_exposure 5 waives the login for local clients, so their page loads get an
-        # anonymous cookie
-        assert security.validate_anonymous_session(mock_request(security.anonymous_session_tag())) is True
-        # An external client still needs to log in, so no tag is good enough
-        external = mock_request(security.anonymous_session_tag(), remote_ip="9.8.7.6")
-        assert security.validate_anonymous_session(external) is False
+    def test_waived_for_local_client_only(self, session_store):
+        # inet_exposure 5 waives the login for local clients
+        assert security.validate_any_session(mock_request(None)) is True
+        # An external client still needs to log in
+        assert security.validate_any_session(mock_request(None, remote_ip="9.8.7.6")) is False
 
     @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
-    def test_check_apikey_accepts_anonymous_without_key(self):
-        assert interface.check_apikey(api_request(security.anonymous_session_tag())) is None
+    def test_check_apikey_accepts_csrf_without_key_or_cookie(self):
+        assert interface.check_apikey(api_request(None)) is None
+
+    @pytest.mark.config({"username": "", "password": "", "inet_exposure": 0})
+    def test_check_apikey_rejects_without_csrf(self):
+        assert interface.check_apikey(api_request(None, with_token=False)) is not None
 
     @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 5})
-    def test_check_apikey_accepts_anonymous_when_login_waived(self, session_store):
-        assert interface.check_apikey(api_request(security.anonymous_session_tag())) is None
+    def test_check_apikey_accepts_waived_local_with_csrf(self, session_store):
+        assert interface.check_apikey(api_request(None)) is None
+
+
+class TestCsrfIdentity:
+    """The CSRF token binds to a session identity; a request without one never matches"""
 
     @pytest.mark.config({"username": "", "password": ""})
-    def test_create_sets_matching_cookie(self):
-        request = Mock()
-        response = Mock()
-        security.create_anonymous_session(request, response)
-        assert response.set_cookie.call_args.args[1] == security.anonymous_session_tag()
-        assert response.set_cookie.call_args.args[0] == security.SESSION_COOKIE_USER
+    def test_bypassed_login_uses_the_stable_identity(self):
+        assert security.csrf_identity(mock_request(None)) == security._ANONYMOUS_CSRF_IDENTITY
+
+    @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 0})
+    def test_session_cookie_is_the_identity(self):
+        # The cookie value stands as the identity whether or not it names a live session
+        assert security.csrf_identity(mock_request("some-token")) == "some-token"
+
+    @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 0})
+    def test_no_identity_when_login_enforced_without_cookie(self):
+        assert security.csrf_identity(mock_request(None)) == ""
+
+    @pytest.mark.config({"username": "user", "password": "pass", "inet_exposure": 0})
+    def test_empty_identity_never_matches(self, session_store):
+        """The token for the empty identity is computable only by this instance, yet a
+        request that carries no identity must still be refused (guards direct callers)."""
+        request = mock_request(csrf=security.csrf_token_for(""))
+        assert security.csrf_identity(request) == ""
+        assert security.csrf_token_matches(request) is False


### PR DESCRIPTION
Previously, UI access for login-bypassed clients relied on issuing a stateless "anonymous session" cookie to enable CSRF protection. This commit removes that cookie mechanism.

Instead, when the login is bypassed (e.g., for local clients without credentials), the CSRF token is now bound to a stable, internal "anonymous" identity. This maintains robust CSRF protection for browser interactions without requiring an explicit session cookie, simplifying overall session management.