### PR TITLE
Match navbar height between styles

### DIFF
--- a/interfaces/Glitter/templates/static/stylesheets/colorschemes/Night.css
+++ b/interfaces/Glitter/templates/static/stylesheets/colorschemes/Night.css
@@ -40,9 +40,7 @@ legend,
 /* Navbar needs structural dark-mode overrides */
 nav {
     background-color: #444444 !important;
-    border: 0 !important;
     border-radius: var(--radius-lg);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }
 
 nav .btn {

--- a/interfaces/Glitter/templates/static/stylesheets/glitter.css
+++ b/interfaces/Glitter/templates/static/stylesheets/glitter.css
@@ -49,6 +49,7 @@ h2 {
     z-index: 999;
     padding-left: 0;
     padding-right: 0;
+    border: 0;
 }
 
 .navbar.main-navbar {


### PR DESCRIPTION
Currently on Night `.main-navbar` has height 50px and Light 52px

border-radius does apply at some breakpoint, Night box shadow is ignored because of more specific `.navbar.main-navbar` and doesn't really matter since there is no difference between a 0.3 and 0.15 opacity black on black shadow.
