### PR TITLE
Fix macOS tray crashing when the notification center is unavailable

### DIFF
--- a/sabnzbd/macosmenu.py
+++ b/sabnzbd/macosmenu.py
@@ -90,7 +90,8 @@ class SABnzbdDelegate(NSObject):
             time.sleep(0.5)
 
         # Set this thread as default handler for notification actions
-        DefaultUserNotificationCenter.setDelegate_(self)
+        if DefaultUserNotificationCenter:
+            DefaultUserNotificationCenter.setDelegate_(self)
 
         # Do we want the menu
         if sabnzbd.cfg.tray_icon():
@@ -557,6 +558,9 @@ class SABnzbdDelegate(NSObject):
         button_action: Optional[str] = None,
     ):
         """Send a macOS notification, optionally with 1 action button"""
+        if not DefaultUserNotificationCenter:
+            return
+
         notification = NSUserNotification.alloc().init()
         notification.setTitle_(title)
         notification.setSubtitle_(subtitle)


### PR DESCRIPTION
Running form source, there is no bundle id so it fails to init - there are hacky workarounds but I would not suggest using them.

This change lets the tray icon still function, but without notifications.

It may be worth switching to UNUserNotificationCenter, but it still won't let notifications work.

```
  File "/Users/mnightingale/personal/sabnzbd/SABnzbd.py", line 1568, in <module>
    sabnzbd.MACOSTRAY.awakeFromNib()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/mnightingale/personal/sabnzbd/sabnzbd/macosmenu.py", line 93, in awakeFromNib
    DefaultUserNotificationCenter.setDelegate_(self)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'setDelegate_'
```