### PR TITLE
Fix "database is locked" when re-evaluating stored RSS jobs (readout=False)

### DIFF
--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -989,9 +989,7 @@ class RSSReader:
             if readout:
                 gen = self.fetch_rss(feed, uris)
             else:
-                # Read all stored jobs before evaluating them: each evaluation writes
-                # through its own connection, which would otherwise be blocked by the
-                # still-open read cursor ("database is locked")
+                # Materialize before evaluating: each write needs the read cursor closed
                 gen = list(repo.get_feed_jobs(feed=feed))
 
             # Evaluate rules and apply side effects

--- a/sabnzbd/rss.py
+++ b/sabnzbd/rss.py
@@ -989,7 +989,10 @@ class RSSReader:
             if readout:
                 gen = self.fetch_rss(feed, uris)
             else:
-                gen = repo.get_feed_jobs(feed=feed)
+                # Read all stored jobs before evaluating them: each evaluation writes
+                # through its own connection, which would otherwise be blocked by the
+                # still-open read cursor ("database is locked")
+                gen = list(repo.get_feed_jobs(feed=feed))
 
             # Evaluate rules and apply side effects
             try:

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -1123,6 +1123,48 @@ class TestRSS:
         assert reader.process_feed(feed_name, readout=True) == ""
         assert repo.find_job_by_url(feed_name, old_url) is None
 
+    def test_process_feed_without_readout_updates_all_stored_jobs(self, httpserver: HTTPServer, tmp_rss):
+        """Re-evaluating stored jobs (readout=False) must persist the new state for every job.
+
+        The stored jobs are read through one database connection while each
+        re-evaluated job is written through another connection to the same
+        file. If the read cursor is still open while writing, SQLite reports
+        "database is locked" and the write is silently dropped.
+        """
+        repo, reader = tmp_rss
+        feed_name = "ReEvaluateFeed"
+        # Start without any filter: every stored job is BAD
+        self.setup_rss(feed_name, httpserver.url_for("/unused.xml"))
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        urls = [f"http://example.test/re-evaluate/{n}" for n in range(5)]
+        for n, url in enumerate(urls):
+            repo.upsert(
+                ResolvedEntry(
+                    feed=feed_name,
+                    link=url,
+                    title=f"Some.Show.S01E0{n}.720p",
+                    infourl=None,
+                    size=1000,
+                    age=now - datetime.timedelta(hours=n + 1),
+                    seen_at=now,
+                    season=1,
+                    episode=n,
+                    category=None,
+                    state=RSSState.BAD,
+                )
+            )
+        assert all(repo.find_job_by_url(feed_name, url).state is RSSState.BAD for url in urls)
+
+        # Add an accept-all filter and replay the stored jobs, like the filter editor does
+        self.setup_rss(feed_name, httpserver.url_for("/unused.xml"), filters=[("", "", "", "A", "*", "", "1")])
+        assert reader.process_feed(feed_name, readout=False) == ""
+
+        for url in urls:
+            job = repo.find_job_by_url(feed_name, url)
+            assert job is not None
+            assert job.state is RSSState.GOOD, f"{url} was not updated"
+
     def test_downloaded_item_still_in_feed_is_not_redownloaded(self, httpserver: HTTPServer, tmp_rss, mocker):
         """An item that stays in the feed must survive the retention period and not be grabbed twice."""
         repo, reader = tmp_rss


### PR DESCRIPTION
## Problem

Since RSS state moved into `history1.db` (#3253), every RSS filter add / update / delete from the web interface or the API (`mode=set_config section=rss filter_action=add|update|delete`) calls `process_feed(feed, readout=False)`. That path iterates the stored jobs lazily through one `HistoryDB` connection (`repo.get_feed_jobs()`), while `_process_entry()` writes each re-evaluated job through a **second** connection to the same file.

In the default rollback-journal mode the still-open SELECT cursor holds a SHARED lock, so every upsert waits out the busy timeout (5 attempts × 5 s + 4 × 0.5 s ≈ 27 s) and then fails:

```
ERROR::[database:188] SQL Command Failed, see log
INFO::[database:189] SQL: INSERT INTO rss ( ... ) ON CONFLICT(feed, url) DO UPDATE SET ...
sqlite3.OperationalError: database is locked
```

Observed on 5.1.2 (Docker, local ZFS storage, single process): a feed with ~100 GOOD/BAD jobs turns one filter change into 45–80 minutes of these errors (one every 27 s). The filter change is not applied to the stored jobs, and because `RSS_LOCK` is held the whole time, scheduled read-outs are blocked as well. Every "Writing settings to INI file" line in the last week was followed 27 s later by such an error storm.

`develop` no longer shows this because #3550 moved the database to WAL mode with a connection pool, but the `5.1.x` line is still affected.

## Fix

Materialize the stored jobs before evaluating them (`list(repo.get_feed_jobs(...))`) so no read cursor is open while writing. Minimal and safe to backport.

## Test

`test_process_feed_without_readout_updates_all_stored_jobs` stores five BAD jobs, adds an accept-all filter, replays with `readout=False`, and asserts every job became GOOD.

- On `5.1.x` without the fix: fails after ~3.5 min (`database is locked` on every job but the last).
- With the fix: `37 passed in 6.14s` for `tests/test_rss.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
