### PR TITLE
Store the Windows API connection info per config file

### DIFF
--- a/SABnzbd.py
+++ b/SABnzbd.py
@@ -1009,7 +1009,7 @@ def main():
     # Windows instance is reachable through registry
     url = None
     if sabnzbd.WINDOWS and not new_instance:
-        url = get_connection_info()
+        url = get_connection_info(inifile)
         if url and check_for_sabnzbd(url, upload_nzbs, autobrowser):
             exit_sab(0)
 
@@ -1271,7 +1271,7 @@ def main():
 
     if sabnzbd.WINDOWS:
         # Write URL for uploads and version check directly to registry
-        set_connection_info(f"{sabnzbd.BROWSER_URL}/api?apikey={sabnzbd.cfg.api_key()}")
+        set_connection_info(f"{sabnzbd.BROWSER_URL}/api?apikey={sabnzbd.cfg.api_key()}", inifile)
 
     if pid_path or pid_file:
         sabnzbd.pid_file(pid_path, pid_file, web_port)

--- a/sabnzbd/__init__.py
+++ b/sabnzbd/__init__.py
@@ -359,7 +359,7 @@ def halt():
 
         # Remove registry information
         if sabnzbd.WINDOWS:
-            del_connection_info()
+            del_connection_info(config.CONFIG.filename)
 
         sabnzbd.zconfig.remove_server()
         sabnzbd.utils.ssdp.stop_ssdp()

--- a/sabnzbd/utils/apireg.py
+++ b/sabnzbd/utils/apireg.py
@@ -19,6 +19,9 @@
 util.apireg - Registration of API connection info
 """
 
+import hashlib
+import os
+import sys
 import winreg
 from typing import Optional, Tuple
 
@@ -47,8 +50,8 @@ LANGUAGE_MAP = {
 }
 
 
-def reg_info(user: bool) -> Tuple[int, str]:
-    """Return the registry hive and key path for the API info
+def reg_info(user: bool, inifile: str) -> Tuple[int, str]:
+    """Return the registry hive and key path for the API info of one instance
 
     The URL of a running instance is stored so that a second start of SABnzbd
     (for example by double-clicking an NZB) can hand off to the running instance
@@ -56,19 +59,24 @@ def reg_info(user: bool) -> Tuple[int, str]:
     but a Windows Service runs under a service account whose HKCU is invisible
     to the desktop user, so it uses the machine-wide service key in HKLM instead.
     Readers check HKCU first and fall back to HKLM to find either kind of instance.
+
+    Each config file gets its own subkey, so instances running side by side on
+    separate configs do not share an entry.
     """
+    # Subkey names cannot contain a path separator
+    instance = hashlib.sha256(os.path.normcase(os.path.abspath(inifile)).encode("utf-8")).hexdigest()
     if user:
         # Normally use the USER part of the registry
-        return winreg.HKEY_CURRENT_USER, r"Software\SABnzbd\api"
+        return winreg.HKEY_CURRENT_USER, r"Software\SABnzbd\api\%s" % instance
     # A Windows Service will use the service key instead
-    return winreg.HKEY_LOCAL_MACHINE, r"SYSTEM\CurrentControlSet\Services\SABnzbd\api"
+    return winreg.HKEY_LOCAL_MACHINE, r"SYSTEM\CurrentControlSet\Services\SABnzbd\api\%s" % instance
 
 
-def get_connection_info(user: bool = True) -> Optional[str]:
-    """Return URL of the running SABnzbd instance
+def get_connection_info(inifile: str, user: bool = True) -> Optional[str]:
+    """Return URL of the running SABnzbd instance using inifile
     'user' == True will first try user's registry, otherwise system is used
     """
-    section, keypath = reg_info(user)
+    section, keypath = reg_info(user, inifile)
     try:
         with winreg.OpenKey(section, keypath) as key:
             url, _ = winreg.QueryValueEx(key, "url")
@@ -79,29 +87,29 @@ def get_connection_info(user: bool = True) -> Optional[str]:
 
     # Nothing in user's registry, try system registry
     if user:
-        return get_connection_info(user=False)
+        return get_connection_info(inifile, user=False)
     return None
 
 
-def set_connection_info(url: str, user: bool = True):
+def set_connection_info(url: str, inifile: str, user: bool = True):
     """Set API info in registry"""
-    section, keypath = reg_info(user)
+    section, keypath = reg_info(user, inifile)
     try:
         with winreg.CreateKey(section, keypath) as key:
             winreg.SetValueEx(key, "url", None, winreg.REG_SZ, url)
     except OSError:
         if user:
-            set_connection_info(url, user=False)
+            set_connection_info(url, inifile, user=False)
 
 
-def del_connection_info(user: bool = True):
+def del_connection_info(inifile: str, user: bool = True):
     """Remove API info from registry"""
-    section, keypath = reg_info(user)
+    section, keypath = reg_info(user, inifile)
     try:
         winreg.DeleteKey(section, keypath)
     except OSError:
         if user:
-            del_connection_info(user=False)
+            del_connection_info(inifile, user=False)
 
 
 def get_install_lng() -> str:
@@ -115,5 +123,5 @@ def get_install_lng() -> str:
 
 
 if __name__ == "__main__":
-    print(f"URL = {get_connection_info()}")
+    print(f"URL = {get_connection_info(sys.argv[1])}")
     print(f"Language = {get_install_lng()}")

--- a/tests/test_win_utils.py
+++ b/tests/test_win_utils.py
@@ -30,19 +30,36 @@ import sabnzbd.utils.apireg as ar
 
 
 class TestAPIReg:
-    def test_set_get_connection_info_user(self):
+    def test_set_get_connection_info_user(self, tmp_path):
         """Test the saving of the URL in USER-registery
         We can't test the SYSTEM one.
         """
-
+        inifile = str(tmp_path / "sabnzbd.ini")
         test_url = "sab_test:8080"
-        ar.set_connection_info(test_url, True)
-        assert ar.get_connection_info(True) == test_url
-        assert not ar.get_connection_info(False)
+        ar.set_connection_info(test_url, inifile, True)
+        assert ar.get_connection_info(inifile, True) == test_url
+        assert not ar.get_connection_info(inifile, False)
 
         # Remove and check if gone
-        ar.del_connection_info(True)
-        assert not ar.get_connection_info(True)
+        ar.del_connection_info(inifile, True)
+        assert not ar.get_connection_info(inifile, True)
+
+    def test_connection_info_is_per_config_file(self, tmp_path):
+        """Instances on separate config files must not see each other's URL"""
+        first_ini = str(tmp_path / "first" / "sabnzbd.ini")
+        second_ini = str(tmp_path / "second" / "sabnzbd.ini")
+        ar.set_connection_info("sab_test:8080", first_ini, True)
+        ar.set_connection_info("sab_test:9090", second_ini, True)
+
+        assert ar.get_connection_info(first_ini, True) == "sab_test:8080"
+        assert ar.get_connection_info(second_ini, True) == "sab_test:9090"
+
+        ar.del_connection_info(first_ini, True)
+        assert not ar.get_connection_info(first_ini, True)
+        assert ar.get_connection_info(second_ini, True) == "sab_test:9090"
+
+        ar.del_connection_info(second_ini, True)
+        assert not ar.get_connection_info(second_ini, True)
 
     def test_get_install_lng(self):
         """Not much to test yet.."""


### PR DESCRIPTION
On Windows the URL of a running instance is stored in a single registry value, `HKCU\Software\SABnzbd\api\url`. Every instance under one account writes to that one slot, so a starting instance reads whichever one happened to write last.

When it finds that URL alive, `check_for_sabnzbd` hands off and calls `exit_sab(0)`. That happens before the logging handlers are installed, so the instance disappears without a single line of output.

Two instances on separate config files are not duplicates of each other, so each config file now gets its own subkey, named after a hash of the config path (a subkey name cannot contain a path separator). `get`/`set`/`del_connection_info` take the config path, and `halt()` passes `config.CONFIG.filename`.

Restarting an instance running alongside another one no longer silently exits into the other one's web interface. It also fixes a flaky `test_queue_repair` on Windows CI, where four xdist workers each run their own SABnzbd and fight over that shared value.

No fallback to the old value: a starting instance that misses the registry still finds a running one through the port check.