### PR TITLE
Safer open folder from macOS menu

### DIFF
--- a/sabnzbd/macosmenu.py
+++ b/sabnzbd/macosmenu.py
@@ -20,6 +20,7 @@ sabnzbd.macosmenu - macOS Top Menu
 """
 
 import os
+import subprocess
 import sys
 import time
 import logging
@@ -506,7 +507,7 @@ class SABnzbdDelegate(NSObject):
 
     def openFolderAction_(self, sender):
         folder2open = sender.representedObject()
-        os.system('open "%s"' % folder2open)
+        subprocess.run(["/usr/bin/open", folder2open])
 
     def restartAction_(self, sender):
         self.setMenuTitle_("\n\n%s\n" % (T("Stopping...")))
@@ -585,7 +586,7 @@ class SABnzbdDelegate(NSObject):
         elif notification.activationType() == 2:
             # User clicked on the action button
             if os.path.exists(folder2open := notification.userInfo()["value"]):
-                os.system('open "%s"' % folder2open)
+                subprocess.run(["/usr/bin/open", folder2open])
 
         # Remove this notification after interaction
         DefaultUserNotificationCenter._removeDisplayedNotification_(notification)


### PR DESCRIPTION
Potentially folder2open can be manipulated to execute commands, I've not checked maybe the name sanitisation prevents it but we should change this anyway