### PR TITLE
Functional tests with Playwright instead of Selenium

### DIFF
--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -68,9 +68,6 @@ jobs:
         pip install -r requirements.txt --no-dependencies
         pip install --upgrade -r tests/requirements.txt
     - name: Install Playwright browser
-      run: python -m playwright install chromium
-    - name: Install Playwright system dependencies
-      if: runner.os == 'Linux'
-      run: python -m playwright install-deps chromium
+      run: python -m playwright install chromium --with-deps
     - name: Test SABnzbd
       run: pytest -n auto --dist loadscope

--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -67,5 +67,10 @@ jobs:
         python -m pip install --upgrade pip wheel
         pip install -r requirements.txt --no-dependencies
         pip install --upgrade -r tests/requirements.txt
+    - name: Install Playwright browser
+      run: python -m playwright install chromium
+    - name: Install Playwright system dependencies
+      if: runner.os == 'Linux'
+      run: python -m playwright install-deps chromium
     - name: Test SABnzbd
       run: pytest -n auto --dist loadscope

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ anyio==4.14.2
 sniffio==1.3.1
 uvicorn==0.52.1
 click==8.4.2
+h11==0.16.0
 python-multipart==0.0.32
 httptools==0.8.0
 

--- a/sabnzbd/interface.py
+++ b/sabnzbd/interface.py
@@ -654,10 +654,13 @@ def get_access_info(request: Optional[Request] = None) -> list[str]:
     host = socket.gethostname().lower()
     socks = [host]
 
-    try:
-        addresses = socket.getaddrinfo(host, None)
-    except Exception:
-        addresses = []
+    # Only the wildcard hosts below use these, and the lookup stalls where the hostname does not resolve
+    addresses = []
+    if web_host in ("0.0.0.0", "::"):
+        try:
+            addresses = socket.getaddrinfo(host, None)
+        except Exception:
+            pass
 
     if web_host == "0.0.0.0":
         # Grab a list of all ips for the hostname

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,8 +32,6 @@ from warnings import warn
 
 import pytest
 import requests
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options as ChromeOptions
 
 import sabnzbd
 import sabnzbd.sessionstore as sessionstore
@@ -211,24 +209,8 @@ def run_sabnzbd(clean_cache_dir, compiled_language_files, request):
 
 
 @pytest.fixture(scope="session")
-def run_sabnews_and_selenium(request):
-    """Start SABNews and Selenium/Chromedriver, shared across the pytest session."""
-    # We only try Chrome for consistent results
-    driver_options = ChromeOptions()
-
-    # Headless during CI testing
-    if "CI" in os.environ:
-        driver_options.browser_version = "127"
-        driver_options.add_argument("--headless")
-        driver_options.add_argument("--no-sandbox")
-
-        # Useful for stability on Linux/macOS, doesn't work on Windows
-        if not sys.platform.startswith("win"):
-            driver_options.add_argument("--single-process")
-
-    # Start the driver and pass it on to all the classes
-    driver = webdriver.Chrome(options=driver_options)
-
+def run_sabnews(request):
+    """Start SABNews, shared across the pytest session."""
     # Start SABNews on this worker's own host/port so parallel workers don't
     # collide on a single fixed newsserver port.
     sabnews_process = subprocess.Popen(
@@ -242,8 +224,7 @@ def run_sabnews_and_selenium(request):
         ]
     )
 
-    # Now we run the tests
-    yield driver
+    yield
 
     # Shutdown SABNews
     try:
@@ -251,14 +232,6 @@ def run_sabnews_and_selenium(request):
         sabnews_process.communicate(timeout=10)
     except Exception as err:
         warn("Failed to shutdown the sabnews process: %s" % err)
-
-    # Shutdown Selenium/Chrome
-    try:
-        driver.close()
-        driver.quit()
-    except Exception as err:
-        # If something else fails, this can cause very non-informative long tracebacks
-        warn("Failed to shutdown the selenium/chromedriver process: %s" % err)
 
 
 @pytest.fixture(scope="class")

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,8 @@
 # Testing requirements
 pytest
 setuptools
-selenium
+pytest-playwright
+playwright>=1.55
 requests
 pyfakefs
 werkzeug

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,7 +5,6 @@ selenium
 requests
 pyfakefs
 werkzeug
-pytest-httpbin
 pytest-httpserver
 flaky
 xmltodict

--- a/tests/test_api_and_interface.py
+++ b/tests/test_api_and_interface.py
@@ -19,7 +19,6 @@
 tests.test_api - Tests for API functions
 """
 
-import asyncio
 import os
 from functools import cached_property
 import pytest
@@ -37,13 +36,13 @@ import sabnzbd
 import sabnzbd.database as db
 from sabnzbd.constants import DB_HISTORY_NAME, DEF_ADMIN_DIR, PP_LOOKUP, AddNzbFileResult, Status
 from sabnzbd.misc import pp_to_opts
-from tests.testhelper import FakeHistoryDB, SAB_CACHE_DIR
+from tests.testhelper import FakeHistoryDB, SAB_CACHE_DIR, run_async
 from tests.test_interface import resolve_client
 
 
 def run_api_handler(kwargs) -> Response:
     """Run the (async) api_handler to completion, like the /api route does"""
-    return asyncio.run(api.api_handler(kwargs))
+    return run_async(api.api_handler(kwargs))
 
 
 class TestApiInternals:
@@ -207,7 +206,7 @@ def run_get_request_params(method, query_string="", body=b"", content_type=None,
         return {"type": "http.request", "body": body, "more_body": False}
 
     request = Request(scope, receive)
-    return asyncio.run(interface.get_request_params(request, merge_query=merge_query))
+    return run_async(interface.get_request_params(request, merge_query=merge_query))
 
 
 FORM = "application/x-www-form-urlencoded"

--- a/tests/test_functional_api.py
+++ b/tests/test_functional_api.py
@@ -123,11 +123,15 @@ class ApiTestFunctions:
         result = run(
             os.path.join(SAB_DATA_DIR, "tavern", test_name + ".yaml"),
             tavern_global_cfg={"variables": dict(vars)},
+            # A pytest session inside a pytest test: pytest-playwright wraps every test in a
+            # soft-assertion scope, and Playwright refuses to nest those
             pytest_args=[
                 "--tavern-file-path-regex",
                 "api_.*.yaml",
                 "--ignore-glob",
                 os.path.join(SAB_BASE_DIR, "cache*"),
+                "-p",
+                "no:playwright",
             ],
         )
         assert result is result.OK

--- a/tests/test_functional_config.py
+++ b/tests/test_functional_config.py
@@ -19,13 +19,12 @@
 tests.test_functional_config - Basic testing if Config pages work
 """
 
-from selenium.common.exceptions import NoSuchElementException
-from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
+from playwright.sync_api import expect
 from pytest_httpserver import HTTPServer
 
 
 import os
+import re
 from tests.testhelper import (
     SAB_DATA_DIR,
     SAB_HOST,
@@ -60,31 +59,18 @@ class TestBasicPages(SABnzbdBaseTest):
             self.open_page("http://%s:%s/%s" % (SAB_HOST, SAB_PORT, test_url))
 
             # Can only click the visible buttons
-            submit_btns = self.selenium_wrapper(self.driver.find_elements, By.CLASS_NAME, "saveButton")
-            for submit_btn in submit_btns:
-                if submit_btn.is_displayed():
-                    break
-            else:
-                raise NoSuchElementException
+            submit_btn = self.page.locator(".saveButton:visible").first
+            expect(submit_btn).to_be_visible()
 
             # Click the right button
             submit_btn.click()
-
-            # Saving here may or may not raise a restart-request (depends on whether
-            # an option actually changed against the test ini), so dismiss it only
-            # if it appears. Cancel = no restart, so the process keeps serving.
-            self.dismiss_alert_if_present()
 
             # For Specials page we get redirected after save, so check for no crash
             if "special" in test_url:
                 self.no_page_crash()
             else:
                 # For others if all is fine, button will be back to normal in 1 second
-                wait_for(
-                    lambda: submit_btn.text == "Save Changes",
-                    timeout=1.5,
-                    err_msg=f"submit_btn.text was '{submit_btn.text}' but expected 'Save Changes'",
-                )
+                expect(submit_btn).to_have_text("Save Changes", timeout=1500)
 
 
 class TestConfigLogin(SABnzbdBaseTest):
@@ -93,62 +79,43 @@ class TestConfigLogin(SABnzbdBaseTest):
         self.open_page("http://%s:%s/config/general" % (SAB_HOST, SAB_PORT))
 
         # Set the username and password
-        username_imp = self.selenium_wrapper(self.driver.find_element, By.CSS_SELECTOR, "input[data-hide='username']")
-        username_imp.clear()
-        username_imp.send_keys("test_username")
-        pass_inp = self.selenium_wrapper(self.driver.find_element, By.CSS_SELECTOR, "input[data-hide='password']")
-        pass_inp.clear()
-        pass_inp.send_keys("test_password")
+        self.page.locator("input[data-hide='username']").fill("test_username")
+        self.page.locator("input[data-hide='password']").fill("test_password")
 
         # Submit and dismiss the restart-request (cancel, so no restart happens)
-        self.selenium_wrapper(self.driver.find_element, By.CLASS_NAME, "saveButton").click()
-        self.dismiss_restart_prompt()
+        self.click_expecting_dialog(self.page.locator(".saveButton").first)
 
         # Open any page and check if we get redirected
         self.open_page("http://%s:%s/config/general" % (SAB_HOST, SAB_PORT))
-        assert "/login" in self.driver.current_url
+        assert "/login" in self.page.url
 
         # Fill nonsense and submit
-        username_login = self.selenium_wrapper(self.driver.find_element, By.CSS_SELECTOR, "input[name='username']")
-        username_login.clear()
-        username_login.send_keys("nonsense")
-        pass_login = self.selenium_wrapper(self.driver.find_element, By.CSS_SELECTOR, "input[name='password']")
-        pass_login.clear()
-        pass_login.send_keys("nonsense")
-        self.driver.find_element(By.TAG_NAME, "button").click()
+        self.page.locator("input[name='username']").fill("nonsense")
+        self.page.locator("input[name='password']").fill("nonsense")
+        self.page.locator("button").first.click()
 
         # Check if we were denied
-        assert (
-            "Authentication failed"
-            in self.selenium_wrapper(self.driver.find_element, By.CLASS_NAME, "alert-danger").text
-        )
+        expect(self.page.locator(".alert-danger")).to_contain_text("Authentication failed")
 
         # Fill right stuff
-        username_login = self.selenium_wrapper(self.driver.find_element, By.CSS_SELECTOR, "input[name='username']")
-        username_login.clear()
-        username_login.send_keys("test_username")
-        pass_login = self.selenium_wrapper(self.driver.find_element, By.CSS_SELECTOR, "input[name='password']")
-        pass_login.clear()
-        pass_login.send_keys("test_password")
-        self.driver.find_element(By.TAG_NAME, "button").click()
+        self.page.locator("input[name='username']").fill("test_username")
+        self.page.locator("input[name='password']").fill("test_password")
+        self.page.locator("button").first.click()
 
         # Can we now go to the page and empty the settings again?
         self.open_page("http://%s:%s/config/general" % (SAB_HOST, SAB_PORT))
-        assert "/login" not in self.driver.current_url
+        assert "/login" not in self.page.url
 
         # Set the username and password
-        username_imp = self.selenium_wrapper(self.driver.find_element, By.CSS_SELECTOR, "input[data-hide='username']")
-        username_imp.clear()
-        pass_inp = self.selenium_wrapper(self.driver.find_element, By.CSS_SELECTOR, "input[data-hide='password']")
-        pass_inp.clear()
+        self.page.locator("input[data-hide='username']").fill("")
+        self.page.locator("input[data-hide='password']").fill("")
 
         # Submit and dismiss the restart-request (cancel, so no restart happens)
-        self.selenium_wrapper(self.driver.find_element, By.CLASS_NAME, "saveButton").click()
-        self.dismiss_restart_prompt()
+        self.click_expecting_dialog(self.page.locator(".saveButton").first)
 
         # Open any page and check we are NOT redirected to login (no credentials set)
         self.open_page("http://%s:%s/config/general" % (SAB_HOST, SAB_PORT))
-        assert "/login" not in self.driver.current_url
+        assert "/login" not in self.page.url
 
 
 class TestConfigCategories(SABnzbdBaseTest):
@@ -159,24 +126,22 @@ class TestConfigCategories(SABnzbdBaseTest):
         self.open_page("http://%s:%s/config/categories" % (SAB_HOST, SAB_PORT))
 
         # Add new category
-        self.driver.find_elements(By.NAME, "newname")[1].send_keys(self.category_name)
-        self.selenium_wrapper(
-            self.driver.find_element, By.XPATH, "//button/text()[normalize-space(.)='Add']/parent::*"
-        ).click()
+        self.page.locator("[name='newname']").nth(1).fill(self.category_name)
+        self.page.locator("xpath=//button/text()[normalize-space(.)='Add']/parent::*").click()
         self.no_page_crash()
-        self.wait_for_ajax()
+        self.page.wait_for_load_state("networkidle")
 
         # Category names are stored lowercased, so the name as typed must not come back
-        assert self.category_name not in self.driver.page_source
+        assert self.category_name not in self.page.content()
 
         # Reload and confirm it was really saved. Without this the test passes whether the
         # POST was accepted or refused, because a rejected save leaves the name absent too.
         self.open_page("http://%s:%s/config/categories" % (SAB_HOST, SAB_PORT))
-        assert self.category_name.lower() in self.driver.page_source
+        assert self.category_name.lower() in self.page.content()
 
 
 class TestConfigRSS(SABnzbdBaseTest):
-    rss_name = "_SeleniumFeed"
+    rss_name = "_PlaywrightFeed"
 
     def test_rss_basic_flow(self, httpserver: HTTPServer):
         # Setup the response for the NZB
@@ -195,44 +160,31 @@ class TestConfigRSS(SABnzbdBaseTest):
         self.open_page("http://%s:%s/config/rss" % (SAB_HOST, SAB_PORT))
 
         # Uncheck enabled-checkbox for new feeds
-        self.selenium_wrapper(
-            self.driver.find_element, By.XPATH, '//form[@data-form="add-rss-feed"]//input[@name="enable"]'
-        ).click()
-        input_name = self.selenium_wrapper(
-            self.driver.find_element, By.XPATH, '//form[@data-form="add-rss-feed"]//input[@name="feed"]'
-        )
-        input_name.clear()
-        input_name.send_keys(self.rss_name)
-        self.selenium_wrapper(
-            self.driver.find_element, By.XPATH, '//form[@data-form="add-rss-feed"]//input[@name="uri"]'
-        ).send_keys(rss_url)
-        self.selenium_wrapper(self.driver.find_element, By.XPATH, '//form[@data-form="add-rss-feed"]//button').click()
+        add_form = self.page.locator('form[data-form="add-rss-feed"]')
+        add_form.locator("input[name='enable']").click()
+        add_form.locator("input[name='feed']").fill(self.rss_name)
+        add_form.locator("input[name='uri']").fill(rss_url)
+        add_form.locator("button").click()
 
         # Check if we have results
-        tab_results = int(
-            self.selenium_wrapper(self.driver.find_element, By.XPATH, '//a[@href="#rss-tab-matched"]/span').text
-        )
+        matched_count = self.page.locator('xpath=//a[@href="#rss-tab-matched"]/span')
+        expect(matched_count).to_be_visible()
+        tab_results = int(matched_count.inner_text())
         assert tab_results > 0
 
         # Check if it matches the number of rows
-        tab_table_results = len(self.driver.find_elements(By.XPATH, '//div[@id="rss-tab-matched"]/table/tbody/tr'))
+        tab_table_results = self.page.locator('xpath=//div[@id="rss-tab-matched"]/table/tbody/tr').count()
         assert tab_table_results == tab_results
 
         # Pause the queue do we don't download stuff
         assert get_api_result("pause") == {"status": True}
 
         # Download something
-        download_btn = self.selenium_wrapper(
-            self.driver.find_element, By.XPATH, '//div[@id="rss-tab-matched"]/table/tbody//button'
-        )
+        download_btn = self.page.locator('xpath=//div[@id="rss-tab-matched"]/table/tbody//button').first
         download_btn.click()
 
         # Does the page think it's a success?
-        wait_for(
-            lambda: "Added NZB" in download_btn.text,
-            timeout=5,
-            err_msg="Added NZB is not visible",
-        )
+        expect(download_btn).to_contain_text("Added NZB", timeout=5000)
 
         # Check if the fetch-request was added to the queue
         wait_for(
@@ -250,64 +202,52 @@ class TestConfigRSS(SABnzbdBaseTest):
 
 
 class TestConfigServers(SABnzbdBaseTest):
-    server_name = "_SeleniumServer"
+    server_name = "_PlaywrightServer"
 
     def open_config_servers(self):
         # Test if base page works
         self.open_page("http://%s:%s/config/server" % (SAB_HOST, SAB_PORT))
-        self.scroll_to_top()
 
         # Show advanced options
-        advanced_btn = self.selenium_wrapper(self.driver.find_element, By.NAME, "advanced-settings-button")
-        if not advanced_btn.get_attribute("checked"):
+        advanced_btn = self.page.locator("[name='advanced-settings-button']")
+        if not advanced_btn.is_checked():
             advanced_btn.click()
 
     def add_test_server(self):
         # Add server
-        self.selenium_wrapper(self.driver.find_element, By.ID, "addServerButton").click()
-        host_inp = self.selenium_wrapper(self.driver.find_element, By.NAME, "host")
-        host_inp.clear()
-        host_inp.send_keys(SAB_NEWSSERVER_HOST)
+        self.page.locator("#addServerButton").click()
+        self.page.locator("[name='host']").fill(SAB_NEWSSERVER_HOST)
 
         # Change port
-        port_inp = self.selenium_wrapper(self.driver.find_element, By.NAME, "port")
-        port_inp.clear()
-        port_inp.send_keys(SAB_NEWSSERVER_PORT)
+        port_inp = self.page.locator("[name='port']")
+        port_inp.fill(str(SAB_NEWSSERVER_PORT))
 
         # Disable SSL for testing
-        self.selenium_wrapper(self.driver.find_element, By.NAME, "ssl").click()
+        self.page.locator("[name='ssl']").click()
 
         # Test server-check
-        result_box = self.selenium_wrapper(self.driver.find_element, By.CSS_SELECTOR, "#addServerContent .result-box")
-        self.selenium_wrapper(self.driver.find_element, By.CSS_SELECTOR, "#addServerContent .testServer").click()
-        wait_for(
-            lambda: "Connection Successful" in result_box.text,
-            timeout=5,
-            err_msg="The connection test was not successful",
+        self.page.locator("#addServerContent .testServer").click()
+        expect(self.page.locator("#addServerContent .result-box")).to_contain_text(
+            "Connection Successful", timeout=5000
         )
 
         # Set test-servername
-        self.selenium_wrapper(self.driver.find_element, By.ID, "displayname").send_keys(self.server_name)
+        self.page.locator("#displayname").fill(self.server_name)
 
-        # Add and show details
-        port_inp.send_keys(Keys.RETURN)
-        wait_for(
-            lambda: not self.selenium_wrapper(self.driver.find_element, By.ID, "host0").is_displayed(),
-            timeout=2,
-            err_msg="The Add Server interface did not close",
-        )
-        self.selenium_wrapper(self.driver.find_element, By.CLASS_NAME, "showserver").click()
+        # Add and show details, once the reload that saving a new server triggers has landed
+        with self.page.expect_navigation():
+            port_inp.press("Enter")
+        expect(self.page.locator("#host0")).to_be_hidden(timeout=2000)
+        self.page.locator(".showserver").first.click()
+        expect(self.page.locator(".delServer").first).to_be_visible()
 
     def remove_server(self):
-        # Remove the first server and accept the confirmation. The confirm() is
-        # opened synchronously by the click handler, but Selenium's click() can
-        # return before it is registered, so wait for it rather than racing.
-        self.selenium_wrapper(self.driver.find_element, By.CLASS_NAME, "delServer").click()
-        self.wait_for_alert().accept()
+        # Remove the first server and accept the confirmation
+        self.click_expecting_dialog(self.page.locator(".delServer").first, accept=True)
 
         # Check that it's gone
         wait_for(
-            lambda: self.server_name not in self.driver.page_source,
+            lambda: self.server_name not in self.page.content(),
             timeout=2,
             err_msg=f"Page still contains '{self.server_name}'",
         )
@@ -324,17 +264,20 @@ class TestGlitterInterface(SABnzbdBaseTest):
     def test_interface_loads_and_polls(self):
         # skip_wizard because the test ini configures no servers, so / would redirect there
         self.open_page("http://%s:%s/?skip_wizard=1" % (SAB_HOST, SAB_PORT))
-        self.wait_for_ajax()
+
+        # Glitter polls forever, so there is no network-idle; isLoaded marks the first refresh
+        expect(self.page.locator(".main-content")).to_have_class(re.compile(r"main-content-loaded"))
 
         # The token reached the page and was installed for every request. Checked because a
         # missing csrfToken global would throw inside glitter.basic.js and stop the rest of
         # the interface from initialising -- which leaves the overlay below hidden, so the
         # overlay alone would not notice.
-        assert self.driver.execute_script(
-            "return csrfToken.length === 64 && ($.ajaxSettings.headers || {})['X-SABnzbd-CSRF'] === csrfToken"
+        assert self.page.evaluate(
+            "csrfToken.length === 64 && ($.ajaxSettings.headers || {})['X-SABnzbd-CSRF'] === csrfToken"
         ), "Glitter did not install the CSRF header on its API calls"
 
         # The queue and history refresh drop this overlay over the page when they fail, so
         # its absence is what says those calls came back authorized
-        overlay = self.selenium_wrapper(self.driver.find_element, By.CLASS_NAME, "main-restarting")
-        assert not overlay.is_displayed(), "Glitter showed the reconnect overlay, so its API calls failed"
+        assert not self.page.locator(
+            ".main-restarting"
+        ).is_visible(), "Glitter showed the reconnect overlay, so its API calls failed"

--- a/tests/test_functional_config.py
+++ b/tests/test_functional_config.py
@@ -19,7 +19,7 @@
 tests.test_functional_config - Basic testing if Config pages work
 """
 
-from playwright.sync_api import expect
+from playwright.sync_api import Error as PlaywrightError, expect
 from pytest_httpserver import HTTPServer
 
 
@@ -248,11 +248,12 @@ class TestConfigServers(SABnzbdBaseTest):
         # Remove the first server and accept the confirmation
         self.click_expecting_dialog(self.page.locator(".delServer").first, accept=True)
 
-        # Check that it's gone
+        # Check that it's gone. Deleting reloads, so a read can land mid-navigation and raise
         wait_for(
             lambda: self.server_name not in self.page.content(),
-            timeout=2,
+            timeout=5,
             err_msg=f"Page still contains '{self.server_name}'",
+            suppress=(PlaywrightError,),
         )
 
     def test_add_and_remove_server(self):

--- a/tests/test_functional_config.py
+++ b/tests/test_functional_config.py
@@ -47,6 +47,8 @@ class TestBasicPages(SABnzbdBaseTest):
             self.open_page("http://%s:%s/%s" % (SAB_HOST, SAB_PORT, test_url))
 
     def test_base_submit_pages(self):
+        # The save button is re-enabled on a 1s timer that is only scheduled once the response lands
+        self.page.clock.install()
         test_urls_with_submit = [
             "config/general",
             "config/folders",
@@ -62,14 +64,15 @@ class TestBasicPages(SABnzbdBaseTest):
             submit_btn = self.page.locator(".saveButton:visible").first
             expect(submit_btn).to_be_visible()
 
-            # Click the right button
-            submit_btn.click()
+            with self.page.expect_response(lambda r: r.request.method == "POST"):
+                submit_btn.click()
+            self.page.clock.run_for(1000)
 
             # For Specials page we get redirected after save, so check for no crash
             if "special" in test_url:
                 self.no_page_crash()
             else:
-                # For others if all is fine, button will be back to normal in 1 second
+                # For others if all is fine, the button will be back to normal
                 expect(submit_btn).to_have_text("Save Changes", timeout=1500)
 
 
@@ -127,9 +130,9 @@ class TestConfigCategories(SABnzbdBaseTest):
 
         # Add new category
         self.page.locator("[name='newname']").nth(1).fill(self.category_name)
-        self.page.locator("xpath=//button/text()[normalize-space(.)='Add']/parent::*").click()
+        with self.page.expect_response(lambda r: r.request.method == "POST"):
+            self.page.locator("xpath=//button/text()[normalize-space(.)='Add']/parent::*").click()
         self.no_page_crash()
-        self.page.wait_for_load_state("networkidle")
 
         # Category names are stored lowercased, so the name as typed must not come back
         assert self.category_name not in self.page.content()

--- a/tests/test_functional_misc.py
+++ b/tests/test_functional_misc.py
@@ -56,7 +56,7 @@ class TestShowLogging(SABnzbdBaseTest):
 
     def test_showlog(self):
         """Test the output of the filtered-log button"""
-        # Basic URL-fetching, easier than Selenium file download
+        # Basic URL-fetching, easier than driving a browser file download
         self._assert_is_the_log(get_api_result("showlog"))
 
     def test_log_page_route(self):

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -19,7 +19,6 @@
 tests.test_interface - Testing functions in interface.py
 """
 
-import asyncio
 import inspect
 import logging
 import logging.config
@@ -49,6 +48,8 @@ from tests.test_security import (
 )
 from sabnzbd.misc import is_local_addr, is_loopback_addr, xff_trusted_networks
 
+from tests.testhelper import run_async
+
 
 def resolve_client(remote_ip: str, xff_header: str | None = None, remote_port: int = 12345) -> Address:
     """Pass a connection through uvicorn's ProxyHeadersMiddleware, configured
@@ -63,7 +64,7 @@ def resolve_client(remote_ip: str, xff_header: str | None = None, remote_port: i
     if xff_header:
         headers.append((b"x-forwarded-for", xff_header.encode("latin1")))
     scope = {"type": "http", "client": (remote_ip, remote_port), "headers": headers}
-    asyncio.run(middleware(scope, None, None))
+    run_async(middleware(scope, None, None))
     return Address(*captured["client"])
 
 
@@ -367,7 +368,7 @@ def feed_raw_request(protocol_class, data: bytes):
         protocol.connection_made(transport)
         protocol.data_received(data)
 
-    asyncio.run(_run())
+    run_async(_run())
 
 
 class TestUvicornLogging:
@@ -551,7 +552,7 @@ class TestUseSecureCookies:
                 "server": ("127.0.0.1", 8080),
                 "headers": [(b"host", b"sab.example.com"), (b"x-forwarded-proto", b"https")],
             }
-            asyncio.run(middleware(scope, None, None))
+            run_async(middleware(scope, None, None))
             return captured["secure"]
 
         # Trusted proxy: the forwarded scheme is honoured
@@ -718,7 +719,7 @@ class TestLogRoute:
             "server": ("127.0.0.1", 8080),
             "scheme": "http",
         }
-        asyncio.run(route.app(scope, receive, send))
+        run_async(route.app(scope, receive, send))
         # Redirected to the login form, and the handler never ran to stream any of the log
         assert captured["status"] == 302
         assert captured["headers"]["location"].endswith("/login")
@@ -868,7 +869,7 @@ def run_page_request(cookie: Optional[str] = None, remote_ip: str = "127.0.0.1")
         if message["type"] == "http.response.start":
             captured.extend(Headers(raw=message["headers"]).getlist("set-cookie"))
 
-    asyncio.run(middleware(scope, None, send))
+    run_async(middleware(scope, None, send))
     return captured, rendered_token
 
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -19,7 +19,6 @@
 tests.test_security - Testing authentication, sessions and the CSRF token
 """
 
-import asyncio
 import io
 import time
 from typing import Optional
@@ -33,6 +32,8 @@ import sabnzbd
 import sabnzbd.cfg as cfg
 import sabnzbd.security as security
 from sabnzbd import interface
+
+from tests.testhelper import run_async
 
 
 def mock_request(
@@ -312,7 +313,7 @@ class TestLoginRateLimiting:
             patch("sabnzbd.interface.template_filtered_response") as render,
             patch("sabnzbd.security.create_session") as create_session,
         ):
-            asyncio.run(interface.login_index(request))
+            run_async(interface.login_index(request))
 
         # No session handed out, despite the credentials being exactly right
         create_session.assert_not_called()
@@ -327,12 +328,12 @@ class TestLoginRateLimiting:
             patch("sabnzbd.interface.build_header", return_value={}),
             patch("sabnzbd.interface.template_filtered_response") as render,
         ):
-            asyncio.run(interface.login_index(wrong))
+            run_async(interface.login_index(wrong))
         assert render.call_args.kwargs["status_code"] == 200
         assert security._login_attempts["127.0.0.1"][0] == 1
 
         right = login_post(username="user", password="pass")
-        asyncio.run(interface.login_index(right))
+        run_async(interface.login_index(right))
         assert "127.0.0.1" not in security._login_attempts
 
     def test_cooldown_remaining_counts_down_and_rounds_up(self):
@@ -386,7 +387,7 @@ class TestLoginRateLimiting:
                 side_effect=lambda **kwargs: HTMLResponse("", status_code=kwargs["status_code"]),
             ),
         ):
-            response = asyncio.run(interface.login_index(request))
+            response = run_async(interface.login_index(request))
 
         assert response.status_code == 429
         assert 0 < int(response.headers["Retry-After"]) <= security.LOGIN_LOCKOUT_TIME + 1

--- a/tests/test_urlgrabber.py
+++ b/tests/test_urlgrabber.py
@@ -19,19 +19,72 @@
 tests.test_urlgrabber - Testing functions in urlgrabber.py
 """
 
+import base64
+
+import binascii
 import json
+import re
 import urllib.error
 import urllib.parse
 
 import pytest
-import pytest_httpbin
+from pytest_httpserver import HTTPServer
+from werkzeug import Request, Response
 
 import sabnzbd
 import sabnzbd.urlgrabber as urlgrabber
 import sabnzbd.cfg as cfg
 
 
-@pytest_httpbin.use_class_based_httpbin
+def _json_response(payload, status: int = 200) -> Response:
+    return Response(json.dumps(payload), status=status, content_type="application/json")
+
+
+def _basic_auth_credentials(request: Request):
+    """Return the (username, password) of the Basic auth header, or None"""
+    scheme, _, payload = request.headers.get("Authorization", "").partition(" ")
+    if scheme.lower() != "basic":
+        return None
+    try:
+        # Credentials are sent as utf-8, so they may contain non-ascii characters
+        username, _, password = base64.b64decode(payload).decode("utf-8").partition(":")
+    except (binascii.Error, UnicodeDecodeError, ValueError):
+        return None
+    return username, password
+
+
+def _request_handler(request: Request) -> Response:
+    """Handle the (subset of the) httpbin endpoints used by the tests below"""
+    if request.path.startswith("/status/"):
+        return Response(status=int(request.path[len("/status/") :]))
+
+    if request.path == "/user-agent":
+        return _json_response({"user-agent": request.headers.get("User-Agent")})
+
+    if request.path.startswith("/basic-auth/"):
+        username, _, password = request.path[len("/basic-auth/") :].partition("/")
+        if _basic_auth_credentials(request) != (username, password):
+            return Response(status=401, headers={"WWW-Authenticate": 'Basic realm="Test"'})
+        return _json_response({"authenticated": True, "user": username})
+
+    if request.path in ("/", "/headers") or request.path.startswith("/anything"):
+        return _json_response({"headers": dict(request.headers), "url": request.url})
+
+    return Response(status=404)
+
+
+@pytest.fixture(scope="class")
+def local_server(request):
+    """Local webserver serving a minimal, httpbin-like API on a random port"""
+    server = HTTPServer(host="127.0.0.1")
+    server.expect_request(re.compile(r".*")).respond_with_handler(_request_handler)
+    server.start()
+    request.cls.server = server
+    yield
+    server.stop()
+
+
+@pytest.mark.usefixtures("local_server")
 class TestBuildRequest:
     def test_empty(self):
         with pytest.raises(ValueError):
@@ -83,27 +136,27 @@ class TestBuildRequest:
     def test_http_basic(self):
         # Use selftest_host for the most basic URL
         self._runner("http://" + cfg.selftest_host(), 200)
-        # Repeat with httpbin, which runs on a random non-standard port
-        self._runner(self.httpbin.url, 200)
+        # Repeat with the local server, which runs on a random non-standard port
+        self._runner(self.server.url_for("/"), 200)
 
     def test_https_basic(self):
-        # Use a real HTTPS server; httpbin_secure uses a self-signed cert
+        # Use a real HTTPS server, since the local server only serves plain HTTP
         self._runner("https://" + cfg.selftest_host(), 200)
         # Repeat with the port explicitly specified
         self._runner("https://" + cfg.selftest_host() + ":443/", 200)
 
     def test_http_code(self):
         # Make the server reply with a non-standard status code
-        self._runner(self.httpbin.url + "/status/242", 242)
+        self._runner(self.server.url_for("/status/242"), 242)
 
     def test_user_agent(self):
         # Verify the User-Agent string
-        assert ("SABnzbd/%s" % sabnzbd.__version__) in self._runner(self.httpbin.url + "/user-agent", 200, True)
+        assert ("SABnzbd/%s" % sabnzbd.__version__) in self._runner(self.server.url_for("/user-agent"), 200, True)
 
     def test_http_userpass(self):
         usr = "abcdefghijklm01234"
         pwd = "56789nopqrstuvwxyz"
-        common = "@" + self.httpbin.host + ":" + str(self.httpbin.port) + "/basic-auth/" + usr + "/" + pwd
+        common = "@" + self.server.host + ":" + str(self.server.port) + "/basic-auth/" + usr + "/" + pwd
         self._runner("http://" + usr + ":" + pwd + common, 200)
         with pytest.raises(urllib.error.HTTPError):
             # Authorisation should fail
@@ -111,34 +164,34 @@ class TestBuildRequest:
 
     def test_http_userpass_email(self):
         for usr, pwd in [("nobody@example.org", "secret!"), ("USER", "P@SS"), ("a@B.cd", "e@F.gh")]:
-            host = "http://" + usr + ":" + pwd + "@" + self.httpbin.host + ":" + str(self.httpbin.port)
+            host = "http://" + usr + ":" + pwd + "@" + self.server.host + ":" + str(self.server.port)
             self._runner(host + "/basic-auth/" + usr + "/" + pwd, 200)
 
     def test_http_userpass_non_ascii(self):
         usr = "유즈넷"
         pwd = "َอักษรไทย"
-        host = "http://" + usr + ":" + pwd + "@" + self.httpbin.host + ":" + str(self.httpbin.port)
+        host = "http://" + usr + ":" + pwd + "@" + self.server.host + ":" + str(self.server.port)
         path = "/basic-auth/" + urllib.parse.quote(usr) + "/" + urllib.parse.quote(pwd)
         self._runner(host + path, 200)
 
     def test_http_user_only(self):
-        h = self._runner("http://root@" + self.httpbin.host + ":" + str(self.httpbin.port) + "/headers", 200, True)
+        h = self._runner("http://root@" + self.server.host + ":" + str(self.server.port) + "/headers", 200, True)
         self._check_auth(h)
 
     def test_http_pass_only(self):
-        h = self._runner("http://:pass@" + self.httpbin.host + ":" + str(self.httpbin.port) + "/headers", 200, True)
+        h = self._runner("http://:pass@" + self.server.host + ":" + str(self.server.port) + "/headers", 200, True)
         self._check_auth(h)
 
     def test_http_userpass_empty(self):
         # Add colon and at-sign but no username or password
-        host = "http://:@" + self.httpbin.host + ":" + str(self.httpbin.port)
+        host = "http://:@" + self.server.host + ":" + str(self.server.port)
         h = self._runner(host + "/headers", 200, True)
         self._check_auth(h)
 
     def test_http_params_etc(self):
-        self._runner(self.httpbin.url + "/anything/test/this.html?urlgrabber=test#says_hi", 200)
+        self._runner(self.server.url_for("/anything/test/this.html?urlgrabber=test#says_hi"), 200)
         # Add all possible elements, even unnecessary authorisation parameters
-        host = "http://abcdefghijklm:nopqrstuvwxyz@" + self.httpbin.host + ":" + str(self.httpbin.port)
+        host = "http://abcdefghijklm:nopqrstuvwxyz@" + self.server.host + ":" + str(self.server.port)
         path = "/anything/goes/even/params.like;this?testing=urlgrabber&more=tests#longpath"
         self._runner(host + path, 200)
 
@@ -152,13 +205,13 @@ class TestBuildRequest:
 
     def test_http_invalid_scheme(self):
         with pytest.raises(urllib.error.URLError):
-            self._runner("_://" + self.httpbin.host + ":" + str(self.httpbin.port) + "/")
+            self._runner("_://" + self.server.host + ":" + str(self.server.port) + "/")
 
     def test_http_not_found(self):
         with pytest.raises(urllib.error.HTTPError):
-            self._runner(self.httpbin.url + "/status/404", 404)
+            self._runner(self.server.url_for("/status/404"), 404)
         with pytest.raises(urllib.error.HTTPError):
-            self._runner(self.httpbin.url + "/no/such/file", 404)
+            self._runner(self.server.url_for("/no/such/file"), 404)
 
 
 class TestFilenameFromDispositionHeader:

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -29,21 +29,15 @@ import socket
 import tempfile
 import time
 import uuid
-from http.client import RemoteDisconnected
 from concurrent.futures import ThreadPoolExecutor
 from typing import BinaryIO, Optional, Callable
 
 import pytest
 from random import choice, randint
 import requests
-from selenium.common.exceptions import WebDriverException
-from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
+from playwright.sync_api import Page, expect
 from string import ascii_lowercase, digits
 from unittest import mock
-from urllib3.exceptions import ProtocolError
 import xmltodict
 from werkzeug import Request
 from werkzeug.utils import send_from_directory
@@ -522,72 +516,43 @@ class AddingNZBsTestBase:
 @pytest.mark.usefixtures("run_sabnzbd")
 class SABnzbdBaseTest:
     @pytest.fixture(autouse=True)
-    def _setup_driver(self, run_sabnews_and_selenium):
-        self.driver = run_sabnews_and_selenium
+    def _setup_page(self, run_sabnews, page: Page):
+        self.page = page
 
     def no_page_crash(self):
         # Do a base test if CherryPy did not report test
-        assert "500 Internal Server Error" not in self.driver.title
+        assert "500 Internal Server Error" not in self.page.title()
 
     def open_page(self, url):
         # Open a page and test for crash
-        self.driver.get(url)
+        self.page.goto(url)
         self.no_page_crash()
 
-    def scroll_to_top(self):
-        self.driver.find_element(By.TAG_NAME, "body").send_keys(Keys.CONTROL + Keys.HOME)
-        try:
-            wait = WebDriverWait(self.driver, 2)
-            wait.until(lambda driver_wait: self.driver.execute_script("return window.scrollY") == 0)
-        except RemoteDisconnected:
-            pass
+    def click_expecting_dialog(self, locator, accept: bool = False, timeout: int = 15):
+        """Click something that raises a JS confirm()/alert and answer it.
 
-    def wait_for_alert(self, timeout=15):
-        """Wait for a JS confirm()/alert dialog and return it. Use only where a dialog is guaranteed."""
-        WebDriverWait(self.driver, timeout).until(EC.alert_is_present())
-        return self.driver.switch_to.alert
+        The handler is registered before the click: a confirm() raised synchronously from
+        the click handler blocks the page, so click() only returns once it is answered.
+        """
+        answered = []
 
-    def dismiss_restart_prompt(self, timeout=15):
-        """Dismiss the "restart required" confirmation raised after saving"""
-        self.wait_for_alert(timeout).dismiss()
+        def handle_dialog(dialog):
+            answered.append(dialog.message)
+            if accept:
+                dialog.accept()
+            else:
+                dialog.dismiss()
 
-    def dismiss_alert_if_present(self, timeout=15):
-        """Wait until a submitted save settles, dismissing a restart-request confirm() only if one is raised"""
+        self.page.once("dialog", handle_dialog)
+        locator.click()
+
+        # Wait through Playwright, which is what dispatches the event
         deadline = time.time() + timeout
-        while time.time() < deadline:
-            if EC.alert_is_present()(self.driver):
-                self.driver.switch_to.alert.dismiss()
-                return
-            try:
-                if self.driver.execute_script("return jQuery.active") == 0:
-                    return
-            except (RemoteDisconnected, ProtocolError):
-                return
-            time.sleep(0.1)
-        pytest.fail("Config save did not settle within %s seconds" % timeout)
+        while not answered and time.time() < deadline:
+            self.page.wait_for_timeout(100)
 
-    def wait_for_ajax(self):
-        # We catch common nonsense errors from Selenium
-        try:
-            wait = WebDriverWait(self.driver, 15)
-            wait.until(lambda driver_wait: self.driver.execute_script("return jQuery.active") == 0)
-            wait.until(lambda driver_wait: self.driver.execute_script("return document.readyState") == "complete")
-        except (RemoteDisconnected, ProtocolError):
-            pass
-
-    @staticmethod
-    def selenium_wrapper(func, *args):
-        """Wrapper with retries for more stable Selenium"""
-        for _ in range(3):
-            try:
-                return func(*args)
-            except WebDriverException as e:
-                prior_exception = e
-                # Try again in 2 seconds!
-                time.sleep(2)
-                pass
-        else:
-            raise prior_exception
+        if not answered:
+            pytest.fail("No dialog was raised within %s seconds" % timeout)
 
 
 class DownloadFlowBasics(SABnzbdBaseTest):
@@ -602,43 +567,35 @@ class DownloadFlowBasics(SABnzbdBaseTest):
     def start_wizard(self):
         # Language-selection
         self.open_page("http://%s:%s/wizard/" % (SAB_HOST, SAB_PORT))
-        self.selenium_wrapper(self.driver.find_element, By.ID, "en").click()
-        self.selenium_wrapper(self.driver.find_element, By.CSS_SELECTOR, "button.btn.btn-default").click()
+        self.page.locator("#en").click()
+        self.page.locator("button.btn.btn-default").click()
 
         # Fill server-info
         self.no_page_crash()
-        host_inp = self.selenium_wrapper(self.driver.find_element, By.NAME, "host")
-        host_inp.clear()
-        host_inp.send_keys(SAB_NEWSSERVER_HOST)
+        self.page.locator("[name='host']").fill(SAB_NEWSSERVER_HOST)
 
         # Disable SSL for testing
-        self.selenium_wrapper(self.driver.find_element, By.NAME, "ssl").click()
+        self.page.locator("[name='ssl']").click()
 
         # This will fail if the translations failed to compile!
-        self.selenium_wrapper(self.driver.find_element, By.PARTIAL_LINK_TEXT, "Advanced Settings").click()
+        self.page.locator("a:has-text('Advanced Settings')").click()
 
         # Change port
-        port_inp = self.selenium_wrapper(self.driver.find_element, By.NAME, "port")
-        port_inp.clear()
-        port_inp.send_keys(SAB_NEWSSERVER_PORT)
+        port_inp = self.page.locator("[name='port']")
+        port_inp.fill(str(SAB_NEWSSERVER_PORT))
 
         # Test server-check
-        server_response = self.selenium_wrapper(self.driver.find_element, By.ID, "serverResponse")
-        self.selenium_wrapper(self.driver.find_element, By.ID, "serverTest").click()
-        wait_for(
-            lambda: "Connection Successful" in server_response.text,
-            timeout=5,
-            err_msg="The connection test was not successful",
-        )
+        self.page.locator("#serverTest").click()
+        expect(self.page.locator("#serverResponse")).to_contain_text("Connection Successful", timeout=5000)
 
         # Final page done
-        self.selenium_wrapper(self.driver.find_element, By.ID, "next-button").click()
+        self.page.locator("#next-button").click()
         self.no_page_crash()
-        check_result = self.selenium_wrapper(self.driver.find_element, By.CLASS_NAME, "quoteBlock").text
-        assert "http://%s:%s" % (SAB_HOST, SAB_PORT) in check_result
+        # The first block lists the access URLs; the others are the download folders
+        expect(self.page.locator(".quoteBlock").first).to_contain_text("http://%s:%s" % (SAB_HOST, SAB_PORT))
 
         # Go to SAB!
-        self.selenium_wrapper(self.driver.find_element, By.CSS_SELECTOR, ".btn.btn-success").click()
+        self.page.locator(".btn.btn-success").click()
         self.no_page_crash()
 
     def download_nzb(self, nzb_dir: str, file_output: list[str], dir_name_as_job_name: bool = False):

--- a/tests/testhelper.py
+++ b/tests/testhelper.py
@@ -19,6 +19,7 @@
 tests.testhelper - Basic helper functions
 """
 
+import asyncio
 import copy
 import io
 import os
@@ -29,6 +30,7 @@ import tempfile
 import time
 import uuid
 from http.client import RemoteDisconnected
+from concurrent.futures import ThreadPoolExecutor
 from typing import BinaryIO, Optional, Callable
 
 import pytest
@@ -62,6 +64,22 @@ from sabnzbd.misc import pp_to_opts
 import sabnzbd.filesystem as filesystem
 
 import tests.sabnews
+
+
+def run_async(coro):
+    """Run a coroutine to completion, also when the thread already has a running loop.
+
+    Playwright's sync API keeps a loop running for as long as a browser fixture is alive,
+    which makes asyncio.run() refuse to start another one in the same thread.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(asyncio.run, coro).result()
+
 
 SAB_HOST = "127.0.0.1"
 SAB_NEWSSERVER_HOST = "127.0.0.1"


### PR DESCRIPTION
Why move off Selenium:

- **CI was pinned to Chrome 127** (mid-2024), 24 major versions behind. Playwright manages its own browser and ran Chrome 151. I tried getting selenium to use newer versions and it was too unstable.
- **Better API.** Auto-waiting removes 43 `selenium_wrapper` retry sites, the sleep-and-poll waits they papered over, and the `jQuery.active` dependency
- **Better failures.** Tests now name the locator and the step they stalled on, not a bare `NoSuchElementException`.

`test_functional_api.py` is untouched; it never used Selenium. Less obvious:

- **`h11` was a real gap in `requirements.txt`** — uvicorn requires it, selenium supplied it transitively.
- **httpbin had to go**: it pins `greenlet<3` below Python 3.12, Playwright needs `>=3.1.1`. `test_urlgrabber.py` now uses `pytest-httpserver` which we were already using elsewhere
- **One production change.** `get_access_info` blocked on an unbounded hostname lookup, hanging the wizard on macOS; Selenium hid it by waiting indefinitely. Guarded, not fixed — the default `0.0.0.0` still stalls.

Note Playwright defaults to headless mode, but can be ran in [headed mode](https://playwright.dev/python/docs/running-tests#run-tests-in-headed-mode) but you probably don't need it because the errors it gives when it couldn't do something are much nicer.
With xdist I'm pretty sure we used to download the browser multiple times, this done it once and is not worth caching.