### PR TITLE
fix background color for .table-server-connections thead

### DIFF
--- a/interfaces/Glitter/templates/static/stylesheets/glitter.css
+++ b/interfaces/Glitter/templates/static/stylesheets/glitter.css
@@ -1610,7 +1610,7 @@ tr.queue-item>td:first-child>a {
 #modal-options .table-server-connections thead {
     height: auto;
     visibility: visible;
-    background-color: #f5f5f5;
+    background-color: var(--clr-input-bg);
 }
 
 #modal-options .table-server-connections td,


### PR DESCRIPTION
This fixes the background color of the table head in the server connections table.
Before:
<img width="2427" height="610" alt="grafik" src="https://github.com/user-attachments/assets/856745e1-02d8-49be-8237-34496766f086" />

After:
<img width="2420" height="603" alt="grafik" src="https://github.com/user-attachments/assets/dc856014-8256-43f2-885c-0611522e9b61" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the server connections table header to use the active theme’s input background color, improving consistency across light and dark modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->