### PR TITLE
Fix mobile dropdown menu styling

### DIFF
--- a/interfaces/Glitter/templates/static/stylesheets/glitter.css
+++ b/interfaces/Glitter/templates/static/stylesheets/glitter.css
@@ -93,9 +93,7 @@ h2 {
 }
 
 .navbar-collapse.in .dropdown-menu a,
-.navbar-collapse.in .dropdown-menu a:hover,
-.navbar-collapse.in .dropdown-menu form button,
-.navbar-collapse.in .dropdown-menu form button:hover {
+.navbar-collapse.in .dropdown-menu a:hover {
     color: black !important;
 }
 
@@ -106,7 +104,7 @@ h2 {
 .dropdown-menu > li > form > button {
     display: block;
     width: 100%;
-    padding: 3px 20px;
+    padding: 5px 15px 5px 25px;
     border: 0;
     background: transparent;
     text-align: left;
@@ -114,6 +112,12 @@ h2 {
     line-height: 1.42857143;
     color: var(--clr-text);
     white-space: nowrap;
+}
+
+@media (min-width: 768px) {
+    .dropdown-menu > li > form > button {
+        padding: 3px 20px;
+    }
 }
 
 .navbar-nav>li>a {


### PR DESCRIPTION
Padding and colour was off on mobile

<img width="282" height="314" alt="image" src="https://github.com/user-attachments/assets/f427d9b0-12d0-44c7-8521-318e373d00e7" />

<img width="272" height="348" alt="image" src="https://github.com/user-attachments/assets/4ea0def3-84f7-4e25-a898-58f7fb2adca8" />
