### PR TITLE
Optimise NzbQueue add, remove and reorder

### DIFF
--- a/sabnzbd/nzbparser.py
+++ b/sabnzbd/nzbparser.py
@@ -170,6 +170,7 @@ def process_nzb_archive_file(
     Accepts archive files with ONLY nzb/nfo/folder files in it.
     """
     nzo_ids = []
+    added_nzos: list[NzbObject] = []
     if catdir is None:
         catdir = cat
     filename, cat = name_to_cat(filename, catdir)
@@ -247,7 +248,12 @@ def process_nzb_archive_file(
                     if nzo:
                         # We can only use existing nzo_id once
                         nzo_id = None
-                        nzo_ids.append(sabnzbd.NzbQueue.add(nzo))
+                        added_nzos.append(nzo)
+                        nzo_ids.append(sabnzbd.NzbQueue.add(nzo, save=False))
+
+        # One queue-admin save for the whole archive
+        if added_nzos:
+            sabnzbd.NzbQueue.save(added_nzos)
 
         # Close the pointer to the compressed file
         zf.close()

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -24,6 +24,8 @@ import os
 import logging
 import time
 import uuid
+from itertools import chain
+from operator import attrgetter
 from typing import Optional
 
 from starlette.datastructures import UploadFile
@@ -569,11 +571,11 @@ class NzbQueue:
             sort_function = lambda nzo: nzo.final_name.lower()
         elif field == "size" or field == "bytes":
             logging.info("Sorting by size (reversed: %s)", reverse)
-            sort_function = lambda nzo: nzo.bytes
+            sort_function = attrgetter("bytes")
         elif field == "avg_age":
             reverse = not reverse
             logging.info("Sorting by average date... (reversed: %s)", reverse)
-            sort_function = lambda nzo: nzo.avg_date
+            sort_function = attrgetter("avg_date")
         elif field == "remaining":
             if self.__nzo_list:
                 logging.debug("Sorting by percentage downloaded...")
@@ -581,14 +583,14 @@ class NzbQueue:
         elif field == "remaining_bytes":
             if self.__nzo_list:
                 logging.debug("Sorting by remaining size...")
-            sort_function = lambda nzo: nzo.remaining
+            sort_function = attrgetter("remaining")
         else:
             logging.debug("Sort: %s not recognized", field)
             return
 
         # Apply sort by requested order, then restore priority ordering
         self.__nzo_list.sort(key=sort_function, reverse=reverse)
-        self.__nzo_list.sort(key=lambda nzo: nzo.priority, reverse=True)
+        self.__nzo_list.sort(key=attrgetter("priority"), reverse=True)
 
     def update_sort_order(self):
         """Resorts the queue if it is useful for the selected sort method"""
@@ -947,7 +949,7 @@ class NzbQueue:
         """Check whether this name or md5sum is already
         in the queue or the post-processing queue"""
         lname = name.lower()
-        for nzo in self.__nzo_list + sabnzbd.PostProcessor.get_queue():
+        for nzo in chain(self.__nzo_list, sabnzbd.PostProcessor.get_queue()):
             # Skip any jobs already marked as duplicate, to prevent double-triggers
             # URL's do not have an MD5!
             if not nzo.duplicate and (
@@ -960,7 +962,7 @@ class NzbQueue:
     def have_duplicate_key(self, duplicate_key: str) -> bool:
         """Check whether this duplicate key is already
         in the queue or the post-processing queue"""
-        for nzo in self.__nzo_list + sabnzbd.PostProcessor.get_queue():
+        for nzo in chain(self.__nzo_list, sabnzbd.PostProcessor.get_queue()):
             # Skip any jobs already marked as duplicate, to prevent double-triggers
             if not nzo.duplicate and nzo.duplicate_key == duplicate_key:
                 return True

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -235,16 +235,23 @@ class NzbQueue:
             self.__nzo_table[nzo_ids[0]].reuse = None
 
     @NzbQueueLocker
-    def save(self, save_nzo: NzbObject | bool | None = None):
-        """Save queue, all nzo's or just the specified one"""
+    def save(self, save_nzo: NzbObject | list[NzbObject] | bool | None = None):
+        """Save queue, all nzo's, just the specified one or the ones in a list"""
         logging.info("Saving queue")
+
+        if isinstance(save_nzo, NzbObject):
+            save_nzo_ids = {save_nzo.nzo_id}
+        elif isinstance(save_nzo, list):
+            save_nzo_ids = {nzo.nzo_id for nzo in save_nzo}
+        else:
+            save_nzo_ids = set()
 
         nzo_ids = []
         # Aggregate nzo_ids and save each nzo
         for nzo in self.__nzo_list[:]:
             if not nzo.removed_from_queue:
                 nzo_ids.append(os.path.join(nzo.work_name, nzo.nzo_id))
-                if save_nzo is None or nzo is save_nzo:
+                if save_nzo is None or nzo.nzo_id in save_nzo_ids:
                     if not nzo.futuretype:
                         # Also includes save_data for NZO
                         nzo.save_to_disk()
@@ -356,7 +363,9 @@ class NzbQueue:
         return nzo.nzo_id
 
     @NzbQueueLocker
-    def remove(self, nzo_id: str, cleanup: bool = True, delete_all_data: bool = True) -> Optional[NzbObject]:
+    def remove(
+        self, nzo_id: str, cleanup: bool = True, delete_all_data: bool = True, save: bool = True
+    ) -> Optional[NzbObject]:
         """Remove NZO from queue.
         It can be added to history directly.
         Or, we do some clean-up, sometimes leaving some data.
@@ -371,7 +380,8 @@ class NzbQueue:
             if cleanup:
                 nzo.status = Status.DELETED
                 nzo.purge_data(delete_all_data=delete_all_data)
-            self.save(False)
+            if save:
+                self.save(False)
             return nzo
 
     @NzbQueueLocker
@@ -380,10 +390,13 @@ class NzbQueue:
         and downloader-disconnect, so intended for external use only!"""
         removed = []
         for nzo_id in nzo_ids:
-            if nzo := self.remove(nzo_id, delete_all_data=delete_all_data):
+            if nzo := self.remove(nzo_id, delete_all_data=delete_all_data, save=False):
                 removed.append(nzo_id)
                 # Start an alternative, if available
                 self.handle_duplicate_alternatives(nzo, success=False)
+
+        if removed:
+            self.save(False)
 
         # Any files left? Otherwise let's disconnect
         if not self.actives(grabs=False) and cfg.autodisconnect():

--- a/sabnzbd/nzbqueue.py
+++ b/sabnzbd/nzbqueue.py
@@ -19,6 +19,7 @@
 sabnzbd.nzbqueue - nzb queue
 """
 
+import bisect
 import os
 import logging
 import time
@@ -39,8 +40,6 @@ from sabnzbd.constants import (
     QUEUE_VERSION,
     FUTURE_Q_FOLDER,
     JOB_ADMIN,
-    LOW_PRIORITY,
-    HIGH_PRIORITY,
     FORCE_PRIORITY,
     STOP_PRIORITY,
     VERIFIED_FILE,
@@ -340,32 +339,8 @@ class NzbQueue:
             nzo.status = Status.PAUSED
 
         self.__nzo_table[nzo.nzo_id] = nzo
-        if priority > HIGH_PRIORITY:
-            # Top and repair priority items are added to the top of the queue
-            self.__nzo_list.insert(0, nzo)
-        elif priority == LOW_PRIORITY:
-            self.__nzo_list.append(nzo)
-        else:
-            # for high priority we need to add the item at the bottom
-            # of any other high priority items above the normal priority
-            # for normal priority we need to add the item at the bottom
-            # of the normal priority items above the low priority
-            if self.__nzo_list:
-                pos = 0
-                added = False
-                for position in self.__nzo_list:
-                    if position.priority < priority:
-                        self.__nzo_list.insert(pos, nzo)
-                        added = True
-                        break
-                    pos += 1
-                if not added:
-                    # if there are no other items classed as a lower priority
-                    # then it will be added to the bottom of the queue
-                    self.__nzo_list.append(nzo)
-            else:
-                # if the queue is empty then simple append the item to the bottom
-                self.__nzo_list.append(nzo)
+        self.__insert_in_priority_order(nzo)
+
         if save:
             self.save(nzo)
 
@@ -647,38 +622,7 @@ class NzbQueue:
 
             if nzo_id_pos1 != -1:
                 del self.__nzo_list[nzo_id_pos1]
-                if priority == FORCE_PRIORITY:
-                    # A top priority item (usually a completed download fetching pars)
-                    # is added to the top of the queue
-                    self.__nzo_list.insert(0, nzo)
-                    pos = 0
-                elif priority == LOW_PRIORITY:
-                    pos = len(self.__nzo_list)
-                    self.__nzo_list.append(nzo)
-                else:
-                    # for high priority we need to add the item at the bottom
-                    # of any other high priority items above the normal priority
-                    # for normal priority we need to add the item at the bottom
-                    # of the normal priority items above the low priority
-                    if self.__nzo_list:
-                        p = 0
-                        added = False
-                        for position in self.__nzo_list:
-                            if position.priority < priority:
-                                self.__nzo_list.insert(p, nzo)
-                                pos = p
-                                added = True
-                                break
-                            p += 1
-                        if not added:
-                            # if there are no other items classed as a lower priority
-                            # then it will be added to the bottom of the queue
-                            pos = len(self.__nzo_list)
-                            self.__nzo_list.append(nzo)
-                    else:
-                        # if the queue is empty then simple append the item to the bottom
-                        self.__nzo_list.append(nzo)
-                        pos = 0
+                pos = self.__insert_in_priority_order(nzo)
 
             logging.info(
                 "Set priority=%s for job %s => position=%s ", priority, self.__nzo_table[nzo_id].final_name, pos
@@ -697,6 +641,15 @@ class NzbQueue:
             return n
         except Exception:
             return -1
+
+    def __insert_in_priority_order(self, nzo: NzbObject) -> int:
+        """Insert a job into the priority-ordered queue and return its position.
+        Jobs join the back of their own priority group, so repair jobs outrank
+        forced ones and a group stays in the order its jobs arrived.
+        """
+        position = bisect.bisect_right(self.__nzo_list, -nzo.priority, key=lambda queued_nzo: -queued_nzo.priority)
+        self.__nzo_list.insert(position, nzo)
+        return position
 
     def has_forced_jobs(self) -> bool:
         """Check if the queue contains any Forced

--- a/tests/test_nzbqueue.py
+++ b/tests/test_nzbqueue.py
@@ -30,7 +30,17 @@ from unittest import mock
 import pytest
 
 import sabnzbd
-from sabnzbd.constants import NORMAL_PRIORITY, JOB_ADMIN, ONDISK_VERSION, ONDISK_FILE, RENAMES_FILE, Status
+from sabnzbd.constants import (
+    JOB_ADMIN,
+    ONDISK_VERSION,
+    ONDISK_FILE,
+    RENAMES_FILE,
+    Status,
+    LOW_PRIORITY,
+    NORMAL_PRIORITY,
+    HIGH_PRIORITY,
+    FORCE_PRIORITY,
+)
 from sabnzbd.database import HistoryDB
 from sabnzbd.downloader import Server
 from sabnzbd.filesystem import save_compressed, save_data
@@ -71,6 +81,7 @@ def nzbqueue_env(monkeypatch, mocker, tmp_path):
         )
     ]
     sabnzbd.NzbQueue = NzbQueue()
+    sabnzbd.Downloader.disconnect = mocker.Mock()
     monkeypatch.setattr(sabnzbd.cfg.admin_dir, "get_path", lambda: str(tmp_path))
     monkeypatch.setattr(sabnzbd.cfg.download_dir, "get_path", lambda: str(tmp_path))
 
@@ -346,3 +357,320 @@ class TestNzbQueue:
         # With all_jobs=True the download queue itself is not considered registered
         orphans_all = sabnzbd.NzbQueue.scan_jobs(all_jobs=True, action=False)
         assert queued_nzo.work_name in orphans_all
+
+    @pytest.fixture
+    def queue(self, nzbqueue_env):
+        return NzbQueue()
+
+    def test_add_inserts_and_tracks_jobs(self, queue):
+        a = make_dummy_nzo("a", priority=NORMAL_PRIORITY)
+        b = make_dummy_nzo("b", priority=LOW_PRIORITY)
+        c = make_dummy_nzo("c", priority=FORCE_PRIORITY)
+
+        ida = queue.add(a, save=False, quiet=True)
+        idb = queue.add(b, save=False, quiet=True)
+        idc = queue.add(c, save=False, quiet=True)
+
+        # All ids registered
+        assert queue.get_nzo(ida) is a
+        assert queue.get_nzo(idb) is b
+        assert queue.get_nzo(idc) is c
+
+        # queue_info returns all three, first should be the forced job
+        _, _, _, nzo_list, _, count = queue.queue_info()
+        assert count == 3
+        assert [n.final_name for n in nzo_list] == [c.final_name, a.final_name, b.final_name]
+
+    def test_remove_removes_from_queue_and_table(self, queue):
+        a = make_dummy_nzo("a", priority=0)
+        b = make_dummy_nzo("b", priority=0)
+        c = make_dummy_nzo("c", priority=0)
+
+        _ida = queue.add(a, save=False, quiet=True)
+        idb = queue.add(b, save=False, quiet=True)
+        _idc = queue.add(c, save=False, quiet=True)
+
+        removed = queue.remove(idb, cleanup=False, delete_all_data=False)
+        assert removed is b
+        assert queue.get_nzo(idb) is None
+
+        _, _, _, nzo_list, _, count = queue.queue_info()
+        assert count == 2
+        assert [nzo.final_name for nzo in nzo_list] == ["job-a", "job-c"]
+
+    def test_remove_multiple_and_remove_all(self, queue):
+        jobs = [make_dummy_nzo(f"job-{i}", priority=0) for i in range(5)]
+        ids = [queue.add(nzo, save=False, quiet=True) for nzo in jobs]
+
+        # Remove two specific jobs
+        subset = ids[1:3]
+        removed_ids = queue.remove_multiple(subset, delete_all_data=False)
+        assert set(removed_ids) == set(subset)
+
+        # Remaining ids still there
+        remaining_ids = {nid for nid in ids if nid not in subset}
+        assert {nzo.nzo_id for nzo in queue.queue_info()[3]} == remaining_ids
+
+        # remove_all with search pattern should remove the rest
+        removed_all = queue.remove_all(search="job-")
+        assert set(removed_all) == remaining_ids
+        assert queue.queue_info()[5] == 0  # nzos_matched
+
+    def test_change_opts_sets_pp(self, queue):
+        a = make_dummy_nzo("a", priority=LOW_PRIORITY)
+        ida = queue.add(a, save=False, quiet=True)
+
+        changed = queue.change_opts([ida], pp=3)
+        assert changed == 1
+        assert a.pp == 3
+
+    def test_change_script_only_when_valid(self, queue, monkeypatch):
+        from sabnzbd import nzbqueue as nzbqueue_mod
+
+        # Always accept given script
+        monkeypatch.setattr(nzbqueue_mod, "is_valid_script", lambda s: True)
+
+        a = make_dummy_nzo("a", priority=0)
+        b = make_dummy_nzo("b", priority=0)
+        ida = queue.add(a, save=False, quiet=True)
+        idb = queue.add(b, save=False, quiet=True)
+
+        changed = queue.change_script([ida, idb], script="myscript.py")
+        assert changed == 2
+        assert a.script == "myscript.py"
+        assert b.script == "myscript.py"
+
+        # Now mark scripts invalid; no changes should be made
+        monkeypatch.setattr(nzbqueue_mod, "is_valid_script", lambda s: False)
+        changed = queue.change_script([ida, idb], script="other.py")
+        assert changed == 0
+        assert a.script == "myscript.py"
+        assert b.script == "myscript.py"
+
+    def test_change_cat_updates_cat_pp_script_and_priority(self, queue, monkeypatch):
+        from sabnzbd import nzbqueue as nzbqueue_mod
+
+        # Fake cat_to_opts: (cat, pp, script, prio)
+        def fake_cat_to_opts(cat):
+            return f"{cat}-cat", 2, "cat_script.py", FORCE_PRIORITY
+
+        monkeypatch.setattr(nzbqueue_mod, "cat_to_opts", fake_cat_to_opts)
+
+        a = make_dummy_nzo("a", priority=0)
+        ida = queue.add(a, save=False, quiet=True)
+
+        changed = queue.change_cat([ida], cat="movies")
+        assert changed == 1
+        assert a.cat == "movies-cat"
+        assert a.script == "cat_script.py"
+        assert a.priority == FORCE_PRIORITY
+
+    def test_change_name_updates_final_name(self, queue):
+        a = make_dummy_nzo("a", priority=0)
+        ida = queue.add(a, save=False, quiet=True)
+
+        ok = queue.change_name(ida, "renamed")
+        assert ok is True
+        assert a.final_name == "renamed"
+
+    @staticmethod
+    def get_queue_order(queue):
+        return [n.final_name for n in queue.queue_info()[3]]
+
+    def test_set_priority_moves_job_to_forced_top(self, queue):
+        a = make_dummy_nzo("a", priority=0)
+        b = make_dummy_nzo("b", priority=0)
+        c = make_dummy_nzo("c", priority=0)
+
+        _ida = queue.add(a, save=False, quiet=True)
+        idb = queue.add(b, save=False, quiet=True)
+        _idc = queue.add(c, save=False, quiet=True)
+
+        assert self.get_queue_order(queue) == ["job-a", "job-b", "job-c"]
+
+        # Set b to FORCE_PRIORITY, should go to the top
+        _pos = queue.set_priority([idb], FORCE_PRIORITY)
+        # pos is index; we just verify ordering
+        assert self.get_queue_order(queue)[0] == "job-b"
+        assert b.priority == FORCE_PRIORITY
+
+    def test_switch_swaps_positions(self, queue):
+        a = make_dummy_nzo("a", priority=NORMAL_PRIORITY)
+        b = make_dummy_nzo("b", priority=NORMAL_PRIORITY)
+        c = make_dummy_nzo("c", priority=NORMAL_PRIORITY)
+
+        ida = queue.add(a, save=False, quiet=True)
+        _idb = queue.add(b, save=False, quiet=True)
+        idc = queue.add(c, save=False, quiet=True)
+
+        assert self.get_queue_order(queue) == ["job-a", "job-b", "job-c"]
+
+        # Move a to c
+        new_pos, _prio = queue.switch(ida, idc)
+        assert new_pos != -1
+        assert self.get_queue_order(queue) == ["job-b", "job-c", "job-a"]
+
+    def test_switch_swaps_positions_different_priority(self, queue):
+        a = make_dummy_nzo("a", priority=HIGH_PRIORITY)
+        b = make_dummy_nzo("b", priority=NORMAL_PRIORITY)
+        c = make_dummy_nzo("c", priority=NORMAL_PRIORITY)
+
+        ida = queue.add(a, save=False, quiet=True)
+        _idb = queue.add(b, save=False, quiet=True)
+        idc = queue.add(c, save=False, quiet=True)
+
+        assert self.get_queue_order(queue) == ["job-a", "job-b", "job-c"]
+
+        # Move a to c
+        new_pos, _prio = queue.switch(ida, idc)
+        assert new_pos != -1
+        assert a.priority == NORMAL_PRIORITY
+        assert b.priority == NORMAL_PRIORITY
+        assert c.priority == NORMAL_PRIORITY
+        assert self.get_queue_order(queue) == ["job-b", "job-c", "job-a"]
+
+    def test_switch_swaps_positions_different_priority_2(self, queue):
+        a = make_dummy_nzo("a", priority=HIGH_PRIORITY)
+        b = make_dummy_nzo("b", priority=HIGH_PRIORITY)
+        c = make_dummy_nzo("c", priority=NORMAL_PRIORITY)
+
+        ida = queue.add(a, save=False, quiet=True)
+        _idb = queue.add(b, save=False, quiet=True)
+        idc = queue.add(c, save=False, quiet=True)
+
+        assert self.get_queue_order(queue) == ["job-a", "job-b", "job-c"]
+
+        # Move a to c
+        new_pos, _prio = queue.switch(ida, idc)
+        assert new_pos != -1
+        assert b.priority == HIGH_PRIORITY
+        assert c.priority == NORMAL_PRIORITY
+        assert a.priority == NORMAL_PRIORITY
+        assert self.get_queue_order(queue) == ["job-b", "job-c", "job-a"]
+
+    def test_switch_swaps_positions_different_priority_3(self, queue):
+        a = make_dummy_nzo("a", priority=HIGH_PRIORITY)
+        b = make_dummy_nzo("b", priority=NORMAL_PRIORITY)
+        c = make_dummy_nzo("c", priority=NORMAL_PRIORITY)
+
+        ida = queue.add(a, save=False, quiet=True)
+        _idb = queue.add(b, save=False, quiet=True)
+        idc = queue.add(c, save=False, quiet=True)
+
+        assert self.get_queue_order(queue) == ["job-a", "job-b", "job-c"]
+
+        # Move c to a
+        new_pos, _prio = queue.switch(idc, ida)
+        assert new_pos != -1
+        assert c.priority == HIGH_PRIORITY
+        assert a.priority == HIGH_PRIORITY
+        assert b.priority == NORMAL_PRIORITY
+        assert self.get_queue_order(queue) == ["job-c", "job-a", "job-b"]
+
+    def test_switch_moves_job_below_its_lower_priority_neighbour(self, queue):
+        """Moving onto the first job of the next priority group must actually move it"""
+        a = make_dummy_nzo("a", priority=HIGH_PRIORITY)
+        b = make_dummy_nzo("b", priority=NORMAL_PRIORITY)
+        queue.add(a, save=False, quiet=True)
+        queue.add(b, save=False, quiet=True)
+
+        pos, prio = queue.switch(a.nzo_id, b.nzo_id)
+
+        assert self.get_queue_order(queue) == ["job-b", "job-a"]
+        assert pos == 1
+        assert prio == NORMAL_PRIORITY
+
+    def test_send_back_keeps_job_removable_when_its_priority_changed(self, queue, monkeypatch):
+        """The replacement job can resolve a different priority than the job it replaces"""
+        old = make_dummy_nzo("old", priority=HIGH_PRIORITY)
+        queue.add(old, save=False, quiet=True)
+        monkeypatch.setattr(old, "download_path", "/tmp/old", raising=False)
+        monkeypatch.setattr(sabnzbd.filesystem, "globber_full", lambda *a, **k: ["/tmp/old.nzb.gz"])
+        monkeypatch.setattr("sabnzbd.nzbqueue.globber_full", lambda *a, **k: ["/tmp/old.nzb.gz"])
+
+        def fake_process_single_nzb(*args, **kwargs):
+            queue.remove(kwargs["nzo_id"], cleanup=False, delete_all_data=False)
+            replacement = make_dummy_nzo("new", priority=NORMAL_PRIORITY)
+            replacement.nzo_id = kwargs["nzo_id"]
+            queue.add(replacement, save=False, quiet=True)
+            return 0, [replacement.nzo_id]
+
+        monkeypatch.setattr("sabnzbd.nzbqueue.process_single_nzb", fake_process_single_nzb)
+        queue.send_back(old)
+
+        # Removing must still find the job even though the replacement resolved another priority
+        nzo_id = queue.queue_info()[3][0].nzo_id
+        assert queue.remove(nzo_id, cleanup=False, delete_all_data=False)
+        assert queue.queue_info()[3] == []
+
+    @pytest.mark.parametrize(
+        "value2, expected_order",
+        [
+            ("1", ["job-b", "job-a", "job-c"]),
+            ("-1", ["job-b", "job-c", "job-a"]),
+            ("-2", ["job-b", "job-a", "job-c"]),
+            # Out of range, unparsable and non-decimal numerics all leave the queue alone
+            ("99", ["job-a", "job-b", "job-c"]),
+            ("-99", ["job-a", "job-b", "job-c"]),
+            ("\u00b2", ["job-a", "job-b", "job-c"]),
+            ("abc", ["job-a", "job-b", "job-c"]),
+            ("", ["job-a", "job-b", "job-c"]),
+        ],
+    )
+    def test_switch_accepts_an_index_as_second_parameter(self, queue, value2, expected_order):
+        jobs = [make_dummy_nzo(name) for name in "abc"]
+        for nzo in jobs:
+            queue.add(nzo, save=False, quiet=True)
+
+        queue.switch(jobs[0].nzo_id, value2)
+
+        assert self.get_queue_order(queue) == expected_order
+
+    def test_has_forced_jobs_true_when_forced_and_active(self, queue):
+        forced = make_dummy_nzo("forced", priority=FORCE_PRIORITY)
+        normal = make_dummy_nzo("normal", priority=0)
+
+        queue.add(forced, save=False, quiet=True)
+        queue.add(normal, save=False, quiet=True)
+
+        assert queue.has_forced_jobs() is True
+
+        # If forced job is paused, it should no longer count
+        forced.status = Status.PAUSED
+        assert queue.has_forced_jobs() is False
+
+    def test_has_forced_jobs_false_when_no_forced(self, queue):
+        a = make_dummy_nzo("a", priority=0)
+        b = make_dummy_nzo("b", priority=LOW_PRIORITY)
+        queue.add(a, save=False, quiet=True)
+        queue.add(b, save=False, quiet=True)
+
+        assert queue.has_forced_jobs() is False
+
+    def test_add_future_job_saves_with_expected_prefix(self, queue):
+        """Queue repair deletes anything in the future folder not named SABnzbd_nzo_*"""
+        nzo = NzbObject("future-job", futuretype=True)
+        queue.add(nzo)
+
+        written = os.listdir(nzo.admin_path)
+        assert written
+        assert all(name.startswith("SABnzbd_nzo_") for name in written), written
+
+    @pytest.mark.parametrize("field", ["name", "size", "bytes", "avg_age", "remaining", "remaining_bytes"])
+    @pytest.mark.parametrize("direction", ["asc", "desc"])
+    def test_sort_queue_every_field(self, queue, field, direction):
+        for name, priority in (("a", NORMAL_PRIORITY), ("b", LOW_PRIORITY), ("c", HIGH_PRIORITY)):
+            queue.add(make_dummy_nzo(name, priority=priority), save=False, quiet=True)
+
+        queue.sort_queue(field, direction)
+
+        # Whatever the field, priority grouping is preserved
+        priorities = [nzo.priority for nzo in queue.queue_info()[3]]
+        assert priorities == sorted(priorities, reverse=True)
+
+    @pytest.mark.parametrize("auto_sort", ["name asc", "remaining asc", "remaining_bytes asc"])
+    def test_update_sort_order(self, queue, monkeypatch, auto_sort):
+        monkeypatch.setattr(sabnzbd.cfg.auto_sort, "get", lambda: auto_sort)
+        queue.add(make_dummy_nzo("a"), save=False, quiet=True)
+
+        queue.update_sort_order()

--- a/tests/test_nzbqueue.py
+++ b/tests/test_nzbqueue.py
@@ -417,6 +417,31 @@ class TestNzbQueue:
         assert set(removed_all) == remaining_ids
         assert queue.queue_info()[5] == 0  # nzos_matched
 
+    def test_remove_multiple_writes_the_queue_admin_once(self, queue, monkeypatch, mocker):
+        jobs = [make_dummy_nzo(f"job-{i}", priority=NORMAL_PRIORITY) for i in range(5)]
+        ids = [queue.add(nzo, save=False, quiet=True) for nzo in jobs]
+
+        save_admin = mocker.Mock()
+        monkeypatch.setattr(sabnzbd.filesystem, "save_admin", save_admin)
+        removed = queue.remove_multiple(ids, delete_all_data=False)
+
+        assert set(removed) == set(ids)
+        assert save_admin.call_count == 1
+
+    def test_save_accepts_a_list_of_jobs(self, queue, monkeypatch, mocker):
+        jobs = [make_dummy_nzo(f"job-{i}", priority=NORMAL_PRIORITY) for i in range(3)]
+        for nzo in jobs:
+            queue.add(nzo, save=False, quiet=True)
+            mocker.patch.object(nzo, "save_to_disk")
+
+        save_admin = mocker.Mock()
+        monkeypatch.setattr(sabnzbd.filesystem, "save_admin", save_admin)
+        queue.save(jobs[:2])
+
+        # Only the listed jobs are written, the queue admin just once for the batch
+        assert [nzo.save_to_disk.call_count for nzo in jobs] == [1, 1, 0]
+        assert save_admin.call_count == 1
+
     def test_change_opts_sets_pp(self, queue):
         a = make_dummy_nzo("a", priority=LOW_PRIORITY)
         ida = queue.add(a, save=False, quiet=True)

--- a/tests/test_nzbqueue.py
+++ b/tests/test_nzbqueue.py
@@ -40,6 +40,7 @@ from sabnzbd.constants import (
     NORMAL_PRIORITY,
     HIGH_PRIORITY,
     FORCE_PRIORITY,
+    REPAIR_PRIORITY,
 )
 from sabnzbd.database import HistoryDB
 from sabnzbd.downloader import Server
@@ -625,6 +626,36 @@ class TestNzbQueue:
         queue.switch(jobs[0].nzo_id, value2)
 
         assert self.get_queue_order(queue) == expected_order
+
+    @pytest.mark.parametrize("via_set_priority", [False, True])
+    @pytest.mark.parametrize(
+        "priority", [REPAIR_PRIORITY, FORCE_PRIORITY, HIGH_PRIORITY, NORMAL_PRIORITY, LOW_PRIORITY]
+    )
+    def test_jobs_queue_in_arrival_order_within_their_priority(self, queue, priority, via_set_priority):
+        """Every group keeps the order its jobs arrived in, so a repair re-add does not starve"""
+        for name in "abc":
+            nzo = make_dummy_nzo(name, priority=NORMAL_PRIORITY if via_set_priority else priority)
+            queue.add(nzo, save=False, quiet=True)
+            if via_set_priority:
+                queue.set_priority([nzo.nzo_id], priority)
+
+        assert self.get_queue_order(queue) == ["job-a", "job-b", "job-c"]
+
+    def test_set_priority_keeps_the_order_of_the_selection(self, queue):
+        """Changing the priority of several jobs at once must not reverse them"""
+        nzo_ids = [queue.add(make_dummy_nzo(name), save=False, quiet=True) for name in "abc"]
+        queue.set_priority(nzo_ids, FORCE_PRIORITY)
+
+        assert self.get_queue_order(queue) == ["job-a", "job-b", "job-c"]
+
+    @pytest.mark.parametrize("add_order", [("forced", "repair"), ("repair", "forced")])
+    def test_repair_outranks_forced(self, queue, add_order):
+        """Whichever job arrives first, the repair job ends up above the forced one"""
+        priorities = {"forced": FORCE_PRIORITY, "repair": REPAIR_PRIORITY}
+        for name in add_order:
+            queue.add(make_dummy_nzo(name, priority=priorities[name]), save=False, quiet=True)
+
+        assert self.get_queue_order(queue) == ["job-repair", "job-forced"]
 
     def test_has_forced_jobs_true_when_forced_and_active(self, queue):
         forced = make_dummy_nzo("forced", priority=FORCE_PRIORITY)


### PR DESCRIPTION
The download queue is a single list kept in priority order. Adding a job and changing a job's priority both scanned it for the right slot, with the same branching written out in `add()` and `set_priority()`. Both now call one helper that uses `bisect` on the priority key. It uses `bisect_right` rather than `insort` because `set_priority()` needs the resulting position for its return value, which `insort` would cost a second scan to recover.

That gives every job one rule, join the back of your own priority group, which the two paths used to disagree about. `add()` shared a branch with FORCE and inserted at the very top, so a repair re-add went in newest first and kept sinking as later jobs completed. `set_priority()` put REPAIR above FORCE and oldest first, but sent FORCE to the very top. Repair now outranks force in both paths and a re-add no longer starves.

Forced jobs lose their front-of-group insert, a leftover from before REPAIR existed (396e77951, 2011, which moved fetching extra par2 files to priority 3). The visible effect is that a multi-select no longer reverses: selecting a, b, c and pressing Force gave c, b, a and now gives a, b, c.

Every add and remove also walked the queue to rebuild the nzo_id admin file before writing it, so removing twenty jobs meant twenty walks and twenty writes. `remove()` takes a `save` flag so `remove_multiple()` writes once per batch, and `save()` accepts a list so adding an archive of NZBs does the same. Those are the only signature changes.

The last commit is two micro-optimisations: `attrgetter` for the attribute sort keys, and `itertools.chain` instead of concatenating the queue and post-processing lists in the two duplicate checks, which run on every added NZB and copied the whole queue each time.

`tests/test_nzbqueue.py` had nothing covering add, remove, reorder, priority or sorting, so this adds 25 tests.
